### PR TITLE
Add sqlite DSN parse workaround

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -24,10 +24,16 @@ type SQLStore struct {
 
 // New constructs a new instance of SQLStore.
 func New(dsn string, logger logrus.FieldLogger) (*SQLStore, error) {
+	// TODO: fix this dirty workaround
+	// https://github.com/golang/go/issues/33633
+	if strings.Contains(dsn, "file:") {
+		dsn = strings.Replace(dsn, "file:", "fileColonPlaceholder", 1)
+	}
 	url, err := url.Parse(dsn)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse dsn as an url")
 	}
+	url.Host = strings.Replace(url.Host, "fileColonPlaceholder", "file:", 1)
 
 	var db *sqlx.DB
 

--- a/internal/store/testing.go
+++ b/internal/store/testing.go
@@ -12,21 +12,23 @@ import (
 )
 
 func makeUnmigratedTestSQLStore(tb testing.TB, logger log.FieldLogger) *SQLStore {
+	// TODO: fix this dirty workaround
+	// https://github.com/golang/go/issues/33633
 	dsn := os.Getenv("CLOUD_DATABASE")
 	if dsn == "" {
 		dsn = fmt.Sprintf("sqlite3://file:%s.db?mode=memory&cache=shared", model.NewID())
-	}
+	} else {
+		dsnURL, err := url.Parse(dsn)
+		require.NoError(tb, err)
 
-	dsnURL, err := url.Parse(dsn)
-	require.NoError(tb, err)
-
-	switch dsnURL.Scheme {
-	case "sqlite", "sqlite3":
-	case "postgres", "postgresql":
-		q := dsnURL.Query()
-		q.Add("pg_temp", "true")
-		dsnURL.RawQuery = q.Encode()
-		dsn = dsnURL.String()
+		switch dsnURL.Scheme {
+		case "sqlite", "sqlite3":
+		case "postgres", "postgresql":
+			q := dsnURL.Query()
+			q.Add("pg_temp", "true")
+			dsnURL.RawQuery = q.Encode()
+			dsn = dsnURL.String()
+		}
 	}
 
 	sqlStore, err := New(dsn, logger)


### PR DESCRIPTION
This is a less-than-ideal workaround for the go 1.12.8 url.Parse
change that now errors when processing our sqlite DSN string. We
should consider this temporary until we can find a better solution.