### PR TITLE
[MM-17415] Add cloud server webhooks

### DIFF
--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -25,6 +25,7 @@ func init() {
 	rootCmd.AddCommand(installationCmd)
 	rootCmd.AddCommand(groupCmd)
 	rootCmd.AddCommand(schemaCmd)
+	rootCmd.AddCommand(webhookCmd)
 	rootCmd.AddCommand(completionCmd)
 }
 

--- a/cmd/cloud/webhook.go
+++ b/cmd/cloud/webhook.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	webhookCmd.PersistentFlags().String("server", "http://localhost:8075", "The provisioning server whose API will be queried.")
+
+	webhookCreateCmd.Flags().String("owner", "", "An opaque identifier describing the owner of the webhook.")
+	webhookCreateCmd.Flags().String("url", "", "The callback URL of the webhook.")
+	webhookCreateCmd.MarkFlagRequired("owner")
+	webhookCreateCmd.MarkFlagRequired("url")
+
+	webhookGetCmd.Flags().String("webhook", "", "The id of the webhook to be fetched.")
+	webhookGetCmd.MarkFlagRequired("webhook")
+
+	webhookListCmd.Flags().String("owner", "", "The owner by which to filter webhooks.")
+	webhookListCmd.Flags().Int("page", 0, "The page of webhooks to fetch, starting at 0.")
+	webhookListCmd.Flags().Int("per-page", 100, "The number of webhooks to fetch per page.")
+	webhookListCmd.Flags().Bool("include-deleted", false, "Whether to include deleted webhooks.")
+
+	webhookDeleteCmd.Flags().String("webhook", "", "The id of the webhook to be deleted.")
+	webhookDeleteCmd.MarkFlagRequired("webhook")
+
+	webhookCmd.AddCommand(webhookCreateCmd)
+	webhookCmd.AddCommand(webhookGetCmd)
+	webhookCmd.AddCommand(webhookListCmd)
+	webhookCmd.AddCommand(webhookDeleteCmd)
+}
+
+var webhookCmd = &cobra.Command{
+	Use:   "webhook",
+	Short: "Manipulate webhooks managed by the provisioning server.",
+}
+
+var webhookCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a webhook.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		ownerID, _ := command.Flags().GetString("owner")
+		url, _ := command.Flags().GetString("url")
+
+		webhook, err := client.CreateWebhook(&model.CreateWebhookRequest{
+			OwnerID: ownerID,
+			URL:     url,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to create webhook")
+		}
+
+		err = printJSON(webhook)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var webhookGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get a particular webhook.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		webhookID, _ := command.Flags().GetString("webhook")
+		webhook, err := client.GetWebhook(webhookID)
+		if err != nil {
+			return errors.Wrap(err, "failed to query webhook")
+		}
+		if webhook == nil {
+			return nil
+		}
+
+		err = printJSON(webhook)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var webhookListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List created webhooks.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		owner, _ := command.Flags().GetString("owner")
+		page, _ := command.Flags().GetInt("page")
+		perPage, _ := command.Flags().GetInt("per-page")
+		includeDeleted, _ := command.Flags().GetBool("include-deleted")
+		webhooks, err := client.GetWebhooks(&model.GetWebhooksRequest{
+			OwnerID:        owner,
+			Page:           page,
+			PerPage:        perPage,
+			IncludeDeleted: includeDeleted,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to query webhooks")
+		}
+
+		err = printJSON(webhooks)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var webhookDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a webhook.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		webhookID, _ := command.Flags().GetString("webhook")
+
+		err := client.DeleteWebhook(webhookID)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete webhook")
+		}
+
+		return nil
+	},
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -10,4 +10,5 @@ func Register(rootRouter *mux.Router, context *Context) {
 	initInstallation(apiRouter, context)
 	initClusterInstallation(apiRouter, context)
 	initGroup(apiRouter, context)
+	initWebhook(apiRouter, context)
 }

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -37,6 +37,11 @@ type Store interface {
 	GetGroups(filter *model.GroupFilter) ([]*model.Group, error)
 	UpdateGroup(group *model.Group) error
 	DeleteGroup(groupID string) error
+
+	CreateWebhook(webhook *model.Webhook) error
+	GetWebhook(webhookID string) (*model.Webhook, error)
+	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
+	DeleteWebhook(webhookID string) error
 }
 
 // Provisioner describes the interface required to communicate with the Kubernetes cluster.

