### PR TITLE
Add support for managing multiple clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-tmp
+clusters

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -7,7 +7,6 @@ import (
 )
 
 func init() {
-	clusterCreateCmd.Flags().String("cluster", "", "The id of the cluster to be created. A random id will be used if left empty.")
 	clusterCreateCmd.Flags().String("provider", "aws", "Cloud provider hosting the cluster.")
 	clusterCreateCmd.Flags().String("size", "", "The size constant describing the cluster.")
 	clusterCreateCmd.MarkFlagRequired("size")
@@ -28,13 +27,12 @@ var clusterCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a cluster.",
 	RunE: func(command *cobra.Command, args []string) error {
-		clusterId, _ := command.Flags().GetString("cluster")
 		provider, _ := command.Flags().GetString("provider")
 		size, _ := command.Flags().GetString("size")
 
 		command.SilenceUsage = true
 
-		return provisioner.CreateCluster(clusterId, provider, size, logger)
+		return provisioner.CreateCluster(provider, size, logger)
 	},
 }
 

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -7,6 +7,7 @@ import (
 )
 
 func init() {
+	clusterCreateCmd.Flags().String("cluster", "", "The id of the cluster to be created. A random id will be used if left empty.")
 	clusterCreateCmd.Flags().String("provider", "aws", "Cloud provider hosting the cluster.")
 	clusterCreateCmd.Flags().String("size", "", "The size constant describing the cluster.")
 	clusterCreateCmd.MarkFlagRequired("size")
@@ -27,12 +28,13 @@ var clusterCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a cluster.",
 	RunE: func(command *cobra.Command, args []string) error {
+		clusterId, _ := command.Flags().GetString("cluster")
 		provider, _ := command.Flags().GetString("provider")
 		size, _ := command.Flags().GetString("size")
 
 		command.SilenceUsage = true
 
-		return provisioner.CreateCluster(provider, size, logger)
+		return provisioner.CreateCluster(clusterId, provider, size, logger)
 	},
 }
 

--- a/internal/provisioner/cluster.go
+++ b/internal/provisioner/cluster.go
@@ -24,7 +24,7 @@ const SizeAlef500 = "SizeAlef500"
 const clusterRootDir = "clusters"
 
 // CreateCluster creates a cluster using kops and terraform.
