### PR TITLE
Allow for custom kops cluster AMIs

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -16,6 +16,7 @@ func init() {
 
 	clusterCreateCmd.Flags().String("provider", "aws", "Cloud provider hosting the cluster.")
 	clusterCreateCmd.Flags().String("version", "latest", "The Kubernetes version to target. Use 'latest' or versions such as '1.14.1'.")
+	clusterCreateCmd.Flags().String("kops-ami", "", "The AMI to use for the cluster hosts. Leave empty for the default kops image.")
 	clusterCreateCmd.Flags().String("size", "SizeAlef500", "The size constant describing the cluster. Add '-HA2' or '-HA3' to the size for multiple master nodes.")
 	clusterCreateCmd.Flags().String("zones", "us-east-1a", "The zones where the cluster will be deployed. Use commas to separate multiple zones.")
 	clusterCreateCmd.Flags().Bool("allow-installations", true, "Whether the cluster will allow for new installations to be scheduled.")
@@ -75,6 +76,7 @@ var clusterCreateCmd = &cobra.Command{
 
 		provider, _ := command.Flags().GetString("provider")
 		version, _ := command.Flags().GetString("version")
+		kopsAMI, _ := command.Flags().GetString("kops-ami")
 		size, _ := command.Flags().GetString("size")
 		zones, _ := command.Flags().GetString("zones")
 		allowInstallations, _ := command.Flags().GetBool("allow-installations")
@@ -82,6 +84,7 @@ var clusterCreateCmd = &cobra.Command{
 		cluster, err := client.CreateCluster(&model.CreateClusterRequest{
 			Provider:           provider,
 			Version:            version,
+			KopsAMI:            kopsAMI,
 			Size:               size,
 			Zones:              strings.Split(zones, ","),
 			AllowInstallations: allowInstallations,

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -85,6 +85,7 @@ func handleCreateCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	cluster.SetProvisionerMetadata(model.KopsMetadata{
 		Version: createClusterRequest.Version,
+		AMI:     createClusterRequest.KopsAMI,
 	})
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to set provisioner metadata")

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -133,6 +133,7 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 	err = kops.CreateCluster(
 		kopsMetadata.Name,
 		kopsMetadata.Version,
+		kopsMetadata.AMI,
 		cluster.Provider,
 		clusterSize,
 		awsMetadata.Zones,

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CreateCluster invokes kops create cluster, using the context of the created Cmd.
-func (c *Cmd) CreateCluster(name, version, cloud string, clusterSize ClusterSize, zones []string, privateSubnetIds, publicSubnetIds, masterSecurityGroups, workerSecurityGroups []string) error {
+func (c *Cmd) CreateCluster(name, version, ami, cloud string, clusterSize ClusterSize, zones, privateSubnetIds, publicSubnetIds, masterSecurityGroups, workerSecurityGroups []string) error {
 	if len(zones) == 0 {
 		return fmt.Errorf("must supply at least one zone")
 	}
@@ -32,6 +32,9 @@ func (c *Cmd) CreateCluster(name, version, cloud string, clusterSize ClusterSize
 		args = append(args,
 			arg("kubernetes-version", version),
 		)
+	}
+	if ami != "" {
+		args = append(args, arg("image", ami))
 	}
 	if len(privateSubnetIds) != 0 {
 		args = append(args,

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -13,6 +13,7 @@ import (
 type CreateClusterRequest struct {
 	Provider           string
 	Version            string
+	KopsAMI            string
 	Size               string
 	Zones              []string
 	AllowInstallations bool

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -8,6 +8,7 @@ import (
 type KopsMetadata struct {
 	Name    string
 	Version string
+	AMI     string
 }
 
 // NewKopsMetadata creates an instance of KopsMetadata given the raw provisioner metadata.


### PR DESCRIPTION
This change adds support for custom AMIs to be used when creating
a kops cluster. Another change will be made later to allow for
updating AMIs on running clusters.

Initial pass at https://mattermost.atlassian.net/browse/MM-20635