### PR TITLE
[MM-16407] Add no-compatible-clusters state for installations

### DIFF
--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -295,6 +295,7 @@ func handleDeleteInstallation(c *Context, w http.ResponseWriter, r *http.Request
 	switch installation.State {
 	case model.InstallationStateStable:
 	case model.InstallationStateCreationRequested:
+	case model.InstallationStateCreationNoCompatibleClusters:
 	case model.InstallationStateCreationFailed:
 	case model.InstallationStateDeletionRequested:
 	case model.InstallationStateDeletionInProgress:

--- a/internal/model/installation.go
+++ b/internal/model/installation.go
@@ -12,6 +12,9 @@ const (
 	InstallationStateCreationDNS = "creation-configuring-dns"
 	// InstallationStateCreationFailed is an installation that failed creation.
 	InstallationStateCreationFailed = "creation-failed"
+	// InstallationStateCreationNoCompatibleClusters is an installation that
+	// can't be fully created because there are no compatible clusters.
+	InstallationStateCreationNoCompatibleClusters = "creation-no-compatible-clusters"
 	// InstallationStateDeletionRequested is an installation to be deleted.
 	InstallationStateDeletionRequested = "deletion-requested"
 	// InstallationStateDeletionInProgress is an installation being deleted.

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -41,6 +41,7 @@ func (sqlStore *SQLStore) GetUnlockedInstallationsPendingWork() ([]*model.Instal
 			"State": []string{
 				model.InstallationStateCreationRequested,
 				model.InstallationStateCreationDNS,
+				model.InstallationStateCreationNoCompatibleClusters,
 				model.InstallationStateUpgradeRequested,
 				model.InstallationStateUpgradeInProgress,
 				model.InstallationStateDeletionInProgress,

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -118,6 +118,9 @@ func (s *InstallationSupervisor) transitionInstallation(installation *model.Inst
 	case model.InstallationStateCreationRequested:
 		return s.createInstallation(installation, instanceID, logger)
 
+	case model.InstallationStateCreationNoCompatibleClusters:
+		return s.createInstallation(installation, instanceID, logger)
+
 	case model.InstallationStateCreationDNS:
 		return s.configureInstallationDNS(installation, logger)
 
@@ -197,9 +200,9 @@ func (s *InstallationSupervisor) createInstallation(installation *model.Installa
 	}
 
 	// TODO: Support creating a cluster on demand if no existing cluster meets the criteria.
-	logger.Debug("No empty clusters available for installation")
+	logger.Debug("No compatible clusters available for installation")
 
-	return installation.State
+	return model.InstallationStateCreationNoCompatibleClusters
 }
 
 // createClusterInstallation attempts to schedule a cluster installation onto the given cluster.


### PR DESCRIPTION
This new state is reached by an installation when there are no
clusters that can run said installation. This could happen due
to clusters being full, or an installation requiring isolation
and being in a state with no empty clusters.

https://mattermost.atlassian.net/browse/MM-16407