### PR TITLE
Add cluster option to toggle installation scheduling

### DIFF
--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -489,4 +489,19 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.9.0"), semver.MustParse("0.10.0"), func(e execer) error {
+		if e.DriverName() == driverPostgres {
+			_, err := e.Exec(`UPDATE Cluster SET AllowInstallations = 'TRUE';`)
+			if err != nil {
+				return err
+			}
+		} else if e.DriverName() == driverSqlite {
+			_, err := e.Exec(`UPDATE Cluster SET AllowInstallations = '1';`)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}},
 }

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -249,7 +249,7 @@ func (s *InstallationSupervisor) createInstallation(installation *model.Installa
 	}
 
 	// TODO: Support creating a cluster on demand if no existing cluster meets the criteria.
-	logger.Debug("No compatible clusters available for installation")
+	logger.Warn("No compatible clusters available for installation scheduling")
 
 	return model.InstallationStateCreationNoCompatibleClusters
 }
@@ -265,6 +265,10 @@ func (s *InstallationSupervisor) createClusterInstallation(cluster *model.Cluste
 
 	if cluster.State != model.ClusterStateStable {
 		logger.Debugf("Cluster %s is not stable (currently %s)", cluster.ID, cluster.State)
+		return nil
+	}
+	if !cluster.AllowInstallations {
+		logger.Debugf("Cluster %s is set to not allow for new installation scheduling", cluster.ID)
 		return nil
 	}
 
@@ -641,7 +645,7 @@ func (s *InstallationSupervisor) finalDeletionCleanup(installation *model.Instal
 		return model.InstallationStateDeletionFinalCleanup
 	}
 
-	logger.Infof("Finished deleting cluster installation")
+	logger.Info("Finished deleting installation")
 
 	return model.InstallationStateDeleted
 }

--- a/model/client.go
+++ b/model/client.go
@@ -203,6 +203,23 @@ func (c *Client) GetClusters(request *GetClustersRequest) ([]*Cluster, error) {
 	}
 }
 
+// UpdateCluster updates a cluster's configuration.
+func (c *Client) UpdateCluster(clusterID string, request *UpdateClusterRequest) (*Cluster, error) {
+	resp, err := c.doPut(c.buildURL("/api/cluster/%s", clusterID), request)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return ClusterFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // UpgradeCluster upgrades a cluster to the latest recommended production ready k8s version.
 func (c *Client) UpgradeCluster(clusterID, version string) error {
 	resp, err := c.doPut(c.buildURL("/api/cluster/%s/kubernetes/%s", clusterID, version), nil)

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -11,9 +11,10 @@ import (
 
 // CreateClusterRequest specifies the parameters for a new cluster.
 type CreateClusterRequest struct {
-	Provider string
-	Size     string
-	Zones    []string
+	Provider           string
+	Size               string
+	Zones              []string
+	AllowInstallations bool
 }
 
 // NewCreateClusterRequestFromReader will create a CreateClusterRequest from an io.Reader with JSON data.
@@ -61,4 +62,20 @@ func (request *GetClustersRequest) ApplyToURL(u *url.URL) {
 		q.Add("include_deleted", "true")
 	}
 	u.RawQuery = q.Encode()
+}
+
+// UpdateClusterRequest specifies the parameters available for updating a cluster.
+type UpdateClusterRequest struct {
+	AllowInstallations bool
+}
+
+// NewUpdateClusterRequestFromReader will create an UpdateClusterRequest from an io.Reader with JSON data.
+func NewUpdateClusterRequestFromReader(reader io.Reader) (*UpdateClusterRequest, error) {
+	var updateClusterRequest UpdateClusterRequest
+	err := json.NewDecoder(reader).Decode(&updateClusterRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode update cluster request")
+	}
+
+	return &updateClusterRequest, nil
 }


### PR DESCRIPTION
This allows clusters to be skipped when new cluster installations
are being scheduled. The configuration can be changed via a new
cluster API endpoint.

https://mattermost.atlassian.net/browse/MM-19741