### PR TITLE
[MM-14991] Additional kops functionality

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -51,7 +51,7 @@ var clusterCreateCmd = &cobra.Command{
 
 var clusterUpgradeCmd = &cobra.Command{
 	Use:   "upgrade",
-	Short: "Upgrade a cluster.",
+	Short: "Upgrade k8s on a cluster.",
 	RunE: func(command *cobra.Command, args []string) error {
 		clusterId, _ := command.Flags().GetString("cluster")
 		s3StateStore, _ := command.Flags().GetString("state-store")

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -16,10 +16,14 @@ func init() {
 	clusterCreateCmd.Flags().String("zones", "us-east-1a", "The zones where the cluster will be deployed. Use commas to separate multiple zones.")
 	clusterCreateCmd.MarkFlagRequired("size")
 
+	clusterUpgradeCmd.Flags().String("cluster", "", "The id of the cluster to be upgraded.")
+	clusterUpgradeCmd.MarkFlagRequired("cluster")
+
 	clusterDeleteCmd.Flags().String("cluster", "", "The id of the cluster to be deleted.")
 	clusterDeleteCmd.MarkFlagRequired("cluster")
 
 	clusterCmd.AddCommand(clusterCreateCmd)
+	clusterCmd.AddCommand(clusterUpgradeCmd)
 	clusterCmd.AddCommand(clusterDeleteCmd)
 }
 
@@ -42,6 +46,19 @@ var clusterCreateCmd = &cobra.Command{
 		command.SilenceUsage = true
 
 		return provisioner.CreateCluster(provider, s3StateStore, size, splitZones, logger)
+	},
+}
+
+var clusterUpgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Upgrade a cluster.",
+	RunE: func(command *cobra.Command, args []string) error {
+		clusterId, _ := command.Flags().GetString("cluster")
+		s3StateStore, _ := command.Flags().GetString("state-store")
+
+		command.SilenceUsage = true
+
+		return provisioner.UpgradeCluster(clusterId, s3StateStore, logger)
 	},
 }
 

--- a/internal/provisioner/cluster.go
+++ b/internal/provisioner/cluster.go
@@ -71,14 +71,14 @@ func CreateCluster(provider, s3StateStore, size string, zones []string, logger l
 		return fmt.Errorf("failed to rename kops output directory to %q", outputDir)
 	}
 
-	terraform := terraform.New(outputDir, logger)
-	defer terraform.Close()
-	err = terraform.Init()
+	terraformClient := terraform.New(outputDir, logger)
+	defer terraformClient.Close()
+	err = terraformClient.Init()
 	if err != nil {
 		return err
 	}
 
-	err = terraform.Apply()
+	err = terraformClient.Apply()
 	if err != nil {
 		return err
 	}
@@ -104,13 +104,13 @@ func UpgradeCluster(clusterId, s3StateStore string, logger log.FieldLogger) erro
 		return errors.Wrapf(err, "failed to find cluster directory %q", outputDir)
 	}
 
-	terraform := terraform.New(outputDir, logger)
-	defer terraform.Close()
-	err = terraform.Init()
+	terraformClient := terraform.New(outputDir, logger)
+	defer terraformClient.Close()
+	err = terraformClient.Init()
 	if err != nil {
 		return err
 	}
-	out, err := terraform.Output("cluster_name")
+	out, err := terraformClient.Output("cluster_name")
 	if err != nil {
 		return err
 	}
@@ -119,10 +119,10 @@ func UpgradeCluster(clusterId, s3StateStore string, logger log.FieldLogger) erro
 	}
 
 	kops, err := kops.New(s3StateStore, logger)
-	defer kops.Close()
 	if err != nil {
 		return errors.Wrap(err, "failed to create kops wrapper")
 	}
+	defer kops.Close()
 	_, err = kops.GetCluster(dns)
 	if err != nil {
 		return err
@@ -139,7 +139,7 @@ func UpgradeCluster(clusterId, s3StateStore string, logger log.FieldLogger) erro
 		return err
 	}
 
-	err = terraform.Apply()
+	err = terraformClient.Apply()
 	if err != nil {
 		return err
 	}
@@ -174,13 +174,13 @@ func DeleteCluster(clusterId, s3StateStore string, logger log.FieldLogger) error
 		return errors.Wrapf(err, "failed to find cluster directory %q", outputDir)
 	}
 
-	terraform := terraform.New(outputDir, logger)
-	defer terraform.Close()
-	err = terraform.Init()
+	terraformClient := terraform.New(outputDir, logger)
+	defer terraformClient.Close()
+	err = terraformClient.Init()
 	if err != nil {
 		return err
 	}
-	out, err := terraform.Output("cluster_name")
+	out, err := terraformClient.Output("cluster_name")
 	if err != nil {
 		return err
 	}
@@ -189,17 +189,17 @@ func DeleteCluster(clusterId, s3StateStore string, logger log.FieldLogger) error
 	}
 
 	kops, err := kops.New(s3StateStore, logger)
-	defer kops.Close()
 	if err != nil {
 		return errors.Wrap(err, "failed to create kops wrapper")
 	}
+	defer kops.Close()
 	_, err = kops.GetCluster(dns)
 	if err != nil {
 		return err
 	}
 
 	logger.Info("deleting cluster")
