### PR TITLE
Allow deletion of clusters in provision-failed state

### DIFF
--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -263,6 +263,7 @@ func handleDeleteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 	case model.ClusterStateStable:
 	case model.ClusterStateCreationRequested:
 	case model.ClusterStateCreationFailed:
+	case model.ClusterStateProvisioningFailed:
 	case model.ClusterStateUpgradeRequested:
 	case model.ClusterStateUpgradeFailed:
 	case model.ClusterStateDeletionRequested:

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -706,6 +706,7 @@ func TestDeleteCluster(t *testing.T) {
 		model.ClusterStateStable,
 		model.ClusterStateCreationRequested,
 		model.ClusterStateCreationFailed,
+		model.ClusterStateProvisioningFailed,
 		model.ClusterStateUpgradeRequested,
 		model.ClusterStateUpgradeFailed,
 		model.ClusterStateDeletionRequested,


### PR DESCRIPTION
This permits the provisioner to attempt to delete clusters that
are currently in the provisioning-failed state.

Note: the delete process makes a bunch of assumptions about
the cluster. Mainly, it assumes that it was fully stable and healthy
which means that it could fail deletion still.