### PR TITLE
[MM-15368] Support installation version changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/kubernetes/client-go v11.0.0+incompatible
 	github.com/lib/pq v1.0.0
-	github.com/mattermost/mattermost-operator v0.0.0-20190516183748-6723b29a6757
+	github.com/mattermost/mattermost-operator v0.0.0-20190528162820-699b61753dd1
 	github.com/mattn/go-sqlite3 v1.9.0
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/mattermost/mattermost-operator v0.0.0-20190516082539-76ed319d853b h1:
 github.com/mattermost/mattermost-operator v0.0.0-20190516082539-76ed319d853b/go.mod h1:Rinpkr6ordw53vU23itYjIaypS117QJwCGKr3YiriNI=
 github.com/mattermost/mattermost-operator v0.0.0-20190516183748-6723b29a6757 h1:/8nbpholfU7/obIUjoLHd60ytBOPMrml+s9eVNPUKy0=
 github.com/mattermost/mattermost-operator v0.0.0-20190516183748-6723b29a6757/go.mod h1:Rinpkr6ordw53vU23itYjIaypS117QJwCGKr3YiriNI=
+github.com/mattermost/mattermost-operator v0.0.0-20190528162820-699b61753dd1 h1:0DRxpC0cdsZ8dJIT3QYP20lfUDT5C2z9BGOAy8GgeUE=
+github.com/mattermost/mattermost-operator v0.0.0-20190528162820-699b61753dd1/go.mod h1:Rinpkr6ordw53vU23itYjIaypS117QJwCGKr3YiriNI=
 github.com/mattn/go-sqlite3 v1.9.0 h1:pDRiWfl+++eC2FEFRy6jXmQlvp4Yh3z1MJKg4UeYM/4=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -172,6 +172,7 @@ func handleUpgradeInstallation(c *Context, w http.ResponseWriter, r *http.Reques
 	switch installation.State {
 	case model.InstallationStateStable:
 	case model.InstallationStateUpgradeRequested:
+	case model.InstallationStateUpgradeInProgress:
 	case model.InstallationStateUpgradeFailed:
 	default:
 		c.Logger.Warnf("unable to upgrade installation while in state %s", installation.State)
@@ -179,15 +180,9 @@ func handleUpgradeInstallation(c *Context, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// TODO: Support something other than "latest".
-	if version != "latest" {
-		c.Logger.Warnf("unsupported mattermost version %s", version)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
 	if installation.State != model.InstallationStateUpgradeRequested {
 		installation.State = model.InstallationStateUpgradeRequested
+		installation.Version = version
 
 		err := c.Store.UpdateInstallation(installation)
 		if err != nil {

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -468,15 +468,6 @@ func TestUpgradeInstallation(t *testing.T) {
 		require.Equal(t, model.InstallationStateUpgradeRequested, installation1.State)
 	})
 
-	t.Run("while stable, to invalid version", func(t *testing.T) {
-		installation1.State = model.InstallationStateStable
-		err = sqlStore.UpdateInstallation(installation1)
-		require.NoError(t, err)
-
-		err = client.UpgradeInstallation(installation1.ID, "invalid")
-		require.EqualError(t, err, "failed with status code 400")
-	})
-
 	t.Run("after deletion failed", func(t *testing.T) {
 		installation1.State = model.InstallationStateDeletionFailed
 		err = sqlStore.UpdateInstallation(installation1)

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -489,6 +489,19 @@ func TestUpgradeInstallation(t *testing.T) {
 		err = client.UpgradeInstallation(installation1.ID, "latest")
 		require.EqualError(t, err, "failed with status code 400")
 	})
+
+	t.Run("installation record updated", func(t *testing.T) {
+		installation1.State = model.InstallationStateStable
+		err = sqlStore.UpdateInstallation(installation1)
+		require.NoError(t, err)
+
+		err = client.UpgradeInstallation(installation1.ID, "5.9.0")
+		require.NoError(t, err)
+
+		installation1, err = client.GetInstallation(installation1.ID)
+		require.NoError(t, err)
+		require.Equal(t, "5.9.0", installation1.Version)
+	})
 }
 
 func TestJoinGroup(t *testing.T) {

--- a/internal/model/cluster_installation.go
+++ b/internal/model/cluster_installation.go
@@ -16,6 +16,8 @@ const (
 	ClusterInstallationStateDeletionFailed = "deletion-failed"
 	// ClusterInstallationStateDeleted is a cluster installation that has been deleted
 	ClusterInstallationStateDeleted = "deleted"
+	// ClusterInstallationStateReconciling is a cluster installation that in undergoing changes and is not yet stable.
+	ClusterInstallationStateReconciling = "reconciling"
 	// ClusterInstallationStateStable is a cluster installation in a stable state and undergoing no changes.
 	ClusterInstallationStateStable = "stable"
 )

--- a/internal/model/installation.go
+++ b/internal/model/installation.go
@@ -6,23 +6,25 @@ import (
 )
 
 const (
-	// InstallationStateCreationRequested is a installation in the process of being created.
+	// InstallationStateCreationRequested is an installation in the process of being created.
 	InstallationStateCreationRequested = "creation-requested"
-	// InstallationStateCreationFailed is a installation that failed creation.
+	// InstallationStateCreationFailed is an installation that failed creation.
 	InstallationStateCreationFailed = "creation-failed"
-	// InstallationStateDeletionRequested is a installation to be deleted.
+	// InstallationStateDeletionRequested is an installation to be deleted.
 	InstallationStateDeletionRequested = "deletion-requested"
-	// InstallationStateDeletionInProgress is a installation being deleted.
+	// InstallationStateDeletionInProgress is an installation being deleted.
 	InstallationStateDeletionInProgress = "deletion-in-progress"
-	// InstallationStateDeletionFailed is a installation that failed deletion.
+	// InstallationStateDeletionFailed is an installation that failed deletion.
 	InstallationStateDeletionFailed = "deletion-failed"
-	// InstallationStateDeleted is a installation that has been deleted
+	// InstallationStateDeleted is an installation that has been deleted
 	InstallationStateDeleted = "deleted"
-	// InstallationStateUpgradeRequested is a installation in the process of upgrading.
+	// InstallationStateUpgradeRequested is an installation that is about to undergo a version change.
 	InstallationStateUpgradeRequested = "upgrade-requested"
-	// InstallationStateUpgradeFailed is a installation that failed to upgrade.
+	// InstallationStateUpgradeInProgress is an installation that is undergoing a version change.
+	InstallationStateUpgradeInProgress = "upgrade-in-progress"
+	// InstallationStateUpgradeFailed is an installation that failed to change versions.
 	InstallationStateUpgradeFailed = "upgrade-failed"
-	// InstallationStateStable is a installation in a stable state and undergoing no changes.
+	// InstallationStateStable is an installation in a stable state and undergoing no changes.
 	InstallationStateStable = "stable"
 )
 

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -554,6 +554,7 @@ func (provisioner *KopsProvisioner) UpdateClusterInstallation(cluster *model.Clu
 
 	version := translateMattermostVersion(installation.Version)
 	if cr.Spec.Version == version {
+		logger.Debugf("Cluster installation already on version %s", version)
 		return nil
 	}
 	cr.Spec.Version = version

--- a/internal/store/cluster_installation.go
+++ b/internal/store/cluster_installation.go
@@ -42,6 +42,7 @@ func (sqlStore *SQLStore) GetUnlockedClusterInstallationsPendingWork() ([]*model
 			"State": []string{
 				model.ClusterInstallationStateCreationRequested,
 				model.ClusterInstallationStateDeletionRequested,
+				model.ClusterInstallationStateReconciling,
 			},
 		}).
 		Where("LockAcquiredAt = 0").

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -41,6 +41,7 @@ func (sqlStore *SQLStore) GetUnlockedInstallationsPendingWork() ([]*model.Instal
 			"State": []string{
 				model.InstallationStateCreationRequested,
 				model.InstallationStateUpgradeRequested,
+				model.InstallationStateUpgradeInProgress,
 				model.InstallationStateDeletionInProgress,
 				model.InstallationStateDeletionRequested,
 			},

--- a/internal/supervisor/cluster_installation_test.go
+++ b/internal/supervisor/cluster_installation_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/supervisor"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/stretchr/testify/require"
+
+	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 )
 
 type mockClusterInstallationStore struct {
@@ -59,6 +61,20 @@ func (p *mockClusterInstallationProvisioner) CreateClusterInstallation(cluster *
 
 func (p *mockClusterInstallationProvisioner) DeleteClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterIntallation *model.ClusterInstallation) error {
 	return nil
+}
+
+func (p *mockClusterInstallationProvisioner) UpdateClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterIntallation *model.ClusterInstallation) error {
+	return nil
+}
+
+func (p *mockClusterInstallationProvisioner) GetClusterInstallationResource(cluster *model.Cluster, installation *model.Installation, clusterIntallation *model.ClusterInstallation) (*mmv1alpha1.ClusterInstallation, error) {
+	return &mmv1alpha1.ClusterInstallation{
+			Spec: mmv1alpha1.ClusterInstallationSpec{},
+			Status: mmv1alpha1.ClusterInstallationStatus{
+				State: mmv1alpha1.Stable,
+			},
+		},
+		nil
 }
 
 func TestClusterInstallationSupervisorDo(t *testing.T) {
@@ -186,7 +202,8 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 			ExpectedState string
 		}{
 			{"unexpected state", model.ClusterInstallationStateStable, model.ClusterInstallationStateStable},
-			{"creation requested", model.ClusterInstallationStateCreationRequested, model.ClusterInstallationStateStable},
+			{"creation requested", model.ClusterInstallationStateCreationRequested, model.ClusterInstallationStateReconciling},
+			{"creation reconciling", model.ClusterInstallationStateReconciling, model.ClusterInstallationStateStable},
 			{"deletion requested", model.ClusterInstallationStateDeletionRequested, model.ClusterInstallationStateDeleted},
 		}
 


### PR DESCRIPTION
This change introduces support for spinning up installations with
specified versions. It also allows for changing the version of a
previously-running installation.

Fixes https://mattermost.atlassian.net/browse/MM-15368