### PR TITLE
not fail if coveralls is down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
     - *save_cache
     - run:
         name: coveralls
-        command: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken $COVERALLS_REPO_TOKEN
+        command: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken $COVERALLS_REPO_TOKEN || true
 
   test-postgres:
     docker:


### PR DESCRIPTION
coverall is down since yestarday or more and the pipeline is failing.
This change not fail the pipeline if we cannot push the results to coveralls


will do the same for the operator. we need to fix that to have a green pipeline and then be able to deploy
```
#!/bin/bash -eo pipefail
goveralls -coverprofile=coverage.out -service=circle-ci -repotoken $COVERALLS_REPO_TOKEN
Bad response status from coveralls: 405
<html>
<head><title>405 Not Allowed</title></head>
<body bgcolor="white">
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx</center>
</body>
```