### PR TITLE
Refactor cluster and installation states

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -44,6 +44,7 @@ func init() {
 	clusterCmd.AddCommand(clusterGetCmd)
 	clusterCmd.AddCommand(clusterListCmd)
 	clusterCmd.AddCommand(clusterInstallationCmd)
+	clusterCmd.AddCommand(clusterShowStateReport)
 }
 
 var clusterCmd = &cobra.Command{
@@ -200,6 +201,24 @@ var clusterListCmd = &cobra.Command{
 		}
 
 		err = printJSON(clusters)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+// TODO:
+// Instead of showing the state data from the model of the CLI binary, add a new
+// API endpoint to return the server's state model.
+var clusterShowStateReport = &cobra.Command{
+	Use:   "state-report",
+	Short: "Shows information regarding changing cluster state.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		err := printJSON(model.GetClusterRequestStateReport())
 		if err != nil {
 			return err
 		}

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -42,6 +42,7 @@ func init() {
 	installationCmd.AddCommand(installationDeleteCmd)
 	installationCmd.AddCommand(installationGetCmd)
 	installationCmd.AddCommand(installationListCmd)
+	installationCmd.AddCommand(installationShowStateReport)
 }
 
 var installationCmd = &cobra.Command{
@@ -188,6 +189,24 @@ var installationListCmd = &cobra.Command{
 		}
 
 		err = printJSON(installations)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+// TODO:
+// Instead of showing the state data from the model of the CLI binary, add a new
+// API endpoint to return the server's state model.
+var installationShowStateReport = &cobra.Command{
+	Use:   "state-report",
+	Short: "Shows information regarding changing installation state.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		err := printJSON(model.GetInstallationRequestStateReport())
 		if err != nil {
 			return err
 		}

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -37,12 +37,7 @@ func (sqlStore *SQLStore) GetCluster(id string) (*model.Cluster, error) {
 func (sqlStore *SQLStore) GetUnlockedClustersPendingWork() ([]*model.Cluster, error) {
 	builder := clusterSelect.
 		Where(sq.Eq{
-			"State": []string{
-				model.ClusterStateCreationRequested,
-				model.ClusterStateProvisioningRequested,
-				model.ClusterStateUpgradeRequested,
-				model.ClusterStateDeletionRequested,
-			},
+			"State": model.AllCusterStatesPendingWork,
 		}).
 		Where("LockAcquiredAt = 0").
 		OrderBy("CreateAt ASC")

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -37,7 +37,7 @@ func (sqlStore *SQLStore) GetCluster(id string) (*model.Cluster, error) {
 func (sqlStore *SQLStore) GetUnlockedClustersPendingWork() ([]*model.Cluster, error) {
 	builder := clusterSelect.
 		Where(sq.Eq{
-			"State": model.AllCusterStatesPendingWork,
+			"State": model.AllClusterStatesPendingWork,
 		}).
 		Where("LockAcquiredAt = 0").
 		OrderBy("CreateAt ASC")

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -39,18 +39,7 @@ func (sqlStore *SQLStore) GetInstallation(id string) (*model.Installation, error
 func (sqlStore *SQLStore) GetUnlockedInstallationsPendingWork() ([]*model.Installation, error) {
 	builder := installationSelect.
 		Where(sq.Eq{
-			"State": []string{
-				model.InstallationStateCreationRequested,
-				model.InstallationStateCreationPreProvisioning,
-				model.InstallationStateCreationInProgress,
-				model.InstallationStateCreationNoCompatibleClusters,
-				model.InstallationStateCreationDNS,
-				model.InstallationStateUpgradeRequested,
-				model.InstallationStateUpgradeInProgress,
-				model.InstallationStateDeletionRequested,
-				model.InstallationStateDeletionInProgress,
-				model.InstallationStateDeletionFinalCleanup,
-			},
+			"State": model.AllInstallationStatesPendingWork,
 		}).
 		Where("LockAcquiredAt = 0").
 		OrderBy("CreateAt ASC")

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -7,30 +7,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	// ClusterStateCreationRequested is a cluster in the process of being created.
-	ClusterStateCreationRequested = "creation-requested"
-	// ClusterStateCreationFailed is a cluster that failed creation.
-	ClusterStateCreationFailed = "creation-failed"
-	// ClusterStateProvisioningRequested is a cluster in the process of being
-	// provisioned with operators.
-	ClusterStateProvisioningRequested = "provisioning-requested"
-	// ClusterStateProvisioningFailed is a cluster that failed provisioning.
-	ClusterStateProvisioningFailed = "provisioning-failed"
-	// ClusterStateDeletionRequested is a cluster in the process of being deleted.
-	ClusterStateDeletionRequested = "deletion-requested"
-	// ClusterStateDeletionFailed is a cluster that failed deletion.
-	ClusterStateDeletionFailed = "deletion-failed"
-	// ClusterStateDeleted is a cluster that has been deleted
-	ClusterStateDeleted = "deleted"
-	// ClusterStateUpgradeRequested is a cluster in the process of upgrading.
-	ClusterStateUpgradeRequested = "upgrade-requested"
-	// ClusterStateUpgradeFailed is a cluster that failed to upgrade.
-	ClusterStateUpgradeFailed = "upgrade-failed"
-	// ClusterStateStable is a cluster in a stable state and undergoing no changes.
-	ClusterStateStable = "stable"
-)
-
 // Cluster represents a Kubernetes cluster.
 type Cluster struct {
 	ID                  string

--- a/model/cluster_states.go
+++ b/model/cluster_states.go
@@ -1,0 +1,173 @@
+package model
+
+const (
+	// ClusterStateStable is a cluster in a stable state and undergoing no changes.
+	ClusterStateStable = "stable"
+	// ClusterStateCreationRequested is a cluster in the process of being created.
+	ClusterStateCreationRequested = "creation-requested"
+	// ClusterStateCreationFailed is a cluster that failed creation.
+	ClusterStateCreationFailed = "creation-failed"
+	// ClusterStateProvisioningRequested is a cluster in the process of being
+	// provisioned with operators.
+	ClusterStateProvisioningRequested = "provisioning-requested"
+	// ClusterStateProvisioningFailed is a cluster that failed provisioning.
+	ClusterStateProvisioningFailed = "provisioning-failed"
+	// ClusterStateUpgradeRequested is a cluster in the process of upgrading.
+	ClusterStateUpgradeRequested = "upgrade-requested"
+	// ClusterStateUpgradeFailed is a cluster that failed to upgrade.
+	ClusterStateUpgradeFailed = "upgrade-failed"
+	// ClusterStateDeletionRequested is a cluster in the process of being deleted.
+	ClusterStateDeletionRequested = "deletion-requested"
+	// ClusterStateDeletionFailed is a cluster that failed deletion.
+	ClusterStateDeletionFailed = "deletion-failed"
+	// ClusterStateDeleted is a cluster that has been deleted
+	ClusterStateDeleted = "deleted"
+)
+
+// AllClusterStates is a list of all states a cluster can be in.
+// Warning:
+// When creating a new cluster state, it must be added to this list.
+var AllClusterStates = []string{
+	ClusterStateStable,
+	ClusterStateCreationRequested,
+	ClusterStateCreationFailed,
+	ClusterStateProvisioningRequested,
+	ClusterStateProvisioningFailed,
+	ClusterStateUpgradeRequested,
+	ClusterStateUpgradeFailed,
+	ClusterStateDeletionRequested,
+	ClusterStateDeletionFailed,
+	ClusterStateDeleted,
+}
+
+// AllCusterStatesPendingWork is a list of all cluster states that the supervisor
+// will attempt to transition towards stable on the next "tick".
+// Warning:
+// When creating a new cluster state, it must be added to this list if the cloud
+// cluster supervisor should perform some action on its next work cycle.
+var AllCusterStatesPendingWork = []string{
+	ClusterStateCreationRequested,
+	ClusterStateProvisioningRequested,
+	ClusterStateUpgradeRequested,
+	ClusterStateDeletionRequested,
+}
+
+// AllClusterRequestStates is a list of all states that a cluster can be put in
+// via the API.
+// Warning:
+// When creating a new cluster state, it must be added to this list if an API
+// endpoint should put the cluster in this state.
+var AllClusterRequestStates = []string{
+	ClusterStateCreationRequested,
+	ClusterStateProvisioningRequested,
+	ClusterStateUpgradeRequested,
+	ClusterStateDeletionRequested,
+}
+
+// ValidTransitionState returns whether a cluster can be transitioned into the
+// new state or not based on its current state.
+func (c *Cluster) ValidTransitionState(newState string) bool {
+	switch newState {
+	case ClusterStateCreationRequested:
+		return validTransitionToClusterStateCreationRequested(c.State)
+	case ClusterStateProvisioningRequested:
+		return validTransitionToClusterStateProvisioningRequested(c.State)
+	case ClusterStateUpgradeRequested:
+		return validTransitionToClusterStateUpgradeRequested(c.State)
+	case ClusterStateDeletionRequested:
+		return validTransitionToClusterStateDeletionRequested(c.State)
+	}
+
+	return false
+}
+
+func validTransitionToClusterStateCreationRequested(currentState string) bool {
+	switch currentState {
+	case ClusterStateCreationRequested,
+		ClusterStateCreationFailed:
+		return true
+	}
+
+	return false
+}
+
+func validTransitionToClusterStateProvisioningRequested(currentState string) bool {
+	switch currentState {
+	case ClusterStateStable,
+		ClusterStateProvisioningFailed,
+		ClusterStateProvisioningRequested:
+		return true
+	}
+
+	return false
+}
+
+func validTransitionToClusterStateUpgradeRequested(currentState string) bool {
+	switch currentState {
+	case ClusterStateStable,
+		ClusterStateUpgradeRequested,
+		ClusterStateUpgradeFailed:
+		return true
+	}
+
+	return false
+}
+
+func validTransitionToClusterStateDeletionRequested(currentState string) bool {
+	switch currentState {
+	case ClusterStateStable,
+		ClusterStateCreationRequested,
+		ClusterStateCreationFailed,
+		ClusterStateProvisioningFailed,
+		ClusterStateUpgradeRequested,
+		ClusterStateUpgradeFailed,
+		ClusterStateDeletionRequested,
+		ClusterStateDeletionFailed:
+		return true
+	}
+
+	return false
+}
+
+// ClusterStateReport is a report of all cluster requests states.
+type ClusterStateReport []StateReportEntry
+
+// StateReportEntry is a report entry of a given request state.
+type StateReportEntry struct {
+	RequestedState string
+	ValidStates    StateList
+	InvalidStates  StateList
+}
+
+// StateList is a list of states
+type StateList []string
+
+// Count provides the number of states in a StateList.
+func (sl *StateList) Count() int {
+	return len(*sl)
+}
+
+// GetClusterRequestStateReport returns a ClusterStateReport based on the current
+// model of cluster states.
+func GetClusterRequestStateReport() ClusterStateReport {
+	report := ClusterStateReport{}
+
+	for _, requestState := range AllClusterRequestStates {
+		entry := StateReportEntry{
+			RequestedState: requestState,
+		}
+
+		for _, newState := range AllClusterStates {
+			c := Cluster{State: newState}
+			if c.ValidTransitionState(requestState) {
+				entry.ValidStates = append(entry.ValidStates, newState)
+			} else {
+				entry.InvalidStates = append(entry.InvalidStates, newState)
+			}
+		}
+
+		report = append(report, entry)
+	}
+
+	return report
+}

--- a/model/cluster_states.go
+++ b/model/cluster_states.go
@@ -40,12 +40,12 @@ var AllClusterStates = []string{
 	ClusterStateDeleted,
 }
 
-// AllCusterStatesPendingWork is a list of all cluster states that the supervisor
+// AllClusterStatesPendingWork is a list of all cluster states that the supervisor
 // will attempt to transition towards stable on the next "tick".
 // Warning:
 // When creating a new cluster state, it must be added to this list if the cloud
 // cluster supervisor should perform some action on its next work cycle.
-var AllCusterStatesPendingWork = []string{
+var AllClusterStatesPendingWork = []string{
 	ClusterStateCreationRequested,
 	ClusterStateProvisioningRequested,
 	ClusterStateUpgradeRequested,

--- a/model/installation.go
+++ b/model/installation.go
@@ -3,47 +3,6 @@ package model
 import (
 	"encoding/json"
 	"io"
-
-	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
-)
-
-const (
-	// InstallationStateCreationRequested is an installation waiting to be created.
-	InstallationStateCreationRequested = "creation-requested"
-	// InstallationStateCreationPreProvisioning in an installation in the process
-	// of having managed services created along with any other preparation.
-	InstallationStateCreationPreProvisioning = "creation-pre-provisioning"
-	// InstallationStateCreationInProgress is an installation in the process of
-	// being created.
-	InstallationStateCreationInProgress = "creation-in-progress"
-	// InstallationStateCreationDNS is an installation in the process having configuring DNS.
-	InstallationStateCreationDNS = "creation-configuring-dns"
-	// InstallationStateCreationFailed is an installation that failed creation.
-	InstallationStateCreationFailed = "creation-failed"
-	// InstallationStateCreationNoCompatibleClusters is an installation that
-	// can't be fully created because there are no compatible clusters.
-	InstallationStateCreationNoCompatibleClusters = "creation-no-compatible-clusters"
-	// InstallationStateDeletionRequested is an installation to be deleted.
-	InstallationStateDeletionRequested = "deletion-requested"
-	// InstallationStateDeletionInProgress is an installation being deleted.
-	InstallationStateDeletionInProgress = "deletion-in-progress"
-	// InstallationStateDeletionFinalCleanup is the final step of installation deletion.
-	InstallationStateDeletionFinalCleanup = "deletion-final-cleanup"
-	// InstallationStateDeletionFailed is an installation that failed deletion.
-	InstallationStateDeletionFailed = "deletion-failed"
-	// InstallationStateDeleted is an installation that has been deleted
-	InstallationStateDeleted = "deleted"
-	// InstallationStateUpgradeRequested is an installation that is about to undergo a version change.
-	InstallationStateUpgradeRequested = "upgrade-requested"
-	// InstallationStateUpgradeInProgress is an installation that is undergoing a version change.
-	InstallationStateUpgradeInProgress = "upgrade-in-progress"
-	// InstallationStateUpgradeFailed is an installation that failed to change versions.
-	InstallationStateUpgradeFailed = "upgrade-failed"
-	// InstallationStateStable is an installation in a stable state and undergoing no changes.
-	InstallationStateStable = "stable"
-
-	// InstallationDefaultSize is the default size for an installation.
-	InstallationDefaultSize = mmv1alpha1.Size100String
 )
 
 // Installation represents a Mattermost installation.

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -1,0 +1,181 @@
+package model
+
+import mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
+
+const (
+	// InstallationStateStable is an installation in a stable state and undergoing no changes.
+	InstallationStateStable = "stable"
+	// InstallationStateCreationRequested is an installation waiting to be created.
+	InstallationStateCreationRequested = "creation-requested"
+	// InstallationStateCreationPreProvisioning in an installation in the process
+	// of having managed services created along with any other preparation.
+	InstallationStateCreationPreProvisioning = "creation-pre-provisioning"
+	// InstallationStateCreationInProgress is an installation in the process of
+	// being created.
+	InstallationStateCreationInProgress = "creation-in-progress"
+	// InstallationStateCreationDNS is an installation in the process having configuring DNS.
+	InstallationStateCreationDNS = "creation-configuring-dns"
+	// InstallationStateCreationFailed is an installation that failed creation.
+	InstallationStateCreationFailed = "creation-failed"
+	// InstallationStateCreationNoCompatibleClusters is an installation that
+	// can't be fully created because there are no compatible clusters.
+	InstallationStateCreationNoCompatibleClusters = "creation-no-compatible-clusters"
+	// InstallationStateUpgradeRequested is an installation that is about to undergo a version change.
+	InstallationStateUpgradeRequested = "upgrade-requested"
+	// InstallationStateUpgradeInProgress is an installation that is undergoing a version change.
+	InstallationStateUpgradeInProgress = "upgrade-in-progress"
+	// InstallationStateUpgradeFailed is an installation that failed to change versions.
+	InstallationStateUpgradeFailed = "upgrade-failed"
+	// InstallationStateDeletionRequested is an installation to be deleted.
+	InstallationStateDeletionRequested = "deletion-requested"
+	// InstallationStateDeletionInProgress is an installation being deleted.
+	InstallationStateDeletionInProgress = "deletion-in-progress"
+	// InstallationStateDeletionFinalCleanup is the final step of installation deletion.
+	InstallationStateDeletionFinalCleanup = "deletion-final-cleanup"
+	// InstallationStateDeletionFailed is an installation that failed deletion.
+	InstallationStateDeletionFailed = "deletion-failed"
+	// InstallationStateDeleted is an installation that has been deleted
+	InstallationStateDeleted = "deleted"
+)
+
+const (
+	// InstallationDefaultSize is the default size for an installation.
+	InstallationDefaultSize = mmv1alpha1.Size100String
+)
+
+// AllInstallationStates is a list of all states an installation can be in.
+// Warning:
+// When creating a new installation state, it must be added to this list.
+var AllInstallationStates = []string{
+	InstallationStateStable,
+	InstallationStateCreationRequested,
+	InstallationStateCreationPreProvisioning,
+	InstallationStateCreationInProgress,
+	InstallationStateCreationDNS,
+	InstallationStateCreationFailed,
+	InstallationStateCreationNoCompatibleClusters,
+	InstallationStateUpgradeRequested,
+	InstallationStateUpgradeInProgress,
+	InstallationStateUpgradeFailed,
+	InstallationStateDeletionRequested,
+	InstallationStateDeletionInProgress,
+	InstallationStateDeletionFinalCleanup,
+	InstallationStateDeletionFailed,
+	InstallationStateDeleted,
+}
+
+// AllInstallationStatesPendingWork is a list of all installation states that
+// the supervisor will attempt to transition towards stable on the next "tick".
+// Warning:
+// When creating a new installation state, it must be added to this list if the
+// cloud installation supervisor should perform some action on its next work cycle.
+var AllInstallationStatesPendingWork = []string{
+	InstallationStateCreationRequested,
+	InstallationStateCreationPreProvisioning,
+	InstallationStateCreationInProgress,
+	InstallationStateCreationNoCompatibleClusters,
+	InstallationStateCreationDNS,
+	InstallationStateUpgradeRequested,
+	InstallationStateUpgradeInProgress,
+	InstallationStateDeletionRequested,
+	InstallationStateDeletionInProgress,
+	InstallationStateDeletionFinalCleanup,
+}
+
+// AllInstallationRequestStates is a list of all states that an installation can
+// be put in via the API.
+// Warning:
+// When creating a new installation state, it must be added to this list if an
+// API endpoint should put the installation in this state.
+var AllInstallationRequestStates = []string{
+	InstallationStateCreationRequested,
+	InstallationStateUpgradeRequested,
+	InstallationStateDeletionRequested,
+}
+
+// ValidTransitionState returns whether an installation can be transitioned into
+// the new state or not based on its current state.
+func (i *Installation) ValidTransitionState(newState string) bool {
+	switch newState {
+	case InstallationStateCreationRequested:
+		return validTransitionToInstallationStateCreationRequested(i.State)
+	case InstallationStateUpgradeRequested:
+		return validTransitionToInstallationStateUpgradeRequested(i.State)
+	case InstallationStateDeletionRequested:
+		return validTransitionToInstallationStateDeletionRequested(i.State)
+	}
+
+	return false
+}
+
+func validTransitionToInstallationStateCreationRequested(currentState string) bool {
+	switch currentState {
+	case InstallationStateCreationRequested,
+		InstallationStateCreationFailed:
+		return true
+	}
+
+	return false
+}
+
+func validTransitionToInstallationStateUpgradeRequested(currentState string) bool {
+	switch currentState {
+	case InstallationStateStable,
+		InstallationStateUpgradeRequested,
+		InstallationStateUpgradeInProgress,
+		InstallationStateUpgradeFailed:
+		return true
+	}
+
+	return false
+}
+
+func validTransitionToInstallationStateDeletionRequested(currentState string) bool {
+	switch currentState {
+	case InstallationStateStable,
+		InstallationStateCreationRequested,
+		InstallationStateCreationPreProvisioning,
+		InstallationStateCreationInProgress,
+		InstallationStateCreationDNS,
+		InstallationStateCreationNoCompatibleClusters,
+		InstallationStateCreationFailed,
+		InstallationStateUpgradeRequested,
+		InstallationStateUpgradeInProgress,
+		InstallationStateUpgradeFailed,
+		InstallationStateDeletionRequested,
+		InstallationStateDeletionInProgress,
+		InstallationStateDeletionFinalCleanup,
+		InstallationStateDeletionFailed:
+		return true
+	}
+
+	return false
+}
+
+// InstallationStateReport is a report of all installation requests states.
+type InstallationStateReport []StateReportEntry
+
+// GetInstallationRequestStateReport returns a InstallationStateReport based on
+// the current model of installation states.
+func GetInstallationRequestStateReport() InstallationStateReport {
+	report := InstallationStateReport{}
+
+	for _, requestState := range AllInstallationRequestStates {
+		entry := StateReportEntry{
+			RequestedState: requestState,
+		}
+
+		for _, newState := range AllInstallationStates {
+			i := Installation{State: newState}
+			if i.ValidTransitionState(requestState) {
+				entry.ValidStates = append(entry.ValidStates, newState)
+			} else {
+				entry.InvalidStates = append(entry.InvalidStates, newState)
+			}
+		}
+
+		report = append(report, entry)
+	}
+
+	return report
+}


### PR DESCRIPTION
This change does the following:
 - Moves state definition and handling for clusters and installations
   into the model package.
 - Provides new tooling for exporting state data of the current model
   for clusters and installations.
 - Adds two new subcommands for viewing this state data.

Note: no state decision-making was altered in this PR, although changes
that could be made are now easier to understand via the state reports.

https://mattermost.atlassian.net/browse/MM-19789

Example Report:
```
cloud cluster state-report
[
    {
        "RequestedState": "creation-requested",
        "ValidStates": [
            "creation-requested",
            "creation-failed"
        ],
        "InvalidStates": [
            "stable",
            "provisioning-requested",
            "provisioning-failed",
            "upgrade-requested",
            "upgrade-failed",
            "deletion-requested",
            "deletion-failed",
            "deleted"
        ]
    },
    {
        "RequestedState": "provisioning-requested",
        "ValidStates": [
            "stable",
            "provisioning-requested",
            "provisioning-failed"
        ],
        "InvalidStates": [
            "creation-requested",
            "creation-failed",
            "upgrade-requested",
            "upgrade-failed",
            "deletion-requested",
            "deletion-failed",
            "deleted"
        ]
    },
    {
        "RequestedState": "upgrade-requested",
        "ValidStates": [
            "stable",
            "upgrade-requested",
            "upgrade-failed"
        ],
        "InvalidStates": [
            "creation-requested",
            "creation-failed",
            "provisioning-requested",
            "provisioning-failed",
            "deletion-requested",
            "deletion-failed",
            "deleted"
        ]
    },
    {
        "RequestedState": "deletion-requested",
        "ValidStates": [
            "stable",
            "creation-requested",
            "creation-failed",
            "provisioning-failed",
            "upgrade-requested",
            "upgrade-failed",
            "deletion-requested",
            "deletion-failed"
        ],
        "InvalidStates": [
            "provisioning-requested",
            "deleted"
        ]
    }
]
```