### PR TITLE
Check for empty strings on DNS registration

### DIFF
--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -21,6 +21,11 @@ func (a *Client) CreateCNAME(dnsName string, dnsEndpoints []string, logger log.F
 	if len(dnsEndpoints) == 0 {
 		return errors.New("no DNS endpoints provided for route53 creation request")
 	}
+	for _, endpoint := range dnsEndpoints {
+		if endpoint == "" {
+			return errors.New("at least one of the DNS endpoints was set to an empty string")
+		}
+	}
 
 	svc, err := a.api.getRoute53Client()
 	if err != nil {

--- a/internal/tools/aws/route53_test.go
+++ b/internal/tools/aws/route53_test.go
@@ -59,8 +59,14 @@ func TestCreateCNAME(t *testing.T) {
 			nil,
 			false,
 		}, {
-			"session client error",
+			"empty string endpoint",
 			"dns4",
+			[]string{"example1.mattermost.com", ""},
+			nil,
+			true,
+		}, {
+			"session client error",
+			"dns5",
 			[]string{"example1.mattermost.com", "example2.mattermost.com"},
 			errors.New("mock api error"),
 			true,


### PR DESCRIPTION
This additional check ensures that DNS registration is not
attempted when an empty string is passed in.