### PR TITLE
Improve cluster version handling

### DIFF
--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-cloud/internal/api"
-	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -604,12 +604,25 @@ func TestUpgradeCluster(t *testing.T) {
 		require.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
 	})
 
-	t.Run("while stable", func(t *testing.T) {
+	t.Run("while stable, to latest", func(t *testing.T) {
 		cluster1.State = model.ClusterStateStable
 		err = sqlStore.UpdateCluster(cluster1)
 		require.NoError(t, err)
 
 		err = client.UpgradeCluster(cluster1.ID, "latest")
+		require.NoError(t, err)
+
+		cluster1, err = client.GetCluster(cluster1.ID)
+		require.NoError(t, err)
+		require.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
+	})
+
+	t.Run("while stable, to valid version", func(t *testing.T) {
+		cluster1.State = model.ClusterStateStable
+		err = sqlStore.UpdateCluster(cluster1)
+		require.NoError(t, err)
+
+		err = client.UpgradeCluster(cluster1.ID, "1.14.1")
 		require.NoError(t, err)
 
 		cluster1, err = client.GetCluster(cluster1.ID)

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -10,10 +10,13 @@ import (
 )
 
 func TestNewCreateClusterRequestFromReader(t *testing.T) {
-	defaultCreateClusterRequest := &model.CreateClusterRequest{
-		Provider: "aws",
-		Size:     "SizeAlef500",
-		Zones:    []string{"us-east-1a"},
+	defaultCreateClusterRequest := func() *model.CreateClusterRequest {
+		return &model.CreateClusterRequest{
+			Provider: "aws",
+			Version:  "latest",
+			Size:     "SizeAlef500",
+			Zones:    []string{"us-east-1a"},
+		}
 	}
 
 	t.Run("empty request", func(t *testing.T) {
@@ -21,7 +24,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			``,
 		)))
 		require.NoError(t, err)
-		require.Equal(t, defaultCreateClusterRequest, clusterRequest)
+		require.Equal(t, defaultCreateClusterRequest(), clusterRequest)
 	})
 
 	t.Run("invalid request", func(t *testing.T) {
@@ -45,15 +48,17 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			`{"Size": "SizeAlef1000"}`,
 		)))
 		require.NoError(t, err)
-		require.Equal(t, &model.CreateClusterRequest{Provider: model.ProviderAWS, Size: model.SizeAlef1000, Zones: []string{"us-east-1a"}}, clusterRequest)
+		modifiedDefaultCreateClusterRequest := defaultCreateClusterRequest()
+		modifiedDefaultCreateClusterRequest.Size = "SizeAlef1000"
+		require.Equal(t, modifiedDefaultCreateClusterRequest, clusterRequest)
 	})
 
 	t.Run("full request", func(t *testing.T) {
 		clusterRequest, err := model.NewCreateClusterRequestFromReader(bytes.NewReader([]byte(
-			`{"Provider": "aws", "Size": "SizeAlef1000", "Zones":["zone1", "zone2"]}`,
+			`{"Provider": "aws", "Version": "1.12.4", "Size": "SizeAlef1000", "Zones": ["zone1", "zone2"]}`,
 		)))
 		require.NoError(t, err)
-		require.Equal(t, &model.CreateClusterRequest{Provider: model.ProviderAWS, Size: model.SizeAlef1000, Zones: []string{"zone1", "zone2"}}, clusterRequest)
+		require.Equal(t, &model.CreateClusterRequest{Provider: model.ProviderAWS, Version: "1.12.4", Size: model.SizeAlef1000, Zones: []string{"zone1", "zone2"}}, clusterRequest)
 	})
 }
 

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -14,7 +14,7 @@ func init() {
 	clusterSelect = sq.
 		Select(
 			"ID", "Provider", "Provisioner", "ProviderMetadata", "ProvisionerMetadata",
-			"Size", "State", "AllowInstallations", "CreateAt", "DeleteAt",
+			"Version", "Size", "State", "AllowInstallations", "CreateAt", "DeleteAt",
 			"LockAcquiredBy", "LockAcquiredAt",
 		).
 		From("Cluster")
@@ -98,6 +98,7 @@ func (sqlStore *SQLStore) CreateCluster(cluster *model.Cluster) error {
 			"Provisioner":         cluster.Provisioner,
 			"ProviderMetadata":    cluster.ProviderMetadata,
 			"ProvisionerMetadata": cluster.ProvisionerMetadata,
+			"Version":             cluster.Version,
 			"Size":                cluster.Size,
 			"State":               cluster.State,
 			"AllowInstallations":  cluster.AllowInstallations,
@@ -123,6 +124,7 @@ func (sqlStore *SQLStore) UpdateCluster(cluster *model.Cluster) error {
 			"Provisioner":         cluster.Provisioner,
 			"ProviderMetadata":    cluster.ProviderMetadata,
 			"ProvisionerMetadata": cluster.ProvisionerMetadata,
+			"Version":             cluster.Version,
 			"Size":                cluster.Size,
 			"State":               cluster.State,
 			"AllowInstallations":  cluster.AllowInstallations,

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -78,6 +78,10 @@ func (p *mockClusterProvisioner) DeleteCluster(cluster *model.Cluster, aws aws.A
 	return nil
 }
 
+func (p *mockClusterProvisioner) GetClusterVersion(cluster *model.Cluster) (string, error) {
+	return "0.0.0", nil
+}
+
 func TestClusterSupervisorDo(t *testing.T) {
 	t.Run("no clusters pending work", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
@@ -106,7 +110,7 @@ func TestClusterSupervisorDo(t *testing.T) {
 		require.NoError(t, err)
 
 		<-mockStore.UnlockChan
-		require.Equal(t, 2, mockStore.UpdateClusterCalls)
+		require.Equal(t, 3, mockStore.UpdateClusterCalls)
 	})
 }
 

--- a/internal/tools/kops/run.go
+++ b/internal/tools/kops/run.go
@@ -64,6 +64,7 @@ func (c *Cmd) run(arg ...string) ([]byte, []byte, error) {
 	cmd := exec.Command(c.kopsPath, arg...)
 	cmd.Env = append(
 		os.Environ(),
+		"KOPS_FEATURE_FLAGS=SpecOverrideFlag", // Required in kops 1.14.0 for set command.
 		fmt.Sprintf("KUBECONFIG=%s", c.GetKubeConfigPath()),
 	)
 
@@ -74,6 +75,7 @@ func (c *Cmd) runSilent(arg ...string) ([]byte, []byte, error) {
 	cmd := exec.Command(c.kopsPath, arg...)
 	cmd.Env = append(
 		os.Environ(),
+		"KOPS_FEATURE_FLAGS=SpecOverrideFlag", // Required in kops 1.14.0 for set command.
 		fmt.Sprintf("KUBECONFIG=%s", c.GetKubeConfigPath()),
 	)
 

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"regexp"
 
 	"github.com/pkg/errors"
 )
@@ -15,6 +16,7 @@ type Cluster struct {
 	ProviderMetadata    []byte `json:",omitempty"`
 	ProvisionerMetadata []byte `json:",omitempty"`
 	AllowInstallations  bool
+	Version             string
 	Size                string
 	State               string
 	CreateAt            int64
@@ -94,4 +96,12 @@ type ClusterFilter struct {
 	Page           int
 	PerPage        int
 	IncludeDeleted bool
+}
+
+var clusterVersionMatcher = regexp.MustCompile(`^(([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3})|(latest))$`)
+
+// ValidClusterVersion returns true if the provided version is either "latest"
+// or a valid k8s version number.
+func ValidClusterVersion(name string) bool {
+	return clusterVersionMatcher.MatchString(name)
 }

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -12,6 +12,7 @@ import (
 // CreateClusterRequest specifies the parameters for a new cluster.
 type CreateClusterRequest struct {
 	Provider           string
+	Version            string
 	Size               string
 	Zones              []string
 	AllowInstallations bool
@@ -28,6 +29,9 @@ func NewCreateClusterRequestFromReader(reader io.Reader) (*CreateClusterRequest,
 	if createClusterRequest.Provider == "" {
 		createClusterRequest.Provider = ProviderAWS
 	}
+	if createClusterRequest.Version == "" {
+		createClusterRequest.Version = "latest"
+	}
 	if createClusterRequest.Size == "" {
 		createClusterRequest.Size = SizeAlef500
 	}
@@ -37,6 +41,9 @@ func NewCreateClusterRequestFromReader(reader io.Reader) (*CreateClusterRequest,
 
 	if createClusterRequest.Provider != ProviderAWS {
 		return nil, errors.Errorf("unsupported provider %s", createClusterRequest.Provider)
+	}
+	if !ValidClusterVersion(createClusterRequest.Version) {
+		return nil, errors.Errorf("unsupported cluster version %s", createClusterRequest.Version)
 	}
 	if !IsSupportedClusterSize(createClusterRequest.Size) {
 		return nil, errors.Errorf("unsupported size %s", createClusterRequest.Size)

--- a/model/cluster_test.go
+++ b/model/cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,4 +111,35 @@ func TestClustersFromReader(t *testing.T) {
 			&Cluster{ID: "id2", Provider: "aws"},
 		}, cluster)
 	})
+}
+
+func TestValidClusterVersion(t *testing.T) {
+	tests := []struct {
+		name  string
+		valid bool
+	}{
+		{"latest", true},
+		{"0.0.0", true},
+		{"1.1.1", true},
+		{"1.11.11", true},
+		{"1.111.111", true},
+		{"1.12.34", true},
+		{"1.12.0", true},
+		{"0.12.34", true},
+		{"latest1", false},
+		{"lates", false},
+		{"1.12.34.56", false},
+		{"1111.1.2", false},
+		{"bad.bad.bad", false},
+		{"1.bad.2", false},
+		{".", false},
+		{"..", false},
+		{"...", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.valid, ValidClusterVersion(test.name))
+		})
+	}
 }

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -6,7 +6,8 @@ import (
 
 // KopsMetadata is the provisioner metadata stored in a model.Cluster.
 type KopsMetadata struct {
-	Name string
+	Name    string
+	Version string
 }
 
 // NewKopsMetadata creates an instance of KopsMetadata given the raw provisioner metadata.


### PR DESCRIPTION
This change does the following:
 - Adds new version column for clusters that stores the kubernetes
   version running on the cluster. This version value is updated
   when a cluster is created, provisioned, or upgraded.
 - Allows new clusters to have a specified version when created and
   for cluster upgrades to target a specific version instead of
   latest stable.
 - Exposes the `kops set cluster` command for updating cluster
   configuration.
 - Exposes a provisioner method for kops to get the current running
   kubernetes version at any time.
 - Removed unused `wait` flag for create and upgrade commands.

https://mattermost.atlassian.net/browse/MM-19742