### PR TITLE
[MM-17021] Add new deletion-valid installation states

### DIFF
--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -340,8 +340,12 @@ func handleDeleteInstallation(c *Context, w http.ResponseWriter, r *http.Request
 	switch installation.State {
 	case model.InstallationStateStable:
 	case model.InstallationStateCreationRequested:
+	case model.InstallationStateCreationDNS:
 	case model.InstallationStateCreationNoCompatibleClusters:
 	case model.InstallationStateCreationFailed:
+	case model.InstallationStateUpgradeRequested:
+	case model.InstallationStateUpgradeInProgress:
+	case model.InstallationStateUpgradeFailed:
 	case model.InstallationStateDeletionRequested:
 	case model.InstallationStateDeletionInProgress:
 	case model.InstallationStateDeletionFailed:

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-cloud/internal/api"
-	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -763,7 +763,12 @@ func TestDeleteInstallation(t *testing.T) {
 		validDeletingStates := []string{
 			model.InstallationStateStable,
 			model.InstallationStateCreationRequested,
+			model.InstallationStateCreationDNS,
+			model.InstallationStateCreationNoCompatibleClusters,
 			model.InstallationStateCreationFailed,
+			model.InstallationStateUpgradeRequested,
+			model.InstallationStateUpgradeInProgress,
+			model.InstallationStateUpgradeFailed,
 			model.InstallationStateDeletionRequested,
 			model.InstallationStateDeletionInProgress,
 			model.InstallationStateDeletionFailed,


### PR DESCRIPTION
These installation states should be valid for marking an
installation for deletion.

https://mattermost.atlassian.net/browse/MM-17021