--- a/internal/api/webhook.go
+++ b/internal/api/webhook.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+// initWebhook registers webhook endpoints on the given router.
+func initWebhook(apiRouter *mux.Router, context *Context) {
+	addContext := func(handler contextHandlerFunc) *contextHandler {
+		return newContextHandler(context, handler)
+	}
+
+	webhooksRouter := apiRouter.PathPrefix("/webhooks").Subrouter()
+	webhooksRouter.Handle("", addContext(handleGetWebhooks)).Methods("GET")
+	webhooksRouter.Handle("", addContext(handleCreateWebhook)).Methods("POST")
+
+	webhookRouter := apiRouter.PathPrefix("/webhook/{webhook:[A-Za-z0-9]{26}}").Subrouter()
+	webhookRouter.Handle("", addContext(handleGetWebhook)).Methods("GET")
+	webhookRouter.Handle("", addContext(handleDeleteWebhook)).Methods("DELETE")
+}
+
+// handleCreateWebhook responds to POST /api/webhooks, creating a new webhook.
+func handleCreateWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
+	createWebhookRequest, err := model.NewCreateWebhookRequestFromReader(r.Body)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to decode request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	webhook := model.Webhook{
+		OwnerID: createWebhookRequest.OwnerID,
+		URL:     createWebhookRequest.URL,
+	}
+
+	err = c.Store.CreateWebhook(&webhook)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to create webhook")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	outputJSON(c, w, webhook)
+}
+
+// handleGetWebhook responds to GET /api/webhook/{webhook}, returning the webhook in question.
+func handleGetWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	webhookID := vars["webhook"]
+	c.Logger = c.Logger.WithField("webhook", webhookID)
+
+	webhook, err := c.Store.GetWebhook(webhookID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query installation")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if webhook == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	outputJSON(c, w, webhook)
+}
+
+// handleGetWebhooks responds to GET /api/webhooks, returning the specified page of webhooks.
+func handleGetWebhooks(c *Context, w http.ResponseWriter, r *http.Request) {
+	var err error
+	owner := r.URL.Query().Get("owner")
+
+	page, perPage, includeDeleted, err := parsePaging(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse paging parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	filter := &model.WebhookFilter{
+		OwnerID:        owner,
+		Page:           page,
+		PerPage:        perPage,
+		IncludeDeleted: includeDeleted,
+	}
+
+	webhooks, err := c.Store.GetWebhooks(filter)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query webhooks")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if webhooks == nil {
+		webhooks = []*model.Webhook{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	outputJSON(c, w, webhooks)
+}
+
+// handleDeleteWebhook responds to DELETE /api/webhook/{webhook}, deleting the webhook.
+func handleDeleteWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	webhookID := vars["webhook"]
+	c.Logger = c.Logger.WithField("webhook", webhookID)
+
+	webhook, err := c.Store.GetWebhook(webhookID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query webhook")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if webhook == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	if webhook.IsDeleted() {
+		c.Logger.Warn("unable to delete webhook that is already deleted")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err = c.Store.DeleteWebhook(webhookID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to mark webhook as deleted")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/api/webhook_test.go
+++ b/internal/api/webhook_test.go
@@ -1,0 +1,305 @@
+package api_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateWebhook(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	t.Run("invalid payload", func(t *testing.T) {
+		resp, err := http.Post(fmt.Sprintf("%s/api/webhooks", ts.URL), "application/json", bytes.NewReader([]byte("invalid")))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("empty payload", func(t *testing.T) {
+		resp, err := http.Post(fmt.Sprintf("%s/api/webhooks", ts.URL), "application/json", bytes.NewReader([]byte("")))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("missing owner", func(t *testing.T) {
+		_, err := client.CreateWebhook(&model.CreateWebhookRequest{
+			URL: "https://validurl.com",
+		})
+		require.EqualError(t, err, "failed with status code 400")
+	})
+
+	t.Run("missing url", func(t *testing.T) {
+		_, err := client.CreateWebhook(&model.CreateWebhookRequest{
+			OwnerID: "owner",
+		})
+		require.EqualError(t, err, "failed with status code 400")
+	})
+
+	t.Run("invalid url", func(t *testing.T) {
+		_, err := client.CreateWebhook(&model.CreateWebhookRequest{
+			OwnerID: "owner",
+			URL:     "htp://invalidurl.com",
+		})
+		require.EqualError(t, err, "failed with status code 400")
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		webhook, err := client.CreateWebhook(&model.CreateWebhookRequest{
+			OwnerID: "owner",
+			URL:     "https://validurl.com",
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, webhook.ID)
+		require.Equal(t, "owner", webhook.OwnerID)
+		require.Equal(t, "https://validurl.com", webhook.URL)
+		require.NotEqual(t, 0, webhook.CreateAt)
+		require.EqualValues(t, 0, webhook.DeleteAt)
+	})
+}
+
+func TestGetWebhooks(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	t.Run("unknown webhook", func(t *testing.T) {
+		webhook, err := client.GetWebhook(model.NewID())
+		require.NoError(t, err)
+		require.Nil(t, webhook)
+	})
+
+	t.Run("no webhooks", func(t *testing.T) {
+		webhooks, err := client.GetWebhooks(&model.GetWebhooksRequest{
+			Page:           0,
+			PerPage:        10,
+			IncludeDeleted: true,
+		})
+		require.NoError(t, err)
+		require.Empty(t, webhooks)
+	})
+
+	t.Run("parameter handling", func(t *testing.T) {
+		t.Run("invalid page", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/webhooks?page=invalid&per_page=100", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("invalid perPage", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/webhooks?page=0&per_page=invalid", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("no paging parameters", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/webhooks", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("missing page", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/webhooks?per_page=100", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("missing perPage", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/webhooks?page=1", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	})
+
+	t.Run("results", func(t *testing.T) {
+		ownerID1 := model.NewID()
+		ownerID2 := model.NewID()
+
+		webhook1, err := client.CreateWebhook(&model.CreateWebhookRequest{
+			OwnerID: ownerID1,
+			URL:     "https://validurl1.com",
+		})
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		webhook2, err := client.CreateWebhook(&model.CreateWebhookRequest{
+			OwnerID: ownerID2,
+			URL:     "https://validurl2.com",
+		})
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		webhook3, err := client.CreateWebhook(&model.CreateWebhookRequest{
+			OwnerID: ownerID1,
+			URL:     "https://validurl3.com",
+		})
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		webhook4, err := client.CreateWebhook(&model.CreateWebhookRequest{
+			OwnerID: ownerID2,
+			URL:     "https://validurl4.com",
+		})
+		err = sqlStore.DeleteWebhook(webhook4.ID)
+		require.NoError(t, err)
+		webhook4, err = client.GetWebhook(webhook4.ID)
+		require.NoError(t, err)
+
+		t.Run("get webhook", func(t *testing.T) {
+			t.Run("webhook 1", func(t *testing.T) {
+				webhook, err := client.GetWebhook(webhook1.ID)
+				require.NoError(t, err)
+				require.Equal(t, webhook1, webhook)
+			})
+
+			t.Run("get deleted webhook", func(t *testing.T) {
+				webhook, err := client.GetWebhook(webhook4.ID)
+				require.NoError(t, err)
+				require.Equal(t, webhook4, webhook)
+			})
+		})
+
+		t.Run("get installations", func(t *testing.T) {
+			testCases := []struct {
+				Description        string
+				GetWebhooksRequest *model.GetWebhooksRequest
+				Expected           []*model.Webhook
+			}{
+				{
+					"page 0, perPage 2, exclude deleted",
+					&model.GetWebhooksRequest{
+						Page:           0,
+						PerPage:        2,
+						IncludeDeleted: false,
+					},
+					[]*model.Webhook{webhook1, webhook2},
+				},
+
+				{
+					"page 1, perPage 2, exclude deleted",
+					&model.GetWebhooksRequest{
+						Page:           1,
+						PerPage:        2,
+						IncludeDeleted: false,
+					},
+					[]*model.Webhook{webhook3},
+				},
+
+				{
+					"page 0, perPage 2, include deleted",
+					&model.GetWebhooksRequest{
+						Page:           0,
+						PerPage:        2,
+						IncludeDeleted: true,
+					},
+					[]*model.Webhook{webhook1, webhook2},
+				},
+
+				{
+					"page 1, perPage 2, include deleted",
+					&model.GetWebhooksRequest{
+						Page:           1,
+						PerPage:        2,
+						IncludeDeleted: true,
+					},
+					[]*model.Webhook{webhook3, webhook4},
+				},
+				{
+					"filter by owner",
+					&model.GetWebhooksRequest{
+						Page:           0,
+						PerPage:        100,
+						OwnerID:        ownerID1,
+						IncludeDeleted: false,
+					},
+					[]*model.Webhook{webhook1, webhook3},
+				},
+			}
+
+			for _, testCase := range testCases {
+				t.Run(testCase.Description, func(t *testing.T) {
+					webhooks, err := client.GetWebhooks(testCase.GetWebhooksRequest)
+					require.NoError(t, err)
+					require.Equal(t, testCase.Expected, webhooks)
+				})
+			}
+		})
+	})
+}
+
+func TestDeleteWebhook(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	webhook, err := client.CreateWebhook(&model.CreateWebhookRequest{
+		OwnerID: "owner",
+		URL:     "https://validurl.com",
+	})
+	require.NoError(t, err)
+
+	t.Run("unknown webhook", func(t *testing.T) {
+		err := client.DeleteWebhook(model.NewID())
+		require.EqualError(t, err, "failed with status code 404")
+	})
+
+	t.Run("known webhook", func(t *testing.T) {
+		err := client.DeleteWebhook(webhook.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("already deleted webhook", func(t *testing.T) {
+		err := client.DeleteWebhook(webhook.ID)
+		require.Error(t, err)
+	})
+
+	t.Run("ensure webhook is deleted", func(t *testing.T) {
+		webhook, err := client.GetWebhook(webhook.ID)
+		require.NoError(t, err)
+		require.True(t, webhook.IsDeleted())
+	})
+}

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -362,12 +362,37 @@ var migrations = []migration{
 		return nil
 	}},
 	{semver.MustParse("0.6.0"), semver.MustParse("0.7.0"), func(e execer) error {
+		// Add installation license column.
 		_, err := e.Exec(`ALTER TABLE Installation ADD COLUMN License TEXT NULL;`)
 		if err != nil {
 			return err
 		}
 
 		_, err = e.Exec(`UPDATE Installation SET License = '';`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
+	{semver.MustParse("0.7.0"), semver.MustParse("0.8.0"), func(e execer) error {
+		// Add webhook table.
+		_, err := e.Exec(`
+			CREATE TABLE Webhooks (
+				ID TEXT PRIMARY KEY,
+				OwnerID TEXT NOT NULL,
+				URL TEXT NOT NULL,
+				CreateAt BIGINT NOT NULL,
+				DeleteAt BIGINT NOT NULL
+			);
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+			CREATE UNIQUE INDEX Webhook_URL_DeleteAt ON Webhooks (URL, DeleteAt);
+		`)
 		if err != nil {
 			return err
 		}

--- a/internal/store/webhook.go
+++ b/internal/store/webhook.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"database/sql"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+var webhookSelect sq.SelectBuilder
+
+func init() {
+	webhookSelect = sq.
+		Select("ID", "OwnerID", "URL", "CreateAt", "DeleteAt").From("Webhooks")
+}
+
+// GetWebhook fetches the given webhook by id.
+func (sqlStore *SQLStore) GetWebhook(id string) (*model.Webhook, error) {
+	var webhook model.Webhook
+	err := sqlStore.getBuilder(sqlStore.db, &webhook,
+		webhookSelect.Where("ID = ?", id),
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Wrap(err, "failed to get webhook by id")
+	}
+
+	return &webhook, nil
+}
+
+// GetWebhooks fetches the given page of created webhooks. The first page is 0.
+func (sqlStore *SQLStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error) {
+	builder := webhookSelect.
+		OrderBy("CreateAt ASC")
+
+	if filter.PerPage != model.AllPerPage {
+		builder = builder.
+			Limit(uint64(filter.PerPage)).
+			Offset(uint64(filter.Page * filter.PerPage))
+	}
+
+	if filter.OwnerID != "" {
+		builder = builder.Where("OwnerID = ?", filter.OwnerID)
+	}
+	if !filter.IncludeDeleted {
+		builder = builder.Where("DeleteAt = 0")
+	}
+
+	var webhooks []*model.Webhook
+	err := sqlStore.selectBuilder(sqlStore.db, &webhooks, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query for webhooks")
+	}
+
+	return webhooks, nil
+}
+
+// CreateWebhook records the given webhook to the database, assigning it a unique ID.
+func (sqlStore *SQLStore) CreateWebhook(webhook *model.Webhook) error {
+	webhook.ID = model.NewID()
+	webhook.CreateAt = GetMillis()
+
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Insert("Webhooks").
+		SetMap(map[string]interface{}{
+			"ID":       webhook.ID,
+			"OwnerID":  webhook.OwnerID,
+			"URL":      webhook.URL,
+			"CreateAt": webhook.CreateAt,
+			"DeleteAt": 0,
+		}),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to create webhook")
+	}
+
+	return nil
+}
+
+// DeleteWebhook marks the given webhook as deleted, but does not remove the
+// record from the database.
+func (sqlStore *SQLStore) DeleteWebhook(id string) error {
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Update("Webhooks").
+		Set("DeleteAt", GetMillis()).
+		Where("ID = ?", id).
+		Where("DeleteAt = 0"),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to mark webhook as deleted")
+	}
+
+	return nil
+}

--- a/internal/store/webhook_test.go
+++ b/internal/store/webhook_test.go
@@ -1,0 +1,142 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhooks(t *testing.T) {
+	t.Run("get unknown webhook", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := MakeTestSQLStore(t, logger)
+
+		webhook, err := sqlStore.GetWebhook("unknown")
+		require.NoError(t, err)
+		require.Nil(t, webhook)
+	})
+
+	t.Run("get webhooks", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := MakeTestSQLStore(t, logger)
+
+		webhook1 := &model.Webhook{
+			OwnerID: "owner1",
+			URL:     "https://url1.com",
+		}
+
+		webhook2 := &model.Webhook{
+			OwnerID: "owner2",
+			URL:     "https://url2.com",
+		}
+
+		err := sqlStore.CreateWebhook(webhook1)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		err = sqlStore.CreateWebhook(webhook2)
+		require.NoError(t, err)
+
+		actualWebhook1, err := sqlStore.GetWebhook(webhook1.ID)
+		require.NoError(t, err)
+		require.Equal(t, webhook1, actualWebhook1)
+
+		actualWebhook2, err := sqlStore.GetWebhook(webhook2.ID)
+		require.NoError(t, err)
+		require.Equal(t, webhook2, actualWebhook2)
+
+		actualWebhooks, err := sqlStore.GetWebhooks(&model.WebhookFilter{Page: 0, PerPage: 0, IncludeDeleted: false})
+		require.NoError(t, err)
+		require.Empty(t, actualWebhooks)
+
+		actualWebhooks, err = sqlStore.GetWebhooks(&model.WebhookFilter{Page: 0, PerPage: 1, IncludeDeleted: false})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Webhook{webhook1}, actualWebhooks)
+
+		actualWebhooks, err = sqlStore.GetWebhooks(&model.WebhookFilter{Page: 0, PerPage: 10, IncludeDeleted: false})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Webhook{webhook1, webhook2}, actualWebhooks)
+
+		actualWebhooks, err = sqlStore.GetWebhooks(&model.WebhookFilter{Page: 0, PerPage: 1, IncludeDeleted: true})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Webhook{webhook1}, actualWebhooks)
+
+		actualWebhooks, err = sqlStore.GetWebhooks(&model.WebhookFilter{Page: 0, PerPage: 10, IncludeDeleted: true})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Webhook{webhook1, webhook2}, actualWebhooks)
+
+		actualWebhooks, err = sqlStore.GetWebhooks(&model.WebhookFilter{PerPage: model.AllPerPage, IncludeDeleted: true})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Webhook{webhook1, webhook2}, actualWebhooks)
+	})
+
+	t.Run("delete webhook", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := MakeTestSQLStore(t, logger)
+
+		webhook1 := &model.Webhook{
+			OwnerID: "owner1",
+			URL:     "https://url1.com",
+		}
+
+		webhook2 := &model.Webhook{
+			OwnerID: "owner2",
+			URL:     "https://url2.com",
+		}
+
+		err := sqlStore.CreateWebhook(webhook1)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		err = sqlStore.CreateWebhook(webhook2)
+		require.NoError(t, err)
+
+		err = sqlStore.DeleteWebhook(webhook1.ID)
+		require.NoError(t, err)
+
+		actualWebhook1, err := sqlStore.GetWebhook(webhook1.ID)
+		require.NoError(t, err)
+		require.NotEqual(t, 0, actualWebhook1.DeleteAt)
+		webhook1.DeleteAt = actualWebhook1.DeleteAt
+		require.Equal(t, webhook1, actualWebhook1)
+
+		actualWebhook2, err := sqlStore.GetWebhook(webhook2.ID)
+		require.NoError(t, err)
+		require.Equal(t, webhook2, actualWebhook2)
+
+		actualWebhooks, err := sqlStore.GetWebhooks(&model.WebhookFilter{Page: 0, PerPage: 0, IncludeDeleted: false})
+		require.NoError(t, err)
+		require.Empty(t, actualWebhooks)
+
+		actualWebhooks, err = sqlStore.GetWebhooks(&model.WebhookFilter{Page: 0, PerPage: 1, IncludeDeleted: false})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Webhook{webhook2}, actualWebhooks)
+
+		actualWebhooks, err = sqlStore.GetWebhooks(&model.WebhookFilter{Page: 0, PerPage: 10, IncludeDeleted: false})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Webhook{webhook2}, actualWebhooks)
+
+		actualWebhooks, err = sqlStore.GetWebhooks(&model.WebhookFilter{Page: 0, PerPage: 1, IncludeDeleted: true})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Webhook{webhook1}, actualWebhooks)
+
+		actualWebhooks, err = sqlStore.GetWebhooks(&model.WebhookFilter{Page: 0, PerPage: 10, IncludeDeleted: true})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Webhook{webhook1, webhook2}, actualWebhooks)
+
+		time.Sleep(1 * time.Millisecond)
+
+		// Deleting again shouldn't change timestamp
+		err = sqlStore.DeleteWebhook(webhook1.ID)
+		require.NoError(t, err)
+
+		actualWebhook1, err = sqlStore.GetWebhook(webhook1.ID)
+		require.NoError(t, err)
+		require.Equal(t, webhook1, actualWebhook1)
+	})
+}

--- a/internal/supervisor/cluster_installation_test.go
+++ b/internal/supervisor/cluster_installation_test.go
@@ -3,10 +3,10 @@ package supervisor_test
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/supervisor"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/require"
 
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
@@ -50,6 +50,10 @@ func (s *mockClusterInstallationStore) UpdateClusterInstallation(clusterInstalla
 }
 func (s *mockClusterInstallationStore) DeleteClusterInstallation(clusterInstallationID string) error {
 	return nil
+}
+
+func (s *mockClusterInstallationStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error) {
+	return nil, nil
 }
 
 type mockClusterInstallationProvisioner struct {

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -3,11 +3,11 @@ package supervisor_test
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/supervisor"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,6 +50,10 @@ func (s *mockClusterStore) UnlockCluster(clusterID string, lockerID string, forc
 
 func (s *mockClusterStore) DeleteCluster(clusterID string) error {
 	return nil
+}
+
+func (s *mockClusterStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error) {
+	return nil, nil
 }
 
 type mockClusterProvisioner struct {

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -90,6 +90,10 @@ func (s *mockInstallationStore) UpdateClusterInstallation(clusterInstallation *m
 	return nil
 }
 
+func (s *mockInstallationStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error) {
+	return nil, nil
+}
+
 type mockInstallationProvisioner struct {
 	UseCustomClusterResources bool
 	CustomClusterResources    *k8s.ClusterResources

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,0 +1,64 @@
+package webhook
+
+import (
+	"bytes"
+	"net/http"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type webhookStore interface {
+	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
+}
+
+// SendToAllWebhooks sends a given payload to all webhooks.
+func SendToAllWebhooks(store webhookStore, payload *model.WebhookPayload, logger *log.Entry) error {
+	hooks, err := store.GetWebhooks(&model.WebhookFilter{
+		PerPage:        model.AllPerPage,
+		IncludeDeleted: false,
+	})
+	if err != nil {
+		return errors.Wrap(err, "Failed to find webhooks")
+	}
+
+	sendWebhooks(hooks, payload, logger)
+
+	return nil
+}
+
+// sendWebhooks sends webhooks via fire-and-forget goroutines. The send-webhook
+// failures are logged, but not handled.
+func sendWebhooks(hooks []*model.Webhook, payload *model.WebhookPayload, logger *log.Entry) {
+	if len(hooks) == 0 {
+		return
+	}
+
+	logger.Debugf("Sending %d webhook(s)", len(hooks))
+
+	for _, hook := range hooks {
+		go sendWebhook(hook, payload, logger)
+	}
+}
+
+func sendWebhook(hook *model.Webhook, payload *model.WebhookPayload, logger *log.Entry) error {
+	payloadStr, err := payload.ToJSON()
+	if err != nil {
+		logger.WithField("webhookURL", hook.URL).WithError(err).Error("Unable to create payload string to send to webhook")
+		return errors.Wrap(err, "unable to create payload string to send to webhook")
+	}
+
+	req, err := http.NewRequest("POST", hook.URL, bytes.NewBuffer([]byte(payloadStr)))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err = client.Do(req)
+	if err != nil {
+		logger.WithField("webhookURL", hook.URL).WithError(err).Error("Unable to send webhook")
+		return errors.Wrap(err, "unable to send webhook")
+	}
+
+	return nil
+}

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -1,0 +1,80 @@
+package webhook
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/require"
+)
+
+type mockWebhookStore struct {
+	Webhooks []*model.Webhook
+}
+
+func (s *mockWebhookStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error) {
+	return s.Webhooks, nil
+}
+
+func TestGetAndSendWebhooks(t *testing.T) {
+	mockStore := &mockWebhookStore{}
+	logger := testlib.MakeLogger(t).WithFields(map[string]interface{}{
+		"webhooks-tests": true,
+	})
+
+	t.Run("no webhooks", func(t *testing.T) {
+		err := SendToAllWebhooks(mockStore, nil, logger)
+		require.NoError(t, err)
+	})
+
+	mockStore.Webhooks = append(mockStore.Webhooks, &model.Webhook{
+		ID:       model.NewID(),
+		OwnerID:  model.NewID(),
+		URL:      "https://test.com",
+		CreateAt: 10,
+		DeleteAt: 0,
+	})
+
+	t.Run("1 webhook", func(t *testing.T) {
+		err := SendToAllWebhooks(mockStore, nil, logger)
+		require.NoError(t, err)
+	})
+
+	mockStore.Webhooks = append(mockStore.Webhooks, &model.Webhook{
+		ID:       model.NewID(),
+		OwnerID:  model.NewID(),
+		URL:      "https://test2.com",
+		CreateAt: 10,
+		DeleteAt: 0,
+	})
+
+	t.Run("2 webhooks", func(t *testing.T) {
+		err := SendToAllWebhooks(mockStore, nil, logger)
+		require.NoError(t, err)
+	})
+}
+
+// TODO: add happy-path test.
+func TestSendWebhooks(t *testing.T) {
+	logger := testlib.MakeLogger(t).WithFields(map[string]interface{}{
+		"webhooks-tests": true,
+	})
+	hook := &model.Webhook{
+		ID:       model.NewID(),
+		OwnerID:  model.NewID(),
+		URL:      "https://not-a-real-host",
+		CreateAt: 10,
+		DeleteAt: 0,
+	}
+	payload := &model.WebhookPayload{
+		Type:      "type",
+		ID:        model.NewID(),
+		NewState:  "new_state",
+		OldState:  "old_state",
+		Timestamp: time.Now().UnixNano(),
+	}
+
+	err := sendWebhook(hook, payload, logger)
+	require.Contains(t, err.Error(), "unable to send webhook")
+}

--- a/model/webhook.go
+++ b/model/webhook.go
@@ -1,0 +1,82 @@
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+const (
+	// TypeCluster is the string value that represents a cluster.
+	TypeCluster = "cluster"
+	// TypeInstallation is the string value that represents an installation.
+	TypeInstallation = "installation"
+	// TypeClusterInstallation is the string value that represents a cluster
+	// installation.
+	TypeClusterInstallation = "cluster_installaton"
+)
+
+// Webhook is
+type Webhook struct {
+	ID       string
+	OwnerID  string
+	URL      string
+	CreateAt int64
+	DeleteAt int64
+}
+
+// WebhookFilter describes the parameters used to constrain a set of webhooks.
+type WebhookFilter struct {
+	OwnerID        string
+	Page           int
+	PerPage        int
+	IncludeDeleted bool
+}
+
+// WebhookPayload is the payload sent in every webhook.
+type WebhookPayload struct {
+	Timestamp int64  `json:"timestamp"`
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	NewState  string `json:"new_state"`
+	OldState  string `json:"old_state"`
+}
+
+// IsDeleted returns whether the webhook was marked as deleted or not.
+func (w *Webhook) IsDeleted() bool {
+	return w.DeleteAt != 0
+}
+
+// ToJSON returns a JSON string representation of the webhook payload.
+func (p *WebhookPayload) ToJSON() (string, error) {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}
+
+// WebhookFromReader decodes a json-encoded list of webhooks from the given io.Reader.
+func WebhookFromReader(reader io.Reader) (*Webhook, error) {
+	webhook := Webhook{}
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&webhook)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &webhook, nil
+}
+
+// WebhooksFromReader decodes a json-encoded webhook from the given io.Reader.
+func WebhooksFromReader(reader io.Reader) ([]*Webhook, error) {
+	webhooks := []*Webhook{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&webhooks)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return webhooks, nil
+}

--- a/model/webhook_request.go
+++ b/model/webhook_request.go
@@ -1,0 +1,67 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// CreateWebhookRequest specifies the parameters for a new webhook.
+type CreateWebhookRequest struct {
+	OwnerID string
+	URL     string
+}
+
+// NewCreateWebhookRequestFromReader will create a CreateWebhookRequest from an io.Reader with JSON data.
+func NewCreateWebhookRequestFromReader(reader io.Reader) (*CreateWebhookRequest, error) {
+	var createWebhookRequest CreateWebhookRequest
+	err := json.NewDecoder(reader).Decode(&createWebhookRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode create webhook request")
+	}
+
+	if createWebhookRequest.OwnerID == "" {
+		return nil, errors.New("must specify owner")
+	}
+	if createWebhookRequest.URL == "" {
+		return nil, errors.New("must specify callback URL")
+	}
+	uri, err := url.ParseRequestURI(createWebhookRequest.URL)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to parse callback URL")
+	}
+	switch uri.Scheme {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("'%s' is not a valid scheme: should be 'http' or 'https'", uri.Scheme)
+	}
+	if uri.Host == "" {
+		return nil, errors.New("must specify host")
+	}
+
+	return &createWebhookRequest, nil
+}
+
+// GetWebhooksRequest describes the parameters to request a list of webhooks.
+type GetWebhooksRequest struct {
+	OwnerID        string
+	Page           int
+	PerPage        int
+	IncludeDeleted bool
+}
+
+// ApplyToURL modifies the given url to include query string parameters for the request.
+func (request *GetWebhooksRequest) ApplyToURL(u *url.URL) {
+	q := u.Query()
+	q.Add("owner", request.OwnerID)
+	q.Add("page", strconv.Itoa(request.Page))
+	q.Add("per_page", strconv.Itoa(request.PerPage))
+	if request.IncludeDeleted {
+		q.Add("include_deleted", "true")
+	}
+	u.RawQuery = q.Encode()
+}

--- a/model/webhook_test.go
+++ b/model/webhook_test.go
@@ -1,0 +1,130 @@
+package model
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhookIsDeleted(t *testing.T) {
+	webhook := &Webhook{
+		DeleteAt: 0,
+	}
+
+	t.Run("not deleted", func(t *testing.T) {
+		require.False(t, webhook.IsDeleted())
+	})
+
+	webhook.DeleteAt = 1
+
+	t.Run("deleted", func(t *testing.T) {
+		require.True(t, webhook.IsDeleted())
+	})
+}
+
+func TestWebhookPayloadToJSON(t *testing.T) {
+	payload := &WebhookPayload{
+		Timestamp: 123456789,
+		ID:        "id",
+		Type:      "type",
+		NewState:  "state1",
+		OldState:  "state2",
+	}
+
+	expectedStr := `{"timestamp":123456789,"id":"id","type":"type","new_state":"state1","old_state":"state2"}`
+
+	payloadStr, err := payload.ToJSON()
+	require.NoError(t, err)
+	require.Equal(t, expectedStr, payloadStr)
+}
+
+func TestWebhookFromReader(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		webhook, err := WebhookFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &Webhook{}, webhook)
+	})
+
+	t.Run("invalid request", func(t *testing.T) {
+		webhook, err := WebhookFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, webhook)
+	})
+
+	t.Run("request", func(t *testing.T) {
+		webhook, err := WebhookFromReader(bytes.NewReader([]byte(`{
+			"ID":"id",
+			"OwnerID":"owner",
+			"URL":"https://domain.com",
+			"CreateAt":10,
+			"DeleteAt":20
+		}`)))
+		require.NoError(t, err)
+		require.Equal(t, &Webhook{
+			ID:       "id",
+			OwnerID:  "owner",
+			URL:      "https://domain.com",
+			CreateAt: 10,
+			DeleteAt: 20,
+		}, webhook)
+	})
+}
+
+func TestWebhooksFromReader(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		webhooks, err := WebhooksFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*Webhook{}, webhooks)
+	})
+
+	t.Run("invalid request", func(t *testing.T) {
+		webhooks, err := WebhooksFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, webhooks)
+	})
+
+	t.Run("request", func(t *testing.T) {
+		webhooks, err := WebhooksFromReader(bytes.NewReader([]byte(`[
+			{
+				"ID":"id1",
+				"OwnerID":"owner1",
+				"URL":"https://domain1.com",
+				"CreateAt":10,
+				"DeleteAt":20
+			},
+			{
+				"ID":"id2",
+				"OwnerID":"owner2",
+				"URL":"https://domain2.com",
+				"CreateAt":30,
+				"DeleteAt":40
+			}
+		]`)))
+		require.NoError(t, err)
+		require.Equal(t, []*Webhook{
+			&Webhook{
+				ID:       "id1",
+				OwnerID:  "owner1",
+				URL:      "https://domain1.com",
+				CreateAt: 10,
+				DeleteAt: 20,
+			},
+			&Webhook{
+				ID:       "id2",
+				OwnerID:  "owner2",
+				URL:      "https://domain2.com",
+				CreateAt: 30,
+				DeleteAt: 40,
+			},
+		}, webhooks)
+	})
+}


