### PR TITLE
Filestore cleanup test

### DIFF
--- a/internal/tools/aws/database_test.go
+++ b/internal/tools/aws/database_test.go
@@ -13,10 +13,9 @@ import (
 // database in a real AWS account. Only set the test env vars below if you wish
 // to test this process with real AWS resources.
 
-var id = "test-id-1"
-
 func TestDatabaseProvision(t *testing.T) {
-	if os.Getenv("SUPER_AWS_DATABASE_TEST") == "" {
+	id := os.Getenv("SUPER_AWS_DATABASE_TEST")
+	if id == "" {
 		return
 	}
 
@@ -29,7 +28,9 @@ func TestDatabaseProvision(t *testing.T) {
 }
 
 func TestDatabaseTeardown(t *testing.T) {
-	if os.Getenv("SUPER_AWS_DATABASE_TEST") == "" {
+
+	id := os.Getenv("SUPER_AWS_DATABASE_TEST")
+	if id == "" {
 		return
 	}
 

--- a/internal/tools/aws/filestore_test.go
+++ b/internal/tools/aws/filestore_test.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// WARNING:
+// This test is meant to exercise the provisioning and teardown of an AWS S3
+// filestore in a real AWS account. Only set the test env vars below if you wish
+// to test this process with real AWS resources.
+
+func TestFilestoreProvision(t *testing.T) {
+	id := os.Getenv("SUPER_AWS_FILESTORE_TEST")
+	if id == "" {
+		return
+	}
+
+	logger := logrus.New()
+
+	filestore := NewS3Filestore(id)
+
+	err := filestore.Provision(logger)
+	require.NoError(t, err)
+}
+
+func TestFilestoreTeardown(t *testing.T) {
+
+	id := os.Getenv("SUPER_AWS_FILESTORE_TEST")
+	if id == "" {
+		return
+	}
+
+	logger := logrus.New()
+	logger.Warnf("Tearing down S3 bucket %s", id)
+
+	filestore := NewS3Filestore(id)
+
+	err := filestore.Teardown(false, logger)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Posting more small improvements made as I go, this change allows you to specify the ID of the RDS instance being torn down as a environment variable. 

Also adds the same test but for S3.