### PR TITLE
Cluster installation state improvements

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -186,7 +186,7 @@ var serverCmd = &cobra.Command{
 			logger.WithField("addr", srv.Addr).Info("Listening")
 			err := srv.ListenAndServe()
 			if err != nil && err != http.ErrServerClosed {
-				logger.WithField("err", err).Error("Failed to listen and serve")
+				logger.WithError(err).Error("Failed to listen and serve")
 			}
 		}()
 

--- a/internal/store/cluster_installation.go
+++ b/internal/store/cluster_installation.go
@@ -39,11 +39,7 @@ func (sqlStore *SQLStore) GetUnlockedClusterInstallationsPendingWork() ([]*model
 
 	builder := clusterInstallationSelect.
 		Where(sq.Eq{
-			"State": []string{
-				model.ClusterInstallationStateCreationRequested,
-				model.ClusterInstallationStateDeletionRequested,
-				model.ClusterInstallationStateReconciling,
-			},
+			"State": model.AllClusterInstallationStatesPendingWork,
 		}).
 		Where("LockAcquiredAt = 0").
 		OrderBy("CreateAt ASC")

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -202,20 +202,21 @@ func (s *InstallationSupervisor) createInstallation(installation *model.Installa
 	// installation to be stable once all cluster installations are stable. Or, if
 	// some cluster installations have failed, mark the installation as failed.
 	if len(clusterInstallations) > 0 {
-		var stable, reconciling, failed int
+		var stable, reconciling, failed, other int
 		for _, clusterInstallation := range clusterInstallations {
-			if clusterInstallation.State == model.ClusterInstallationStateStable {
+			switch clusterInstallation.State {
+			case model.ClusterInstallationStateStable:
 				stable++
-			}
-			if clusterInstallation.State == model.ClusterInstallationStateReconciling {
+			case model.ClusterInstallationStateReconciling:
 				reconciling++
-			}
-			if clusterInstallation.State == model.ClusterInstallationStateCreationFailed {
+			case model.ClusterInstallationStateCreationFailed:
 				failed++
+			default:
+				other++
 			}
 		}
 
-		logger.Debugf("Found %d cluster installations, %d stable, %d reconciling, %d failed", len(clusterInstallations), stable, reconciling, failed)
+		logger.Debugf("Found %d cluster installations: %d stable, %d reconciling, %d failed, %d other", len(clusterInstallations), stable, reconciling, failed, other)
 
 		if len(clusterInstallations) == stable {
 			logger.Infof("Finished creating installation")

--- a/model/cluster_installation.go
+++ b/model/cluster_installation.go
@@ -5,23 +5,6 @@ import (
 	"io"
 )
 
-const (
-	// ClusterInstallationStateCreationRequested is a cluster installation in the process of being created.
-	ClusterInstallationStateCreationRequested = "creation-requested"
-	// ClusterInstallationStateCreationFailed is a cluster installation that failed creation.
-	ClusterInstallationStateCreationFailed = "creation-failed"
-	// ClusterInstallationStateDeletionRequested is a cluster installation in the process of being deleted.
-	ClusterInstallationStateDeletionRequested = "deletion-requested"
-	// ClusterInstallationStateDeletionFailed is a cluster installation that failed deletion.
-	ClusterInstallationStateDeletionFailed = "deletion-failed"
-	// ClusterInstallationStateDeleted is a cluster installation that has been deleted
-	ClusterInstallationStateDeleted = "deleted"
-	// ClusterInstallationStateReconciling is a cluster installation that in undergoing changes and is not yet stable.
-	ClusterInstallationStateReconciling = "reconciling"
-	// ClusterInstallationStateStable is a cluster installation in a stable state and undergoing no changes.
-	ClusterInstallationStateStable = "stable"
-)
-
 // ClusterInstallation is a single namespace within a cluster composing a potentially larger installation.
 type ClusterInstallation struct {
 	ID             string

--- a/model/cluster_installation_states.go
+++ b/model/cluster_installation_states.go
@@ -1,0 +1,45 @@
+package model
+
+const (
+	// ClusterInstallationStateCreationRequested is a cluster installation in the process of being created.
+	ClusterInstallationStateCreationRequested = "creation-requested"
+	// ClusterInstallationStateCreationFailed is a cluster installation that failed creation.
+	ClusterInstallationStateCreationFailed = "creation-failed"
+	// ClusterInstallationStateDeletionRequested is a cluster installation in the process of being deleted.
+	ClusterInstallationStateDeletionRequested = "deletion-requested"
+	// ClusterInstallationStateDeletionFailed is a cluster installation that failed deletion.
+	ClusterInstallationStateDeletionFailed = "deletion-failed"
+	// ClusterInstallationStateDeleted is a cluster installation that has been deleted
+	ClusterInstallationStateDeleted = "deleted"
+	// ClusterInstallationStateReconciling is a cluster installation that in undergoing changes and is not yet stable.
+	ClusterInstallationStateReconciling = "reconciling"
+	// ClusterInstallationStateStable is a cluster installation in a stable state and undergoing no changes.
+	ClusterInstallationStateStable = "stable"
+)
+
+// AllClusterInstallationStates is a list of all states a cluster installation
+// can be in.
+// Warning:
+// When creating a new cluster installation state, it must be added to this list.
+var AllClusterInstallationStates = []string{
+	ClusterInstallationStateCreationRequested,
+	ClusterInstallationStateCreationFailed,
+	ClusterInstallationStateDeletionRequested,
+	ClusterInstallationStateDeletionFailed,
+	ClusterInstallationStateDeleted,
+	ClusterInstallationStateReconciling,
+	ClusterInstallationStateStable,
+}
+
+// AllClusterInstallationStatesPendingWork is a list of all cluster installation
+// states that the supervisor will attempt to transition towards stable on the
+// next "tick".
+// Warning:
+// When creating a new cluster installation state, it must be added to this list
+// if the cloud installation supervisor should perform some action on its next
+// work cycle.
+var AllClusterInstallationStatesPendingWork = []string{
+	ClusterInstallationStateCreationRequested,
+	ClusterInstallationStateReconciling,
+	ClusterInstallationStateDeletionRequested,
+}


### PR DESCRIPTION
This change does the following:
 - Refactors the cluster installation states to be in line with
   clusters and installations in the model package.
 - Improves logging related to installation creation where certain
   cluster installation states were not reported on.

https://mattermost.atlassian.net/browse/MM-20011