### PR TITLE
Expose kops configuration and sizing options

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -9,14 +9,14 @@ import (
 )
 
 func init() {
+	clusterCmd.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
+
 	clusterCreateCmd.Flags().String("provider", "aws", "Cloud provider hosting the cluster.")
-	clusterCreateCmd.Flags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
 	clusterCreateCmd.Flags().String("size", "SizeAlef500", "The size constant describing the cluster.")
 	clusterCreateCmd.Flags().String("zones", "us-east-1a", "The zones where the cluster will be deployed. Use commas to separate multiple zones.")
 	clusterCreateCmd.MarkFlagRequired("size")
 
 	clusterDeleteCmd.Flags().String("cluster", "", "The id of the cluster to be deleted.")
-	clusterDeleteCmd.Flags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket where the existing cluster state is stored.")
 	clusterDeleteCmd.MarkFlagRequired("cluster")
 
 	clusterCmd.AddCommand(clusterCreateCmd)

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -12,11 +12,11 @@ func init() {
 	clusterCreateCmd.Flags().String("provider", "aws", "Cloud provider hosting the cluster.")
 	clusterCreateCmd.Flags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
 	clusterCreateCmd.Flags().String("size", "SizeAlef500", "The size constant describing the cluster.")
-	clusterCreateCmd.Flags().String("zones", "us-east-1a", "The zones where the cluster will be deployed.")
+	clusterCreateCmd.Flags().String("zones", "us-east-1a", "The zones where the cluster will be deployed. Use commas to separate multiple zones.")
 	clusterCreateCmd.MarkFlagRequired("size")
 
 	clusterDeleteCmd.Flags().String("cluster", "", "The id of the cluster to be deleted.")
-	clusterDeleteCmd.Flags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket where the cluster state is stored.")
+	clusterDeleteCmd.Flags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket where the existing cluster state is stored.")
 	clusterDeleteCmd.MarkFlagRequired("cluster")
 
 	clusterCmd.AddCommand(clusterCreateCmd)

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mattermost-cloud/internal/provisioner"
@@ -8,10 +10,13 @@ import (
 
 func init() {
 	clusterCreateCmd.Flags().String("provider", "aws", "Cloud provider hosting the cluster.")
-	clusterCreateCmd.Flags().String("size", "", "The size constant describing the cluster.")
+	clusterCreateCmd.Flags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state")
+	clusterCreateCmd.Flags().String("size", "SizeAlef500", "The size constant describing the cluster.")
+	clusterCreateCmd.Flags().String("zones", "us-east-1a", "The zones where the cluster will be deployed")
 	clusterCreateCmd.MarkFlagRequired("size")
 
 	clusterDeleteCmd.Flags().String("cluster", "", "The id of the cluster to be deleted.")
+	clusterDeleteCmd.Flags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket where the cluster state is stored")
 	clusterDeleteCmd.MarkFlagRequired("cluster")
 
 	clusterCmd.AddCommand(clusterCreateCmd)
@@ -28,11 +33,15 @@ var clusterCreateCmd = &cobra.Command{
 	Short: "Create a cluster.",
 	RunE: func(command *cobra.Command, args []string) error {
 		provider, _ := command.Flags().GetString("provider")
+		s3StateStore, _ := command.Flags().GetString("state-store")
 		size, _ := command.Flags().GetString("size")
+		zones, _ := command.Flags().GetString("zones")
+
+		splitZones := strings.Split(zones, ",")
 
 		command.SilenceUsage = true
 
-		return provisioner.CreateCluster(provider, size, logger)
+		return provisioner.CreateCluster(provider, s3StateStore, size, splitZones, logger)
 	},
 }
 
@@ -41,9 +50,10 @@ var clusterDeleteCmd = &cobra.Command{
 	Short: "Delete a cluster.",
 	RunE: func(command *cobra.Command, args []string) error {
 		clusterId, _ := command.Flags().GetString("cluster")
+		s3StateStore, _ := command.Flags().GetString("state-store")
 
 		command.SilenceUsage = true
 
-		return provisioner.DeleteCluster(clusterId, logger)
+		return provisioner.DeleteCluster(clusterId, s3StateStore, logger)
 	},
 }

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -10,13 +10,13 @@ import (
 
 func init() {
 	clusterCreateCmd.Flags().String("provider", "aws", "Cloud provider hosting the cluster.")
-	clusterCreateCmd.Flags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state")
+	clusterCreateCmd.Flags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
 	clusterCreateCmd.Flags().String("size", "SizeAlef500", "The size constant describing the cluster.")
-	clusterCreateCmd.Flags().String("zones", "us-east-1a", "The zones where the cluster will be deployed")
+	clusterCreateCmd.Flags().String("zones", "us-east-1a", "The zones where the cluster will be deployed.")
 	clusterCreateCmd.MarkFlagRequired("size")
 
 	clusterDeleteCmd.Flags().String("cluster", "", "The id of the cluster to be deleted.")
-	clusterDeleteCmd.Flags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket where the cluster state is stored")
+	clusterDeleteCmd.Flags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket where the cluster state is stored.")
 	clusterDeleteCmd.MarkFlagRequired("cluster")
 
 	clusterCmd.AddCommand(clusterCreateCmd)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/stretchr/testify v1.2.2
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/pelletier/go-toml v1.3.0 h1:e5+lF2E4Y2WCIxBefVowBuB0iHrUH4HZ8q+6mGF7f
 github.com/pelletier/go-toml v1.3.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/internal/provisioner/cluster.go
+++ b/internal/provisioner/cluster.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/pkg/errors"
@@ -19,8 +18,7 @@ const clusterRootDir = "clusters"
 
 // CreateCluster creates a cluster using kops and terraform.
 func CreateCluster(provider, s3StateStore, size string, zones []string, logger log.FieldLogger) error {
-	provider = strings.ToLower(provider)
-	err := checkProvider(provider)
+	provider, err := checkProvider(provider)
 	if err != nil {
 		return err
 	}

--- a/internal/provisioner/cluster.go
+++ b/internal/provisioner/cluster.go
@@ -14,31 +14,27 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/tools/terraform"
 )
 
-// ProviderAWS is the cloud provider AWS.
-const ProviderAWS = "aws"
-
-// SizeAlef500 is a cluster sized for 500 users.
-const SizeAlef500 = "SizeAlef500"
-
 // clusterRootDir is the local directory that contains cluster configuration.
 const clusterRootDir = "clusters"
 
 // CreateCluster creates a cluster using kops and terraform.
-func CreateCluster(provider, size string, logger log.FieldLogger) error {
+func CreateCluster(provider, s3StateStore, size string, zones []string, logger log.FieldLogger) error {
 	provider = strings.ToLower(provider)
-	if provider != ProviderAWS {
-		return fmt.Errorf("unsupported provider %s", provider)
+	err := checkProvider(provider)
+	if err != nil {
+		return err
 	}
 
-	if size != SizeAlef500 {
-		return fmt.Errorf("unsupported size %s", size)
+	kopsClusterSize, err := kops.GetSize(size)
+	if err != nil {
+		return err
 	}
 
 	clusterId := model.NewId()
 
 	// Temporarily locate the kops output directory to a local folder based on the
 	// cluster name. This won't be necessary once we persist the output to S3 instead.
-	_, err := os.Stat(clusterRootDir)
+	_, err = os.Stat(clusterRootDir)
 	if err != nil && os.IsNotExist(err) {
 		err = os.Mkdir(clusterRootDir, 0755)
 		if err != nil {
@@ -56,8 +52,7 @@ func CreateCluster(provider, size string, logger log.FieldLogger) error {
 		return errors.Wrapf(err, "failed to stat cluster directory %q", outputDir)
 	}
 
-	s3StateStore := "dev.cloud.mattermost.com"
-	dns := fmt.Sprintf("%s-kops.k8s.local", clusterId)
+	dns := clusterDNS(clusterId)
 
 	logger = logger.WithField("cluster", clusterId)
 
@@ -68,7 +63,7 @@ func CreateCluster(provider, size string, logger log.FieldLogger) error {
 		return err
 	}
 	defer kops.Close()
-	err = kops.CreateCluster(dns, provider, []string{"us-east-1a"})
+	err = kops.CreateCluster(dns, provider, kopsClusterSize, zones)
 	if err != nil {
 		return err
 	}
@@ -96,11 +91,10 @@ func CreateCluster(provider, size string, logger log.FieldLogger) error {
 }
 
 // DeleteCluster deletes a previously created cluster using kops and terraform.
-func DeleteCluster(clusterId string, logger log.FieldLogger) error {
+func DeleteCluster(clusterId, s3StateStore string, logger log.FieldLogger) error {
 	logger = logger.WithField("cluster", clusterId)
 
-	s3StateStore := "dev.cloud.mattermost.com"
-	dns := fmt.Sprintf("%s-kops.k8s.local", clusterId)
+	dns := clusterDNS(clusterId)
 
 	// Temporarily look for the kops output directory as a local folder named after
 	// the cluster ID. See above.
@@ -155,4 +149,8 @@ func DeleteCluster(clusterId string, logger log.FieldLogger) error {
 	logger.Info("successfully deleted cluster")
 
 	return nil
+}
+
+func clusterDNS(id string) string {
+	return fmt.Sprintf("%s-kops.k8s.local", id)
 }

--- a/internal/provisioner/providers.go
+++ b/internal/provisioner/providers.go
@@ -1,14 +1,18 @@
 package provisioner
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // providerAWS is the cloud provider AWS.
 const providerAWS = "aws"
 
-func checkProvider(provider string) error {
+func checkProvider(provider string) (string, error) {
+	provider = strings.ToLower(provider)
 	if provider == providerAWS {
-		return nil
+		return provider, nil
 	}
 
-	return fmt.Errorf("unsupported provider %s", provider)
+	return provider, fmt.Errorf("unsupported provider %s", provider)
 }

--- a/internal/provisioner/providers.go
+++ b/internal/provisioner/providers.go
@@ -1,0 +1,14 @@
+package provisioner
+
+import "fmt"
+
+// providerAWS is the cloud provider AWS.
+const providerAWS = "aws"
+
+func checkProvider(provider string) error {
+	if provider == providerAWS {
+		return nil
+	}
+
+	return fmt.Errorf("unsupported provider %s", provider)
+}

--- a/internal/provisioner/providers_test.go
+++ b/internal/provisioner/providers_test.go
@@ -8,22 +8,30 @@ import (
 
 func TestCheckProvider(t *testing.T) {
 	var sizeTests = []struct {
-		provider    string
-		expectError bool
+		provider               string
+		expectedProviderString string
+		expectError            bool
 	}{
-		{"aws", false},
-		{"gce", true},
-		{"azure", true},
+		{"aws", "aws", false},
+		{"AWS", "aws", false},
+		{"Aws", "aws", false},
+		{"gce", "gce", true},
+		{"GCE", "gce", true},
+		{"Gce", "gce", true},
+		{"azure", "azure", true},
+		{"AZURE", "azure", true},
+		{"Azure", "azure", true},
 	}
 
 	for _, tt := range sizeTests {
 		t.Run(tt.provider, func(t *testing.T) {
-			err := checkProvider(tt.provider)
+			provider, err := checkProvider(tt.provider)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
+			assert.Equal(t, provider, tt.expectedProviderString)
 		})
 	}
 }

--- a/internal/provisioner/providers_test.go
+++ b/internal/provisioner/providers_test.go
@@ -1,0 +1,26 @@
+package provisioner
+
+import "testing"
+
+func TestCheckProvider(t *testing.T) {
+	var sizeTests = []struct {
+		provider    string
+		expectError bool
+	}{
+		{"aws", false},
+		{"gce", true},
+		{"azure", true},
+	}
+
+	for _, tt := range sizeTests {
+		t.Run(tt.provider, func(t *testing.T) {
+			err := checkProvider(tt.provider)
+			if err != nil && !tt.expectError {
+				t.Errorf("got error when expecting none: %s", err)
+			}
+			if err == nil && tt.expectError {
+				t.Errorf("expecting error, got none")
+			}
+		})
+	}
+}

--- a/internal/provisioner/providers_test.go
+++ b/internal/provisioner/providers_test.go
@@ -1,6 +1,10 @@
 package provisioner
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestCheckProvider(t *testing.T) {
 	var sizeTests = []struct {
@@ -15,11 +19,10 @@ func TestCheckProvider(t *testing.T) {
 	for _, tt := range sizeTests {
 		t.Run(tt.provider, func(t *testing.T) {
 			err := checkProvider(tt.provider)
-			if err != nil && !tt.expectError {
-				t.Errorf("got error when expecting none: %s", err)
-			}
-			if err == nil && tt.expectError {
-				t.Errorf("expecting error, got none")
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CreateCluster invokes kops create cluster, using the context of the created Cmd.
-func (c *Cmd) CreateCluster(name, cloud string, zones []string) error {
+func (c *Cmd) CreateCluster(name, cloud string, clusterSize ClusterSize, zones []string) error {
 	if len(zones) == 0 {
 		return fmt.Errorf("must supply at least one zone")
 	}
@@ -19,6 +19,9 @@ func (c *Cmd) CreateCluster(name, cloud string, zones []string) error {
 		arg("cloud", cloud),
 		arg("state", "s3://", c.s3StateStore),
 		commaArg("zones", zones),
+		arg("node-count", clusterSize.NodeCount),
+		arg("node-size", clusterSize.NodeSize),
+		arg("master-size", clusterSize.MasterSize),
 		arg("target", "terraform"),
 		arg("out", c.outputDir),
 		arg("output", "json"),

--- a/internal/tools/kops/sizes.go
+++ b/internal/tools/kops/sizes.go
@@ -1,0 +1,41 @@
+package kops
+
+import "fmt"
+
+// ClusterSize is sizing configuration used by kops at cluster creation.
+type ClusterSize struct {
+	NodeCount  string
+	NodeSize   string
+	MasterSize string
+}
+
+// validSizes is a mapping of a size keyword to kops cluster configuration.
+var validSizes = map[string]ClusterSize{
+	"SizeAlef500":  sizeAlef500,
+	"SizeAlef1000": sizeAlef1000,
+}
+
+// sizeAlef500 is a cluster sized for 500 users.
+var sizeAlef500 = ClusterSize{
+	NodeCount:  "2",
+	NodeSize:   "t2.medium",
+	MasterSize: "m3.medium",
+}
+
+// sizeAlef1000 is a cluster sized for 1000 users.
+var sizeAlef1000 = ClusterSize{
+	NodeCount:  "4",
+	NodeSize:   "t2.medium",
+	MasterSize: "m4.large",
+}
+
+// GetSize takes a size keyword and returns the matching kops cluster
+// configuration.
+func GetSize(size string) (ClusterSize, error) {
+	kopsClusterSize, ok := validSizes[size]
+	if !ok {
+		return ClusterSize{}, fmt.Errorf("unsupported size %s", size)
+	}
+
+	return kopsClusterSize, nil
+}

--- a/internal/tools/kops/sizes_test.go
+++ b/internal/tools/kops/sizes_test.go
@@ -1,0 +1,30 @@
+package kops
+
+import "testing"
+
+func TestGetSize(t *testing.T) {
+	var sizeTests = []struct {
+		size        string
+		clusterSize ClusterSize
+		expectError bool
+	}{
+		{"SizeAlef500", sizeAlef500, false},
+		{"SizeAlef1000", sizeAlef1000, false},
+		{"IncorrectSize", ClusterSize{}, true},
+	}
+
+	for _, tt := range sizeTests {
+		t.Run(tt.size, func(t *testing.T) {
+			clusterSize, err := GetSize(tt.size)
+			if err != nil && !tt.expectError {
+				t.Errorf("got error when expecting none: %s", err)
+			}
+			if err == nil && tt.expectError {
+				t.Errorf("expecting error, got none")
+			}
+			if clusterSize != tt.clusterSize {
+				t.Errorf("got %+v, want %+v", clusterSize, tt.clusterSize)
+			}
+		})
+	}
+}

--- a/internal/tools/kops/sizes_test.go
+++ b/internal/tools/kops/sizes_test.go
@@ -1,6 +1,10 @@
 package kops
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestGetSize(t *testing.T) {
 	var sizeTests = []struct {
@@ -16,15 +20,12 @@ func TestGetSize(t *testing.T) {
 	for _, tt := range sizeTests {
 		t.Run(tt.size, func(t *testing.T) {
 			clusterSize, err := GetSize(tt.size)
-			if err != nil && !tt.expectError {
-				t.Errorf("got error when expecting none: %s", err)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
-			if err == nil && tt.expectError {
-				t.Errorf("expecting error, got none")
-			}
-			if clusterSize != tt.clusterSize {
-				t.Errorf("got %+v, want %+v", clusterSize, tt.clusterSize)
-			}
+			assert.Equal(t, clusterSize, tt.clusterSize)
 		})
 	}
 }


### PR DESCRIPTION
This change provides additional support for defining the size and
configuration of the clusters created by kops.

A few notes on this:
1. The cluster sizing is very arbitrary right now and doesn't support all of the kops command flags for size info.
2. In the longterm, we may want to use the kops template files instead: https://github.com/kubernetes/kops/blob/master/docs/cluster_template.md
3. I moved some of the hard-coded values to the default values of the corresponding command flags. This is simply to save time, but we will probably want to remove them in the longterm.

https://mattermost.atlassian.net/browse/MM-14993