### PR TITLE
MM-16219 Replacing exec commands with k8s client

### DIFF
--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -14,6 +14,8 @@ import (
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -268,7 +270,7 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 	}
 
 	// Setup Helm
-	err = helmSetup(logger, kops)
+	err = helmSetup(logger, k8sClient, kops)
 	if err != nil {
 		return err
 	}
@@ -389,27 +391,39 @@ func installHelmChart(chart helmDeployment, logger log.FieldLogger, configPath s
 }
 
 // helmSetup is used for the initial setup of Helm in cluster.
-func helmSetup(logger log.FieldLogger, kops *kops.Cmd) error {
+func helmSetup(logger log.FieldLogger, k8sClient *k8s.KubeClient, kops *kops.Cmd) error {
+
 	logger.Info("Initializing Helm in the cluster")
 	err := exec.Command("helm", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--upgrade").Run()
 	if err != nil {
 		return err
 	}
+
 	logger.Info("Creating Tiller service account")
-	err = exec.Command("kubectl", "--kubeconfig", kops.GetKubeConfigPath(), "--namespace", "kube-system", "create", "serviceaccount", "tiller").Run()
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "tiller"},
+	}
+	_, err = k8sClient.Clientset.CoreV1().ServiceAccounts("kube-system").Create(serviceAccount)
 	if err != nil {
 		return err
 	}
+	logger.Info("Successfully created Tiller service account")
+
 	logger.Info("Creating Tiller cluster role bind")
-	err = exec.Command("kubectl", "--kubeconfig", kops.GetKubeConfigPath(), "create", "clusterrolebinding", "tiller-cluster-rule", "--clusterrole=cluster-admin", "--serviceaccount=kube-system:tiller").Run()
+	roleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "tiller-cluster-rule"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "tiller", Namespace: "kube-system"},
+		},
+		RoleRef: rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
+	}
+
+	_, err = k8sClient.Clientset.RbacV1().ClusterRoleBindings().Create(roleBinding)
 	if err != nil {
 		return err
 	}
-	logger.Info("Patching tiller")
-	err = exec.Command("kubectl", "--kubeconfig", kops.GetKubeConfigPath(), "--namespace", "kube-system", "patch", "deploy", "tiller-deploy", "-p", "{\"spec\":{\"template\":{\"spec\":{\"serviceAccount\":\"tiller\"}}}}").Run()
-	if err != nil {
-		return err
-	}
+	logger.Info("Successfully created cluster role bind")
+
 	logger.Info("Upgrade Helm")
 	err = exec.Command("helm", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--service-account", "tiller", "--upgrade").Run()
 	if err != nil {


### PR DESCRIPTION
Ticket -> https://mattermost.atlassian.net/browse/MM-16219

- Exec commands were used to deploy Helm k8s services.
- Exec commands replaced by k8s client.