### PR TITLE
[MM-17782] Installation upgrade improvements

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -97,7 +97,12 @@ var installationUpgradeCmd = &cobra.Command{
 		version, _ := command.Flags().GetString("version")
 		license, _ := command.Flags().GetString("license")
 
-		err := client.UpgradeInstallation(installationID, version, license)
+		upgradeRequest := &model.UpgradeInstallationRequest{
+			Version: version,
+			License: license,
+		}
+
+		err := client.UpgradeInstallation(installationID, upgradeRequest)
 		if err != nil {
 			return errors.Wrap(err, "failed to change installation version")
 		}

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -218,7 +218,9 @@ func handleUpgradeInstallation(c *Context, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if installation.State != model.InstallationStateUpgradeRequested {
+	if installation.State != model.InstallationStateUpgradeRequested ||
+		installation.Version != upgradeInstallationRequest.Version ||
+		installation.License != upgradeInstallationRequest.License {
 		webhookPayload := &model.WebhookPayload{
 			Type:      model.TypeInstallation,
 			ID:        installation.ID,

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -416,8 +416,17 @@ func TestUpgradeInstallation(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	ensureInstallationMatchesRequest := func(t *testing.T, installation *model.Installation, request *model.UpgradeInstallationRequest) {
+		require.Equal(t, request.Version, installation.Version)
+		require.Equal(t, request.License, installation.License)
+	}
+
 	t.Run("unknown installation", func(t *testing.T) {
-		err := client.UpgradeInstallation(model.NewID(), "latest", "")
+		upgradeRequest := &model.UpgradeInstallationRequest{
+			Version: model.NewID(),
+			License: model.NewID(),
+		}
+		err := client.UpgradeInstallation(model.NewID(), upgradeRequest)
 		require.EqualError(t, err, "failed with status code 404")
 	})
 
@@ -437,7 +446,11 @@ func TestUpgradeInstallation(t *testing.T) {
 			require.True(t, unlocked)
 		}()
 
-		err = client.UpgradeInstallation(installation1.ID, "latest", "")
+		upgradeRequest := &model.UpgradeInstallationRequest{
+			Version: model.NewID(),
+			License: model.NewID(),
+		}
+		err = client.UpgradeInstallation(installation1.ID, upgradeRequest)
 		require.EqualError(t, err, "failed with status code 409")
 	})
 
@@ -446,25 +459,17 @@ func TestUpgradeInstallation(t *testing.T) {
 		err = sqlStore.UpdateInstallation(installation1)
 		require.NoError(t, err)
 
-		err = client.UpgradeInstallation(installation1.ID, "latest", "")
+		upgradeRequest := &model.UpgradeInstallationRequest{
+			Version: model.NewID(),
+			License: model.NewID(),
+		}
+		err = client.UpgradeInstallation(installation1.ID, upgradeRequest)
 		require.NoError(t, err)
 
 		installation1, err = client.GetInstallation(installation1.ID)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpgradeRequested, installation1.State)
-	})
-
-	t.Run("add license", func(t *testing.T) {
-		installation1.State = model.InstallationStateUpgradeRequested
-		err = sqlStore.UpdateInstallation(installation1)
-		require.NoError(t, err)
-
-		err = client.UpgradeInstallation(installation1.ID, "latest", "this_is_my_lincese")
-		require.NoError(t, err)
-
-		installation1, err = client.GetInstallation(installation1.ID)
-		require.NoError(t, err)
-		require.Equal(t, model.InstallationStateUpgradeRequested, installation1.State)
+		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
 	})
 
 	t.Run("after upgrade failed", func(t *testing.T) {
@@ -472,12 +477,17 @@ func TestUpgradeInstallation(t *testing.T) {
 		err = sqlStore.UpdateInstallation(installation1)
 		require.NoError(t, err)
 
-		err = client.UpgradeInstallation(installation1.ID, "latest", "")
+		upgradeRequest := &model.UpgradeInstallationRequest{
+			Version: model.NewID(),
+			License: model.NewID(),
+		}
+		err = client.UpgradeInstallation(installation1.ID, upgradeRequest)
 		require.NoError(t, err)
 
 		installation1, err = client.GetInstallation(installation1.ID)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpgradeRequested, installation1.State)
+		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
 	})
 
 	t.Run("while stable", func(t *testing.T) {
@@ -485,12 +495,17 @@ func TestUpgradeInstallation(t *testing.T) {
 		err = sqlStore.UpdateInstallation(installation1)
 		require.NoError(t, err)
 
-		err = client.UpgradeInstallation(installation1.ID, "latest", "")
+		upgradeRequest := &model.UpgradeInstallationRequest{
+			Version: model.NewID(),
+			License: model.NewID(),
+		}
+		err = client.UpgradeInstallation(installation1.ID, upgradeRequest)
 		require.NoError(t, err)
 
 		installation1, err = client.GetInstallation(installation1.ID)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpgradeRequested, installation1.State)
+		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
 	})
 
 	t.Run("after deletion failed", func(t *testing.T) {
@@ -498,12 +513,12 @@ func TestUpgradeInstallation(t *testing.T) {
 		err = sqlStore.UpdateInstallation(installation1)
 		require.NoError(t, err)
 
-		err := client.DeleteInstallation(installation1.ID)
-		require.NoError(t, err)
-
-		installation1, err = client.GetInstallation(installation1.ID)
-		require.NoError(t, err)
-		require.Equal(t, model.InstallationStateDeletionRequested, installation1.State)
+		upgradeRequest := &model.UpgradeInstallationRequest{
+			Version: model.NewID(),
+			License: model.NewID(),
+		}
+		err = client.UpgradeInstallation(installation1.ID, upgradeRequest)
+		require.EqualError(t, err, "failed with status code 400")
 	})
 
 	t.Run("while deleting", func(t *testing.T) {
@@ -511,7 +526,11 @@ func TestUpgradeInstallation(t *testing.T) {
 		err = sqlStore.UpdateInstallation(installation1)
 		require.NoError(t, err)
 
-		err = client.UpgradeInstallation(installation1.ID, "latest", "")
+		upgradeRequest := &model.UpgradeInstallationRequest{
+			Version: model.NewID(),
+			License: model.NewID(),
+		}
+		err = client.UpgradeInstallation(installation1.ID, upgradeRequest)
 		require.EqualError(t, err, "failed with status code 400")
 	})
 
@@ -520,12 +539,16 @@ func TestUpgradeInstallation(t *testing.T) {
 		err = sqlStore.UpdateInstallation(installation1)
 		require.NoError(t, err)
 
-		err = client.UpgradeInstallation(installation1.ID, "5.9.0", "")
+		upgradeRequest := &model.UpgradeInstallationRequest{
+			Version: model.NewID(),
+			License: model.NewID(),
+		}
+		err = client.UpgradeInstallation(installation1.ID, upgradeRequest)
 		require.NoError(t, err)
 
 		installation1, err = client.GetInstallation(installation1.ID)
 		require.NoError(t, err)
-		require.Equal(t, "5.9.0", installation1.Version)
+		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
 	})
 
 	t.Run("to version with embedded slash", func(t *testing.T) {
@@ -533,13 +556,17 @@ func TestUpgradeInstallation(t *testing.T) {
 		err = sqlStore.UpdateInstallation(installation1)
 		require.NoError(t, err)
 
-		err = client.UpgradeInstallation(installation1.ID, "mattermost/mattermost-enterprise:v5.12", "")
+		upgradeRequest := &model.UpgradeInstallationRequest{
+			Version: "mattermost/mattermost-enterprise:v5.12",
+			License: model.NewID(),
+		}
+		err = client.UpgradeInstallation(installation1.ID, upgradeRequest)
 		require.NoError(t, err)
 
 		installation1, err = client.GetInstallation(installation1.ID)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpgradeRequested, installation1.State)
-		require.Equal(t, "mattermost/mattermost-enterprise:v5.12", installation1.Version)
+		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
 	})
 }
 

--- a/model/client.go
+++ b/model/client.go
@@ -280,12 +280,9 @@ func (c *Client) GetInstallations(request *GetInstallationsRequest) ([]*Installa
 	}
 }
 
-// UpgradeInstallation upgrades a installation to the given Mattermost version.
-func (c *Client) UpgradeInstallation(installationID, version, license string) error {
-	resp, err := c.doPut(c.buildURL("/api/installation/%s/mattermost", installationID), UpgradeInstallationRequest{
-		Version: version,
-		License: license,
-	})
+// UpgradeInstallation upgrades an installation.
+func (c *Client) UpgradeInstallation(installationID string, request *UpgradeInstallationRequest) error {
+	resp, err := c.doPut(c.buildURL("/api/installation/%s/mattermost", installationID), request)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change does the following:
 - Changes the model.Client to require an InstallationUpgradeRequest
   when making an installation upgrade request. This brings it in
   line with other client methods.
 - Improves the tests around installation upgrades. This revealed
   a bug which leads to:
 - Fixes bug where an already-upgrading installation would not
   update the database with new version or license info when a
   new request was made.

https://mattermost.atlassian.net/browse/MM-17782