### PR TITLE
MM-19561 Install Team Edition if no license is provided

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -94,6 +94,10 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 
 		mattermostInstallation.Spec.MattermostLicenseSecret = licenseSecretName
 		logger.Debug("Cluster installation configured with a Mattermost license")
+	} else {
+		mattermostInstallation.Spec.Image = "mattermost/mattermost-team-edition"
+		// TODO: is the mattermost team edition image name stored somewhere as a constant?
+		logger.Debug("No license provided; changing the image type to team edition")
 	}
 
 	databaseSpec, databaseSecret, err := installation.GetDatabase().GenerateDatabaseSpecAndSecret(logger)


### PR DESCRIPTION
Corollary to https://github.com/mattermost/mattermost-plugin-cloud/pull/24 , the provisioner needs to be updated to pull down the correct image (Team Edition) when no license is specified.

This change works, and I'd like to go ahead and propose this change, however it does occur to me that this overloads the `license` field a bit, and it might be better to include an edition field explicitly rather than to simply choose Team Edition if there is no license as I have done here. I'm more than open to feedback about that design decision.