### PR TITLE
Update Go and Alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   default:
     docker:
-    - image: circleci/golang:1.12
+    - image: circleci/golang:1.13
 
 aliases:
 - &restore_cache
@@ -41,7 +41,7 @@ jobs:
 
   test-postgres:
     docker:
-    - image: circleci/golang:1.12
+    - image: circleci/golang:1.13
       environment:
         CLOUD_DATABASE=postgres://cloud_test@localhost:5432/cloud_test?sslmode=disable
     - image: circleci/postgres:11.2-alpine

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,25 @@
-GO ?= $(shell command -v go 2> /dev/null)
-MATTERMOST_CLOUD_IMAGE ?= mattermost/mattermost-cloud:test
-MACHINE = $(shell uname -m)
-DOCKER_BUILD_IMAGE = golang:1.12
-DOCKER_BASE_IMAGE = alpine:3.9
-GOFLAGS ?= $(GOFLAGS:)
-BUILD_TIME := $(shell date -u +%Y%m%d.%H%M%S)
-BUILD_HASH := $(shell git rev-parse HEAD)
+################################################################################
+##                             VERSION PARAMS                                 ##
+################################################################################
 
+## Docker Build Versions
+DOCKER_BUILD_IMAGE = golang:1.13
+DOCKER_BASE_IMAGE = alpine:3.10
+
+## Tool Versions
 TERRAFORM_VERSION=0.11.14
 KOPS_VERSION=1.14.1
 HELM_VERSION=v2.14.2
 KUBECTL_VERSION=v1.14.0
+
+################################################################################
+
+GO ?= $(shell command -v go 2> /dev/null)
+MATTERMOST_CLOUD_IMAGE ?= mattermost/mattermost-cloud:test
+MACHINE = $(shell uname -m)
+GOFLAGS ?= $(GOFLAGS:)
+BUILD_TIME := $(shell date -u +%Y%m%d.%H%M%S)
+BUILD_HASH := $(shell git rev-parse HEAD)
 
 export GO111MODULE=on
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # Build the mattermost cloud
-ARG DOCKER_BUILD_IMAGE=golang:1.12
-ARG DOCKER_BASE_IMAGE=alpine:3.9
+ARG DOCKER_BUILD_IMAGE=golang:1.13
+ARG DOCKER_BASE_IMAGE=alpine:3.10
 
 FROM ${DOCKER_BUILD_IMAGE} AS build
 WORKDIR /mattermost-cloud/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost-cloud
 
-go 1.12
+go 1.13
 
 require (
 	github.com/Masterminds/squirrel v1.1.0


### PR DESCRIPTION
Changes:
 - Update Go from 1.12 to 1.13
 - Update Alpine from 3.9 to 3.10

I ran into an issue with Go version 1.12 and one of the k8s modules so I decided to take that as our cue to upgrade:

```
verifying k8s.io/apimachinery@v0.0.0-20190817020851-f2f3a405f61d/go.mod: checksum mismatch
	downloaded: h1:nEP/6rwhzfljWYGVS6pfyES3ipZTR19vzMnSM+ur3ho=
	go.sum:     h1:3jediapYqJ2w1BFw7lAZPCx7scubsTfosqHkhXCWJKw=
```

https://github.com/kubernetes-sigs/kubebuilder/issues/1169