### PR TITLE
Add option for AWS RDS installation databases

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -40,6 +40,7 @@ func init() {
 	serverCmd.PersistentFlags().String("public-subnets", "", "The public subnet IDs to use on AWS.")
 	serverCmd.PersistentFlags().Int("poll", 30, "The interval in seconds to poll for background work.")
 	serverCmd.PersistentFlags().Int("cluster-resource-threshold", 80, "The percent threshold where new installations won't be scheduled on a multi-tenant cluster")
+	serverCmd.PersistentFlags().Bool("keep-database-data", true, "Whether to preserve database data after installation deletion or not")
 	serverCmd.PersistentFlags().Bool("keep-filestore-data", true, "Whether to preserve filestore data after installation deletion or not")
 	serverCmd.PersistentFlags().Bool("debug", false, "Whether to output debug logs.")
 	serverCmd.MarkPersistentFlagRequired("route53-id")
@@ -90,6 +91,7 @@ var serverCmd = &cobra.Command{
 		route53ZoneID, _ := command.Flags().GetString("route53-id")
 		privateRoute53ZoneID, _ := command.Flags().GetString("private-route53-id")
 		privateDNS, _ := command.Flags().GetString("private-dns")
+		keepDatabaseData, _ := command.Flags().GetBool("keep-database-data")
 		keepFilestoreData, _ := command.Flags().GetBool("keep-filestore-data")
 
 		wd, err := os.Getwd()
@@ -109,6 +111,7 @@ var serverCmd = &cobra.Command{
 			"private-route53-id":         privateRoute53ZoneID,
 			"private-dns":                privateDNS,
 			"cluster-resource-threshold": clusterResourceThreshold,
+			"keep-database-data":         keepDatabaseData,
 			"keep-filestore-data":        keepFilestoreData,
 			"debug":                      debug,
 		}).Info("Starting Mattermost Provisioning Server")
@@ -134,7 +137,7 @@ var serverCmd = &cobra.Command{
 		supervisor := supervisor.NewScheduler(
 			supervisor.MultiDoer{
 				supervisor.NewClusterSupervisor(sqlStore, kopsProvisioner, aws.New(privateRoute53ZoneID), instanceID, logger),
-				supervisor.NewInstallationSupervisor(sqlStore, kopsProvisioner, aws.New(route53ZoneID), instanceID, clusterResourceThreshold, keepFilestoreData, logger),
+				supervisor.NewInstallationSupervisor(sqlStore, kopsProvisioner, aws.New(route53ZoneID), instanceID, clusterResourceThreshold, keepDatabaseData, keepFilestoreData, logger),
 				supervisor.NewClusterInstallationSupervisor(sqlStore, kopsProvisioner, aws.New(route53ZoneID), instanceID, logger),
 			},
 			time.Duration(poll)*time.Second,

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -820,6 +820,19 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 		logger.Debug("Cluster installation configured with a Mattermost license")
 	}
 
+	databaseSpec, databaseSecret, err := installation.GetDatabase().GenerateDatabaseSpecAndSecret(logger)
+	if err != nil {
+		return err
+	}
+
+	if databaseSpec != nil {
+		_, err = k8sClient.CreateOrUpdateSecret(clusterInstallation.Namespace, databaseSecret)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create the database secret %s/%s", clusterInstallation.Namespace, databaseSecret.Name)
+		}
+		mattermostInstallation.Spec.Database = *databaseSpec
+	}
+
 	filestoreSpec, filestoreSecret, err := installation.GetFilestore().GenerateFilestoreSpecAndSecret(logger)
 	if err != nil {
 		return err

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -172,7 +172,7 @@ func TestInstallationSupervisorDo(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		mockStore := &mockInstallationStore{}
 
-		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 		err := supervisor.Do()
 		require.NoError(t, err)
 
@@ -190,7 +190,7 @@ func TestInstallationSupervisorDo(t *testing.T) {
 		mockStore.Installation = mockStore.UnlockedInstallationsPendingWork[0]
 		mockStore.UnlockChan = make(chan interface{})
 
-		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 		err := supervisor.Do()
 		require.NoError(t, err)
 
@@ -234,7 +234,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("unexpected state", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -274,7 +274,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations not yet created, no clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		owner := model.NewID()
 		groupID := model.NewID()
@@ -299,7 +299,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations not yet created, no available clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -339,7 +339,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations not yet created, available cluster", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -379,7 +379,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				MilliUsedMemory:  100,
 			},
 		}
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, mockInstallationProvisioner, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, mockInstallationProvisioner, &mockAWS{}, "instanceID", 80, false, false, logger)
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
 		}
@@ -409,7 +409,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations failed", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -449,7 +449,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -489,7 +489,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation dns requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -529,7 +529,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("no compatible clusters, cluster installations not yet created, no clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		owner := model.NewID()
 		groupID := model.NewID()
@@ -554,7 +554,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("no compatible clusters, cluster installations not yet created, no available clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -594,7 +594,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("no compatible clusters, cluster installations not yet created, available cluster", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -625,7 +625,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("upgrade requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -665,7 +665,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("upgrade in progress, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -705,7 +705,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -745,7 +745,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion requested, cluster installations deleting", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -785,7 +785,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion in progress, cluster installations failed", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -825,7 +825,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion requested, cluster installations failed, so retry", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -865,7 +865,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations deleted", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 		cluster := &model.Cluster{
 			State: model.ClusterStateStable,
@@ -906,7 +906,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		t.Run("creation requested, cluster installations not yet created, available cluster", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
-			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 			cluster := &model.Cluster{
 				State: model.ClusterStateStable,
@@ -938,7 +938,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		t.Run("creation requested, cluster installations not yet created, 3 installations, available cluster", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
-			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 			cluster := &model.Cluster{
 				State: model.ClusterStateStable,
@@ -974,7 +974,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		t.Run("creation requested, cluster installations not yet created, 1 isolated and 1 multitenant, available cluster", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
-			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, logger)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 			cluster := &model.Cluster{
 				State: model.ClusterStateStable,
@@ -1035,7 +1035,7 @@ func TestInstallationSupervisor(t *testing.T) {
 					MilliUsedMemory:  100,
 				},
 			}
-			supervisor := supervisor.NewInstallationSupervisor(sqlStore, mockInstallationProvisioner, &mockAWS{}, "instanceID", 80, false, logger)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, mockInstallationProvisioner, &mockAWS{}, "instanceID", 80, false, false, logger)
 
 			cluster := &model.Cluster{
 				State: model.ClusterStateStable,

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -21,8 +21,6 @@ type Client struct {
 	api          api
 }
 
-var _ AWS = &Client{}
-
 // api mocks out the AWS API calls for testing.
 type api interface {
 	getRoute53Client() (*route53.Route53, error)

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -1,0 +1,45 @@
+package aws
+
+const (
+	// S3URL is the S3 URL for making bucket API calls.
+	S3URL = "s3.amazonaws.com"
+
+	// DefaultAWSRegion is the default AWS region for AWS resources.
+	DefaultAWSRegion = "us-east-1"
+
+	// DefaultDBSubnetGroupName is the default DB subnet group name used when
+	// creating DB clusters. This group name is defined by the owner of the AWS
+	// accounts and can be the same across all accounts.
+	// Note: This needs to be manually created before RDS databases can be used.
+	DefaultDBSubnetGroupName = "mattermost-databases"
+
+	// DefaultDBSecurityGroupTagKey is the default DB security group tag key
+	// that is used to find security groups to use in configuration of the RDS
+	// database.
+	// Note: This needs to be manually created before RDS databases can be used.
+	DefaultDBSecurityGroupTagKey = "tag:MattermostCloudInstallationDatabase"
+
+	// DefaultDBSecurityGroupTagValue is the default DB security group tag value
+	// that is used to find security groups to use in configuration of the RDS
+	// database.
+	// Note: This needs to be manually created before RDS databases can be used.
+	DefaultDBSecurityGroupTagValue = "MYSQL/Aurora"
+
+	// cloudIDPrefix is the prefix value used when creating AWS resource names.
+	// Warning:
+	// changing this value will break the connection to AWS resources for
+	// existing installations.
+	cloudIDPrefix = "cloud-"
+
+	// iamSuffix is the suffix value used when referencing an AWS IAM secret.
+	// Warning:
+	// changing this value will break the connection to AWS resources for
+	// existing installations.
+	iamSuffix = "-iam"
+
+	// rdsSuffix is the suffix value used when referencing an AWS RDS secret.
+	// Warning:
+	// changing this value will break the connection to AWS resources for
+	// existing installations.
+	rdsSuffix = "-rds"
+)

--- a/internal/tools/aws/database.go
+++ b/internal/tools/aws/database.go
@@ -64,8 +64,6 @@ func (d *RDSDatabase) GenerateDatabaseSpecAndSecret(logger log.FieldLogger) (*mm
 		rdsSecret.MasterUsername, rdsSecret.MasterPassword, *dbCluster.Endpoint,
 	)
 
-	logger.Warn(databaseConnectionString)
-
 	databaseSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: databaseSecretName,

--- a/internal/tools/aws/database.go
+++ b/internal/tools/aws/database.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RDSDatabase is a database backed by AWS RDS.
+type RDSDatabase struct {
+	installationID string
+}
+
+// NewRDSDatabase returns a new RDSDatabase interface.
+func NewRDSDatabase(installationID string) *RDSDatabase {
+	return &RDSDatabase{
+		installationID: installationID,
+	}
+}
+
+// Provision completes all the steps necessary to provision a RDS database.
+func (d *RDSDatabase) Provision(logger log.FieldLogger) error {
+	err := rdsDatabaseProvision(d.installationID, logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to provision RDS database")
+	}
+
+	return nil
+}
+
+// Teardown removes all AWS resources related to a RDS database.
+func (d *RDSDatabase) Teardown(keepData bool, logger log.FieldLogger) error {
+	err := rdsDatabaseTeardown(d.installationID, keepData, logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to teardown RDS database")
+	}
+
+	return nil
+}
+
+// GenerateDatabaseSpecAndSecret creates the k8s database spec and secret for
+// accessing the RDS database.
+func (d *RDSDatabase) GenerateDatabaseSpecAndSecret(logger log.FieldLogger) (*mmv1alpha1.Database, *corev1.Secret, error) {
+	awsID := CloudID(d.installationID)
+
+	rdsSecret, err := secretsManagerGetRDSSecret(awsID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dbCluster, err := rdsGetDBCluster(awsID, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	databaseSecretName := fmt.Sprintf("%s-rds", d.installationID)
+	databaseConnectionString := fmt.Sprintf(
+		"mysql://%s:%s@tcp(%s:3306)/mattermost?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
+		rdsSecret.MasterUsername, rdsSecret.MasterPassword, *dbCluster.Endpoint,
+	)
+
+	logger.Warn(databaseConnectionString)
+
+	databaseSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: databaseSecretName,
+		},
+		StringData: map[string]string{
+			"externalDB": databaseConnectionString,
+		},
+	}
+
+	databaseSpec := &mmv1alpha1.Database{
+		ExternalSecret: databaseSecretName,
+	}
+
+	logger.Debug("Cluster installation configured to use an AWS RDS Database")
+
+	return databaseSpec, databaseSecret, nil
+}
+
+func rdsDatabaseProvision(installationID string, logger log.FieldLogger) error {
+	logger.Info("Provisioning AWS RDS database")
+
+	a := New("n/a")
+	awsID := CloudID(installationID)
+
+	rdsSecret, err := a.secretsManagerEnsureRDSSecretCreated(awsID, logger)
+	if err != nil {
+		return err
+	}
+
+	err = a.rdsEnsureDBClusterCreated(awsID, rdsSecret.MasterUsername, rdsSecret.MasterPassword, logger)
+	if err != nil {
+		return err
+	}
+
+	masterInstanceName := fmt.Sprintf("%s-master", awsID)
+	err = a.rdsEnsureDBClusterInstanceCreated(awsID, masterInstanceName, logger)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func rdsDatabaseTeardown(installationID string, keepData bool, logger log.FieldLogger) error {
+	logger.Info("Tearing down AWS RDS database")
+
+	a := New("n/a")
+	awsID := CloudID(installationID)
+
+	err := a.secretsManagerEnsureRDSSecretDeleted(awsID, logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to delete RDS secret")
+	}
+
+	if !keepData {
+		err = a.rdsEnsureDBClusterDeleted(awsID, logger)
+		if err != nil {
+			return errors.Wrap(err, "unable to delete RDS DB cluster")
+		}
+		logger.WithField("db-cluster-name", awsID).Debug("AWS RDS DB cluster deleted")
+	} else {
+		logger.WithField("db-cluster-name", awsID).Info("AWS RDS DB cluster was left intact due to the keep-data setting of this server")
+	}
+
+	return nil
+}

--- a/internal/tools/aws/database_test.go
+++ b/internal/tools/aws/database_test.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// WARNING:
+// This test is meant to exercise the provisioning and teardown of an AWS RDS
+// database in a real AWS account. Only set the test env vars below if you wish
+// to test this process with real AWS resources.
+
+var id = "test-id-1"
+
+func TestDatabaseProvision(t *testing.T) {
+	if os.Getenv("SUPER_AWS_DATABASE_TEST") == "" {
+		return
+	}
+
+	logger := logrus.New()
+
+	database := NewRDSDatabase(id)
+
+	err := database.Provision(logger)
+	require.NoError(t, err)
+}
+
+func TestDatabaseTeardown(t *testing.T) {
+	if os.Getenv("SUPER_AWS_DATABASE_TEST") == "" {
+		return
+	}
+
+	logger := logrus.New()
+
+	database := NewRDSDatabase(id)
+
+	err := database.Teardown(false, logger)
+	require.NoError(t, err)
+}

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -1,18 +1,35 @@
 package aws
 
-const (
-	// S3URL is the S3 URL for making bucket API calls.
-	S3URL = "s3.amazonaws.com"
-
-	// cloudIDPrefix is the prefix value used when creating AWS resource names.
-	// Warning:
-	// changing this value will break the connection to AWS resources for
-	// existing installations.
-	cloudIDPrefix = "cloud-"
+import (
+	"math/rand"
+	"time"
 )
 
 // CloudID returns the standard ID used for AWS resource names. This ID is used
 // to correlate installations to AWS resources.
 func CloudID(id string) string {
 	return cloudIDPrefix + id
+}
+
+// IAMSecretName returns the IAM Access Key secret name for a given Cloud ID.
+func IAMSecretName(cloudID string) string {
+	return cloudID + iamSuffix
+}
+
+// RDSSecretName returns the RDS secret name for a given Cloud ID.
+func RDSSecretName(cloudID string) string {
+	return cloudID + rdsSuffix
+}
+
+const passwordBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+
+func newRandomPassword(length int) string {
+	rand.Seed(time.Now().UnixNano())
+
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = passwordBytes[rand.Intn(len(passwordBytes))]
+	}
+
+	return string(b)
 }

--- a/internal/tools/aws/iam.go
+++ b/internal/tools/aws/iam.go
@@ -31,7 +31,7 @@ func (a *Client) iamEnsureUserCreated(awsID string, logger log.FieldLogger) (*ia
 		UserName: aws.String(awsID),
 	})
 	if err == nil {
-		logger.WithField("iam-user-name", *getResult.User.UserName).Info("AWS IAM user already exists. Skipping...")
+		logger.WithField("iam-user-name", *getResult.User.UserName).Debug("AWS IAM user already created")
 		return getResult.User, nil
 	}
 	if aerr, ok := err.(awserr.Error); ok {
@@ -49,7 +49,7 @@ func (a *Client) iamEnsureUserCreated(awsID string, logger log.FieldLogger) (*ia
 		return nil, err
 	}
 
-	logger.WithField("iam-user-name", *createResult.User.UserName).Info("AWS IAM user created")
+	logger.WithField("iam-user-name", *createResult.User.UserName).Debug("AWS IAM user created")
 
 	return createResult.User, nil
 }
@@ -90,7 +90,7 @@ func (a *Client) iamEnsureUserDeleted(awsID string, logger log.FieldLogger) erro
 		logger.WithFields(log.Fields{
 			"iam-user-name":   awsID,
 			"iam-policy-name": *policy.PolicyName,
-		}).Info("AWS IAM policy detached from user")
+		}).Debug("AWS IAM policy detached from user")
 
 		_, err = svc.DeletePolicy(&iam.DeletePolicyInput{
 			PolicyArn: policy.PolicyArn,
@@ -102,7 +102,7 @@ func (a *Client) iamEnsureUserDeleted(awsID string, logger log.FieldLogger) erro
 		logger.WithFields(log.Fields{
 			"iam-user-name":   awsID,
 			"iam-policy-name": *policy.PolicyName,
-		}).Info("AWS IAM policy deleted")
+		}).Debug("AWS IAM policy deleted")
 	}
 
 	accessKeyResult, err := svc.ListAccessKeys(&iam.ListAccessKeysInput{
@@ -123,7 +123,7 @@ func (a *Client) iamEnsureUserDeleted(awsID string, logger log.FieldLogger) erro
 		logger.WithFields(log.Fields{
 			"iam-user-name":     awsID,
 			"iam-access-key-id": *ak.AccessKeyId,
-		}).Info("AWS IAM user access key deleted")
+		}).Debug("AWS IAM user access key deleted")
 	}
 
 	_, err = svc.DeleteUser(&iam.DeleteUserInput{
@@ -133,7 +133,7 @@ func (a *Client) iamEnsureUserDeleted(awsID string, logger log.FieldLogger) erro
 		return err
 	}
 
-	logger.WithField("iam-user-name", awsID).Info("AWS IAM user deleted")
+	logger.WithField("iam-user-name", awsID).Debug("AWS IAM user deleted")
 
 	return nil
 }
@@ -145,7 +145,7 @@ func (a *Client) iamEnsurePolicyCreated(awsID, policyARN string, logger log.Fiel
 		PolicyArn: aws.String(policyARN),
 	})
 	if err == nil {
-		logger.WithField("iam-policy-name", *getResult.Policy.PolicyName).Info("AWS IAM policy already exists. Skipping...")
+		logger.WithField("iam-policy-name", *getResult.Policy.PolicyName).Debug("AWS IAM policy already created")
 		return getResult.Policy, nil
 	}
 	if aerr, ok := err.(awserr.Error); ok {
@@ -194,7 +194,7 @@ func (a *Client) iamEnsurePolicyCreated(awsID, policyARN string, logger log.Fiel
 		return nil, errors.Wrap(err, "unable to create IAM policy")
 	}
 
-	logger.WithField("iam-policy-name", *createResult.Policy.PolicyName).Info("AWS IAM policy created")
+	logger.WithField("iam-policy-name", *createResult.Policy.PolicyName).Debug("AWS IAM policy created")
 
 	return createResult.Policy, nil
 }

--- a/internal/tools/aws/rds.go
+++ b/internal/tools/aws/rds.go
@@ -1,0 +1,193 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+func (a *Client) rdsGetDBSecurityGroupIDs(logger log.FieldLogger) ([]string, error) {
+	svc := ec2.New(session.New(), &aws.Config{
+		Region: aws.String(DefaultAWSRegion),
+	})
+
+	input := &ec2.DescribeSecurityGroupsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String(DefaultDBSecurityGroupTagKey),
+				Values: []*string{
+					aws.String(DefaultDBSecurityGroupTagValue),
+				},
+			},
+		},
+	}
+
+	result, err := svc.DescribeSecurityGroups(input)
+	if err != nil {
+		return []string{}, err
+	}
+
+	var dbSecurityGroups []string
+	for _, sg := range result.SecurityGroups {
+		dbSecurityGroups = append(dbSecurityGroups, *sg.GroupId)
+	}
+
+	if len(dbSecurityGroups) == 0 {
+		return []string{}, fmt.Errorf("unable to find security groups tagged for Mattermost DB usage: %s=%s", DefaultDBSecurityGroupTagKey, DefaultDBSecurityGroupTagValue)
+	}
+
+	logger.WithField("security-group-ids", dbSecurityGroups).Debugf("Found %d DB tagged security groups", len(dbSecurityGroups))
+
+	return dbSecurityGroups, nil
+}
+
+func (a *Client) rdsEnsureDBClusterCreated(awsID, username, password string, logger log.FieldLogger) error {
+	svc := rds.New(session.New(), &aws.Config{
+		Region: aws.String(DefaultAWSRegion),
+	})
+
+	_, err := svc.DescribeDBClusters(&rds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String(awsID),
+	})
+	if err == nil {
+		logger.WithField("db-cluster-name", awsID).Debug("AWS DB cluster already created")
+
+		return nil
+	}
+
+	dbSecurityGroupIDs, err := a.rdsGetDBSecurityGroupIDs(logger)
+	if err != nil {
+		return err
+	}
+
+	input := &rds.CreateDBClusterInput{
+		AvailabilityZones: []*string{
+			aws.String("us-east-1a"),
+			aws.String("us-east-1b"),
+			aws.String("us-east-1c"),
+		},
+		BackupRetentionPeriod: aws.Int64(7),
+		DBClusterIdentifier:   aws.String(awsID),
+		DatabaseName:          aws.String("mattermost"),
+		EngineMode:            aws.String("provisioned"),
+		Engine:                aws.String("aurora-mysql"),
+		EngineVersion:         aws.String("5.7"),
+		MasterUserPassword:    aws.String(password),
+		MasterUsername:        aws.String(username),
+		Port:                  aws.Int64(3306),
+		StorageEncrypted:      aws.Bool(false),
+		DBSubnetGroupName:     aws.String(DefaultDBSubnetGroupName),
+		VpcSecurityGroupIds:   aws.StringSlice(dbSecurityGroupIDs),
+	}
+
+	_, err = svc.CreateDBCluster(input)
+	if err != nil {
+		return err
+	}
+
+	logger.WithField("db-cluster-name", awsID).Debug("AWS DB cluster created")
+
+	return nil
+}
+
+func (a *Client) rdsEnsureDBClusterInstanceCreated(awsID, instanceName string, logger log.FieldLogger) error {
+	svc := rds.New(session.New(), &aws.Config{
+		Region: aws.String(DefaultAWSRegion),
+	})
+
+	_, err := svc.DescribeDBInstances(&rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(instanceName),
+	})
+	if err == nil {
+		logger.WithField("db-instance-name", instanceName).Debug("AWS DB instance already created")
+
+		return nil
+	}
+
+	_, err = svc.CreateDBInstance(&rds.CreateDBInstanceInput{
+		DBClusterIdentifier:  aws.String(awsID),
+		DBInstanceIdentifier: aws.String(instanceName),
+		DBInstanceClass:      aws.String("db.r5.large"),
+		Engine:               aws.String("aurora-mysql"),
+		PubliclyAccessible:   aws.Bool(false),
+	})
+	if err != nil {
+		return err
+	}
+
+	logger.WithField("db-instance-name", instanceName).Debug("AWS DB instance created")
+
+	return nil
+}
+
+func rdsGetDBCluster(awsID string, logger log.FieldLogger) (*rds.DBCluster, error) {
+	svc := rds.New(session.New(), &aws.Config{
+		Region: aws.String(DefaultAWSRegion),
+	})
+
+	result, err := svc.DescribeDBClusters(&rds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String(awsID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.DBClusters) != 1 {
+		return nil, fmt.Errorf("expected 1 DB cluster, but got %d", len(result.DBClusters))
+	}
+
+	return result.DBClusters[0], nil
+}
+
+func (a *Client) rdsEnsureDBClusterDeleted(awsID string, logger log.FieldLogger) error {
+	svc := rds.New(session.New(), &aws.Config{
+		Region: aws.String(DefaultAWSRegion),
+	})
+
+	result, err := svc.DescribeDBClusters(&rds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String(awsID),
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == rds.ErrCodeDBClusterNotFoundFault {
+				logger.WithField("db-cluster-name", awsID).Warn("DBCluster could not be found; assuming already deleted")
+
+				return nil
+			}
+		}
+		return err
+	}
+
+	if len(result.DBClusters) != 1 {
+		return fmt.Errorf("expected 1 DB cluster, but got %d", len(result.DBClusters))
+	}
+
+	for _, instance := range result.DBClusters[0].DBClusterMembers {
+		_, err = svc.DeleteDBInstance(&rds.DeleteDBInstanceInput{
+			DBInstanceIdentifier: instance.DBInstanceIdentifier,
+			SkipFinalSnapshot:    aws.Bool(true),
+		})
+		if err != nil {
+			return err
+		}
+		logger.WithField("db-instance-name", *instance.DBInstanceIdentifier).Debug("DB instance deleted")
+	}
+
+	_, err = svc.DeleteDBCluster(&rds.DeleteDBClusterInput{
+		DBClusterIdentifier: aws.String(awsID),
+		SkipFinalSnapshot:   aws.Bool(true),
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to delete database")
+	}
+
+	logger.WithField("db-cluster-name", awsID).Debug("DBCluster deleted")
+
+	return nil
+}

--- a/internal/tools/aws/s3.go
+++ b/internal/tools/aws/s3.go
@@ -38,7 +38,7 @@ func (a *Client) s3EnsureBucketCreated(bucketName string) error {
 func (a *Client) s3EnsureBucketDeleted(bucketName string) error {
 	svc := s3.New(session.New())
 
-	// AWS forces S3 buckets to be emptry before they can be deleted.
+	// AWS forces S3 buckets to be empty before they can be deleted.
 	iter := s3manager.NewDeleteListIterator(svc, &s3.ListObjectsInput{
 		Bucket: aws.String(bucketName),
 	})

--- a/model/installation_database.go
+++ b/model/installation_database.go
@@ -1,11 +1,76 @@
 package model
 
+import (
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+)
+
 const (
 	// InstallationDatabaseMysqlOperator is a database hosted in kubernetes via the operator.
 	InstallationDatabaseMysqlOperator = "mysql-operator"
 	// InstallationDatabaseAwsRDS is a database hosted via Amazon RDS.
 	InstallationDatabaseAwsRDS = "aws-rds"
 )
+
+// Database is the interface for managing Mattermost databases.
+type Database interface {
+	Provision(logger log.FieldLogger) error
+	Teardown(keepData bool, logger log.FieldLogger) error
+	GenerateDatabaseSpecAndSecret(logger log.FieldLogger) (*mmv1alpha1.Database, *corev1.Secret, error)
+}
+
+// MysqlOperatorDatabase is a database backed by the MySQL operator.
+type MysqlOperatorDatabase struct{}
+
+// NewMysqlOperatorDatabase returns a new MysqlOperatorDatabase interface.
+func NewMysqlOperatorDatabase() *MysqlOperatorDatabase {
+	return &MysqlOperatorDatabase{}
+}
+
+// Provision completes all the steps necessary to provision a MySQL operator database.
+func (d *MysqlOperatorDatabase) Provision(logger log.FieldLogger) error {
+	logger.Info("MySQL operator database requires no pre-provisioning; skipping...")
+
+	return nil
+}
+
+// Teardown removes all MySQL operator resources for a given installation.
+func (d *MysqlOperatorDatabase) Teardown(keepData bool, logger log.FieldLogger) error {
+	logger.Info("MySQL operator database requires no teardown; skipping...")
+	if keepData {
+		logger.Warn("Database preservation was requested, but isn't currently possible with the MySQL operator")
+	}
+
+	return nil
+}
+
+// GenerateDatabaseSpecAndSecret creates the k8s database spec and secret for
+// accessing the MySQL operator database.
+func (d *MysqlOperatorDatabase) GenerateDatabaseSpecAndSecret(logger log.FieldLogger) (*mmv1alpha1.Database, *corev1.Secret, error) {
+	return nil, nil, nil
+}
+
+// GetDatabase returns the Database interface that matches the installation.
+func (i *Installation) GetDatabase() Database {
+	switch i.Database {
+	case InstallationDatabaseMysqlOperator:
+		return NewMysqlOperatorDatabase()
+	case InstallationDatabaseAwsRDS:
+		return aws.NewRDSDatabase(i.ID)
+	}
+
+	// Warning: we should never get here as it would mean that we didn't match
+	// our database type.
+	return NewMysqlOperatorDatabase()
+}
+
+// InternalDatabase returns true if the installation's database is internal
+// to the kubernetes cluster it is running on.
+func (i *Installation) InternalDatabase() bool {
+	return i.Database == InstallationDatabaseMysqlOperator
+}
 
 // IsSupportedDatabase returns true if the given database string is supported.
 func IsSupportedDatabase(database string) bool {

--- a/model/installation_database_test.go
+++ b/model/installation_database_test.go
@@ -7,6 +7,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestInternalDatabase(t *testing.T) {
+	var testCases = []struct {
+		databaseType   string
+		expectInternal bool
+	}{
+		{"", false},
+		{"unknown", false},
+		{model.InstallationDatabaseMysqlOperator, true},
+		{model.InstallationDatabaseAwsRDS, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.databaseType, func(t *testing.T) {
+			installation := &model.Installation{
+				Database: tc.databaseType,
+			}
+
+			assert.Equal(t, tc.expectInternal, installation.InternalDatabase())
+		})
+	}
+}
+
 func TestIsSupportedDatabase(t *testing.T) {
 	var testCases = []struct {
 		database        string

--- a/model/installation_filestore.go
+++ b/model/installation_filestore.go
@@ -37,7 +37,7 @@ func (f *MinioOperatorFilestore) Provision(logger log.FieldLogger) error {
 	return nil
 }
 
-// Teardown removes all MinIO operator resources related to an S3 filestore.
+// Teardown removes all MinIO operator resources related to a given installation.
 func (f *MinioOperatorFilestore) Teardown(keepData bool, logger log.FieldLogger) error {
 	logger.Info("MinIO operator filestore requires no teardown; skipping...")
 	if keepData {


### PR DESCRIPTION
This change includes many enhancements to allow the cloud server
to provision and manage the AWS resources necessary for a secure
RDS database. The changes include:
 - Add RDS functionality to the AWS package.
 - Use Secrets Manager to store RDS connection information in a
   secure way.
 - Provide a flag for server startup to optionally allow for RDS
   database teardown to preserve the RDS database data.
 - Provide a new method for AWS resource lookup. Previously, all
   manually-created AWS resources that are required when creating
   clusters and installations were passed in as server startup
   flags. New AWS logic is used for RDS management that instead
   uses structured AWS tags to find the correct resources.

Todo:
 - Add more tests

Note:
Without https://github.com/mattermost/mattermost-operator/pull/93, RDS
databases work, but the cluster installation reports `stable` before it actually
is.

https://mattermost.atlassian.net/browse/MM-19080