### PR TITLE
Always pull operator images

### DIFF
--- a/operator-manifests/mattermost/operator.yaml
+++ b/operator-manifests/mattermost/operator.yaml
@@ -16,9 +16,9 @@ spec:
       containers:
         - name: mattermost-operator
           image: mattermost/mattermost-operator:latest
+          imagePullPolicy: Always
           command:
           - mattermost-operator
-          imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
               value: ""

--- a/operator-manifests/minio/minio-operator.yaml
+++ b/operator-manifests/minio/minio-operator.yaml
@@ -90,3 +90,4 @@ spec:
       containers:
       - name: minio-operator
         image: minio/k8s-operator:latest
+        imagePullPolicy: Always

--- a/operator-manifests/mysql/mysql-operator.yaml
+++ b/operator-manifests/mysql/mysql-operator.yaml
@@ -231,8 +231,8 @@ spec:
       serviceAccountName: mysql-operator
       containers:
       - name: mysql-operator-controller
-        imagePullPolicy: IfNotPresent
         image: iad.ocir.io/oracle/mysql-operator:0.3.0
+        imagePullPolicy: Always
         ports:
         - containerPort: 10254
         args:


### PR DESCRIPTION
This ensures we don't get stale operator images on long-lived clusters.