### PR TITLE
Increase server connection timeouts

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -150,9 +150,9 @@ var serverCmd = &cobra.Command{
 		srv := &http.Server{
 			Addr:           listen,
 			Handler:        router,
-			ReadTimeout:    10 * time.Second,
-			WriteTimeout:   10 * time.Second,
-			IdleTimeout:    time.Second * 60,
+			ReadTimeout:    60 * time.Second,
+			WriteTimeout:   60 * time.Second,
+			IdleTimeout:    time.Second * 120,
 			MaxHeaderBytes: 1 << 20,
 			ErrorLog:       log.New(&logrusWriter{logger}, "", 0),
 		}


### PR DESCRIPTION
This change increases the timeouts on the server connections to
allow for long-running connections, such as Mattermost CLI commands,
to finish in time.