### PR TITLE
[MM-17782] Check if cluster installation is deleted

### DIFF
--- a/internal/api/cluster_installation.go
+++ b/internal/api/cluster_installation.go
@@ -94,6 +94,11 @@ func handleGetClusterInstallationConfig(c *Context, w http.ResponseWriter, r *ht
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
+	if clusterInstallation.IsDeleted() {
+		c.Logger.Error("cluster installation is deleted")
+		w.WriteHeader(http.StatusGone)
+		return
+	}
 
 	cluster, err := c.Store.GetCluster(clusterInstallation.ClusterID)
 	if err != nil {
@@ -139,6 +144,11 @@ func handleSetClusterInstallationConfig(c *Context, w http.ResponseWriter, r *ht
 	}
 	if clusterInstallation == nil {
 		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	if clusterInstallation.IsDeleted() {
+		c.Logger.Error("cluster installation is deleted")
+		w.WriteHeader(http.StatusGone)
 		return
 	}
 
@@ -232,9 +242,9 @@ func handleRunClusterInstallationMattermostCLI(c *Context, w http.ResponseWriter
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	if clusterInstallation.DeleteAt != 0 {
+	if clusterInstallation.IsDeleted() {
 		c.Logger.Error("cluster installation is deleted")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusGone)
 		return
 	}
 

--- a/internal/api/cluster_installation_test.go
+++ b/internal/api/cluster_installation_test.go
@@ -288,6 +288,15 @@ func TestGetClusterInstallationConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, config, "ServiceSettings")
 	})
+
+	t.Run("cluster installation deleted", func(t *testing.T) {
+		err = sqlStore.DeleteClusterInstallation(clusterInstallation1.ID)
+		require.NoError(t, err)
+
+		config, err := client.GetClusterInstallationConfig(clusterInstallation1.ID)
+		require.Error(t, err)
+		require.Nil(t, config)
+	})
 }
 
 func TestSetClusterInstallationConfig(t *testing.T) {
@@ -345,6 +354,14 @@ func TestSetClusterInstallationConfig(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		err := client.SetClusterInstallationConfig(clusterInstallation1.ID, config)
 		require.NoError(t, err)
+	})
+
+	t.Run("cluster installation deleted", func(t *testing.T) {
+		err = sqlStore.DeleteClusterInstallation(clusterInstallation1.ID)
+		require.NoError(t, err)
+
+		err := client.SetClusterInstallationConfig(clusterInstallation1.ID, config)
+		require.Error(t, err)
 	})
 }
 

--- a/model/cluster_installation.go
+++ b/model/cluster_installation.go
@@ -54,6 +54,11 @@ func (c *ClusterInstallation) Clone() *ClusterInstallation {
 	return &clone
 }
 
+// IsDeleted returns whether the cluster installation was marked as deleted or not.
+func (c *ClusterInstallation) IsDeleted() bool {
+	return c.DeleteAt != 0
+}
+
 // ClusterInstallationFromReader decodes a json-encoded cluster installation from the given io.Reader.
 func ClusterInstallationFromReader(reader io.Reader) (*ClusterInstallation, error) {
 	clusterInstallation := ClusterInstallation{}

--- a/model/cluster_installation_test.go
+++ b/model/cluster_installation_test.go
@@ -24,6 +24,22 @@ func TestClusterInstallationClone(t *testing.T) {
 	require.NotEqual(t, clusterInstallation, clone)
 }
 
+func TestClusterInstallationIsDeleted(t *testing.T) {
+	clusterInstallation := &ClusterInstallation{
+		DeleteAt: 0,
+	}
+
+	t.Run("not deleted", func(t *testing.T) {
+		require.False(t, clusterInstallation.IsDeleted())
+	})
+
+	clusterInstallation.DeleteAt = 1
+
+	t.Run("deleted", func(t *testing.T) {
+		require.True(t, clusterInstallation.IsDeleted())
+	})
+}
+
 func TestClusterInstallationFromReader(t *testing.T) {
 	t.Run("empty request", func(t *testing.T) {
 		clusterInstallation, err := ClusterInstallationFromReader(bytes.NewReader([]byte(


### PR DESCRIPTION
This change adds a few checks for cluster installation deletion
status before trying to run various commands against those cluster
installations. Before, the server would try to run the command
even if the targets were no longer running.

https://mattermost.atlassian.net/browse/MM-17782