-func CreateCluster(clusterId, provider, size string, logger log.FieldLogger) error {
+func CreateCluster(provider, size string, logger log.FieldLogger) error {
 	provider = strings.ToLower(provider)
 	if provider != ProviderAWS {
 		return fmt.Errorf("unsupported provider %s", provider)
@@ -34,9 +34,7 @@ func CreateCluster(clusterId, provider, size string, logger log.FieldLogger) err
 		return fmt.Errorf("unsupported size %s", size)
 	}
 
-	if clusterId == "" {
-		clusterId = model.NewId()
-	}
+	clusterId := model.NewId()
 
 	// Temporarily locate the kops output directory to a local folder based on the
 	// cluster name. This won't be necessary once we persist the output to S3 instead.

--- a/internal/provisioner/cluster.go
+++ b/internal/provisioner/cluster.go
@@ -20,7 +20,7 @@ const ProviderAWS = "aws"
 const SizeAlef500 = "SizeAlef500"
 
 // CreateCluster creates a cluster using kops and terraform.
-func CreateCluster(provider, size string, logger log.FieldLogger) error {
+func CreateCluster(clusterId, provider, size string, logger log.FieldLogger) error {
 	provider = strings.ToLower(provider)
 	if provider != ProviderAWS {
 		return fmt.Errorf("unsupported provider %s", provider)
@@ -30,15 +30,20 @@ func CreateCluster(provider, size string, logger log.FieldLogger) error {
 		return fmt.Errorf("unsupported size %s", size)
 	}
 
-	outputDir := "tmp"
-	_, err := os.Stat("tmp")
-	if err == nil {
-		return errors.New("tmp folder already exists: delete existing cluster first")
-	} else if err != nil && !os.IsNotExist(err) {
-		return errors.Wrap(err, "failed to stat temporary output directory")
+	if clusterId == "" {
+		clusterId = model.NewId()
 	}
 
-	clusterId := model.NewId()
+	// Temporarily relocate the kops output directory to a local folder based on the
+	// cluster name. This won't be necessary once we persist the output to S3 instead.
+	outputDir := fmt.Sprintf("cluster-%s", clusterId)
+	_, err := os.Stat(outputDir)
+	if err == nil {
+		return fmt.Errorf("encountered cluster ID collision: directory %q already exists", outputDir)
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat cluster directory %q: %s", outputDir, err)
+	}
+
 	s3StateStore := "dev.cloud.mattermost.com"
 	dns := fmt.Sprintf("%s-kops.k8s.local", clusterId)
 
@@ -56,11 +61,9 @@ func CreateCluster(provider, size string, logger log.FieldLogger) error {
 		return err
 	}
 
-	// Temporarily relocate the kops output directory to a local folder named `tmp`. This won't
-	// be necessary once we persist the output to S3 instead.
 	err = os.Rename(kops.GetOutputDirectory(), outputDir)
 	if err != nil {
-		return errors.Wrap(err, "failed to rename kops output directory to tmp")
+		return fmt.Errorf("failed to rename kops output directory to %q", outputDir)
 	}
 
 	terraform := terraform.New(outputDir, logger)
@@ -84,29 +87,48 @@ func CreateCluster(provider, size string, logger log.FieldLogger) error {
 func DeleteCluster(clusterId string, logger log.FieldLogger) error {
 	logger = logger.WithField("cluster", clusterId)
 
-	logger.Info("deleting cluster")
-
 	s3StateStore := "dev.cloud.mattermost.com"
 	dns := fmt.Sprintf("%s-kops.k8s.local", clusterId)
 
-	// Temporarily look for the kops output directory as a local folder named `tmp`. See above.
-	outputDir := "tmp"
+	// Temporarily look for the kops output directory as a local folder named after
+	// the cluster ID. See above.
+	outputDir := fmt.Sprintf("cluster-%s", clusterId)
+
+	// Validate the provided cluster ID before we alter state in any way.
+	logger.Info("verifying cluster ID")
+	_, err := os.Stat(outputDir)
+	if err != nil {
+		return fmt.Errorf("failed to find cluster directory %q: %s", outputDir, err)
+	}
 
 	terraform := terraform.New(outputDir, logger)
 	defer terraform.Close()
-	err := terraform.Init()
+	out, err := terraform.Output("cluster_name")
 	if err != nil {
 		return err
 	}
-	err = terraform.Destroy()
-	if err != nil {
-		return err
+	if out != dns {
+		return fmt.Errorf("terraform cluster_name (%s) does not match dns from provided ID (%s)", out, dns)
 	}
 
 	kops, err := kops.New(s3StateStore, logger)
 	defer kops.Close()
 	if err != nil {
 		return errors.Wrap(err, "failed to create kops wrapper")
+	}
+	_, err = kops.GetCluster(dns)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("deleting cluster")
+	err = terraform.Init()
+	if err != nil {
+		return err
+	}
+	err = terraform.Destroy()
+	if err != nil {
+		return err
 	}
 
 	err = kops.DeleteCluster(dns)

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -2,6 +2,7 @@ package kops
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -61,4 +62,33 @@ func (c *Cmd) DeleteCluster(name string) error {
 	}
 
 	return nil
+}
+
+// GetCluster invokes kops get cluster, using the context of the created Cmd, and
+// returns the stdout.
+func (c *Cmd) GetCluster(name string) (string, error) {
+	stdout, _, err := c.run(
+		"get",
+		"cluster",
+		arg("name", name),
+		arg("state", "s3://", c.s3StateStore),
+	)
+	trimmed := strings.TrimSuffix(string(stdout), "\n")
+	if err != nil {
+		return trimmed, errors.Wrap(err, "failed to invoke kops get cluster")
+	}
+
+	return trimmed, nil
+}
+
+// Version invokes kops version, using the context of the created Cmd, and
+// returns the stdout.
+func (c *Cmd) Version() (string, error) {
+	stdout, _, err := c.run("version")
+	trimmed := strings.TrimSuffix(string(stdout), "\n")
+	if err != nil {
+		return trimmed, errors.Wrap(err, "failed to invoke kops version")
+	}
+
+	return trimmed, nil
 }

--- a/internal/tools/terraform/plan.go
+++ b/internal/tools/terraform/plan.go
@@ -1,10 +1,17 @@
 package terraform
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/pkg/errors"
 )
+
+type terraformOutput struct {
+	Sensitive bool   `json:"sensitive"`
+	Type      string `json:"type"`
+	Value     string `json:"value"`
+}
 
 // Init invokes terraform init.
 func (c *Cmd) Init() error {
@@ -47,14 +54,20 @@ func (c *Cmd) Destroy() error {
 func (c *Cmd) Output(variable string) (string, error) {
 	stdout, _, err := c.run(
 		"output",
+		"-json",
 		variable,
 	)
-	trimmed := strings.TrimSuffix(string(stdout), "\n")
 	if err != nil {
-		return trimmed, errors.Wrap(err, "failed to invoke terraform output")
+		return string(stdout), errors.Wrap(err, "failed to invoke terraform output")
 	}
 
-	return trimmed, nil
+	var output terraformOutput
+	err = json.Unmarshal(stdout, &output)
+	if err != nil {
+		return string(stdout), errors.Wrap(err, "failed to parse terraform output")
+	}
+
+	return output.Value, nil
 }
 
 // Version invokes terraform version and returns the value.

--- a/internal/tools/terraform/plan.go
+++ b/internal/tools/terraform/plan.go
@@ -1,6 +1,8 @@
 package terraform
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 )
 
@@ -39,4 +41,29 @@ func (c *Cmd) Destroy() error {
 	}
 
 	return nil
+}
+
+// Output invokes terraform output and returns the value.
+func (c *Cmd) Output(variable string) (string, error) {
+	stdout, _, err := c.run(
+		"output",
+		variable,
+	)
+	trimmed := strings.TrimSuffix(string(stdout), "\n")
+	if err != nil {
+		return trimmed, errors.Wrap(err, "failed to invoke terraform output")
+	}
+
+	return trimmed, nil
+}
+
+// Version invokes terraform version and returns the value.
+func (c *Cmd) Version() (string, error) {
+	stdout, _, err := c.run("version")
+	trimmed := strings.TrimSuffix(string(stdout), "\n")
+	if err != nil {
+		return trimmed, errors.Wrap(err, "failed to invoke terraform version")
+	}
+
+	return trimmed, nil
 }

--- a/internal/tools/terraform/plan.go
+++ b/internal/tools/terraform/plan.go
@@ -2,15 +2,16 @@ package terraform
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
 )
 
 type terraformOutput struct {
-	Sensitive bool   `json:"sensitive"`
-	Type      string `json:"type"`
-	Value     string `json:"value"`
+	Sensitive bool        `json:"sensitive"`
+	Type      string      `json:"type"`
+	Value     interface{} `json:"value"`
 }
 
 // Init invokes terraform init.
@@ -67,7 +68,7 @@ func (c *Cmd) Output(variable string) (string, error) {
 		return string(stdout), errors.Wrap(err, "failed to parse terraform output")
 	}
 
-	return output.Value, nil
+	return fmt.Sprintf("%s", output.Value), nil
 }
 
 // Version invokes terraform version and returns the value.


### PR DESCRIPTION
This adds initial support for having multiple clusters running
concurrently. Most of the cluster state data still resides locally
in directories labelled with the cluster ID.

Addresses https://mattermost.atlassian.net/browse/MM-15036