### PR TITLE
[MM-20635] add custom kops aws ami image to the configs

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -46,6 +46,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("keep-database-data", true, "Whether to preserve database data after installation deletion or not.")
 	serverCmd.PersistentFlags().Bool("keep-filestore-data", true, "Whether to preserve filestore data after installation deletion or not.")
 	serverCmd.PersistentFlags().Bool("debug", false, "Whether to output debug logs.")
+	serverCmd.PersistentFlags().String("custom-kops-aws-ami-image", "", "The custom kops AWS AMI image.")
 	serverCmd.MarkPersistentFlagRequired("route53-id")
 	serverCmd.MarkPersistentFlagRequired("private-route53-id")
 	serverCmd.MarkPersistentFlagRequired("private-dns")
@@ -103,6 +104,7 @@ var serverCmd = &cobra.Command{
 		privateDNS, _ := command.Flags().GetString("private-dns")
 		keepDatabaseData, _ := command.Flags().GetBool("keep-database-data")
 		keepFilestoreData, _ := command.Flags().GetBool("keep-filestore-data")
+		customAWSAMIImageData, _ := command.Flags().GetString("custom-kops-aws-ami-image")
 
 		wd, err := os.Getwd()
 		if err != nil {
@@ -126,6 +128,7 @@ var serverCmd = &cobra.Command{
 			"cluster-resource-threshold":      clusterResourceThreshold,
 			"keep-database-data":              keepDatabaseData,
 			"keep-filestore-data":             keepFilestoreData,
+			"custom-aws-ami-image":            customAWSAMIImageData,
 			"debug":                           debug,
 		}).Info("Starting Mattermost Provisioning Server")
 
@@ -137,6 +140,7 @@ var serverCmd = &cobra.Command{
 			privateSubnetIds,
 			publicSubnetIds,
 			privateDNS,
+			customAWSAMIImageData,
 			logger,
 		)
 

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -34,6 +34,7 @@ type KopsProvisioner struct {
 	privateSubnetIds  string
 	publicSubnetIds   string
 	privateDNS        string
+	customAWSAMIImage string
 	logger            log.FieldLogger
 }
 
@@ -50,7 +51,7 @@ type helmDeployment struct {
 var helmApps = []string{"prometheus"}
 
 // NewKopsProvisioner creates a new KopsProvisioner.
-func NewKopsProvisioner(clusterRootDir, s3StateStore, certificateSslARN, privateSubnetIds, publicSubnetIds, privateDNS string, logger log.FieldLogger) *KopsProvisioner {
+func NewKopsProvisioner(clusterRootDir, s3StateStore, certificateSslARN, privateSubnetIds, publicSubnetIds, privateDNS, customAWSAMIImage string, logger log.FieldLogger) *KopsProvisioner {
 	return &KopsProvisioner{
 		clusterRootDir:    clusterRootDir,
 		s3StateStore:      s3StateStore,
@@ -58,6 +59,7 @@ func NewKopsProvisioner(clusterRootDir, s3StateStore, certificateSslARN, private
 		privateSubnetIds:  privateSubnetIds,
 		publicSubnetIds:   publicSubnetIds,
 		privateDNS:        privateDNS,
+		customAWSAMIImage: customAWSAMIImage,
 		logger:            logger,
 	}
 }
@@ -126,7 +128,7 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 		return err
 	}
 	defer kops.Close()
-	err = kops.CreateCluster(kopsMetadata.Name, kopsMetadata.Version, cluster.Provider, clusterSize, awsMetadata.Zones, provisioner.privateSubnetIds, provisioner.publicSubnetIds)
+	err = kops.CreateCluster(kopsMetadata.Name, kopsMetadata.Version, cluster.Provider, clusterSize, awsMetadata.Zones, provisioner.privateSubnetIds, provisioner.publicSubnetIds, provisioner.customAWSAMIImage)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CreateCluster invokes kops create cluster, using the context of the created Cmd.
-func (c *Cmd) CreateCluster(name, version, cloud string, clusterSize ClusterSize, zones []string, privateSubnetIds, publicSubnetIds string) error {
+func (c *Cmd) CreateCluster(name, version, cloud string, clusterSize ClusterSize, zones []string, privateSubnetIds, publicSubnetIds, customAWSAMIImage string) error {
 	if len(zones) == 0 {
 		return fmt.Errorf("must supply at least one zone")
 	}
@@ -45,6 +45,10 @@ func (c *Cmd) CreateCluster(name, version, cloud string, clusterSize ClusterSize
 	}
 	if cloud == "aws" {
 		args = append(args, arg("networking", "amazon-vpc-routed-eni"))
+	}
+
+	if customAWSAMIImage != "" {
+		args = append(args, arg("image", customAWSAMIImage))
 	}
 
 	_, _, err := c.run(args...)


### PR DESCRIPTION
This adds a new config setting to set when starting the server `--custom-kops-aws-ami-image`

and when we create new clusters it will use the custom image, if that is not set it will use the default from kops.


In another ticket we will implement the upgrade, but need to discuss that before the implementation.

NOTE:
My understanding is every time we would like to upgrade the cluster we need to update kops, so we also will need to update the image


jira: https://mattermost.atlassian.net/browse/MM-20635