### PR TITLE
Add per-cluster VPC support

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -39,8 +39,6 @@ func init() {
 	serverCmd.PersistentFlags().String("route53-id", "", "The route 53 hosted zone ID used for mattermost DNS records.")
 	serverCmd.PersistentFlags().String("private-route53-id", "", "The route 53 hosted zone ID used for mattermost private DNS records.")
 	serverCmd.PersistentFlags().String("private-dns", "", "The DNS used for mattermost private Route53 records.")
-	serverCmd.PersistentFlags().String("private-subnets", "", "The private subnet IDs to use on AWS.")
-	serverCmd.PersistentFlags().String("public-subnets", "", "The public subnet IDs to use on AWS.")
 	serverCmd.PersistentFlags().Int("poll", 30, "The interval in seconds to poll for background work.")
 	serverCmd.PersistentFlags().Int("cluster-resource-threshold", 80, "The percent threshold where new installations won't be scheduled on a multi-tenant cluster.")
 	serverCmd.PersistentFlags().Bool("keep-database-data", true, "Whether to preserve database data after installation deletion or not.")
@@ -96,8 +94,6 @@ var serverCmd = &cobra.Command{
 
 		s3StateStore, _ := command.Flags().GetString("state-store")
 		certificateSslARN, _ := command.Flags().GetString("certificate-aws-arn")
-		privateSubnetIds, _ := command.Flags().GetString("private-subnets")
-		publicSubnetIds, _ := command.Flags().GetString("public-subnets")
 		route53ZoneID, _ := command.Flags().GetString("route53-id")
 		privateRoute53ZoneID, _ := command.Flags().GetString("private-route53-id")
 		privateDNS, _ := command.Flags().GetString("private-dns")
@@ -118,8 +114,6 @@ var serverCmd = &cobra.Command{
 			"state-store":                     s3StateStore,
 			"aws-arn":                         certificateSslARN,
 			"working-directory":               wd,
-			"private-subents":                 privateSubnetIds,
-			"public-subnets":                  publicSubnetIds,
 			"route53-id":                      route53ZoneID,
 			"private-route53-id":              privateRoute53ZoneID,
 			"private-dns":                     privateDNS,
@@ -134,8 +128,6 @@ var serverCmd = &cobra.Command{
 			clusterRootDir,
 			s3StateStore,
 			certificateSslARN,
-			privateSubnetIds,
-			publicSubnetIds,
 			privateDNS,
 			logger,
 		)

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -50,13 +50,11 @@ type helmDeployment struct {
 var helmApps = []string{"prometheus"}
 
 // NewKopsProvisioner creates a new KopsProvisioner.
-func NewKopsProvisioner(clusterRootDir, s3StateStore, certificateSslARN, privateSubnetIds, publicSubnetIds, privateDNS string, logger log.FieldLogger) *KopsProvisioner {
+func NewKopsProvisioner(clusterRootDir, s3StateStore, certificateSslARN, privateDNS string, logger log.FieldLogger) *KopsProvisioner {
 	return &KopsProvisioner{
 		clusterRootDir:    clusterRootDir,
 		s3StateStore:      s3StateStore,
 		certificateSslARN: certificateSslARN,
-		privateSubnetIds:  privateSubnetIds,
-		publicSubnetIds:   publicSubnetIds,
 		privateDNS:        privateDNS,
 		logger:            logger,
 	}
@@ -82,7 +80,7 @@ func (provisioner *KopsProvisioner) PrepareCluster(cluster *model.Cluster) (bool
 }
 
 // CreateCluster creates a cluster using kops and terraform.
-func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aws.AWS) error {
+func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsClient aws.AWS) error {
 	kopsMetadata, err := model.NewKopsMetadata(cluster.ProvisionerMetadata)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse provisioner metadata")
@@ -126,9 +124,30 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 		return err
 	}
 	defer kops.Close()
-	err = kops.CreateCluster(kopsMetadata.Name, kopsMetadata.Version, cluster.Provider, clusterSize, awsMetadata.Zones, provisioner.privateSubnetIds, provisioner.publicSubnetIds)
+
+	clusterResources, err := awsClient.GetAndClaimVpcResources(cluster.ID, logger)
 	if err != nil {
 		return err
+	}
+
+	err = kops.CreateCluster(
+		kopsMetadata.Name,
+		kopsMetadata.Version,
+		cluster.Provider,
+		clusterSize,
+		awsMetadata.Zones,
+		clusterResources.PrivateSubnetIDs,
+		clusterResources.PublicSubnetsIDs,
+		clusterResources.MasterSecurityGroupIDs,
+		clusterResources.WorkerSecurityGroupIDs,
+	)
+	if err != nil {
+		releaseErr := awsClient.ReleaseVpc(cluster.ID, logger)
+		if releaseErr != nil {
+			logger.WithError(releaseErr).Error("Unable to release VPC")
+		}
+
+		return errors.Wrap(err, "unable to create kops cluster")
 	}
 
 	err = os.Rename(kops.GetOutputDirectory(), outputDir)
@@ -182,18 +201,6 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 		// and return original timeout error.
 		kops.ValidateCluster(kopsMetadata.Name, false)
 		return err
-	}
-
-	// Set the ELB tags for the public subnets
-	if provisioner.publicSubnetIds != "" {
-		subnets := strings.Split(provisioner.publicSubnetIds, ",")
-		for _, subnet := range subnets {
-			logger.WithField("name", kopsMetadata.Name).Infof("Tagging subnet %s", subnet)
-			err = aws.TagResource(subnet, fmt.Sprintf("kubernetes.io/cluster/%s", kopsMetadata.Name), "shared", logger)
-			if err != nil {
-				return errors.Wrap(err, "failed to tag subnet")
-			}
-		}
 	}
 
 	logger.WithField("name", kopsMetadata.Name).Info("Successfully deployed kubernetes")
@@ -256,7 +263,7 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, aws aw
 	for _, app := range helmApps {
 		dns := fmt.Sprintf("%s.%s.%s", cluster.ID, app, provisioner.privateDNS)
 		logger.Infof("Registering DNS %s for %s", dns, app)
-		err = aws.CreateCNAME(dns, []string{endpoint}, logger)
+		err = awsClient.CreateCNAME(dns, []string{endpoint}, logger)
 		if err != nil {
 			return err
 		}
@@ -519,7 +526,7 @@ func (provisioner *KopsProvisioner) UpgradeCluster(cluster *model.Cluster) error
 }
 
 // DeleteCluster deletes a previously created cluster using kops and terraform.
-func (provisioner *KopsProvisioner) DeleteCluster(cluster *model.Cluster, aws aws.AWS) error {
+func (provisioner *KopsProvisioner) DeleteCluster(cluster *model.Cluster, awsClient aws.AWS) error {
 	kopsMetadata, err := model.NewKopsMetadata(cluster.ProvisionerMetadata)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse provisioner metadata")
@@ -587,16 +594,9 @@ func (provisioner *KopsProvisioner) DeleteCluster(cluster *model.Cluster, aws aw
 		}
 	}
 
-	// Delete the ELB tags for the public subnets
-	if kopsMetadata.Name != "" && provisioner.publicSubnetIds != "" {
-		subnets := strings.Split(provisioner.publicSubnetIds, ",")
-		for _, subnet := range subnets {
-			logger.WithField("name", kopsMetadata.Name).Infof("Untagging subnet %s", subnet)
-			err = aws.UntagResource(subnet, fmt.Sprintf("kubernetes.io/cluster/%s", kopsMetadata.Name), "shared", logger)
-			if err != nil {
-				return errors.Wrap(err, "failed to untag subnet")
-			}
-		}
+	err = awsClient.ReleaseVpc(cluster.ID, logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to release VPC")
 	}
 
 	err = os.RemoveAll(outputDir)
@@ -607,7 +607,7 @@ func (provisioner *KopsProvisioner) DeleteCluster(cluster *model.Cluster, aws aw
 	for _, app := range helmApps {
 		logger.Infof("Deleting Route53 DNS Record for %s", app)
 		dns := fmt.Sprintf("%s.%s.%s", cluster.ID, app, provisioner.privateDNS)
-		err = aws.DeleteCNAME(dns, logger)
+		err = awsClient.DeleteCNAME(dns, logger)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete Route53 DNS record")
 		}

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -139,6 +139,14 @@ func (p *mockInstallationProvisioner) GetClusterResources(cluster *model.Cluster
 
 type mockAWS struct{}
 
+func (a *mockAWS) GetAndClaimVpcResources(clusterID string, logger log.FieldLogger) (aws.ClusterResources, error) {
+	return aws.ClusterResources{}, nil
+}
+
+func (a *mockAWS) ReleaseVpc(clusterID string, logger log.FieldLogger) error {
+	return nil
+}
+
 func (a *mockAWS) CreateCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error {
 	return nil
 }

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -8,6 +8,9 @@ import (
 
 // AWS interface for use by other packages.
 type AWS interface {
+	GetAndClaimVpcResources(clusterID string, logger log.FieldLogger) (ClusterResources, error)
+	ReleaseVpc(clusterID string, logger log.FieldLogger) error
+
 	CreateCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error
 	DeleteCNAME(dnsName string, logger log.FieldLogger) error
 

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -1,0 +1,270 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// ClusterResources is a collection of AWS resources that will be used to create
+// a kops cluster.
+type ClusterResources struct {
+	VpcID                  string
+	PrivateSubnetIDs       []string
+	PublicSubnetsIDs       []string
+	MasterSecurityGroupIDs []string
+	WorkerSecurityGroupIDs []string
+}
+
+// IsValid returns whether or not ClusterResources is valid or not.
+func (cr *ClusterResources) IsValid() error {
+	if cr.VpcID == "" {
+		return errors.New("vpc ID is empty")
+	}
+	if len(cr.PrivateSubnetIDs) == 0 {
+		return errors.New("private subnet list is empty")
+	}
+	if len(cr.PublicSubnetsIDs) == 0 {
+		return errors.New("public subnet list is empty")
+	}
+	if len(cr.MasterSecurityGroupIDs) == 0 {
+		return errors.New("master security group list is empty")
+	}
+	if len(cr.WorkerSecurityGroupIDs) == 0 {
+		return errors.New("worker security group list is empty")
+	}
+
+	return nil
+}
+
+// GetAndClaimVpcResources creates ClusterResources from an available VPC and
+// tags them appropriately.
+func (a *Client) GetAndClaimVpcResources(clusterID string, logger log.FieldLogger) (ClusterResources, error) {
+	vpcFilters := []*ec2.Filter{
+		{
+			Name:   aws.String(VpcAvailableTagKey),
+			Values: []*string{aws.String(VpcAvailableTagValueTrue)},
+		},
+	}
+
+	vpcs, err := GetVpcsWithFilters(vpcFilters)
+	if err != nil {
+		return ClusterResources{}, err
+	}
+
+	// Loop through the VPCs. Based on the filter above these should all be
+	// valid so we will claim the first one. Before doing that a sanity check of
+	// the VPCs resources will occur.
+	for _, vpc := range vpcs {
+		clusterResources := ClusterResources{
+			VpcID: *vpc.VpcId,
+		}
+
+		baseFilter := []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{vpc.VpcId},
+			},
+		}
+
+		privateSubnetFilter := append(baseFilter, &ec2.Filter{
+			Name:   aws.String("tag:SubnetType"),
+			Values: []*string{aws.String("private")},
+		})
+
+		privateSubnets, err := GetSubnetsWithFilters(privateSubnetFilter)
+		if err != nil {
+			return clusterResources, err
+		}
+
+		for _, subnet := range privateSubnets {
+			clusterResources.PrivateSubnetIDs = append(clusterResources.PrivateSubnetIDs, *subnet.SubnetId)
+		}
+
+		publicSubnetFilter := append(baseFilter, &ec2.Filter{
+			Name:   aws.String("tag:SubnetType"),
+			Values: []*string{aws.String("public")},
+		})
+
+		publicSubnets, err := GetSubnetsWithFilters(publicSubnetFilter)
+		if err != nil {
+			return clusterResources, err
+		}
+
+		for _, subnet := range publicSubnets {
+			clusterResources.PublicSubnetsIDs = append(clusterResources.PublicSubnetsIDs, *subnet.SubnetId)
+		}
+
+		masterSGFilter := append(baseFilter, &ec2.Filter{
+			Name:   aws.String("tag:NodeType"),
+			Values: []*string{aws.String("master")},
+		})
+
+		masterSecurityGroups, err := GetSecurityGroupsWithFilters(masterSGFilter)
+		if err != nil {
+			return clusterResources, err
+		}
+
+		for _, securityGroup := range masterSecurityGroups {
+			clusterResources.MasterSecurityGroupIDs = append(clusterResources.MasterSecurityGroupIDs, *securityGroup.GroupId)
+		}
+
+		workerSGFilter := append(baseFilter, &ec2.Filter{
+			Name:   aws.String("tag:NodeType"),
+			Values: []*string{aws.String("worker")},
+		})
+
+		workerSecurityGroups, err := GetSecurityGroupsWithFilters(workerSGFilter)
+		if err != nil {
+			return clusterResources, err
+		}
+
+		for _, securityGroup := range workerSecurityGroups {
+			clusterResources.WorkerSecurityGroupIDs = append(clusterResources.WorkerSecurityGroupIDs, *securityGroup.GroupId)
+		}
+
+		err = clusterResources.IsValid()
+		if err != nil {
+			logger.Warn(errors.Wrapf(err, "VPC %s is misconfigured", clusterResources.VpcID).Error())
+			continue
+		}
+
+		err = a.claimVpc(clusterResources, clusterID, logger)
+		if err != nil {
+			return clusterResources, err
+		}
+
+		logger.Debugf("Claimed VPC %s", clusterResources.VpcID)
+
+		return clusterResources, nil
+	}
+
+	return ClusterResources{}, fmt.Errorf("%d VPCs were returned as currently available; none of them were configured correctly", len(vpcs))
+}
+
+// ReleaseVpc changes the tags on a VPC to mark it as "available" again.
+func (a *Client) ReleaseVpc(clusterID string, logger log.FieldLogger) error {
+	return a.releaseVpc(clusterID, logger)
+}
+
+// claimVpc will claim the given VPC for a cluster if a final race-check passes.
+// The final race check does the following:
+//   - Requires the VPC to exist. #mindblown
+//   - VPC availabiltiy tag must be "true"
+//   - VPC cluster ID tag must by "none"
+func (a *Client) claimVpc(clusterResources ClusterResources, clusterID string, logger log.FieldLogger) error {
+	vpcFilter := []*ec2.Filter{
+		{
+			Name:   aws.String("vpc-id"),
+			Values: []*string{aws.String(clusterResources.VpcID)},
+		},
+		{
+			Name:   aws.String(VpcAvailableTagKey),
+			Values: []*string{aws.String(VpcAvailableTagValueTrue)},
+		},
+		{
+			Name:   aws.String(VpcClusterIDTagKey),
+			Values: []*string{aws.String(VpcClusterIDTagValueNone)},
+		},
+	}
+	vpcs, err := GetVpcsWithFilters(vpcFilter)
+	if err != nil {
+		return err
+	}
+
+	numVPCs := len(vpcs)
+	if numVPCs == 0 {
+		return fmt.Errorf("query didn't return VPC %s; it either doesn't exist or another cluster claimed it", clusterResources.VpcID)
+	}
+	if numVPCs != 1 {
+		return fmt.Errorf("query for VPC %s somehow returned multiple results", clusterResources.VpcID)
+	}
+
+	for _, subnet := range clusterResources.PublicSubnetsIDs {
+		err = a.TagResource(subnet, fmt.Sprintf("kubernetes.io/cluster/%s", fmt.Sprintf("%s-kops.k8s.local", clusterID)), "shared", logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to tag subnet")
+		}
+	}
+
+	err = a.TagResource(clusterResources.VpcID, trimTagPrefix(VpcAvailableTagKey), VpcAvailableTagValueFalse, logger)
+	if err != nil {
+		return errors.Wrapf(err, "unable to update %s", VpcAvailableTagKey)
+	}
+	err = a.TagResource(clusterResources.VpcID, trimTagPrefix(VpcClusterIDTagKey), clusterID, logger)
+	if err != nil {
+		return errors.Wrapf(err, "unable to update %s", VpcClusterIDTagKey)
+	}
+
+	return nil
+}
+
+func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
+	vpcFilters := []*ec2.Filter{
+		{
+			Name:   aws.String(VpcAvailableTagKey),
+			Values: []*string{aws.String(VpcAvailableTagValueFalse)},
+		},
+		{
+			Name:   aws.String(VpcClusterIDTagKey),
+			Values: []*string{aws.String(clusterID)},
+		},
+	}
+
+	vpcs, err := GetVpcsWithFilters(vpcFilters)
+	if err != nil {
+		return err
+	}
+
+	numVPCs := len(vpcs)
+	if numVPCs == 0 {
+		logger.Warnf("No VPCs are currently claimed by cluster %s, assuming already released", clusterID)
+		return nil
+	}
+	if numVPCs != 1 {
+		logger.Warn("Multiple VPCs found in release process when expecting 1")
+		for i, vpc := range vpcs {
+			logger.WithField("tags", vpc.Tags).Warnf("VPC %d: %s", i+1, *vpc.VpcId)
+		}
+		return fmt.Errorf("multiple VPCs (%d) have been claimed by cluster %s; aborting release process", numVPCs, clusterID)
+	}
+
+	publicSubnetFilter := []*ec2.Filter{
+		{
+			Name:   aws.String("vpc-id"),
+			Values: []*string{vpcs[0].VpcId},
+		},
+		{
+			Name:   aws.String("tag:SubnetType"),
+			Values: []*string{aws.String("public")},
+		},
+	}
+
+	publicSubnets, err := GetSubnetsWithFilters(publicSubnetFilter)
+	if err != nil {
+		return err
+	}
+
+	for _, subnet := range publicSubnets {
+		logger.Debugf("Untagging subnet %s", *subnet.SubnetId)
+		err = a.UntagResource(*subnet.SubnetId, fmt.Sprintf("kubernetes.io/cluster/%s", fmt.Sprintf("%s-kops.k8s.local", clusterID)), "shared", logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to untag subnet")
+		}
+	}
+
+	err = a.TagResource(*vpcs[0].VpcId, trimTagPrefix(VpcClusterIDTagKey), VpcClusterIDTagValueNone, logger)
+	if err != nil {
+		return errors.Wrapf(err, "unable to update %s", VpcClusterIDTagKey)
+	}
+
+	err = a.TagResource(*vpcs[0].VpcId, trimTagPrefix(VpcAvailableTagKey), VpcAvailableTagValueTrue, logger)
+	if err != nil {
+		return errors.Wrapf(err, "unable to update %s", VpcAvailableTagKey)
+	}
+
+	return nil
+}

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -7,6 +7,26 @@ const (
 	// DefaultAWSRegion is the default AWS region for AWS resources.
 	DefaultAWSRegion = "us-east-1"
 
+	// VpcAvailableTagKey is the tag key to determine if a VPC is currently in
+	// use by a cluster or not.
+	VpcAvailableTagKey = "tag:Available"
+
+	// VpcAvailableTagValueTrue is the tag value for VpcAvailableTagKey when the
+	// VPC is currently not in use by a cluster and can be claimed.
+	VpcAvailableTagValueTrue = "true"
+
+	// VpcAvailableTagValueFalse is the tag value for VpcAvailableTagKey when the
+	// VPC is currently in use by a cluster and cannot be claimed.
+	VpcAvailableTagValueFalse = "false"
+
+	// VpcClusterIDTagKey is the tag key used to store the cluster ID of the
+	// cluster running in that VPC.
+	VpcClusterIDTagKey = "tag:CloudClusterID"
+
+	// VpcClusterIDTagValueNone is the tag value for VpcClusterIDTagKey when
+	// there is no cluster running in the VPC.
+	VpcClusterIDTagValueNone = "none"
+
 	// DefaultDBSubnetGroupName is the default DB subnet group name used when
 	// creating DB clusters. This group name is defined by the owner of the AWS
 	// accounts and can be the same across all accounts.

--- a/internal/tools/aws/ec2_test.go
+++ b/internal/tools/aws/ec2_test.go
@@ -2,11 +2,13 @@ package aws
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (api *mockAPI) getEC2Client() (*ec2.EC2, error) {
@@ -121,4 +123,21 @@ func TestUntagResource(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVPCReal(t *testing.T) {
+	if os.Getenv("SUPER_AWS_VPC_TEST") == "" {
+		return
+	}
+
+	logger := logrus.New()
+	awsClient := New("n/a")
+
+	clusterID := "testclusterID1"
+
+	_, err := awsClient.GetAndClaimVpcResources(clusterID, logger)
+	require.NoError(t, err)
+
+	err = awsClient.releaseVpc(clusterID, logger)
+	require.NoError(t, err)
 }

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"math/rand"
+	"strings"
 	"time"
 )
 
@@ -19,6 +20,10 @@ func IAMSecretName(cloudID string) string {
 // RDSSecretName returns the RDS secret name for a given Cloud ID.
 func RDSSecretName(cloudID string) string {
 	return cloudID + rdsSuffix
+}
+
+func trimTagPrefix(tag string) string {
+	return strings.TrimLeft(tag, "tag:")
 }
 
 const passwordBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CreateCluster invokes kops create cluster, using the context of the created Cmd.
-func (c *Cmd) CreateCluster(name, version, cloud string, clusterSize ClusterSize, zones []string, privateSubnetIds, publicSubnetIds string) error {
+func (c *Cmd) CreateCluster(name, version, cloud string, clusterSize ClusterSize, zones []string, privateSubnetIds, publicSubnetIds, masterSecurityGroups, workerSecurityGroups []string) error {
 	if len(zones) == 0 {
 		return fmt.Errorf("must supply at least one zone")
 	}
@@ -33,15 +33,21 @@ func (c *Cmd) CreateCluster(name, version, cloud string, clusterSize ClusterSize
 			arg("kubernetes-version", version),
 		)
 	}
-	if privateSubnetIds != "" {
+	if len(privateSubnetIds) != 0 {
 		args = append(args,
-			arg("subnets", privateSubnetIds),
+			commaArg("subnets", privateSubnetIds),
 			arg("topology", "private"),
 			arg("api-loadbalancer-type", "internal"),
 		)
 	}
-	if publicSubnetIds != "" {
-		args = append(args, arg("utility-subnets", publicSubnetIds))
+	if len(publicSubnetIds) != 0 {
+		args = append(args, commaArg("utility-subnets", publicSubnetIds))
+	}
+	if len(masterSecurityGroups) != 0 {
+		args = append(args, commaArg("master-security-groups", masterSecurityGroups))
+	}
+	if len(workerSecurityGroups) != 0 {
+		args = append(args, commaArg("node-security-groups", workerSecurityGroups))
 	}
 	if cloud == "aws" {
 		args = append(args, arg("networking", "amazon-vpc-routed-eni"))

--- a/operator-manifests/mattermost/operator.yaml
+++ b/operator-manifests/mattermost/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: mattermost-operator
       containers:
         - name: mattermost-operator
-          image: mattermost/mattermost-operator:v0.8.5
+          image: mattermost/mattermost-operator:0de3fa2
           imagePullPolicy: IfNotPresent
           command:
           - mattermost-operator

--- a/operator-manifests/mattermost/operator.yaml
+++ b/operator-manifests/mattermost/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: mattermost-operator
       containers:
         - name: mattermost-operator
-          image: mattermost/mattermost-operator:0de3fa2
+          image: mattermost/mattermost-operator:v1.0.0
           imagePullPolicy: IfNotPresent
           command:
           - mattermost-operator


### PR DESCRIPTION
This change adds functionality for finding AWS VPCs that are tagged
as available. These VPCs are used for new kops cluster creation and
are then tagged as in-use. When a cluster is deleted, the VPC is
released for future use.

https://mattermost.atlassian.net/browse/MM-19824