### PR TITLE
[MM-16413] Add separate cluster 'provisioning' state

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -108,6 +108,23 @@ func (c *Client) RetryCreateCluster(clusterID string) error {
 	}
 }
 
+// ProvisionCluster provisions k8s operators on a cluster from the configured provisioning server.
+func (c *Client) ProvisionCluster(clusterID string) error {
+	resp, err := c.doPost(c.buildURL("/api/cluster/%s/provision", clusterID), nil)
+	if err != nil {
+		return err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return nil
+
+	default:
+		return errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // GetCluster fetches the specified cluster from the configured provisioning server.
 func (c *Client) GetCluster(clusterID string) (*model.Cluster, error) {
 	resp, err := c.doGet(c.buildURL("/api/cluster/%s", clusterID))

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -409,6 +409,128 @@ func TestRetryCreateCluster(t *testing.T) {
 	})
 }
 
+func TestProvisionCluster(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := api.NewClient(ts.URL)
+
+	cluster1, err := client.CreateCluster(&api.CreateClusterRequest{
+		Provider: model.ProviderAWS,
+		Size:     model.SizeAlef500,
+		Zones:    []string{"zone"},
+	})
+	require.NoError(t, err)
+
+	t.Run("unknown cluster", func(t *testing.T) {
+		err := client.ProvisionCluster(model.NewID())
+		require.EqualError(t, err, "failed with status code 404")
+	})
+
+	t.Run("while locked", func(t *testing.T) {
+		cluster1.State = model.ClusterStateStable
+		err = sqlStore.UpdateCluster(cluster1)
+		require.NoError(t, err)
+
+		lockerID := model.NewID()
+
+		locked, err := sqlStore.LockCluster(cluster1.ID, lockerID)
+		require.NoError(t, err)
+		require.True(t, locked)
+		defer func() {
+			unlocked, err := sqlStore.UnlockCluster(cluster1.ID, lockerID, false)
+			require.NoError(t, err)
+			require.True(t, unlocked)
+		}()
+
+		err = client.ProvisionCluster(cluster1.ID)
+		require.EqualError(t, err, "failed with status code 409")
+	})
+
+	t.Run("while provisioning", func(t *testing.T) {
+		cluster1.State = model.ClusterStateProvisioningRequested
+		err = sqlStore.UpdateCluster(cluster1)
+		require.NoError(t, err)
+
+		err = client.ProvisionCluster(cluster1.ID)
+		require.NoError(t, err)
+
+		cluster1, err = client.GetCluster(cluster1.ID)
+		require.NoError(t, err)
+		require.Equal(t, model.ClusterStateProvisioningRequested, cluster1.State)
+	})
+
+	t.Run("after provisioning failed", func(t *testing.T) {
+		cluster1.State = model.ClusterStateProvisioningFailed
+		err = sqlStore.UpdateCluster(cluster1)
+		require.NoError(t, err)
+
+		err = client.ProvisionCluster(cluster1.ID)
+		require.NoError(t, err)
+
+		cluster1, err = client.GetCluster(cluster1.ID)
+		require.NoError(t, err)
+		require.Equal(t, model.ClusterStateProvisioningRequested, cluster1.State)
+	})
+
+	t.Run("while upgrading", func(t *testing.T) {
+		cluster1.State = model.ClusterStateUpgradeRequested
+		err = sqlStore.UpdateCluster(cluster1)
+		require.NoError(t, err)
+
+		err = client.ProvisionCluster(cluster1.ID)
+		require.EqualError(t, err, "failed with status code 400")
+
+		cluster1, err = client.GetCluster(cluster1.ID)
+		require.NoError(t, err)
+		require.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
+	})
+
+	t.Run("after upgrade failed", func(t *testing.T) {
+		cluster1.State = model.ClusterStateUpgradeFailed
+		err = sqlStore.UpdateCluster(cluster1)
+		require.NoError(t, err)
+
+		err = client.ProvisionCluster(cluster1.ID)
+		require.EqualError(t, err, "failed with status code 400")
+
+		cluster1, err = client.GetCluster(cluster1.ID)
+		require.NoError(t, err)
+		require.Equal(t, model.ClusterStateUpgradeFailed, cluster1.State)
+	})
+
+	t.Run("while stable", func(t *testing.T) {
+		cluster1.State = model.ClusterStateStable
+		err = sqlStore.UpdateCluster(cluster1)
+		require.NoError(t, err)
+
+		err = client.ProvisionCluster(cluster1.ID)
+		require.NoError(t, err)
+
+		cluster1, err = client.GetCluster(cluster1.ID)
+		require.NoError(t, err)
+		require.Equal(t, model.ClusterStateProvisioningRequested, cluster1.State)
+	})
+
+	t.Run("while deleting", func(t *testing.T) {
+		cluster1.State = model.ClusterStateDeletionRequested
+		err = sqlStore.UpdateCluster(cluster1)
+		require.NoError(t, err)
+
+		err = client.ProvisionCluster(cluster1.ID)
+		require.EqualError(t, err, "failed with status code 400")
+	})
+}
+
 func TestUpgradeCluster(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)

--- a/internal/model/cluster.go
+++ b/internal/model/cluster.go
@@ -12,6 +12,11 @@ const (
 	ClusterStateCreationRequested = "creation-requested"
 	// ClusterStateCreationFailed is a cluster that failed creation.
 	ClusterStateCreationFailed = "creation-failed"
+	// ClusterStateProvisioningRequested is a cluster in the process of being
+	// provisioned with operators.
+	ClusterStateProvisioningRequested = "provisioning-requested"
+	// ClusterStateProvisioningFailed is a cluster that failed provisioning.
+	ClusterStateProvisioningFailed = "provisioning-failed"
 	// ClusterStateDeletionRequested is a cluster in the process of being deleted.
 	ClusterStateDeletionRequested = "deletion-requested"
 	// ClusterStateDeletionFailed is a cluster that failed deletion.

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -570,7 +570,8 @@ func makeClusterInstallationName(clusterInstallation *model.ClusterInstallation)
 	return fmt.Sprintf("mm-%s", clusterInstallation.Namespace[0:4])
 }
 
-// waitForHelmRunning is used to check when Helm is ready to install charts.
+// waitForNamespacesDeleted is used to check when all of the provided namespaces
+// have been fully terminated.
 func waitForNamespacesDeleted(ctx context.Context, namespaces []string, k8sClient *k8s.KubeClient) error {
 	for {
 		select {

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -193,6 +193,98 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 
 	logger.WithField("name", kopsMetadata.Name).Info("Successfully deployed kubernetes")
 
+	logger.Info("Installing Helm")
+	err = helmSetup(logger, kops)
+	if err != nil {
+		return err
+	}
+
+	wait = 120
+	logger.Infof("Waiting up to %d seconds for helm to become ready...", wait)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(wait)*time.Second)
+	defer cancel()
+	err = waitForHelmRunning(ctx, kops.GetKubeConfigPath())
+	if err != nil {
+		return err
+	}
+
+	prometheusDNS := fmt.Sprintf("%s.prometheus.%s", cluster.ID, provisioner.privateDNS)
+	elasticsearchDNS := fmt.Sprintf("elasticsearch.%s", provisioner.privateDNS)
+
+	helmDeployments := []helmDeployment{
+		{
+			valuesPath:          "helm-charts/private-nginx_values.yaml",
+			chartName:           "stable/nginx-ingress",
+			namespace:           "internal-nginx",
+			chartDeploymentName: "private-nginx",
+		}, {
+			valuesPath:          "helm-charts/prometheus_values.yaml",
+			chartName:           "stable/prometheus",
+			namespace:           "prometheus",
+			chartDeploymentName: "prometheus",
+			setArgument:         fmt.Sprintf("server.ingress.hosts={%s}", prometheusDNS),
+		}, {
+			valuesPath:          "helm-charts/fluentd_values.yaml",
+			chartName:           "stable/fluentd-elasticsearch",
+			namespace:           "fluentd",
+			chartDeploymentName: "fluentd",
+			setArgument:         fmt.Sprintf("elasticsearch.host=%s", elasticsearchDNS),
+		},
+	}
+
+	for _, deployment := range helmDeployments {
+		logger.Infof("Installing helm chart %s", deployment.chartName)
+		err = installHelmChart(deployment, kops.GetKubeConfigPath())
+		if err != nil {
+			return err
+		}
+	}
+
+	logger.Infof("Waiting up to %d seconds for internal ELB to become ready...", wait)
+	ctx, cancel = context.WithTimeout(context.Background(), time.Duration(wait)*time.Second)
+	defer cancel()
+	endpoint, err := getLoadBalancerEndpoint(ctx, "internal-nginx", logger, kops.GetKubeConfigPath())
+	if err != nil {
+		return err
+	}
+
+	for _, app := range helmApps {
+		dns := fmt.Sprintf("%s.%s.%s", cluster.ID, app, provisioner.privateDNS)
+		logger.Infof("Registering DNS %s for %s", dns, app)
+		err = aws.CreateCNAME(dns, []string{endpoint}, logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ProvisionCluster installs all the baseline kubernetes resources needed for
+// managing installations. This can be called on an already-provisioned cluster
+// to reprovision with the newest version of the resources.
+// TODO: Move helm configuration here as well.
+func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster) error {
+	logger := provisioner.logger.WithField("cluster", cluster.ID)
+
+	kops, err := kops.New(provisioner.s3StateStore, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to create kops wrapper")
+	}
+	defer kops.Close()
+
+	kopsMetadata, err := model.NewKopsMetadata(cluster.ProvisionerMetadata)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse provisioner metadata")
+	}
+
+	err = kops.ExportKubecfg(kopsMetadata.Name)
+	if err != nil {
+		return errors.Wrap(err, "failed to export kubecfg")
+	}
+
+	logger.Info("Provisioning cluster")
+
 	// Begin deploying the mattermost operator.
 	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
 	if err != nil {
@@ -208,7 +300,27 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 		mattermostOperatorNamespace,
 	}
 
-	_, err = k8sClient.CreateNamespaces(namespaces)
+	// Remove all previously-installed operator namespaces and resources.
+	for _, namespace := range namespaces {
+		logger.Infof("Cleaning up namespace %s", namespace)
+		err = k8sClient.Clientset.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{})
+		if k8sErrors.IsNotFound(err) {
+			logger.Infof("Namespace %s not found; skipping...", namespace)
+		} else if err != nil {
+			return errors.Wrapf(err, "failed to delete namespace %s", namespace)
+		}
+	}
+
+	wait := 60
+	logger.Infof("Waiting up to %d seconds for namespaces to be terminated...", wait)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(wait)*time.Second)
+	defer cancel()
+	err = waitForNamespacesDeleted(ctx, namespaces, k8sClient)
+	if err != nil {
+		return err
+	}
+
+	_, err = k8sClient.CreateNamespacesIfDoesNotExist(namespaces)
 	if err != nil {
 		return err
 	}
@@ -216,25 +328,25 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 	// TODO: determine if we want to hard-code the k8s resource objects in code.
 	// For now, we will ingest manifest files to deploy the mattermost operator.
 	files := []k8s.ManifestFile{
-		k8s.ManifestFile{
+		{
 			Path:            "operator-manifests/mysql/mysql-operator.yaml",
 			DeployNamespace: mysqlOperatorNamespace,
-		}, k8s.ManifestFile{
+		}, {
 			Path:            "operator-manifests/minio/minio-operator.yaml",
 			DeployNamespace: minioOperatorNamespace,
-		}, k8s.ManifestFile{
+		}, {
 			Path:            "operator-manifests/mattermost/crds/mm_clusterinstallation_crd.yaml",
 			DeployNamespace: mattermostOperatorNamespace,
-		}, k8s.ManifestFile{
+		}, {
 			Path:            "operator-manifests/mattermost/service_account.yaml",
 			DeployNamespace: mattermostOperatorNamespace,
-		}, k8s.ManifestFile{
+		}, {
 			Path:            "operator-manifests/mattermost/role.yaml",
 			DeployNamespace: mattermostOperatorNamespace,
-		}, k8s.ManifestFile{
+		}, {
 			Path:            "operator-manifests/mattermost/role_binding.yaml",
 			DeployNamespace: mattermostOperatorNamespace,
-		}, k8s.ManifestFile{
+		}, {
 			Path:            "operator-manifests/mattermost/operator.yaml",
 			DeployNamespace: mattermostOperatorNamespace,
 		},
@@ -244,7 +356,6 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 		return err
 	}
 
-	wait = 60
 	operators := []string{"mysql-operator", "minio-operator", "mattermost-operator"}
 	for _, operator := range operators {
 		pods, err := k8sClient.GetPodsFromDeployment(operator, operator)
@@ -267,154 +378,8 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 		}
 	}
 
-	// Setup Helm
-	err = helmSetup(logger, kops)
-	if err != nil {
-		return err
-	}
+	logger.WithField("name", kopsMetadata.Name).Info("Successfully provisioned cluster")
 
-	wait = 120
-	logger.Infof("Waiting up to %d seconds for helm to get ready...", wait)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(wait)*time.Second)
-	defer cancel()
-	err = waitForHelmRunning(ctx, kops.GetKubeConfigPath())
-	if err != nil {
-		return err
-	}
-	logger.Info("Helm is ready to install charts")
-
-	// Begin deploying Helm charts
-	privateNginx := helmDeployment{valuesPath: "helm-charts/private-nginx_values.yaml", chartName: "stable/nginx-ingress", namespace: "internal-nginx", chartDeploymentName: "private-nginx"}
-	prometheusDNS := fmt.Sprintf("%s.prometheus.%s", cluster.ID, provisioner.privateDNS)
-	elasticsearchDNS := fmt.Sprintf("elasticsearch.%s", provisioner.privateDNS)
-
-	prometheus := helmDeployment{valuesPath: "helm-charts/prometheus_values.yaml", chartName: "stable/prometheus", namespace: "prometheus", chartDeploymentName: "prometheus", setArgument: fmt.Sprintf("server.ingress.hosts={%s}", prometheusDNS)}
-	fluentd := helmDeployment{valuesPath: "helm-charts/fluentd_values.yaml", chartName: "stable/fluentd-elasticsearch", namespace: "fluentd", chartDeploymentName: "fluentd", setArgument: fmt.Sprintf("elasticsearch.host=%s", elasticsearchDNS)}
-	helmDeployments := []helmDeployment{privateNginx, prometheus, fluentd}
-
-	for _, value := range helmDeployments {
-		err = installHelmChart(value, logger, kops.GetKubeConfigPath())
-		if err != nil {
-			return err
-		}
-	}
-
-	// Get the new ELB internal-nginx endpoint
-	logger.Infof("Waiting up to %d seconds for internal ELB to be ready...", wait)
-	ctx, cancel = context.WithTimeout(context.Background(), time.Duration(wait)*time.Second)
-	defer cancel()
-	endpoint, err := getLoadBalancerEndpoint(ctx, "internal-nginx", logger, kops.GetKubeConfigPath())
-	if err != nil {
-		return err
-	}
-
-	if endpoint == "" {
-		return errors.New("internal DNS ELB endpoint is empty")
-	}
-
-	for _, app := range helmApps {
-		dns := fmt.Sprintf("%s.%s.%s", cluster.ID, app, provisioner.privateDNS)
-		logger.Infof("Registering DNS %s for %s", dns, app)
-		err = aws.CreateCNAME(dns, []string{endpoint}, logger)
-		if err != nil {
-			return err
-		}
-	}
-
-	logger.WithField("name", kopsMetadata.Name).Info("Successfully created cluster")
-
-	return nil
-}
-
-// waitForHelmRunning is used to check when Helm is ready to install charts.
-func waitForHelmRunning(ctx context.Context, configPath string) error {
-	for {
-		cmd := exec.Command("helm", "ls", "--kubeconfig", configPath)
-		var out bytes.Buffer
-		cmd.Stderr = &out
-		cmd.Run()
-		if out.String() == "" {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return errors.Wrap(ctx.Err(), "timed out waiting for helm to become ready")
-		case <-time.After(5 * time.Second):
-		}
-	}
-}
-
-// getLoadBalancerEndpoint is used to get the endpoint of the internal ingress.
-func getLoadBalancerEndpoint(ctx context.Context, namespace string, logger log.FieldLogger, configPath string) (string, error) {
-	k8sClient, err := k8s.New(configPath, logger)
-	if err != nil {
-		return "", err
-	}
-	for {
-		services, err := k8sClient.Clientset.CoreV1().Services(namespace).List(metav1.ListOptions{})
-		if err != nil {
-			return "", err
-		}
-		for _, service := range services.Items {
-			if service.Status.LoadBalancer.Ingress != nil {
-				endpoint := service.Status.LoadBalancer.Ingress[0].Hostname
-				logger.Infof("Succesfully got LoadBalancer endpoint %s for Namespace %s", endpoint, namespace)
-				return endpoint, nil
-			}
-		}
-		select {
-		case <-ctx.Done():
-			return "", errors.Wrap(ctx.Err(), "timed out waiting for helm to become ready")
-		case <-time.After(5 * time.Second):
-		}
-	}
-}
-
-// installHelmChart is used to install Helm charts.
-func installHelmChart(chart helmDeployment, logger log.FieldLogger, configPath string) error {
-	logger.Infof("Installing helm chart %s", chart.chartName)
-	if chart.setArgument != "" {
-		err := exec.Command("helm", "install", "--kubeconfig", configPath, "--set", chart.setArgument, "-f", chart.valuesPath, chart.chartName, "--namespace", chart.namespace, "--name", chart.chartDeploymentName).Run()
-		if err != nil {
-			return err
-		}
-	} else {
-		err := exec.Command("helm", "install", "--kubeconfig", configPath, "-f", chart.valuesPath, chart.chartName, "--namespace", chart.namespace, "--name", chart.chartDeploymentName).Run()
-		if err != nil {
-			return err
-		}
-	}
-	logger.Infof("Successfully installed helm chart %s", chart.chartName)
-	return nil
-}
-
-// helmSetup is used for the initial setup of Helm in cluster.
-func helmSetup(logger log.FieldLogger, kops *kops.Cmd) error {
-	logger.Info("Initializing Helm in the cluster")
-	err := exec.Command("helm", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--upgrade").Run()
-	if err != nil {
-		return err
-	}
-	logger.Info("Creating Tiller service account")
-	err = exec.Command("kubectl", "--kubeconfig", kops.GetKubeConfigPath(), "--namespace", "kube-system", "create", "serviceaccount", "tiller").Run()
-	if err != nil {
-		return err
-	}
-	logger.Info("Creating Tiller cluster role bind")
-	err = exec.Command("kubectl", "--kubeconfig", kops.GetKubeConfigPath(), "create", "clusterrolebinding", "tiller-cluster-rule", "--clusterrole=cluster-admin", "--serviceaccount=kube-system:tiller").Run()
-	if err != nil {
-		return err
-	}
-	logger.Info("Patching tiller")
-	err = exec.Command("kubectl", "--kubeconfig", kops.GetKubeConfigPath(), "--namespace", "kube-system", "patch", "deploy", "tiller-deploy", "-p", "{\"spec\":{\"template\":{\"spec\":{\"serviceAccount\":\"tiller\"}}}}").Run()
-	if err != nil {
-		return err
-	}
-	logger.Info("Upgrade Helm")
-	err = exec.Command("helm", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--service-account", "tiller", "--upgrade").Run()
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -605,6 +570,128 @@ func makeClusterInstallationName(clusterInstallation *model.ClusterInstallation)
 	return fmt.Sprintf("mm-%s", clusterInstallation.Namespace[0:4])
 }
 
+// waitForHelmRunning is used to check when Helm is ready to install charts.
+func waitForNamespacesDeleted(ctx context.Context, namespaces []string, k8sClient *k8s.KubeClient) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "timed out waiting for namespaces to become fully terminated")
+		default:
+			var shouldWait bool
+			for _, namespace := range namespaces {
+				_, err := k8sClient.Clientset.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+				if err != nil && k8sErrors.IsNotFound(err) {
+					continue
+				}
+
+				shouldWait = true
+				break
+			}
+
+			if !shouldWait {
+				return nil
+			}
+
+			time.Sleep(5 * time.Second)
+		}
+	}
+}
+
+// waitForHelmRunning is used to check when Helm is ready to install charts.
+func waitForHelmRunning(ctx context.Context, configPath string) error {
+	for {
+		cmd := exec.Command("helm", "ls", "--kubeconfig", configPath)
+		var out bytes.Buffer
+		cmd.Stderr = &out
+		cmd.Run()
+		if out.String() == "" {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "timed out waiting for helm to become ready")
+		case <-time.After(5 * time.Second):
+		}
+	}
+}
+
+// getLoadBalancerEndpoint is used to get the endpoint of the internal ingress.
+func getLoadBalancerEndpoint(ctx context.Context, namespace string, logger log.FieldLogger, configPath string) (string, error) {
+	k8sClient, err := k8s.New(configPath, logger)
+	if err != nil {
+		return "", err
+	}
+	for {
+		services, err := k8sClient.Clientset.CoreV1().Services(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return "", err
+		}
+		for _, service := range services.Items {
+			if service.Status.LoadBalancer.Ingress != nil {
+				endpoint := service.Status.LoadBalancer.Ingress[0].Hostname
+				if endpoint == "" {
+					return "", errors.New("loadbalancer endpoint value is empty")
+				}
+
+				return endpoint, nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", errors.Wrap(ctx.Err(), "timed out waiting for helm to become ready")
+		case <-time.After(5 * time.Second):
+		}
+	}
+}
+
+// installHelmChart is used to install Helm charts.
+func installHelmChart(chart helmDeployment, configPath string) error {
+	if chart.setArgument != "" {
+		err := exec.Command("helm", "install", "--kubeconfig", configPath, "--set", chart.setArgument, "-f", chart.valuesPath, chart.chartName, "--namespace", chart.namespace, "--name", chart.chartDeploymentName).Run()
+		if err != nil {
+			return err
+		}
+	} else {
+		err := exec.Command("helm", "install", "--kubeconfig", configPath, "-f", chart.valuesPath, chart.chartName, "--namespace", chart.namespace, "--name", chart.chartDeploymentName).Run()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// helmSetup is used for the initial setup of Helm in cluster.
+func helmSetup(logger log.FieldLogger, kops *kops.Cmd) error {
+	logger.Info("Initializing Helm in the cluster")
+	err := exec.Command("helm", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--upgrade").Run()
+	if err != nil {
+		return err
+	}
+	logger.Info("Creating Tiller service account")
+	err = exec.Command("kubectl", "--kubeconfig", kops.GetKubeConfigPath(), "--namespace", "kube-system", "create", "serviceaccount", "tiller").Run()
+	if err != nil {
+		return err
+	}
+	logger.Info("Creating Tiller cluster role bind")
+	err = exec.Command("kubectl", "--kubeconfig", kops.GetKubeConfigPath(), "create", "clusterrolebinding", "tiller-cluster-rule", "--clusterrole=cluster-admin", "--serviceaccount=kube-system:tiller").Run()
+	if err != nil {
+		return err
+	}
+	logger.Info("Patching tiller")
+	err = exec.Command("kubectl", "--kubeconfig", kops.GetKubeConfigPath(), "--namespace", "kube-system", "patch", "deploy", "tiller-deploy", "-p", "{\"spec\":{\"template\":{\"spec\":{\"serviceAccount\":\"tiller\"}}}}").Run()
+	if err != nil {
+		return err
+	}
+	logger.Info("Upgrade Helm")
+	err = exec.Command("helm", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--service-account", "tiller", "--upgrade").Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // CreateClusterInstallation creates a Mattermost installation within the given cluster.
 func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) error {
 	logger := provisioner.logger.WithFields(map[string]interface{}{
@@ -633,7 +720,7 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 		return err
 	}
 
-	_, err = k8sClient.CreateNamespace(clusterInstallation.Namespace)
+	_, err = k8sClient.CreateNamespaceIfDoesNotExist(clusterInstallation.Namespace)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create namespace %s", clusterInstallation.Namespace)
 	}
@@ -715,7 +802,7 @@ func (provisioner *KopsProvisioner) DeleteClusterInstallation(cluster *model.Clu
 		return errors.Wrapf(err, "failed to delete cluster installation %s", clusterInstallation.ID)
 	}
 
-	err = k8sClient.DeleteNamespace(clusterInstallation.Namespace)
+	err = k8sClient.Clientset.CoreV1().Namespaces().Delete(clusterInstallation.Namespace, &metav1.DeleteOptions{})
 	if k8sErrors.IsNotFound(err) {
 		logger.Infof("Namespace %s not found, assuming already deleted.", clusterInstallation.Namespace)
 	} else if err != nil {

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -39,6 +39,7 @@ func (sqlStore *SQLStore) GetUnlockedClustersPendingWork() ([]*model.Cluster, er
 		Where(sq.Eq{
 			"State": []string{
 				model.ClusterStateCreationRequested,
+				model.ClusterStateProvisioningRequested,
 				model.ClusterStateUpgradeRequested,
 				model.ClusterStateDeletionRequested,
 			},

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -63,6 +63,10 @@ func (p *mockClusterProvisioner) CreateCluster(cluster *model.Cluster, aws aws.A
 	return nil
 }
 
+func (p *mockClusterProvisioner) ProvisionCluster(cluster *model.Cluster) error {
+	return nil
+}
+
 func (p *mockClusterProvisioner) UpgradeCluster(cluster *model.Cluster) error {
 	return nil
 }
@@ -111,6 +115,7 @@ func TestClusterSupervisorSupervise(t *testing.T) {
 	}{
 		{"unexpected state", model.ClusterStateStable, model.ClusterStateStable},
 		{"creation requested", model.ClusterStateCreationRequested, model.ClusterStateStable},
+		{"provision requested", model.ClusterStateProvisioningRequested, model.ClusterStateStable},
 		{"upgrade requested", model.ClusterStateUpgradeRequested, model.ClusterStateStable},
 		{"deletion requested", model.ClusterStateDeletionRequested, model.ClusterStateDeleted},
 	}

--- a/internal/tools/k8s/bindings.go
+++ b/internal/tools/k8s/bindings.go
@@ -3,49 +3,58 @@ package k8s
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	rbacbetav1 "k8s.io/api/rbac/v1beta1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (kc *KubeClient) createRoleBindingV1(namespace string, binding *rbacv1.RoleBinding) (metav1.Object, error) {
-	client := kc.Clientset.RbacV1().RoleBindings(namespace)
-
-	result, err := client.Create(binding)
-	if err != nil {
+func (kc *KubeClient) createOrUpdateRoleBindingV1(namespace string, binding *rbacv1.RoleBinding) (metav1.Object, error) {
+	_, err := kc.Clientset.RbacV1().RoleBindings(namespace).Get(binding.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	return result.GetObjectMeta(), nil
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.Clientset.RbacV1().RoleBindings(namespace).Create(binding)
+	}
+
+	return kc.Clientset.RbacV1().RoleBindings(namespace).Update(binding)
 }
 
-func (kc *KubeClient) createRoleBindingBetaV1(namespace string, binding *rbacbetav1.RoleBinding) (metav1.Object, error) {
-	client := kc.Clientset.RbacV1beta1().RoleBindings(namespace)
-
-	result, err := client.Create(binding)
-	if err != nil {
+func (kc *KubeClient) createOrUpdateRoleBindingBetaV1(namespace string, binding *rbacbetav1.RoleBinding) (metav1.Object, error) {
+	_, err := kc.Clientset.RbacV1beta1().RoleBindings(namespace).Get(binding.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	return result.GetObjectMeta(), nil
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.Clientset.RbacV1beta1().RoleBindings(namespace).Create(binding)
+	}
+
+	return kc.Clientset.RbacV1beta1().RoleBindings(namespace).Update(binding)
 }
 
-func (kc *KubeClient) createClusterRoleBindingV1(binding *rbacv1.ClusterRoleBinding) (metav1.Object, error) {
-	client := kc.Clientset.RbacV1().ClusterRoleBindings()
-
-	result, err := client.Create(binding)
-	if err != nil {
+func (kc *KubeClient) createOrUpdateClusterRoleBindingV1(binding *rbacv1.ClusterRoleBinding) (metav1.Object, error) {
+	_, err := kc.Clientset.RbacV1().ClusterRoleBindings().Get(binding.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	return result.GetObjectMeta(), nil
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.Clientset.RbacV1().ClusterRoleBindings().Create(binding)
+	}
+
+	return kc.Clientset.RbacV1().ClusterRoleBindings().Update(binding)
 }
 
-func (kc *KubeClient) createClusterRoleBindingBetaV1(binding *rbacbetav1.ClusterRoleBinding) (metav1.Object, error) {
-	client := kc.Clientset.RbacV1beta1().ClusterRoleBindings()
-
-	result, err := client.Create(binding)
-	if err != nil {
+func (kc *KubeClient) createOrUpdateClusterRoleBindingBetaV1(binding *rbacbetav1.ClusterRoleBinding) (metav1.Object, error) {
+	_, err := kc.Clientset.RbacV1beta1().ClusterRoleBindings().Get(binding.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	return result.GetObjectMeta(), nil
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.Clientset.RbacV1beta1().ClusterRoleBindings().Create(binding)
+	}
+
+	return kc.Clientset.RbacV1beta1().ClusterRoleBindings().Update(binding)
 }

--- a/internal/tools/k8s/bindings_test.go
+++ b/internal/tools/k8s/bindings_test.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 	rbacbetav1 "k8s.io/api/rbac/v1beta1"
@@ -18,13 +17,14 @@ func TestRoleBindingsV1(t *testing.T) {
 	namespace := "testing"
 
 	t.Run("create role binding", func(t *testing.T) {
-		result, err := testClient.createRoleBindingV1(namespace, roleBinding)
+		result, err := testClient.createOrUpdateRoleBindingV1(namespace, roleBinding)
 		require.NoError(t, err)
-		assert.Equal(t, roleBinding.GetName(), result.GetName())
+		require.Equal(t, roleBinding.GetName(), result.GetName())
 	})
 	t.Run("create duplicate role binding", func(t *testing.T) {
-		_, err := testClient.createRoleBindingV1(namespace, roleBinding)
-		assert.Error(t, err)
+		result, err := testClient.createOrUpdateRoleBindingV1(namespace, roleBinding)
+		require.NoError(t, err)
+		require.Equal(t, roleBinding.GetName(), result.GetName())
 	})
 }
 
@@ -36,13 +36,14 @@ func TestRoleBindingsBetaV1(t *testing.T) {
 	namespace := "testing"
 
 	t.Run("create role binding", func(t *testing.T) {
-		result, err := testClient.createRoleBindingBetaV1(namespace, roleBinding)
+		result, err := testClient.createOrUpdateRoleBindingBetaV1(namespace, roleBinding)
 		require.NoError(t, err)
-		assert.Equal(t, roleBinding.GetName(), result.GetName())
+		require.Equal(t, roleBinding.GetName(), result.GetName())
 	})
 	t.Run("create duplicate role binding", func(t *testing.T) {
-		_, err := testClient.createRoleBindingBetaV1(namespace, roleBinding)
-		assert.Error(t, err)
+		result, err := testClient.createOrUpdateRoleBindingBetaV1(namespace, roleBinding)
+		require.NoError(t, err)
+		require.Equal(t, roleBinding.GetName(), result.GetName())
 	})
 }
 
@@ -53,13 +54,14 @@ func TestClusterRoleBindingsV1(t *testing.T) {
 	}
 
 	t.Run("create role binding", func(t *testing.T) {
-		result, err := testClient.createClusterRoleBindingV1(roleBinding)
+		result, err := testClient.createOrUpdateClusterRoleBindingV1(roleBinding)
 		require.NoError(t, err)
-		assert.Equal(t, roleBinding.GetName(), result.GetName())
+		require.Equal(t, roleBinding.GetName(), result.GetName())
 	})
 	t.Run("create duplicate role binding", func(t *testing.T) {
-		_, err := testClient.createClusterRoleBindingV1(roleBinding)
-		assert.Error(t, err)
+		result, err := testClient.createOrUpdateClusterRoleBindingV1(roleBinding)
+		require.NoError(t, err)
+		require.Equal(t, roleBinding.GetName(), result.GetName())
 	})
 }
 
@@ -70,12 +72,13 @@ func TestClusterRoleBindingsBetaV1(t *testing.T) {
 	}
 
 	t.Run("create role binding", func(t *testing.T) {
-		result, err := testClient.createClusterRoleBindingBetaV1(roleBinding)
+		result, err := testClient.createOrUpdateClusterRoleBindingBetaV1(roleBinding)
 		require.NoError(t, err)
-		assert.Equal(t, roleBinding.GetName(), result.GetName())
+		require.Equal(t, roleBinding.GetName(), result.GetName())
 	})
 	t.Run("create duplicate role binding", func(t *testing.T) {
-		_, err := testClient.createClusterRoleBindingBetaV1(roleBinding)
-		assert.Error(t, err)
+		result, err := testClient.createOrUpdateClusterRoleBindingBetaV1(roleBinding)
+		require.NoError(t, err)
+		require.Equal(t, roleBinding.GetName(), result.GetName())
 	})
 }

--- a/internal/tools/k8s/custom_resources.go
+++ b/internal/tools/k8s/custom_resources.go
@@ -1,29 +1,52 @@
 package k8s
 
 import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	apixv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
-func (kc *KubeClient) createCustomResourceDefinition(crd *apixv1beta1.CustomResourceDefinition) (metav1.Object, error) {
-	client := kc.ApixClientset.ApiextensionsV1beta1().CustomResourceDefinitions()
-
-	result, err := client.Create(crd)
-	if err != nil {
+func (kc *KubeClient) createOrUpdateCustomResourceDefinition(crd *apixv1beta1.CustomResourceDefinition) (metav1.Object, error) {
+	_, err := kc.ApixClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	return result.GetObjectMeta(), nil
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.ApixClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
+	}
+
+	// TODO: investigate issue where standard update fails
+	// Trying to use a standard update on CRDs failed for the mysql operator
+	// custom resources definitions. This seems to be related to an issue
+	// where a last-modified value is set after the CRD is deployed to the
+	// kubernetes cluster.
+	// Error: invalid: metadata.resourceVersion: Invalid value: 0x0: must be
+	// specified for an update
+	// Workaround: https://github.com/zalando/postgres-operator/pull/558
+	patch, err := json.Marshal(crd)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not marshal new Custom Resource Defintion")
+	}
+
+	return kc.ApixClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Patch(crd.Name, types.MergePatchType, patch)
 }
 
-func (kc *KubeClient) createClusterInstallation(namespace string, ci *mmv1alpha1.ClusterInstallation) (metav1.Object, error) {
-	client := kc.MattermostClientset.MattermostV1alpha1().ClusterInstallations(namespace)
-
-	result, err := client.Create(ci)
-	if err != nil {
+func (kc *KubeClient) createOrUpdateClusterInstallation(namespace string, ci *mmv1alpha1.ClusterInstallation) (metav1.Object, error) {
+	_, err := kc.MattermostClientset.MattermostV1alpha1().ClusterInstallations(namespace).Get(ci.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	return result.GetObjectMeta(), nil
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.MattermostClientset.MattermostV1alpha1().ClusterInstallations(namespace).Create(ci)
+	}
+
+	return kc.MattermostClientset.MattermostV1alpha1().ClusterInstallations(namespace).Update(ci)
 }

--- a/internal/tools/k8s/custom_resources_test.go
+++ b/internal/tools/k8s/custom_resources_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apixv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,13 +16,14 @@ func TestCustomResourceDefinition(t *testing.T) {
 	}
 
 	t.Run("create custom resource definition", func(t *testing.T) {
-		result, err := testClient.createCustomResourceDefinition(customResourceDefinition)
+		result, err := testClient.createOrUpdateCustomResourceDefinition(customResourceDefinition)
 		require.NoError(t, err)
-		assert.Equal(t, customResourceDefinition.GetName(), result.GetName())
+		require.Equal(t, customResourceDefinition.GetName(), result.GetName())
 	})
 	t.Run("create duplicate custom resource definition", func(t *testing.T) {
-		_, err := testClient.createCustomResourceDefinition(customResourceDefinition)
-		assert.Error(t, err)
+		result, err := testClient.createOrUpdateCustomResourceDefinition(customResourceDefinition)
+		require.NoError(t, err)
+		require.Equal(t, customResourceDefinition.GetName(), result.GetName())
 	})
 }
 
@@ -35,12 +35,13 @@ func TestClusterInstallation(t *testing.T) {
 	namespace := "testing"
 
 	t.Run("create custom resource", func(t *testing.T) {
-		result, err := testClient.createClusterInstallation(namespace, customResource)
+		result, err := testClient.createOrUpdateClusterInstallation(namespace, customResource)
 		require.NoError(t, err)
-		assert.Equal(t, customResource.GetName(), result.GetName())
+		require.Equal(t, customResource.GetName(), result.GetName())
 	})
 	t.Run("create duplicate custom resource", func(t *testing.T) {
-		_, err := testClient.createClusterInstallation(namespace, customResource)
-		assert.Error(t, err)
+		result, err := testClient.createOrUpdateClusterInstallation(namespace, customResource)
+		require.NoError(t, err)
+		require.Equal(t, customResource.GetName(), result.GetName())
 	})
 }

--- a/internal/tools/k8s/deployments.go
+++ b/internal/tools/k8s/deployments.go
@@ -3,27 +3,32 @@ package k8s
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	appsbetav1 "k8s.io/api/apps/v1beta1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (kc *KubeClient) createDeploymentV1(namespace string, deployment *appsv1.Deployment) (metav1.Object, error) {
-	client := kc.Clientset.AppsV1().Deployments(namespace)
-
-	result, err := client.Create(deployment)
-	if err != nil {
+func (kc *KubeClient) createOrUpdateDeploymentV1(namespace string, deployment *appsv1.Deployment) (metav1.Object, error) {
+	_, err := kc.Clientset.AppsV1().Deployments(namespace).Get(deployment.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	return result.GetObjectMeta(), nil
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.Clientset.AppsV1().Deployments(namespace).Create(deployment)
+	}
+
+	return kc.Clientset.AppsV1().Deployments(namespace).Update(deployment)
 }
 
-func (kc *KubeClient) createDeploymentBetaV1(namespace string, deployment *appsbetav1.Deployment) (metav1.Object, error) {
-	client := kc.Clientset.AppsV1beta1().Deployments(namespace)
-
-	result, err := client.Create(deployment)
-	if err != nil {
+func (kc *KubeClient) createOrUpdateDeploymentBetaV1(namespace string, deployment *appsbetav1.Deployment) (metav1.Object, error) {
+	_, err := kc.Clientset.AppsV1beta1().Deployments(namespace).Get(deployment.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	return result.GetObjectMeta(), nil
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.Clientset.AppsV1beta1().Deployments(namespace).Create(deployment)
+	}
+
+	return kc.Clientset.AppsV1beta1().Deployments(namespace).Update(deployment)
 }

--- a/internal/tools/k8s/deployments_test.go
+++ b/internal/tools/k8s/deployments_test.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	appsbetav1 "k8s.io/api/apps/v1beta1"
@@ -18,13 +17,14 @@ func TestDeploymentsV1(t *testing.T) {
 	namespace := "testing"
 
 	t.Run("create deployment", func(t *testing.T) {
-		result, err := testClient.createDeploymentV1(namespace, deployment)
+		result, err := testClient.createOrUpdateDeploymentV1(namespace, deployment)
 		require.NoError(t, err)
-		assert.Equal(t, deployment.GetName(), result.GetName())
+		require.Equal(t, deployment.GetName(), result.GetName())
 	})
 	t.Run("create duplicate deployment", func(t *testing.T) {
-		_, err := testClient.createDeploymentV1(namespace, deployment)
-		assert.Error(t, err)
+		result, err := testClient.createOrUpdateDeploymentV1(namespace, deployment)
+		require.NoError(t, err)
+		require.Equal(t, deployment.GetName(), result.GetName())
 	})
 }
 
@@ -36,12 +36,13 @@ func TestDeploymentsBetaV1(t *testing.T) {
 	namespace := "testing"
 
 	t.Run("create deployment", func(t *testing.T) {
-		result, err := testClient.createDeploymentBetaV1(namespace, deployment)
+		result, err := testClient.createOrUpdateDeploymentBetaV1(namespace, deployment)
 		require.NoError(t, err)
-		assert.Equal(t, deployment.GetName(), result.GetName())
+		require.Equal(t, deployment.GetName(), result.GetName())
 	})
 	t.Run("create duplicate deployment", func(t *testing.T) {
-		_, err := testClient.createDeploymentBetaV1(namespace, deployment)
-		assert.Error(t, err)
+		result, err := testClient.createOrUpdateDeploymentBetaV1(namespace, deployment)
+		require.NoError(t, err)
+		require.Equal(t, deployment.GetName(), result.GetName())
 	})
 }

--- a/internal/tools/k8s/helpers_test.go
+++ b/internal/tools/k8s/helpers_test.go
@@ -50,7 +50,7 @@ func TestGetPodsFromDeployment(t *testing.T) {
 	namespace := "testing"
 
 	t.Run("create deployment", func(t *testing.T) {
-		result, err := testClient.createDeploymentV1(namespace, deployment)
+		result, err := testClient.createOrUpdateDeploymentV1(namespace, deployment)
 		require.NoError(t, err)
 		assert.Equal(t, deployment.GetName(), result.GetName())
 	})

--- a/internal/tools/k8s/namespaces.go
+++ b/internal/tools/k8s/namespaces.go
@@ -5,14 +5,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// CreateNamespaces creates kubernetes namespaces.
+// CreateNamespacesIfDoesNotExist creates kubernetes namespaces if they don't
+// exist already.
 //
 // Any errors will be returned immediately and the remaining namespaces will be
 // skipped.
-func (kc *KubeClient) CreateNamespaces(namespaceNames []string) ([]*corev1.Namespace, error) {
+func (kc *KubeClient) CreateNamespacesIfDoesNotExist(namespaceNames []string) ([]*corev1.Namespace, error) {
 	namespaces := []*corev1.Namespace{}
 	for _, namespaceName := range namespaceNames {
-		namespace, err := kc.CreateNamespace(namespaceName)
+		namespace, err := kc.CreateNamespaceIfDoesNotExist(namespaceName)
 		if err != nil {
 			return namespaces, err
 		}
@@ -22,9 +23,9 @@ func (kc *KubeClient) CreateNamespaces(namespaceNames []string) ([]*corev1.Names
 	return namespaces, nil
 }
 
-// CreateNamespace creates a kubernetes namespace.
-func (kc *KubeClient) CreateNamespace(namespaceName string) (*corev1.Namespace, error) {
-	// Check if namespace exists first.
+// CreateNamespaceIfDoesNotExist creates a kubernetes namespace if it doesn't
+// exist already.
+func (kc *KubeClient) CreateNamespaceIfDoesNotExist(namespaceName string) (*corev1.Namespace, error) {
 	ns, err := kc.Clientset.CoreV1().Namespaces().Get(namespaceName, metav1.GetOptions{})
 	if err == nil {
 		return ns, nil
@@ -64,14 +65,4 @@ func (kc *KubeClient) DeleteNamespaces(namespaceNames []string) error {
 	}
 
 	return nil
-}
-
-// DeleteNamespace returns a given kubernetes namespace object if it exists.
-func (kc *KubeClient) DeleteNamespace(namespaceName string) error {
-	clientset, err := kc.getKubeConfigClientset()
-	if err != nil {
-		return err
-	}
-
-	return clientset.CoreV1().Namespaces().Delete(namespaceName, nil)
 }

--- a/internal/tools/k8s/namespaces_test.go
+++ b/internal/tools/k8s/namespaces_test.go
@@ -12,7 +12,7 @@ func TestNamespaces(t *testing.T) {
 
 	namespaceNames := []string{"namespace1, namespace2, namespace3"}
 	t.Run("create namespaces", func(t *testing.T) {
-		namespaces, err := testClient.CreateNamespaces(namespaceNames)
+		namespaces, err := testClient.CreateNamespacesIfDoesNotExist(namespaceNames)
 		require.NoError(t, err)
 
 		var names []string

--- a/internal/tools/k8s/roles.go
+++ b/internal/tools/k8s/roles.go
@@ -3,27 +3,32 @@ package k8s
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	rbacbetav1 "k8s.io/api/rbac/v1beta1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (kc *KubeClient) createClusterRoleV1(account *rbacv1.ClusterRole) (metav1.Object, error) {
-	client := kc.Clientset.RbacV1().ClusterRoles()
-
-	result, err := client.Create(account)
-	if err != nil {
+func (kc *KubeClient) createOrUpdateClusterRoleV1(account *rbacv1.ClusterRole) (metav1.Object, error) {
+	_, err := kc.Clientset.RbacV1().ClusterRoles().Get(account.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	return result.GetObjectMeta(), nil
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.Clientset.RbacV1().ClusterRoles().Create(account)
+	}
+
+	return kc.Clientset.RbacV1().ClusterRoles().Update(account)
 }
 
-func (kc *KubeClient) createClusterRoleBetaV1(account *rbacbetav1.ClusterRole) (metav1.Object, error) {
-	client := kc.Clientset.RbacV1beta1().ClusterRoles()
-
-	result, err := client.Create(account)
-	if err != nil {
+func (kc *KubeClient) createOrUpdateClusterRoleBetaV1(account *rbacbetav1.ClusterRole) (metav1.Object, error) {
+	_, err := kc.Clientset.RbacV1beta1().ClusterRoles().Get(account.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	return result.GetObjectMeta(), nil
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.Clientset.RbacV1beta1().ClusterRoles().Create(account)
+	}
+
+	return kc.Clientset.RbacV1beta1().ClusterRoles().Update(account)
 }

--- a/internal/tools/k8s/roles_test.go
+++ b/internal/tools/k8s/roles_test.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 	rbacbetav1 "k8s.io/api/rbac/v1beta1"
@@ -17,13 +16,14 @@ func TestClusterRolesV1(t *testing.T) {
 	}
 
 	t.Run("create cluster role", func(t *testing.T) {
-		result, err := testClient.createClusterRoleV1(clusterRole)
+		result, err := testClient.createOrUpdateClusterRoleV1(clusterRole)
 		require.NoError(t, err)
-		assert.Equal(t, clusterRole.GetName(), result.GetName())
+		require.Equal(t, clusterRole.GetName(), result.GetName())
 	})
 	t.Run("create duplicate cluster role", func(t *testing.T) {
-		_, err := testClient.createClusterRoleV1(clusterRole)
-		assert.Error(t, err)
+		result, err := testClient.createOrUpdateClusterRoleV1(clusterRole)
+		require.NoError(t, err)
+		require.Equal(t, clusterRole.GetName(), result.GetName())
 	})
 }
 
@@ -34,12 +34,13 @@ func TestClusterRolesBetaV1(t *testing.T) {
 	}
 
 	t.Run("create cluster role", func(t *testing.T) {
-		result, err := testClient.createClusterRoleBetaV1(clusterRole)
+		result, err := testClient.createOrUpdateClusterRoleBetaV1(clusterRole)
 		require.NoError(t, err)
-		assert.Equal(t, clusterRole.GetName(), result.GetName())
+		require.Equal(t, clusterRole.GetName(), result.GetName())
 	})
 	t.Run("create duplicate cluster role", func(t *testing.T) {
-		_, err := testClient.createClusterRoleBetaV1(clusterRole)
-		assert.Error(t, err)
+		result, err := testClient.createOrUpdateClusterRoleBetaV1(clusterRole)
+		require.NoError(t, err)
+		require.Equal(t, clusterRole.GetName(), result.GetName())
 	})
 }

--- a/internal/tools/k8s/service_accounts.go
+++ b/internal/tools/k8s/service_accounts.go
@@ -2,16 +2,19 @@ package k8s
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (kc *KubeClient) createServiceAccount(namespace string, account *corev1.ServiceAccount) (metav1.Object, error) {
-	client := kc.Clientset.CoreV1().ServiceAccounts(namespace)
-
-	result, err := client.Create(account)
-	if err != nil {
+func (kc *KubeClient) createOrUpdateServiceAccount(namespace string, account *corev1.ServiceAccount) (metav1.Object, error) {
+	_, err := kc.Clientset.CoreV1().ServiceAccounts(namespace).Get(account.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	return result.GetObjectMeta(), nil
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.Clientset.CoreV1().ServiceAccounts(namespace).Create(account)
+	}
+
+	return kc.Clientset.CoreV1().ServiceAccounts(namespace).Update(account)
 }

--- a/internal/tools/k8s/service_accounts_test.go
+++ b/internal/tools/k8s/service_accounts_test.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,12 +16,13 @@ func TestServiceAccounts(t *testing.T) {
 	namespace := "testing"
 
 	t.Run("create service account", func(t *testing.T) {
-		result, err := testClient.createServiceAccount(namespace, serviceAccount)
+		result, err := testClient.createOrUpdateServiceAccount(namespace, serviceAccount)
 		require.NoError(t, err)
-		assert.Equal(t, serviceAccount.GetName(), result.GetName())
+		require.Equal(t, serviceAccount.GetName(), result.GetName())
 	})
 	t.Run("create duplicate service account", func(t *testing.T) {
-		_, err := testClient.createServiceAccount(namespace, serviceAccount)
-		assert.Error(t, err)
+		result, err := testClient.createOrUpdateServiceAccount(namespace, serviceAccount)
+		require.NoError(t, err)
+		require.Equal(t, serviceAccount.GetName(), result.GetName())
 	})
 }


### PR DESCRIPTION
This new state contains the logic for creating the k8s operators
that are necessary to deploy Mattermost installations. This process
used to occur directly after cluster creation with no separation.
Now, clusters can be 'provisioned' again in the stable state, which
will update all operator resources to the newest version contained
in the provisioner manifests.

This change also does the following:
 - Refactors much of the k8s client library to support updates of
   previously-created k8s resources.
 - Fixes a unit test bug where we were not properly checking that
   the right cluster states were being returned for work by the
   supervisor.
 - Cleans up logging in various places.

Ticket: https://mattermost.atlassian.net/browse/MM-16413