### PR TITLE
introduce provisioner.PrepareCluster step

### DIFF
--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -54,6 +54,10 @@ func (s *mockClusterStore) DeleteCluster(clusterID string) error {
 type mockClusterProvisioner struct {
 }
 
+func (p *mockClusterProvisioner) PrepareCluster(cluster *model.Cluster) (bool, error) {
+	return true, nil
+}
+
 func (p *mockClusterProvisioner) CreateCluster(cluster *model.Cluster) error {
 	return nil
 }

--- a/internal/supervisor/scheduler_test.go
+++ b/internal/supervisor/scheduler_test.go
@@ -92,6 +92,8 @@ func TestScheduler(t *testing.T) {
 
 		scheduler.Do()
 
+		time.Sleep(1 * time.Second)
+
 		// Second call should be non-blocking
 		scheduler.Do()
 
@@ -99,6 +101,11 @@ func TestScheduler(t *testing.T) {
 		case <-doer.calls:
 		case <-time.After(5 * time.Second):
 			assert.Fail(t, "doer not invoked within 5 seconds")
+		}
+
+		// Drain the second call, but non-blocking in case it doesn't fire in a racey way.
+		select {
+		case <-doer.calls:
 		}
 	})
 }


### PR DESCRIPTION
This breaks out the part of the provisioner that needs to modify the
cluster (to record changes to the ProvisionerMetadata) from the part
that actually provisions, making it explicit in the supervisor that we
need to write said changes back to disk.

I had incorrectly removed the "save-after-provision" step when an error
occurs during the provisioning. Hopefully this will make it more
obvious.