### PR TITLE
add certificate aws arn to use when installing a new mattermost cluster

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -31,10 +31,12 @@ func init() {
 	serverCmd.PersistentFlags().String("database", "sqlite://cloud.db", "The database backing the provisioning server.")
 	serverCmd.PersistentFlags().String("listen", ":8075", "The interface and port on which to listen.")
 	serverCmd.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
+	serverCmd.PersistentFlags().String("certificate-aws-arn", "", "The certificate ARN from AWS. Generated in the certificate manager console.")
 	serverCmd.PersistentFlags().String("route53-id", "", "The route 53 hosted zone ID used for mattermost DNS records.")
 	serverCmd.PersistentFlags().Int("poll", 30, "The interval in seconds to poll for background work.")
 	serverCmd.PersistentFlags().Bool("debug", false, "Whether to output debug logs.")
 	serverCmd.MarkPersistentFlagRequired("route53-id")
+	serverCmd.MarkPersistentFlagRequired("certificate-aws-arn")
 }
 
 var serverCmd = &cobra.Command{
@@ -70,10 +72,14 @@ var serverCmd = &cobra.Command{
 		s3StateStore, _ := command.Flags().GetString("state-store")
 		logger.Infof("Using state store %s", s3StateStore)
 
+		certificateSslARN, _ := command.Flags().GetString("certificate-aws-arn")
+		logger.Infof("Using aws certificate arn %s", certificateSslARN)
+
 		// Setup the provisioner for actually effecting changes to clusters.
 		kopsProvisioner := provisioner.NewKopsProvisioner(
 			clusterRootDir,
 			s3StateStore,
+			certificateSslARN,
 			logger,
 		)
 


### PR DESCRIPTION
for now, making it configurable via server start, we can add this option as a api request option when creating a new mattermost cluster installation