### PR TITLE
Use apt-get instead of apt in the Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,7 +5,7 @@ ARG DOCKER_BASE_IMAGE=alpine:3.9
 FROM ${DOCKER_BUILD_IMAGE} AS build
 WORKDIR /mattermost-cloud/
 COPY . /mattermost-cloud/
-RUN apt update && apt install -y unzip
+RUN apt-get update -yq && apt-get install -yq unzip
 RUN make get-terraform get-kops get-helm get-kubectl
 RUN make build
 


### PR DESCRIPTION
`apt` complains when you use it in a script, because it's meant for interactive use, not non-interactive:

> WARNING : apt does not have a stable CLI interface. Use with caution in scripts.

This change swaps out the calls to `apt` to use `apt-get` instead, which _does_ have a stable CLI. This is a very minor change, which should have almost no change in functionality besides no longer receiving the warning, but theoretically it could prevent bugs in the future if `apt`'s interface does change, as the warning says.