### PR TITLE
Find terraform on the PATH instead of using a hardcoded location

### DIFF
--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -143,7 +143,11 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 		return errors.Wrap(err, fmt.Sprintf("failed to rename kops output directory to '%s'", outputDir))
 	}
 
-	terraformClient := terraform.New(outputDir, logger)
+	terraformClient, err := terraform.New(outputDir, logger)
+	if err != nil {
+		return err
+	}
+
 	defer terraformClient.Close()
 
 	err = terraformClient.Init()
@@ -434,7 +438,10 @@ func (provisioner *KopsProvisioner) UpgradeCluster(cluster *model.Cluster) error
 		return errors.Wrapf(err, "failed to find cluster directory %q", outputDir)
 	}
 
-	terraformClient := terraform.New(outputDir, logger)
+	terraformClient, err := terraform.New(outputDir, logger)
+	if err != nil {
+		return err
+	}
 	defer terraformClient.Close()
 
 	err = terraformClient.Init()
@@ -521,7 +528,11 @@ func (provisioner *KopsProvisioner) DeleteCluster(cluster *model.Cluster, aws aw
 		return errors.Wrapf(err, "failed to find cluster directory %q", outputDir)
 	}
 
-	terraformClient := terraform.New(outputDir, logger)
+	terraformClient, err := terraform.New(outputDir, logger)
+	if err != nil {
+		return err
+	}
+
 	defer terraformClient.Close()
 
 	err = terraformClient.Init()

--- a/internal/tools/terraform/cmd.go
+++ b/internal/tools/terraform/cmd.go
@@ -1,10 +1,10 @@
 package terraform
 
 import (
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"os/exec"
 )
-
-const defaultTerraformPath = "/usr/local/bin/terraform"
 
 // Cmd is the terraform command to execute.
 type Cmd struct {
@@ -14,12 +14,17 @@ type Cmd struct {
 }
 
 // New creates a new instance of Cmd through which to execute terraform.
-func New(dir string, logger log.FieldLogger) *Cmd {
+func New(dir string, logger log.FieldLogger) (*Cmd, error) {
+	terraformPath, err := exec.LookPath("terraform")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to find terraform installed on your PATH")
+	}
+
 	return &Cmd{
-		terraformPath: defaultTerraformPath,
+		terraformPath: terraformPath,
 		dir:           dir,
 		logger:        logger,
-	}
+	}, nil
 }
 
 // Close is a no-op.


### PR DESCRIPTION
This is a complementary change to the one regarding `kops` yesterday, to do the same thing for the Terraform binary.

Some test output:
```
~/g/s/g/m/mattermost-cloud » docker run -it 756 /bin/sh                                                                                                        my-changes ✗
/mattermost-cloud $ which terraform
/usr/local/bin/terraform
/mattermost-cloud $ terraform
Usage: terraform [-version] [-help] <command> [args]

The available commands for execution are listed below.
The most common, useful commands are shown first, followed by
less common or more advanced commands. If you're just getting
started with Terraform, stick with the common commands. For the
other commands, please read the help and docs before usage.

Common commands:
    apply              Builds or changes infrastructure
    console            Interactive console for Terraform interpolations
    destroy            Destroy Terraform-managed infrastructure
    env                Workspace management
    fmt                Rewrites config files to canonical format
    get                Download and install modules for the configuration
    graph              Create a visual graph of Terraform resources
    import             Import existing infrastructure into Terraform
    init               Initialize a Terraform working directory
    output             Read an output from a state file
    plan               Generate and show an execution plan
    providers          Prints a tree of the providers used in the configuration
    push               Upload this Terraform module to Atlas to run
    refresh            Update local state file against real resources
    show               Inspect Terraform state or plan
    taint              Manually mark a resource for recreation
    untaint            Manually unmark a resource as tainted
    validate           Validates the Terraform files
    version            Prints the Terraform version
    workspace          Workspace management

All other commands:
    0.12checklist      Checks whether the configuration is ready for Terraform v0.12
    debug              Debug output management (experimental)
    force-unlock       Manually unlock the terraform state
    state              Advanced state management
/mattermost-cloud $ 
```