### PR TITLE
Fix upgrade version name constraints

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -266,7 +266,9 @@ func (c *Client) GetInstallations(request *GetInstallationsRequest) ([]*model.In
 
 // UpgradeInstallation upgrades a installation to the given Mattermost version.
 func (c *Client) UpgradeInstallation(installationID, version string) error {
-	resp, err := c.doPut(c.buildURL("/api/installation/%s/mattermost/%s", installationID, version), nil)
+	resp, err := c.doPut(c.buildURL("/api/installation/%s/mattermost", installationID), UpgradeInstallationRequest{
+		Version: version,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/api/installation_request.go
+++ b/internal/api/installation_request.go
@@ -67,3 +67,22 @@ func (request *GetInstallationsRequest) ApplyToURL(u *url.URL) {
 	}
 	u.RawQuery = q.Encode()
 }
+
+// UpgradeInstallationRequest specifies the parameters for an upgraded installation.
+type UpgradeInstallationRequest struct {
+	Version string
+}
+
+func newUpgradeInstallationRequestFromReader(reader io.Reader) (*UpgradeInstallationRequest, error) {
+	var upgradeInstallationRequest UpgradeInstallationRequest
+	err := json.NewDecoder(reader).Decode(&upgradeInstallationRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode upgrade installation request")
+	}
+
+	if upgradeInstallationRequest.Version == "" {
+		return nil, errors.New("must specify version")
+	}
+
+	return &upgradeInstallationRequest, nil
+}

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -502,6 +502,20 @@ func TestUpgradeInstallation(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "5.9.0", installation1.Version)
 	})
+
+	t.Run("to version with embedded slash", func(t *testing.T) {
+		installation1.State = model.InstallationStateStable
+		err = sqlStore.UpdateInstallation(installation1)
+		require.NoError(t, err)
+
+		err = client.UpgradeInstallation(installation1.ID, "mattermost/mattermost-enterprise:v5.12")
+		require.NoError(t, err)
+
+		installation1, err = client.GetInstallation(installation1.ID)
+		require.NoError(t, err)
+		require.Equal(t, model.InstallationStateUpgradeRequested, installation1.State)
+		require.Equal(t, "mattermost/mattermost-enterprise:v5.12", installation1.Version)
+	})
 }
 
 func TestJoinGroup(t *testing.T) {

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -201,4 +201,101 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.4.0"), semver.MustParse("0.5.0"), func(e execer) error {
+		// Switch various columns to TEXT for Postgres. This isn't actually necessary for
+		// SQLite, and it's harder to change types there anyway.
+		if e.DriverName() == driverPostgres {
+			_, err := e.Exec(`ALTER TABLE System ALTER COLUMN Key TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE System ALTER COLUMN Value TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Cluster ALTER COLUMN ID TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Cluster ALTER COLUMN Provider TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Cluster ALTER COLUMN Provisioner TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Cluster ALTER COLUMN Size TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Cluster ALTER COLUMN State TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Cluster ALTER COLUMN LockAcquiredBy TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Installation ALTER COLUMN ID TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Installation ALTER COLUMN OwnerId TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Installation ALTER COLUMN Version TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Installation ALTER COLUMN DNS TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Installation ALTER COLUMN Affinity TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Installation ALTER COLUMN GroupID TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Installation ALTER COLUMN State TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE Installation ALTER COLUMN LockAcquiredBy TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE ClusterInstallation ALTER COLUMN LockAcquiredBy TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+
+			_, err = e.Exec(`ALTER TABLE "Group" ALTER COLUMN ID TYPE TEXT;`)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}},
 }


### PR DESCRIPTION
The existing endpoint relied on the version to be encoded in the URI, but this made it impossible to pass Docker images that contained a slash (since the router would no longer match). Switch to accepting the version via the payload instead.