### PR TITLE
Add missing installation-upgrade license flag

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -20,6 +20,7 @@ func init() {
 
 	installationUpgradeCmd.Flags().String("installation", "", "The id of the installation to be upgraded.")
 	installationUpgradeCmd.Flags().String("version", "stable", "The Mattermost version to target.")
+	installationUpgradeCmd.Flags().String("license", "", "The Mattermost License to use in the server.")
 	installationUpgradeCmd.MarkFlagRequired("installation")
 	installationUpgradeCmd.MarkFlagRequired("version")
 


### PR DESCRIPTION
We were checking the license value, but the flag wasn't set on the command.