### PR TITLE
[MM-16441] Format AWS client output in logs

### DIFF
--- a/internal/tools/aws/ec2.go
+++ b/internal/tools/aws/ec2.go
@@ -1,7 +1,9 @@
 package aws
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -37,7 +39,7 @@ func (a *Client) TagResource(resourceID, key, value string, logger log.FieldLogg
 		return err
 	}
 
-	logger.Debugf("AWS ec2 response: %s", resp)
+	logger.Debugf("AWS ec2 response: %s", prettyCreateTagsResponse(resp))
 
 	return nil
 }
@@ -70,9 +72,27 @@ func (a *Client) UntagResource(resourceID, key, value string, logger log.FieldLo
 		return err
 	}
 
-	logger.Debugf("AWS ec2 response: %s", resp)
+	logger.Debugf("AWS ec2 response: %s", prettyDeleteTagsResponse(resp))
 
 	return nil
+}
+
+func prettyCreateTagsResponse(resp *ec2.CreateTagsOutput) string {
+	prettyResp, err := json.Marshal(resp)
+	if err != nil {
+		return strings.Replace(resp.String(), "\n", " ", -1)
+	}
+
+	return string(prettyResp)
+}
+
+func prettyDeleteTagsResponse(resp *ec2.DeleteTagsOutput) string {
+	prettyResp, err := json.Marshal(resp)
+	if err != nil {
+		return strings.Replace(resp.String(), "\n", " ", -1)
+	}
+
+	return string(prettyResp)
 }
 
 func (api *apiInterface) getEC2Client() (*ec2.EC2, error) {

--- a/internal/tools/aws/mock.go
+++ b/internal/tools/aws/mock.go
@@ -1,5 +1,8 @@
 package aws
 
+// apiInterface abstracts out AWS API calls for testing.
+type apiInterface struct{}
+
 type mockAPI struct {
 	returnedError     error
 	returnedTruncated bool

--- a/internal/tools/aws/route53_test.go
+++ b/internal/tools/aws/route53_test.go
@@ -16,7 +16,9 @@ func (api *mockAPI) getRoute53Client() (*route53.Route53, error) {
 }
 
 func (api *mockAPI) changeResourceRecordSets(svc *route53.Route53, input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
-	return nil, api.returnedError
+	return &route53.ChangeResourceRecordSetsOutput{
+		ChangeInfo: &route53.ChangeInfo{},
+	}, api.returnedError
 }
 
 func (api *mockAPI) listResourceRecordSets(svc *route53.Route53, input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {

--- a/internal/tools/aws/session.go
+++ b/internal/tools/aws/session.go
@@ -1,9 +1,0 @@
-package aws
-
-const (
-	defaultTTL    = 60
-	defaultWeight = 1
-)
-
-// apiInterface abstracts out AWS API calls for testing.
-type apiInterface struct{}


### PR DESCRIPTION
This change ensures that AWS client output is formatted to be on
a single line in our logs. This will ensure that structured
logging is not broken by newlines.

Ticket Link:
https://mattermost.atlassian.net/browse/MM-16441