### PR DESCRIPTION
This change introduces webhooks to the cloud provisioning server.
These webhooks can be registered in order to receive a stream of
events from the server. The payload of the webhooks contains state
information the various clusters, installations, and cluster
installations as the server moves them from one state to another.
This allows clients of the cloud server to know when resources
they care about have reached a desired state or for general logging
and troubleshooting.

https://mattermost.atlassian.net/browse/MM-17415

Here is an example stream of creating a cluster and then deploying an installation on that cluster:

```
{"timestamp":1565724747054220000,"id":"4ihjwzfrjifkikb3eneeg4qm9r","type":"cluster","new_state":"creation-requested","old_state":"n/a"}
{"timestamp":1565725298720123000,"id":"4ihjwzfrjifkikb3eneeg4qm9r","type":"cluster","new_state":"stable","old_state":"creation-requested"}
{"timestamp":1565725335455877000,"id":"18kjbxsojtys3nuy9f5e6k7amh","type":"installation","new_state":"creation-requested","old_state":"n/a"}
{"timestamp":1565725337793324000,"id":"s1cwh4mcnpnk8pq153d5gy4wee","type":"cluster_installaton","new_state":"creation-requested","old_state":"n/a"}
{"timestamp":1565725339467227000,"id":"s1cwh4mcnpnk8pq153d5gy4wee","type":"cluster_installaton","new_state":"reconciling","old_state":"creation-requested"}
{"timestamp":1565725466048969000,"id":"s1cwh4mcnpnk8pq153d5gy4wee","type":"cluster_installaton","new_state":"stable","old_state":"reconciling"}
{"timestamp":1565725498035330000,"id":"18kjbxsojtys3nuy9f5e6k7amh","type":"installation","new_state":"stable","old_state":"creation-requested"}
```