### PR TITLE
[MM-17247] Run Mattermost CLI commands on cluster installations

### DIFF
--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -13,10 +13,16 @@ func (s *mockSupervisor) Do() error {
 }
 
 type mockProvisioner struct {
+	Output       []byte
+	CommandError error
 }
 
 func (s *mockProvisioner) ExecMattermostCLI(*model.Cluster, *model.ClusterInstallation, ...string) ([]byte, error) {
-	return []byte(`{"ServiceSettings":{"SiteURL":"http://test.example.com"}}`), nil
+	if len(s.Output) == 0 {
+		s.Output = []byte(`{"ServiceSettings":{"SiteURL":"http://test.example.com"}}`)
+	}
+
+	return s.Output, s.CommandError
 }
 
 func (s *mockProvisioner) GetClusterResources(*model.Cluster) (*k8s.ClusterResources, error) {

--- a/internal/tools/k8s/helpers.go
+++ b/internal/tools/k8s/helpers.go
@@ -65,13 +65,15 @@ func (kc *KubeClient) RemoteCommand(method string, url *url.URL) ([]byte, error)
 		Stderr: &stderr,
 		Tty:    false,
 	})
+	output := append(stdout.Bytes(), stderr.Bytes()...)
+
 	if err != nil {
 		if exitErr, ok := err.(utilexec.ExitError); ok && exitErr.Exited() {
-			return nil, errors.Errorf("remote command failed with exit status %d: %s%s", exitErr.ExitStatus(), stdout.String(), stderr.String())
+			return output, errors.Errorf("remote command failed with exit status %d: %s%s", exitErr.ExitStatus(), stdout.String(), stderr.String())
 		}
 
-		return nil, errors.Wrapf(err, "remote command failed: %s%s", stdout.String(), stderr.String())
+		return output, errors.Wrapf(err, "remote command failed: %s%s", stdout.String(), stderr.String())
 	}
 
-	return stdout.Bytes(), nil
+	return output, nil
 }

--- a/model/client.go
+++ b/model/client.go
@@ -400,6 +400,25 @@ func (c *Client) SetClusterInstallationConfig(clusterInstallationID string, conf
 	}
 }
 
+// RunMattermostCLICommandOnClusterInstallation runs a Mattermost CLI command against a cluster installation.
+func (c *Client) RunMattermostCLICommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error) {
+	resp, err := c.doPost(c.buildURL("/api/cluster_installation/%s/mattermost_cli", clusterInstallationID), subcommand)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	bytes, _ := ioutil.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return bytes, nil
+
+	default:
+		return bytes, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // CreateGroup requests the creation of a group from the configured provisioning server.
 func (c *Client) CreateGroup(request *CreateGroupRequest) (*Group, error) {
 	resp, err := c.doPost(c.buildURL("/api/groups"), request)

--- a/model/cluster_installation_request.go
+++ b/model/cluster_installation_request.go
@@ -44,3 +44,17 @@ func NewClusterInstallationConfigRequestFromReader(reader io.Reader) (ClusterIns
 
 	return clusterInstallationConfigRequest, nil
 }
+
+// ClusterInstallationMattermostCLISubcommand describes the payload necessary to run Mattermost CLI on a cluster installation.
+type ClusterInstallationMattermostCLISubcommand []string
+
+// NewClusterInstallationMattermostCLISubcommandFromReader will create a ClusterInstallationMattermostCLISubcommand from an io.Reader.
+func NewClusterInstallationMattermostCLISubcommandFromReader(reader io.Reader) (ClusterInstallationMattermostCLISubcommand, error) {
+	var clusterInstallationMattermostCLISubcommand ClusterInstallationMattermostCLISubcommand
+	err := json.NewDecoder(reader).Decode(&clusterInstallationMattermostCLISubcommand)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode cluster installation mattermost CLI request")
+	}
+
+	return clusterInstallationMattermostCLISubcommand, nil
+}


### PR DESCRIPTION
This change adds the functionality to run arbitrary Mattermost
CLI commands against remote cluster installations. Output from
these commands is captured and returned.

https://mattermost.atlassian.net/browse/MM-17247