### PR TITLE
Workaround kops+gossip+terraform issue.

### DIFF
--- a/internal/provisioner/cluster.go
+++ b/internal/provisioner/cluster.go
@@ -78,6 +78,21 @@ func CreateCluster(provider, s3StateStore, size string, zones []string, logger l
 		return err
 	}
 
+	err = terraformClient.ApplyTarget(fmt.Sprintf("aws_internet_gateway.%s-kops-k8s-local", clusterID))
+	if err != nil {
+		return err
+	}
+
+	err = terraformClient.ApplyTarget(fmt.Sprintf("aws_elb.api-%s-kops-k8s-local", clusterID))
+	if err != nil {
+		return err
+	}
+
+	err = kops.UpdateCluster(dns)
+	if err != nil {
+		return err
+	}
+
 	err = terraformClient.Apply()
 	if err != nil {
 		return err

--- a/internal/tools/terraform/plan.go
+++ b/internal/tools/terraform/plan.go
@@ -38,6 +38,21 @@ func (c *Cmd) Apply() error {
 	return nil
 }
 
+// ApplyTarget invokes terraform apply with the given target.
+func (c *Cmd) ApplyTarget(target string) error {
+	_, _, err := c.run(
+		"apply",
+		arg("input", "false"),
+		arg("target", target),
+		arg("auto-approve"),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to invoke terraform apply")
+	}
+
+	return nil
+}
+
 // Destroy invokes terraform destroy.
 func (c *Cmd) Destroy() error {
 	_, _, err := c.run(


### PR DESCRIPTION
Apply the fix from https://github.com/kubernetes/kops/issues/2990#issuecomment-417333014 to ensure the gossip-based cluster is reachable when using terraform output.