### PR TITLE
MM-15205: Group Rest API

### DIFF
--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -1,15 +1,239 @@
 package main
 
 import (
-	"fmt"
-
+	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	groupCmd.PersistentFlags().String("server", "http://localhost:8075", "The provisioning server whose API will be queried.")
+
+	groupCreateCmd.Flags().String("name", "", "A unique name describing this group of installations.")
+	groupCreateCmd.Flags().String("description", "", "An optional description for this group of installations.")
+	groupCreateCmd.Flags().String("version", "stable", "The Mattermost version for installations in this group to target.")
+	groupCreateCmd.MarkFlagRequired("name")
+	groupCreateCmd.MarkFlagRequired("version")
+
+	groupUpdateCmd.Flags().String("group", "", "The id of the group to be updated.")
+	groupUpdateCmd.Flags().String("name", "", "A unique name describing this group of installations.")
+	groupUpdateCmd.Flags().String("description", "", "An optional description for this group of installations.")
+	groupUpdateCmd.Flags().String("version", "", "The Mattermost version for installations in this group to target.")
+	groupUpdateCmd.MarkFlagRequired("group")
+
+	groupDeleteCmd.Flags().String("group", "", "The id of the group to be deleted.")
+	groupDeleteCmd.MarkFlagRequired("group")
+
+	groupGetCmd.Flags().String("group", "", "The id of the group to be fetched.")
+	groupGetCmd.MarkFlagRequired("group")
+
+	groupListCmd.Flags().Int("page", 0, "The page of groups to fetch, starting at 0.")
+	groupListCmd.Flags().Int("per-page", 100, "The number of groups to fetch per page.")
+	groupListCmd.Flags().Bool("include-deleted", false, "Whether to include deleted groups.")
+
+	groupJoinCmd.Flags().String("group", "", "The id of the group to which the installation will be added.")
+	groupJoinCmd.Flags().String("installation", "", "The id of the installation to add to the group.")
+	groupJoinCmd.MarkFlagRequired("group")
+	groupJoinCmd.MarkFlagRequired("installation")
+
+	groupLeaveCmd.Flags().String("installation", "", "The id of the installation to leave its currently configured group.")
+	groupLeaveCmd.MarkFlagRequired("installation")
+
+	groupCmd.AddCommand(groupCreateCmd)
+	groupCmd.AddCommand(groupUpdateCmd)
+	groupCmd.AddCommand(groupDeleteCmd)
+	groupCmd.AddCommand(groupGetCmd)
+	groupCmd.AddCommand(groupListCmd)
+	groupCmd.AddCommand(groupJoinCmd)
+	groupCmd.AddCommand(groupLeaveCmd)
+}
 
 var groupCmd = &cobra.Command{
 	Use:   "group",
 	Short: "Manipulate groups managed by the provisioning server.",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("TODO: implement group command")
+}
+
+var groupCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a group.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := api.NewClient(serverAddress)
+
+		name, _ := command.Flags().GetString("name")
+		description, _ := command.Flags().GetString("description")
+		version, _ := command.Flags().GetString("version")
+
+		group, err := client.CreateGroup(&api.CreateGroupRequest{
+			Name:        name,
+			Description: description,
+			Version:     version,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to create group")
+		}
+
+		err = printJSON(group)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var groupUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update the group metadata.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := api.NewClient(serverAddress)
+
+		groupID, _ := command.Flags().GetString("group")
+		name, _ := command.Flags().GetString("name")
+		description, _ := command.Flags().GetString("description")
+		version, _ := command.Flags().GetString("version")
+
+		patchPointer := func(s string) *string {
+			if s == "" {
+				return nil
+			}
+
+			return &s
+		}
+
+		err := client.UpdateGroup(&api.PatchGroupRequest{
+			ID:          groupID,
+			Name:        patchPointer(name),
+			Description: patchPointer(description),
+			Version:     patchPointer(version),
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to update group")
+		}
+
+		return nil
+	},
+}
+
+var groupDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a group.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := api.NewClient(serverAddress)
+
+		groupID, _ := command.Flags().GetString("group")
+
+		err := client.DeleteGroup(groupID)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete group")
+		}
+
+		return nil
+	},
+}
+
+var groupGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get a particular group.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := api.NewClient(serverAddress)
+
+		groupID, _ := command.Flags().GetString("group")
+		group, err := client.GetGroup(groupID)
+		if err != nil {
+			return errors.Wrap(err, "failed to query group")
+		}
+		if group == nil {
+			return nil
+		}
+
+		err = printJSON(group)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var groupListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List created groups.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := api.NewClient(serverAddress)
+
+		page, _ := command.Flags().GetInt("page")
+		perPage, _ := command.Flags().GetInt("per-page")
+		includeDeleted, _ := command.Flags().GetBool("include-deleted")
+		groups, err := client.GetGroups(&api.GetGroupsRequest{
+			Page:           page,
+			PerPage:        perPage,
+			IncludeDeleted: includeDeleted,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to query groups")
+		}
+
+		err = printJSON(groups)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var groupJoinCmd = &cobra.Command{
+	Use:   "join",
+	Short: "Join an installation to the given group, leaving any existing group.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := api.NewClient(serverAddress)
+
+		groupID, _ := command.Flags().GetString("group")
+		installationID, _ := command.Flags().GetString("installation")
+
+		err := client.JoinGroup(groupID, installationID)
+		if err != nil {
+			return errors.Wrap(err, "failed to join group")
+		}
+
+		return nil
+	},
+}
+
+var groupLeaveCmd = &cobra.Command{
+	Use:   "leave",
+	Short: "Remove an installation from its group, if any.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := api.NewClient(serverAddress)
+
+		installationID, _ := command.Flags().GetString("installation")
+
+		err := client.LeaveGroup(installationID)
+		if err != nil {
+			return errors.Wrap(err, "failed to leave group")
+		}
+
+		return nil
 	},
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -9,4 +9,5 @@ func Register(rootRouter *mux.Router, context *Context) {
 	initCluster(apiRouter, context)
 	initInstallation(apiRouter, context)
 	initClusterInstallation(apiRouter, context)
+	initGroup(apiRouter, context)
 }

