### PR TITLE
Fix issue with kops tmp folder rename

### DIFF
--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -134,10 +134,10 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 	if err != nil && err.(*os.LinkError).Err == syscall.EXDEV {
 		err = utils.CopyDirectory(kops.GetOutputDirectory(), outputDir)
 		if err != nil {
-			return fmt.Errorf("failed to rename kops output directory to %q using utils.CopyFolder", outputDir)
+			return errors.Wrap(err, fmt.Sprintf("failed to rename kops output directory to '%s' using utils.CopyFolder", outputDir))
 		}
-	} else {
-		return fmt.Errorf("failed to rename kops output directory to %q", outputDir)
+	} else if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to rename kops output directory to '%s'", outputDir))
 	}
 
 	terraformClient := terraform.New(outputDir, logger)


### PR DESCRIPTION
This fixes an issue where we were returning an error when the
rename task was actually successful.

Related to https://github.com/mattermost/mattermost-cloud/pull/31