### PR TITLE
MM-16216 Add the ability to create clusters in existing subnets

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -73,6 +73,9 @@ var serverCmd = &cobra.Command{
 
 		s3StateStore, _ := command.Flags().GetString("state-store")
 		certificateSslARN, _ := command.Flags().GetString("certificate-aws-arn")
+		privateSubnetIds, _ := command.Flags().GetString("private-subnets")
+		publicSubnetIds, _ := command.Flags().GetString("public-subnets")
+		route53ZoneID, _ := command.Flags().GetString("route53-id")
 
 		wd, err := os.Getwd()
 		if err != nil {
@@ -85,14 +88,10 @@ var serverCmd = &cobra.Command{
 			"state-store":       s3StateStore,
 			"aws-arn":           certificateSslARN,
 			"working-directory": wd,
+			"private-subents":   privateSubnetIds,
+			"public-subnets":    publicSubnetIds,
+			"route53-id":        route53ZoneID,
 		}).Info("Starting Mattermost Provisioning Server")
-
-		privateSubnetIds, _ := command.Flags().GetString("private-subnets")
-		logger.Infof("Using private subnets %s", privateSubnetIds)
-		publicSubnetIds, _ := command.Flags().GetString("public-subnets")
-		logger.Infof("Using public subnets %s", publicSubnetIds)
-
-		route53ZoneID, _ := command.Flags().GetString("route53-id")
 
 		// Setup the provisioner for actually effecting changes to clusters.
 		kopsProvisioner := provisioner.NewKopsProvisioner(

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -98,7 +98,6 @@ var serverCmd = &cobra.Command{
 		kopsProvisioner := provisioner.NewKopsProvisioner(
 			clusterRootDir,
 			s3StateStore,
-			aws.New(route53ZoneID),
 			certificateSslARN,
 			privateSubnetIds,
 			publicSubnetIds,
@@ -114,7 +113,7 @@ var serverCmd = &cobra.Command{
 		}
 		supervisor := supervisor.NewScheduler(
 			supervisor.MultiDoer{
-				supervisor.NewClusterSupervisor(sqlStore, kopsProvisioner, instanceID, logger),
+				supervisor.NewClusterSupervisor(sqlStore, kopsProvisioner, aws.New(route53ZoneID), instanceID, logger),
 				supervisor.NewInstallationSupervisor(sqlStore, kopsProvisioner, aws.New(route53ZoneID), instanceID, logger),
 				supervisor.NewClusterInstallationSupervisor(sqlStore, kopsProvisioner, instanceID, logger),
 			},

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.19.41 h1:veutzvQP/lOmYmtX26S9mTFJLO6sp7/UsxFcCjglu4A=
 github.com/aws/aws-sdk-go v1.19.41/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.19.49 h1:GUlenK625g5iKrIiRcqRS/CvPMLc8kZRtMxXuXBhFx4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -33,7 +33,7 @@ type KopsProvisioner struct {
 }
 
 // NewKopsProvisioner creates a new KopsProvisioner.
-func NewKopsProvisioner(clusterRootDir, s3StateStore string, certificateSslARN, privateSubnetIds, publicSubnetIds string, logger log.FieldLogger) *KopsProvisioner {
+func NewKopsProvisioner(clusterRootDir, s3StateStore, certificateSslARN, privateSubnetIds, publicSubnetIds string, logger log.FieldLogger) *KopsProvisioner {
 	return &KopsProvisioner{
 		clusterRootDir:    clusterRootDir,
 		s3StateStore:      s3StateStore,

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"github.com/mattermost/mattermost-cloud/internal/model"
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	log "github.com/sirupsen/logrus"
 )
@@ -36,12 +37,6 @@ type installationProvisioner interface {
 	GetClusterInstallationResource(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) (*mmv1alpha1.ClusterInstallation, error)
 }
 
-// aws abstracts the aws client operations required by the installation supervisor.
-type aws interface {
-	CreateCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error
-	DeleteCNAME(dnsName string, logger log.FieldLogger) error
-}
-
 // InstallationSupervisor finds installations pending work and effects the required changes.
 //
 // The degree of parallelism is controlled by a weighted semaphore, intended to be shared with
@@ -49,13 +44,13 @@ type aws interface {
 type InstallationSupervisor struct {
 	store       installationStore
 	provisioner installationProvisioner
-	aws         aws
+	aws         aws.AWS
 	instanceID  string
 	logger      log.FieldLogger
 }
 
 // NewInstallationSupervisor creates a new InstallationSupervisor.
-func NewInstallationSupervisor(store installationStore, installationProvisioner installationProvisioner, aws aws, instanceID string, logger log.FieldLogger) *InstallationSupervisor {
+func NewInstallationSupervisor(store installationStore, installationProvisioner installationProvisioner, aws aws.AWS, instanceID string, logger log.FieldLogger) *InstallationSupervisor {
 	return &InstallationSupervisor{
 		store:       store,
 		provisioner: installationProvisioner,

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -123,6 +123,14 @@ func (a *mockAWS) DeleteCNAME(dnsName string, logger log.FieldLogger) error {
 	return nil
 }
 
+func (a *mockAWS) TagResource(resourceID, key, value string, logger log.FieldLogger) error {
+	return nil
+}
+
+func (a *mockAWS) UntagResource(resourceID, key, value string, logger log.FieldLogger) error {
+	return nil
+}
+
 func TestInstallationSupervisorDo(t *testing.T) {
 	t.Run("no clusters pending work", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -1,6 +1,9 @@
 package aws
 
-import "github.com/aws/aws-sdk-go/service/route53"
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/route53"
+)
 
 // Client is a client for interacting with AWS resources.
 type Client struct {
@@ -10,9 +13,13 @@ type Client struct {
 
 // api mocks out the AWS API calls for testing.
 type api interface {
-	getSessionClient() (*route53.Route53, error)
+	getRoute53Client() (*route53.Route53, error)
 	changeResourceRecordSets(*route53.Route53, *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error)
 	listResourceRecordSets(*route53.Route53, *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)
+
+	getEC2Client() (*ec2.EC2, error)
+	tagResource(*ec2.EC2, *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
+	untagResource(*ec2.EC2, *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error)
 }
 
 // New returns a new AWS client.

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -3,13 +3,24 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/route53"
+	log "github.com/sirupsen/logrus"
 )
+
+// AWS interface for use by other packages.
+type AWS interface {
+	CreateCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error
+	DeleteCNAME(dnsName string, logger log.FieldLogger) error
+	TagResource(resourceID, key, value string, logger log.FieldLogger) error
+	UntagResource(resourceID, key, value string, logger log.FieldLogger) error
+}
 
 // Client is a client for interacting with AWS resources.
 type Client struct {
 	hostedZoneID string
 	api          api
 }
+
+var _ AWS = &Client{}
 
 // api mocks out the AWS API calls for testing.
 type api interface {

--- a/internal/tools/aws/ec2.go
+++ b/internal/tools/aws/ec2.go
@@ -1,0 +1,93 @@
+package aws
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	log "github.com/sirupsen/logrus"
+)
+
+// TagResource tags an AWS EC2 resource.
+func (a *Client) TagResource(resourceID, key, value string, logger log.FieldLogger) error {
+	if resourceID == "" {
+		return errors.New("Missing resource ID")
+	}
+
+	svc, err := a.api.getEC2Client()
+	if err != nil {
+		return err
+	}
+
+	input := &ec2.CreateTagsInput{
+		Resources: []*string{
+			aws.String(resourceID),
+		},
+		Tags: []*ec2.Tag{
+			&ec2.Tag{
+				Key:   aws.String(key),
+				Value: aws.String(value),
+			},
+		},
+	}
+
+	resp, err := a.api.tagResource(svc, input)
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("AWS ec2 response: %s", resp)
+
+	return nil
+}
+
+// UntagResource deletes tags from an AWS EC2 resource.
+func (a *Client) UntagResource(resourceID, key, value string, logger log.FieldLogger) error {
+	if resourceID == "" {
+		return errors.New("Missing resource ID")
+	}
+
+	svc, err := a.api.getEC2Client()
+	if err != nil {
+		return err
+	}
+
+	input := &ec2.DeleteTagsInput{
+		Resources: []*string{
+			aws.String(resourceID),
+		},
+		Tags: []*ec2.Tag{
+			&ec2.Tag{
+				Key:   aws.String(key),
+				Value: aws.String(value),
+			},
+		},
+	}
+
+	resp, err := a.api.untagResource(svc, input)
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("AWS ec2 response: %s", resp)
+
+	return nil
+}
+
+func (api *apiInterface) getEC2Client() (*ec2.EC2, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	return ec2.New(sess), nil
+}
+
+func (api *apiInterface) tagResource(svc *ec2.EC2, input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
+	return svc.CreateTags(input)
+}
+
+func (api *apiInterface) untagResource(svc *ec2.EC2, input *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error) {
+	return svc.DeleteTags(input)
+}

--- a/internal/tools/aws/ec2_test.go
+++ b/internal/tools/aws/ec2_test.go
@@ -1,0 +1,124 @@
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func (api *mockAPI) getEC2Client() (*ec2.EC2, error) {
+	return nil, api.returnedError
+}
+
+func (api *mockAPI) tagResource(svc *ec2.EC2, input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
+	return nil, api.returnedError
+}
+
+func (api *mockAPI) untagResource(svc *ec2.EC2, input *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error) {
+	return nil, api.returnedError
+}
+
+func TestTagResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		resourceID  string
+		key         string
+		value       string
+		mockError   error
+		expectError bool
+	}{
+		{
+			"set tag",
+			"resource1",
+			"key1",
+			"value1",
+			nil,
+			false,
+		},
+		{
+			"missing resource ID",
+			"",
+			"key1",
+			"value1",
+			nil,
+			true,
+		},
+		{
+			"bad resource ID",
+			"badid",
+			"key1",
+			"value1",
+			errors.New("mock bad resource id"),
+			true,
+		},
+	}
+
+	logger := logrus.New()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := Client{
+				hostedZoneID: "ABCDEFGH",
+				api:          &mockAPI{returnedError: tt.mockError},
+			}
+
+			err := a.TagResource(tt.resourceID, tt.key, tt.value, logger)
+			switch tt.expectError {
+			case true:
+				assert.Error(t, err)
+			case false:
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUntagResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		resourceID  string
+		key         string
+		value       string
+		mockError   error
+		expectError bool
+	}{
+		{
+			"unset tag",
+			"resource1",
+			"key1",
+			"value1",
+			nil,
+			false,
+		},
+		{
+			"missing resource ID",
+			"",
+			"key1",
+			"value1",
+			nil,
+			true,
+		},
+	}
+
+	logger := logrus.New()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := Client{
+				hostedZoneID: "ABCDEFGH",
+				api:          &mockAPI{returnedError: tt.mockError},
+			}
+
+			err := a.UntagResource(tt.resourceID, tt.key, tt.value, logger)
+			switch tt.expectError {
+			case true:
+				assert.Error(t, err)
+			case false:
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/tools/aws/mock.go
+++ b/internal/tools/aws/mock.go
@@ -1,0 +1,6 @@
+package aws
+
+type mockAPI struct {
+	returnedError     error
+	returnedTruncated bool
+}

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -10,18 +10,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	defaultTTL    = 60
-	defaultWeight = 1
-)
-
 // CreateCNAME creates an AWS route53 CNAME record.
 func (a *Client) CreateCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error {
 	if len(dnsEndpoints) == 0 {
 		return errors.New("no DNS endpoints provided for route53 creation request")
 	}
 
-	svc, err := a.api.getSessionClient()
+	svc, err := a.api.getRoute53Client()
 	if err != nil {
 		return err
 	}
@@ -123,10 +118,7 @@ func (a *Client) DeleteCNAME(dnsName string, logger log.FieldLogger) error {
 	return nil
 }
 
-// apiInterface abstracts out AWS API calls for testing.
-type apiInterface struct{}
-
-func (api *apiInterface) getSessionClient() (*route53.Route53, error) {
+func (api *apiInterface) getRoute53Client() (*route53.Route53, error) {
 	sess, err := session.NewSession()
 	if err != nil {
 		return nil, err

--- a/internal/tools/aws/route53_test.go
+++ b/internal/tools/aws/route53_test.go
@@ -11,12 +11,7 @@ import (
 
 var testDNSName = "example.mattermost.com"
 
-type mockAPI struct {
-	returnedError     error
-	returnedTruncated bool
-}
-
-func (api *mockAPI) getSessionClient() (*route53.Route53, error) {
+func (api *mockAPI) getRoute53Client() (*route53.Route53, error) {
 	return nil, api.returnedError
 }
 

--- a/internal/tools/aws/session.go
+++ b/internal/tools/aws/session.go
@@ -1,0 +1,9 @@
+package aws
+
+const (
+	defaultTTL    = 60
+	defaultWeight = 1
+)
+
+// apiInterface abstracts out AWS API calls for testing.
+type apiInterface struct{}

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -22,15 +22,17 @@ func (c *Cmd) CreateCluster(name, cloud string, clusterSize ClusterSize, zones [
 		arg("node-count", clusterSize.NodeCount),
 		arg("node-size", clusterSize.NodeSize),
 		arg("master-size", clusterSize.MasterSize),
-		arg("api-loadbalancer-type", "internal"),
-		arg("topology", "private"),
 		arg("target", "terraform"),
 		arg("out", c.GetOutputDirectory()),
 		arg("output", "json"),
 	}
 
 	if privateSubnetIds != "" {
-		args = append(args, arg("subnets", privateSubnetIds))
+		args = append(args,
+			arg("subnets", privateSubnetIds),
+			arg("topology", "private"),
+			arg("api-loadbalancer-type", "internal"),
+		)
 	}
 	if publicSubnetIds != "" {
 		args = append(args, arg("utility-subnets", publicSubnetIds))


### PR DESCRIPTION
##### Summary
The changes are fairly straight-forward once I figured out all the different pieces needed to use existing subnets.

Usage looks like this:

```
cloud server --state-store yourstatestore --route53-id yourroute53id --private-subnets subnetid1,subdnetid2 --public-subnets subnetid3,subnetid4 --certificate-aws-arn yourarn
```

##### Ticket Link
https://mattermost.atlassian.net/browse/MM-16216