--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -6,3 +6,7 @@ type mockSupervisor struct {
 func (s *mockSupervisor) Do() error {
 	return nil
 }
+
+func sToP(s string) *string {
+	return &s
+}

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -30,6 +30,12 @@ type Store interface {
 
 	GetClusterInstallation(clusterInstallationID string) (*model.ClusterInstallation, error)
 	GetClusterInstallations(filter *model.ClusterInstallationFilter) ([]*model.ClusterInstallation, error)
+
+	CreateGroup(group *model.Group) error
+	GetGroup(groupID string) (*model.Group, error)
+	GetGroups(filter *model.GroupFilter) ([]*model.Group, error)
+	UpdateGroup(group *model.Group) error
+	DeleteGroup(groupID string) error
 }
 
 // Context provides the API with all necessary data and interfaces for responding to requests.

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/model"
+)
+
+// initGroup registers group endpoints on the given router.
+func initGroup(apiRouter *mux.Router, context *Context) {
+	addContext := func(handler contextHandlerFunc) *contextHandler {
+		return newContextHandler(context, handler)
+	}
+
+	groupsRouter := apiRouter.PathPrefix("/groups").Subrouter()
+	groupsRouter.Handle("", addContext(handleGetGroups)).Methods("GET")
+	groupsRouter.Handle("", addContext(handleCreateGroup)).Methods("POST")
+
+	groupRouter := apiRouter.PathPrefix("/group/{group:[A-Za-z0-9]{26}}").Subrouter()
+	groupRouter.Handle("", addContext(handleGetGroup)).Methods("GET")
+	groupRouter.Handle("", addContext(handleUpdateGroup)).Methods("PUT")
+	groupRouter.Handle("", addContext(handleDeleteGroup)).Methods("DELETE")
+}
+
+// handleGetGroups responds to GET /api/groups, returning the specified page of groups.
+func handleGetGroups(c *Context, w http.ResponseWriter, r *http.Request) {
+	page, perPage, includeDeleted, err := parsePaging(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse paging parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	filter := &model.GroupFilter{
+		Page:           page,
+		PerPage:        perPage,
+		IncludeDeleted: includeDeleted,
+	}
+
+	groups, err := c.Store.GetGroups(filter)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query groups")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if groups == nil {
+		groups = []*model.Group{}
+	}
+
+	outputJSON(c, w, groups)
+}
+
+// handleCreateGroup responds to POST /api/groups, beginning the process of creating a new group.
+func handleCreateGroup(c *Context, w http.ResponseWriter, r *http.Request) {
+	createGroupRequest, err := newCreateGroupRequestFromReader(r.Body)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to decode request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	group := model.Group{
+		Name:        createGroupRequest.Name,
+		Description: createGroupRequest.Description,
+		Version:     createGroupRequest.Version,
+	}
+
+	err = c.Store.CreateGroup(&group)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to create group")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	c.Supervisor.Do()
+
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, group)
+}
+
+// handleGetGroup responds to GET /api/groups/{group}, returning the group in question.
+func handleGetGroup(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	groupID := vars["group"]
+	c.Logger = c.Logger.WithField("group", groupID)
+
+	group, err := c.Store.GetGroup(groupID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query group")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if group == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	outputJSON(c, w, group)
+}
+
+// handleUpdateGroup responds to PUT /api/groups/{group}, updating the group.
+func handleUpdateGroup(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	groupID := vars["group"]
+	c.Logger = c.Logger.WithField("group", groupID)
+
+	patchGroupRequest, err := newPatchGroupRequestFromReader(r.Body)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to decode request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	group, err := c.Store.GetGroup(groupID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to fetch group")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	} else if group == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if patchGroupRequest.Apply(group) {
+		err := c.Store.UpdateGroup(group)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to update group")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	c.Supervisor.Do()
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleDeleteGroup responds to DELETE /api/groups/{group}, marking the group as deleted.
+//
+// Installations will not automatically leave the group, but they will no longer consider the group version as an upgrade target.
+func handleDeleteGroup(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	groupID := vars["group"]
+	c.Logger = c.Logger.WithField("group", groupID)
+
+	group, err := c.Store.GetGroup(groupID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to fetch group")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	} else if group == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	err = c.Store.DeleteGroup(group.ID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to mark group for deletion")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	c.Supervisor.Do()
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -138,7 +138,8 @@ func handleUpdateGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 
 // handleDeleteGroup responds to DELETE /api/groups/{group}, marking the group as deleted.
 //
-// Installations will not automatically leave the group, but they will no longer consider the group version as an upgrade target.
+// Installations will not automatically leave the group, but they will no longer consider the
+// group version as an upgrade target.
 func handleDeleteGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	groupID := vars["group"]

--- a/internal/api/group_request.go
+++ b/internal/api/group_request.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/url"
+	"strconv"
+
+	"github.com/mattermost/mattermost-cloud/internal/model"
+	"github.com/pkg/errors"
+)
+
+// CreateGroupRequest specifies the parameters for a new group.
+type CreateGroupRequest struct {
+	Name        string
+	Description string
+	Version     string
+}
+
+func newCreateGroupRequestFromReader(reader io.Reader) (*CreateGroupRequest, error) {
+	var createGroupRequest CreateGroupRequest
+	err := json.NewDecoder(reader).Decode(&createGroupRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode create group request")
+	}
+
+	if createGroupRequest.Name == "" {
+		return nil, errors.New("must specify name")
+	}
+	if createGroupRequest.Version == "" {
+		return nil, errors.New("must specify version")
+	}
+
+	return &createGroupRequest, nil
+}
+
+// PatchGroupRequest specifies the parameters for an updated group.
+type PatchGroupRequest struct {
+	ID          string
+	Name        *string
+	Description *string
+	Version     *string
+}
+
+func newPatchGroupRequestFromReader(reader io.Reader) (*PatchGroupRequest, error) {
+	var patchGroupRequest PatchGroupRequest
+	err := json.NewDecoder(reader).Decode(&patchGroupRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode patch group request")
+	}
+
+	return &patchGroupRequest, nil
+}
+
+// Apply applies the patch to the given group.
+func (p *PatchGroupRequest) Apply(group *model.Group) bool {
+	var applied bool
+
+	if p.Name != nil && *p.Name != group.Name {
+		applied = true
+		group.Name = *p.Name
+	}
+	if p.Description != nil && *p.Description != group.Description {
+		applied = true
+		group.Description = *p.Description
+	}
+	if p.Version != nil && *p.Version != group.Version {
+		applied = true
+		group.Version = *p.Version
+	}
+
+	return applied
+}
+
+// GetGroupsRequest describes the parameters to request a list of groups.
+type GetGroupsRequest struct {
+	Page           int
+	PerPage        int
+	IncludeDeleted bool
+}
+
+// ApplyToURL modifies the given url to include query string parameters for the request.
+func (request *GetGroupsRequest) ApplyToURL(u *url.URL) {
+	q := u.Query()
+	q.Add("page", strconv.Itoa(request.Page))
+	q.Add("per_page", strconv.Itoa(request.PerPage))
+	if request.IncludeDeleted {
+		q.Add("include_deleted", "true")
+	}
+	u.RawQuery = q.Encode()
+}

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -1,0 +1,373 @@
+package api_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/mattermost/mattermost-cloud/internal/model"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGroups(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := api.NewClient(ts.URL)
+
+	t.Run("unknown group", func(t *testing.T) {
+		group, err := client.GetGroup(model.NewID())
+		require.NoError(t, err)
+		require.Nil(t, group)
+
+	})
+
+	t.Run("no groups", func(t *testing.T) {
+		groups, err := client.GetGroups(&api.GetGroupsRequest{
+			Page:           0,
+			PerPage:        10,
+			IncludeDeleted: true,
+		})
+		require.NoError(t, err)
+		require.Empty(t, groups)
+	})
+
+	t.Run("parameter handling", func(t *testing.T) {
+		t.Run("invalid page", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/groups?page=invalid&per_page=100", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("invalid perPage", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/groups?page=0&per_page=invalid", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("no paging parameters", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/groups", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("missing page", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/groups?per_page=100", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("missing perPage", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/groups?page=1", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	})
+
+	t.Run("results", func(t *testing.T) {
+		group1 := &model.Group{
+			Name:        "group1",
+			Description: "This is group 1",
+			Version:     "version1",
+		}
+		err := sqlStore.CreateGroup(group1)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		group2 := &model.Group{
+			Name:        "group2",
+			Description: "This is group 2",
+			Version:     "version2",
+		}
+		err = sqlStore.CreateGroup(group2)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		group3 := &model.Group{
+			Name:        "group3",
+			Description: "This is group 3",
+			Version:     "version3",
+		}
+		err = sqlStore.CreateGroup(group3)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		group4 := &model.Group{
+			Name:        "group4",
+			Description: "This is group 4",
+			Version:     "version4",
+		}
+		err = sqlStore.CreateGroup(group4)
+		require.NoError(t, err)
+		err = sqlStore.DeleteGroup(group4.ID)
+		require.NoError(t, err)
+		group4, err = client.GetGroup(group4.ID)
+		require.NoError(t, err)
+
+		t.Run("get group", func(t *testing.T) {
+			t.Run("group 1", func(t *testing.T) {
+				group, err := client.GetGroup(group1.ID)
+				require.NoError(t, err)
+				require.Equal(t, group1, group)
+			})
+
+			t.Run("get deleted group", func(t *testing.T) {
+				group, err := client.GetGroup(group4.ID)
+				require.NoError(t, err)
+				require.Equal(t, group4, group)
+			})
+		})
+
+		t.Run("get groups", func(t *testing.T) {
+			testCases := []struct {
+				Description      string
+				GetGroupsRequest *api.GetGroupsRequest
+				Expected         []*model.Group
+			}{
+				{
+					"page 0, perPage 2, exclude deleted",
+					&api.GetGroupsRequest{
+						Page:           0,
+						PerPage:        2,
+						IncludeDeleted: false,
+					},
+					[]*model.Group{group1, group2},
+				},
+
+				{
+					"page 1, perPage 2, exclude deleted",
+					&api.GetGroupsRequest{
+						Page:           1,
+						PerPage:        2,
+						IncludeDeleted: false,
+					},
+					[]*model.Group{group3},
+				},
+
+				{
+					"page 0, perPage 2, include deleted",
+					&api.GetGroupsRequest{
+						Page:           0,
+						PerPage:        2,
+						IncludeDeleted: true,
+					},
+					[]*model.Group{group1, group2},
+				},
+
+				{
+					"page 1, perPage 2, include deleted",
+					&api.GetGroupsRequest{
+						Page:           1,
+						PerPage:        2,
+						IncludeDeleted: true,
+					},
+					[]*model.Group{group3, group4},
+				},
+			}
+
+			for _, testCase := range testCases {
+				t.Run(testCase.Description, func(t *testing.T) {
+					groups, err := client.GetGroups(testCase.GetGroupsRequest)
+					require.NoError(t, err)
+					require.Equal(t, testCase.Expected, groups)
+				})
+			}
+		})
+	})
+}
+
+func TestCreateGroup(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := api.NewClient(ts.URL)
+
+	t.Run("invalid payload", func(t *testing.T) {
+		resp, err := http.Post(fmt.Sprintf("%s/api/groups", ts.URL), "application/json", bytes.NewReader([]byte("invalid")))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("empty payload", func(t *testing.T) {
+		resp, err := http.Post(fmt.Sprintf("%s/api/groups", ts.URL), "application/json", bytes.NewReader([]byte("")))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		_, err := client.CreateGroup(&api.CreateGroupRequest{
+			Description: "description",
+			Version:     "version",
+		})
+		require.EqualError(t, err, "failed with status code 400")
+	})
+
+	t.Run("missing version", func(t *testing.T) {
+		_, err := client.CreateGroup(&api.CreateGroupRequest{
+			Name:        "name",
+			Description: "description",
+		})
+		require.EqualError(t, err, "failed with status code 400")
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		group, err := client.CreateGroup(&api.CreateGroupRequest{
+			Name:        "name",
+			Description: "description",
+			Version:     "version",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "name", group.Name)
+		require.Equal(t, "description", group.Description)
+		require.Equal(t, "version", group.Version)
+		require.NotEqual(t, 0, group.CreateAt)
+		require.EqualValues(t, 0, group.DeleteAt)
+	})
+}
+
+func TestUpdateGroup(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := api.NewClient(ts.URL)
+
+	group1, err := client.CreateGroup(&api.CreateGroupRequest{
+		Name:        "name",
+		Description: "description",
+		Version:     "version",
+	})
+	require.NoError(t, err)
+
+	t.Run("invalid payload", func(t *testing.T) {
+		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/group/%s", ts.URL, group1.ID), bytes.NewReader([]byte("invalid")))
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(httpRequest)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("empty payload", func(t *testing.T) {
+		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/group/%s", ts.URL, group1.ID), bytes.NewReader([]byte("")))
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(httpRequest)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("unknown group", func(t *testing.T) {
+		err := client.UpdateGroup(&api.PatchGroupRequest{ID: model.NewID()})
+		require.EqualError(t, err, "failed with status code 404")
+	})
+
+	t.Run("partial update", func(t *testing.T) {
+		err = client.UpdateGroup(&api.PatchGroupRequest{
+			ID:      group1.ID,
+			Version: sToP("version2"),
+		})
+		require.NoError(t, err)
+
+		group1, err = client.GetGroup(group1.ID)
+		require.NoError(t, err)
+		require.Equal(t, "name", group1.Name)
+		require.Equal(t, "description", group1.Description)
+		require.Equal(t, "version2", group1.Version)
+	})
+
+	t.Run("full update", func(t *testing.T) {
+		err = client.UpdateGroup(&api.PatchGroupRequest{
+			ID:          group1.ID,
+			Name:        sToP("name2"),
+			Description: sToP("description2"),
+			Version:     sToP("version2"),
+		})
+		require.NoError(t, err)
+
+		group1, err = client.GetGroup(group1.ID)
+		require.NoError(t, err)
+		require.Equal(t, "name2", group1.Name)
+		require.Equal(t, "description2", group1.Description)
+		require.Equal(t, "version2", group1.Version)
+	})
+}
+
+func TestDeleteGroup(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := api.NewClient(ts.URL)
+
+	group1, err := client.CreateGroup(&api.CreateGroupRequest{
+		Name:        "name",
+		Description: "description",
+		Version:     "version",
+	})
+	require.NoError(t, err)
+
+	t.Run("unknown group", func(t *testing.T) {
+		err := client.DeleteGroup(model.NewID())
+		require.EqualError(t, err, "failed with status code 404")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		err := client.DeleteGroup(group1.ID)
+		require.NoError(t, err)
+
+		group1, err = client.GetGroup(group1.ID)
+		require.NoError(t, err)
+		require.NotEqual(t, 0, group1.DeleteAt)
+	})
+
+	t.Run("delete again", func(t *testing.T) {
+		err = client.DeleteGroup(group1.ID)
+		require.NoError(t, err)
+		require.NotEqual(t, 0, group1.DeleteAt)
+	})
+}

--- a/internal/model/group.go
+++ b/internal/model/group.go
@@ -1,0 +1,57 @@
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// Group represents a group of Mattermost installations.
+type Group struct {
+	ID          string
+	Name        string
+	Description string
+	Version     string
+	CreateAt    int64
+	DeleteAt    int64
+}
+
+// GroupFilter describes the parameters used to constrain a set of groups.
+type GroupFilter struct {
+	Page           int
+	PerPage        int
+	IncludeDeleted bool
+}
+
+// Clone returns a deep copy the group.
+func (c *Group) Clone() *Group {
+	var clone Group
+	data, _ := json.Marshal(c)
+	json.Unmarshal(data, &clone)
+
+	return &clone
+}
+
+// GroupFromReader decodes a json-encoded group from the given io.Reader.
+func GroupFromReader(reader io.Reader) (*Group, error) {
+	group := Group{}
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&group)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &group, nil
+}
+
+// GroupsFromReader decodes a json-encoded list of groups from the given io.Reader.
+func GroupsFromReader(reader io.Reader) ([]*Group, error) {
+	groups := []*Group{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&groups)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return groups, nil
+}

--- a/internal/model/group_test.go
+++ b/internal/model/group_test.go
@@ -1,0 +1,120 @@
+package model
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroupClone(t *testing.T) {
+	group := &Group{
+		ID:          "id",
+		Name:        "name",
+		Description: "description",
+		Version:     "version",
+	}
+
+	clone := group.Clone()
+	require.Equal(t, group, clone)
+
+	// Verify changing fields in the clone doesn't affect the original.
+	clone.Version = "new version"
+	require.NotEqual(t, group, clone)
+}
+
+func TestGroupFromReader(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		group, err := GroupFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &Group{}, group)
+	})
+
+	t.Run("invalid request", func(t *testing.T) {
+		group, err := GroupFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, group)
+	})
+
+	t.Run("request", func(t *testing.T) {
+		group, err := GroupFromReader(bytes.NewReader([]byte(`{
+			"ID":"id",
+			"Name":"name",
+			"Description":"description",
+			"Version":"version",
+			"CreateAt":10,
+			"DeleteAt":20
+		}`)))
+		require.NoError(t, err)
+		require.Equal(t, &Group{
+			ID:          "id",
+			Name:        "name",
+			Description: "description",
+			Version:     "version",
+			CreateAt:    10,
+			DeleteAt:    20,
+		}, group)
+	})
+}
+
+func TestGroupsFromReader(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		groups, err := GroupsFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*Group{}, groups)
+	})
+
+	t.Run("invalid request", func(t *testing.T) {
+		groups, err := GroupsFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, groups)
+	})
+
+	t.Run("request", func(t *testing.T) {
+		group, err := GroupsFromReader(bytes.NewReader([]byte(`[
+			{
+				"ID":"id1",
+				"Name":"name1",
+				"Description":"description1",
+				"Version":"version1",
+				"CreateAt":10,
+				"DeleteAt":20
+			},
+			{
+				"ID":"id2",
+				"Name":"name2",
+				"Description":"description2",
+				"Version":"version2",
+				"CreateAt":30,
+				"DeleteAt":40
+			}
+		]`)))
+		require.NoError(t, err)
+		require.Equal(t, []*Group{
+			&Group{
+				ID:          "id1",
+				Name:        "name1",
+				Description: "description1",
+				Version:     "version1",
+				CreateAt:    10,
+				DeleteAt:    20,
+			},
+			&Group{
+				ID:          "id2",
+				Name:        "name2",
+				Description: "description2",
+				Version:     "version2",
+				CreateAt:    30,
+				DeleteAt:    40,
+			},
+		}, group)
+	})
+}

--- a/internal/store/group.go
+++ b/internal/store/group.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"database/sql"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/mattermost/mattermost-cloud/internal/model"
+	"github.com/pkg/errors"
+)
+
+var groupSelect sq.SelectBuilder
+
+func init() {
+	groupSelect = sq.
+		Select("ID", "Name", "Description", "Version", "CreateAt", "DeleteAt").
+		From(`"Group"`)
+}
+
+// GetGroup fetches the given group by id.
+func (sqlStore *SQLStore) GetGroup(id string) (*model.Group, error) {
+	var group model.Group
+	err := sqlStore.getBuilder(sqlStore.db, &group,
+		groupSelect.Where("ID = ?", id),
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Wrap(err, "failed to get group by id")
+	}
+
+	return &group, nil
+}
+
+// GetGroups fetches the given page of created groups. The first page is 0.
+func (sqlStore *SQLStore) GetGroups(filter *model.GroupFilter) ([]*model.Group, error) {
+	builder := groupSelect.
+		OrderBy("CreateAt ASC")
+
+	if filter.PerPage != model.AllPerPage {
+		builder = builder.
+			Limit(uint64(filter.PerPage)).
+			Offset(uint64(filter.Page * filter.PerPage))
+	}
+
+	if !filter.IncludeDeleted {
+		builder = builder.Where("DeleteAt = 0")
+	}
+
+	var groups []*model.Group
+	err := sqlStore.selectBuilder(sqlStore.db, &groups, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query for groups")
+	}
+
+	return groups, nil
+}
+
+// CreateGroup records the given group to the database, assigning it a unique ID.
+func (sqlStore *SQLStore) CreateGroup(group *model.Group) error {
+	group.ID = model.NewID()
+	group.CreateAt = GetMillis()
+
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Insert(`"Group"`).
+		SetMap(map[string]interface{}{
+			"ID":          group.ID,
+			"Name":        group.Name,
+			"Description": group.Description,
+			"Version":     group.Version,
+			"CreateAt":    group.CreateAt,
+			"DeleteAt":    0,
+		}),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to create group")
+	}
+
+	return nil
+}
+
+// UpdateGroup updates the given group in the database.
+func (sqlStore *SQLStore) UpdateGroup(group *model.Group) error {
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Update(`"Group"`).
+		SetMap(map[string]interface{}{
+			"Name":        group.Name,
+			"Description": group.Description,
+			"Version":     group.Version,
+		}).
+		Where("ID = ?", group.ID),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to update group")
+	}
+
+	return nil
+}
+
+// DeleteGroup marks the given group as deleted, but does not remove the record from the
+// database.
+func (sqlStore *SQLStore) DeleteGroup(id string) error {
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Update(`"Group"`).
+		Set("DeleteAt", GetMillis()).
+		Where("ID = ?", id).
+		Where("DeleteAt = 0"),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to mark group as deleted")
+	}
+
+	return nil
+}

--- a/internal/store/group_test.go
+++ b/internal/store/group_test.go
@@ -1,0 +1,216 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/model"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroups(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+
+	group1 := &model.Group{
+		Name:        "name1",
+		Description: "description1",
+		Version:     "version1",
+	}
+
+	err := sqlStore.CreateGroup(group1)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Millisecond)
+
+	group2 := &model.Group{
+		Name:        "name2",
+		Description: "description2",
+		Version:     "version2",
+	}
+
+	err = sqlStore.CreateGroup(group2)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Millisecond)
+
+	group3 := &model.Group{
+		Name:        "name3",
+		Description: "description3",
+		Version:     "version3",
+	}
+
+	err = sqlStore.CreateGroup(group3)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Millisecond)
+
+	group4 := &model.Group{
+		Name:        "name4",
+		Description: "description4",
+		Version:     "version4",
+	}
+
+	err = sqlStore.CreateGroup(group4)
+	require.NoError(t, err)
+	err = sqlStore.DeleteGroup(group4.ID)
+	require.NoError(t, err)
+	group4, err = sqlStore.GetGroup(group4.ID)
+	require.NoError(t, err)
+
+	t.Run("get unknown group", func(t *testing.T) {
+		group, err := sqlStore.GetGroup("unknown")
+		require.NoError(t, err)
+		require.Nil(t, group)
+	})
+
+	t.Run("get group 1", func(t *testing.T) {
+		group, err := sqlStore.GetGroup(group1.ID)
+		require.NoError(t, err)
+		require.Equal(t, group1, group)
+	})
+
+	t.Run("get group 2", func(t *testing.T) {
+		group, err := sqlStore.GetGroup(group2.ID)
+		require.NoError(t, err)
+		require.Equal(t, group2, group)
+	})
+
+	testCases := []struct {
+		Description string
+		Filter      *model.GroupFilter
+		Expected    []*model.Group
+	}{
+		{
+			"page 0, perPage 0",
+			&model.GroupFilter{
+				Page:           0,
+				PerPage:        0,
+				IncludeDeleted: false,
+			},
+			nil,
+		},
+		{
+			"page 0, perPage 1",
+			&model.GroupFilter{
+				Page:           0,
+				PerPage:        1,
+				IncludeDeleted: false,
+			},
+			[]*model.Group{group1},
+		},
+		{
+			"page 0, perPage 10",
+			&model.GroupFilter{
+				Page:           0,
+				PerPage:        10,
+				IncludeDeleted: false,
+			},
+			[]*model.Group{group1, group2, group3},
+		},
+		{
+			"page 0, perPage 10, include deleted",
+			&model.GroupFilter{
+				Page:           0,
+				PerPage:        10,
+				IncludeDeleted: true,
+			},
+			[]*model.Group{group1, group2, group3, group4},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			actual, err := sqlStore.GetGroups(testCase.Filter)
+			require.NoError(t, err)
+			require.Equal(t, testCase.Expected, actual)
+		})
+	}
+}
+
+func TestUpdateGroup(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+
+	group1 := &model.Group{
+		Name:        "name1",
+		Description: "description1",
+		Version:     "version1",
+	}
+
+	err := sqlStore.CreateGroup(group1)
+	require.NoError(t, err)
+
+	group2 := &model.Group{
+		Name:        "name2",
+		Description: "description2",
+		Version:     "version2",
+	}
+
+	err = sqlStore.CreateGroup(group2)
+	require.NoError(t, err)
+
+	group1.Name = "name3"
+	group1.Description = "description3"
+	group1.Version = "version3"
+
+	err = sqlStore.UpdateGroup(group1)
+	require.NoError(t, err)
+
+	actualGroup1, err := sqlStore.GetGroup(group1.ID)
+	require.NoError(t, err)
+	require.Equal(t, group1, actualGroup1)
+
+	actualGroup2, err := sqlStore.GetGroup(group2.ID)
+	require.NoError(t, err)
+	require.Equal(t, group2, actualGroup2)
+}
+
+func TestDeleteGroup(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+
+	group1 := &model.Group{
+		Name:        "name1",
+		Description: "description1",
+		Version:     "version1",
+	}
+
+	err := sqlStore.CreateGroup(group1)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Millisecond)
+
+	group2 := &model.Group{
+		Name:        "name2",
+		Description: "description2",
+		Version:     "version2",
+	}
+
+	err = sqlStore.CreateGroup(group2)
+	require.NoError(t, err)
+
+	err = sqlStore.DeleteGroup(group1.ID)
+	require.NoError(t, err)
+
+	actualGroup1, err := sqlStore.GetGroup(group1.ID)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, actualGroup1.DeleteAt)
+	group1.DeleteAt = actualGroup1.DeleteAt
+	require.Equal(t, group1, actualGroup1)
+
+	actualGroup2, err := sqlStore.GetGroup(group2.ID)
+	require.NoError(t, err)
+	require.Equal(t, group2, actualGroup2)
+
+	time.Sleep(1 * time.Millisecond)
+
+	// Deleting again shouldn't change timestamp
+	err = sqlStore.DeleteGroup(group1.ID)
+	require.NoError(t, err)
+
+	actualGroup1, err = sqlStore.GetGroup(group1.ID)
+	require.NoError(t, err)
+	require.Equal(t, group1, actualGroup1)
+}

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -177,4 +177,28 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.3.0"), semver.MustParse("0.4.0"), func(e execer) error {
+		_, err := e.Exec(`
+			CREATE TABLE "Group" (
+				ID CHAR(26) PRIMARY KEY,
+				Name TEXT,
+				Description TEXT,
+				Version TEXT,
+				CreateAt BIGINT NOT NULL,
+				DeleteAt BIGINT NOT NULL
+			);
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+			CREATE UNIQUE INDEX Group_Name_DeleteAt ON "Group" (Name, DeleteAt);
+		`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/internal/tools/k8s/manifest_test.go
+++ b/internal/tools/k8s/manifest_test.go
@@ -93,7 +93,7 @@ rules:
 func TestCreate(t *testing.T) {
 	testClient := newTestKubeClient()
 
-	tempDir, err := ioutil.TempDir("", "k8s-file-testing-")
+	tempDir, err := ioutil.TempDir(".", "k8s-file-testing-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 


### PR DESCRIPTION
This introduces the `/api/group` endpoints, as well as new `/api/installation` endpoints for joining and leaving a group.

The API supports changing the target version of the installation group, but defers the propagation of same to the corresponding installations to https://mattermost.atlassian.net/browse/MM-15369.

I also fixed a minor caching issue in `internal/tools/k8s` with the use of `TempDir` that precludes `go test ./...` from successfully caching these tests.