-	err = terraform.Destroy()
+	err = terraformClient.Destroy()
 	if err != nil {
 		return err
 	}

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -33,6 +33,22 @@ func (c *Cmd) CreateCluster(name, cloud string, clusterSize ClusterSize, zones [
 	return nil
 }
 
+// RollingUpdateCluster invokes kops rolling-update cluster, using the context of the created Cmd.
+func (c *Cmd) RollingUpdateCluster(name string) error {
+	_, _, err := c.run(
+		"rolling-update",
+		"cluster",
+		arg("name", name),
+		arg("state", "s3://", c.s3StateStore),
+		"--yes",
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to invoke kops rolling-update cluster")
+	}
+
+	return nil
+}
+
 // UpdateCluster invokes kops update cluster, using the context of the created Cmd.
 func (c *Cmd) UpdateCluster(name string) error {
 	_, _, err := c.run(
@@ -46,6 +62,37 @@ func (c *Cmd) UpdateCluster(name string) error {
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to invoke kops update cluster")
+	}
+
+	return nil
+}
+
+// UpgradeCluster invokes kops upgrade cluster, using the context of the created Cmd.
+func (c *Cmd) UpgradeCluster(name string) error {
+	_, _, err := c.run(
+		"upgrade",
+		"cluster",
+		arg("name", name),
+		arg("state", "s3://", c.s3StateStore),
+		"--yes",
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to invoke kops upgrade cluster")
+	}
+
+	return nil
+}
+
+// ValidateCluster invokes kops validate cluster, using the context of the created Cmd.
+func (c *Cmd) ValidateCluster(name string) error {
+	_, _, err := c.run(
+		"validate",
+		"cluster",
+		arg("name", name),
+		arg("state", "s3://", c.s3StateStore),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to invoke kops validate cluster")
 	}
 
 	return nil

--- a/internal/tools/kops/run.go
+++ b/internal/tools/kops/run.go
@@ -40,12 +40,12 @@ func outputLogger(line string, logger log.FieldLogger) {
 	matches := glogRe.FindStringSubmatch(line)
 	if matches == nil {
 		// Assume non-glog output is a warning.
-		logger.Warnf("kops: %s", line)
+		logger.Warnf("[kops] %s", line)
 		return
 	}
 
 	level := matches[1]
-	msg := fmt.Sprintf("kops: %s", matches[len(matches)-1])
+	msg := fmt.Sprintf("[kops] %s", matches[len(matches)-1])
 	switch level {
 	case "I":
 		logger.Info(msg)

--- a/internal/tools/kops/run_test.go
+++ b/internal/tools/kops/run_test.go
@@ -1,0 +1,63 @@
+package kops
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArg(t *testing.T) {
+	var sizeTests = []struct {
+		key      string
+		vals     []string
+		expected string
+	}{
+		{
+			"1valNoKeyDash",
+			[]string{"val1"},
+			"--1valNoKeyDash=val1",
+		}, {
+			"3valsNoKeyDash",
+			[]string{"val1", "val2", "val3"},
+			"--3valsNoKeyDash=val1val2val3",
+		}, {
+			"--3valsWithKeyDash",
+			[]string{"val1", "val2", "val3"},
+			"--3valsWithKeyDash=val1val2val3",
+		},
+	}
+
+	for _, tt := range sizeTests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equal(t, arg(tt.key, tt.vals...), tt.expected)
+		})
+	}
+}
+
+func TestCommaArg(t *testing.T) {
+	var sizeTests = []struct {
+		key      string
+		vals     []string
+		expected string
+	}{
+		{
+			"1valNoKeyDash",
+			[]string{"val1"},
+			"--1valNoKeyDash=val1",
+		}, {
+			"3valsNoKeyDash",
+			[]string{"val1", "val2", "val3"},
+			"--3valsNoKeyDash=val1,val2,val3",
+		}, {
+			"--3valsWithKeyDash",
+			[]string{"val1", "val2", "val3"},
+			"--3valsWithKeyDash=val1,val2,val3",
+		},
+	}
+
+	for _, tt := range sizeTests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equal(t, commaArg(tt.key, tt.vals), tt.expected)
+		})
+	}
+}

--- a/internal/tools/terraform/run.go
+++ b/internal/tools/terraform/run.go
@@ -30,7 +30,7 @@ func outputLogger(line string, logger log.FieldLogger) {
 		return
 	}
 
-	logger.Infof("terraform: %s", line)
+	logger.Infof("[terraform] %s", line)
 }
 
 func (c *Cmd) run(arg ...string) ([]byte, []byte, error) {

--- a/internal/tools/terraform/run_test.go
+++ b/internal/tools/terraform/run_test.go
@@ -1,0 +1,39 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArg(t *testing.T) {
+	var sizeTests = []struct {
+		key      string
+		vals     []string
+		expected string
+	}{
+		{
+			"1valNoKeyDash",
+			[]string{"val1"},
+			"-1valNoKeyDash=val1",
+		}, {
+			"3valsNoKeyDash",
+			[]string{"val1", "val2", "val3"},
+			"-3valsNoKeyDash=val1val2val3",
+		}, {
+			"-3valsWithKeyDash",
+			[]string{"val1", "val2", "val3"},
+			"-3valsWithKeyDash=val1val2val3",
+		}, {
+			"KeyNoVal",
+			[]string{},
+			"-KeyNoVal",
+		},
+	}
+
+	for _, tt := range sizeTests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equal(t, arg(tt.key, tt.vals...), tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
This change provides additional kops functionality in the form
of wrapping the kops 'validate', 'upgrade', and 'rolling-update'
commands. This, along with the 'update' command, allows for cluster
alteration of previously-created kops clusters.

A new cloud CLI command 'upgrade' is provided which wraps these
individual commands to update a previously-created cluster to
the latest recommended production ready k8s version.

Also, some additional unit tests were added for both kops and
terraform.

Addresses https://mattermost.atlassian.net/browse/MM-14991