### PR TITLE
ELB configuration fixes

### DIFF
--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -485,9 +485,10 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 			IngressName:            installation.DNS,
 			UseServiceLoadBalancer: true,
 			ServiceAnnotations: map[string]string{
-				"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http",
-				"service.beta.kubernetes.io/aws-load-balancer-ssl-cert":         provisioner.certificateSslARN,
-				"service.beta.kubernetes.io/aws-load-balancer-ssl-ports":        "https",
+				"service.beta.kubernetes.io/aws-load-balancer-backend-protocol":        "tcp",
+				"service.beta.kubernetes.io/aws-load-balancer-ssl-cert":                provisioner.certificateSslARN,
+				"service.beta.kubernetes.io/aws-load-balancer-ssl-ports":               "https",
+				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "120",
 			},
 		},
 	})


### PR DESCRIPTION
This change includes two alterations to how we create ELBs:
 - Set idle timeout to 120 seconds per Mattermost documentation.
 - Set backend protocol to TCP to allow for web socket connections.