### PR TITLE
MM-19772 Update cluster AWS instance types

### DIFF
--- a/internal/tools/kops/sizes.go
+++ b/internal/tools/kops/sizes.go
@@ -19,33 +19,51 @@ type ClusterSize struct {
 
 // validSizes is a mapping of a size keyword to kops cluster configuration.
 var validSizes = map[string]ClusterSize{
-	model.SizeAlef500:  sizeAlef500,
-	model.SizeAlef1000: sizeAlef1000,
-	model.SizeAlef5000: sizeAlef5000,
+	model.SizeAlefDev:   sizeAlefDev,
+	model.SizeAlef500:   sizeAlef500,
+	model.SizeAlef1000:  sizeAlef1000,
+	model.SizeAlef5000:  sizeAlef5000,
+	model.SizeAlef10000: sizeAlef10000,
+}
+
+// sizeAlefDev is a cluster sized for development and testing.
+var sizeAlefDev = ClusterSize{
+	NodeCount:   "2",
+	NodeSize:    "t3.medium",
+	MasterCount: "1",
+	MasterSize:  "t3.medium",
 }
 
 // sizeAlef500 is a cluster sized for 500 users.
 var sizeAlef500 = ClusterSize{
 	NodeCount:   "2",
-	NodeSize:    "t2.medium",
+	NodeSize:    "m5.large",
 	MasterCount: "1",
-	MasterSize:  "t2.medium",
+	MasterSize:  "t3.medium",
 }
 
 // sizeAlef1000 is a cluster sized for 1000 users.
 var sizeAlef1000 = ClusterSize{
 	NodeCount:   "4",
-	NodeSize:    "t2.medium",
+	NodeSize:    "m5.large",
 	MasterCount: "1",
-	MasterSize:  "t2.large",
+	MasterSize:  "t3.large",
 }
 
 // sizeAlef5000 is a cluster sized for 5000 users.
 var sizeAlef5000 = ClusterSize{
 	NodeCount:   "6",
-	NodeSize:    "t2.large",
+	NodeSize:    "m5.large",
 	MasterCount: "1",
-	MasterSize:  "t2.large",
+	MasterSize:  "t3.large",
+}
+
+// sizeAlef10000 is a cluster sized for 10000 users.
+var sizeAlef10000 = ClusterSize{
+	NodeCount:   "10",
+	NodeSize:    "m5.large",
+	MasterCount: "1",
+	MasterSize:  "t3.large",
 }
 
 // GetSize takes a size keyword and returns the matching kops cluster

--- a/internal/tools/kops/sizes_test.go
+++ b/internal/tools/kops/sizes_test.go
@@ -12,9 +12,11 @@ func TestGetSize(t *testing.T) {
 		clusterSize ClusterSize
 		expectError bool
 	}{
+		{"SizeAlefDev", sizeAlefDev, false},
 		{"SizeAlef500", sizeAlef500, false},
 		{"SizeAlef1000", sizeAlef1000, false},
 		{"SizeAlef5000", sizeAlef5000, false},
+		{"SizeAlef10000", sizeAlef10000, false},
 		{"IncorrectSize", ClusterSize{}, true},
 	}
 

--- a/model/size.go
+++ b/model/size.go
@@ -1,12 +1,16 @@
 package model
 
 const (
-	// SizeAlef500 is the first definition of a cluster supporting 500 users.
+	// SizeAlefDev is the definition of a cluster supporting dev purposes.
+	SizeAlefDev = "SizeAlefDev"
+	// SizeAlef500 is the key representing a cluster supporting 500 users.
 	SizeAlef500 = "SizeAlef500"
-	// SizeAlef1000 is the second definition of a cluster supporting 1000 users.
+	// SizeAlef1000 is the key representing a cluster supporting 1000 users.
 	SizeAlef1000 = "SizeAlef1000"
-	// SizeAlef5000 is the third definition of a cluster supporting 5000 users.
+	// SizeAlef5000 is the key representing a cluster supporting 5000 users.
 	SizeAlef5000 = "SizeAlef5000"
+	// SizeAlef10000 is the key representing a cluster supporting 10000 users.
+	SizeAlef10000 = "SizeAlef10000"
 )
 
 // IsSupportedClusterSize returns true if the given size string is supported.
@@ -15,9 +19,11 @@ func IsSupportedClusterSize(size string) bool {
 	for _, suffix := range validSuffixes {
 		switch size {
 		case
+			SizeAlefDev + suffix,
 			SizeAlef500 + suffix,
 			SizeAlef1000 + suffix,
-			SizeAlef5000 + suffix:
+			SizeAlef5000 + suffix,
+			SizeAlef10000 + suffix:
 			return true
 		}
 	}


### PR DESCRIPTION
Clusters are now deployed with updated AWS instance types based
on resource metrics collected in initial deployments.

https://mattermost.atlassian.net/browse/MM-19772