### PR TITLE
Add timestamps to TTY logs

### DIFF
--- a/cmd/cloud/logger.go
+++ b/cmd/cloud/logger.go
@@ -8,6 +8,9 @@ var logger *log.Logger
 
 func init() {
 	logger = log.New()
+	logger.SetFormatter(&log.TextFormatter{
+		FullTimestamp: true,
+	})
 }
 
 type logrusWriter struct {


### PR DESCRIPTION
By default logrus doesn't display timestamps on logs output to the TTY and I found timestamps to be useful for me when running the provisioning server on the TTY, for identifying which logs pertain to actions taken at certain times.

Since this is not related to an issue or anything like that, this is a proposal in the lightest sense, maybe a 1/5 for me on wanting this -- not a strong feeling but it's a nice-to-have I would like. I can always find a different way to configure this for myself on my dev system if this change is undesirable to everyone else.

New log output would look like this:

```
INFO[2019-11-22T15:45:02-06:00] Listening                                     addr=":8075" instance=instanceID
INFO[2019-11-22T15:46:17-06:00] Provisioning AWS RDS database                 installation=installID instance=instanceID
INFO[2019-11-22T15:46:21-06:00] Provisioning AWS S3 filestore                 installation=installID instance=instanceID
```
Feel free to merge or close this PR on my behalf whenever we reach consensus.