### PR TITLE
[MM-16290] Prevent cluster deletion if there are running cluster installations

### DIFF
--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -227,6 +227,23 @@ func handleDeleteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	clusterInstallations, err := c.Store.GetClusterInstallations(&model.ClusterInstallationFilter{
+		ClusterID:      cluster.ID,
+		IncludeDeleted: false,
+		PerPage:        model.AllPerPage,
+	})
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to get cluster installations")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if len(clusterInstallations) != 0 {
+		c.Logger.Errorf("unable to delete cluster while it still has %d cluster installations", len(clusterInstallations))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	if cluster.State != model.ClusterStateDeletionRequested {
 		cluster.State = model.ClusterStateDeletionRequested
 


### PR DESCRIPTION
This check prevents clusters from being deleted when there is an
actively-running cluster installation on it.

Ticket: https://mattermost.atlassian.net/browse/MM-16290