### PR TITLE
Add server flag for default kops creation

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -41,6 +41,7 @@ func init() {
 	serverCmd.PersistentFlags().String("private-dns", "", "The DNS used for mattermost private Route53 records.")
 	serverCmd.PersistentFlags().Int("poll", 30, "The interval in seconds to poll for background work.")
 	serverCmd.PersistentFlags().Int("cluster-resource-threshold", 80, "The percent threshold where new installations won't be scheduled on a multi-tenant cluster.")
+	serverCmd.PersistentFlags().Bool("use-existing-aws-resources", true, "Whether to use existing AWS resources (VPCs, subnets, etc.) or not.")
 	serverCmd.PersistentFlags().Bool("keep-database-data", true, "Whether to preserve database data after installation deletion or not.")
 	serverCmd.PersistentFlags().Bool("keep-filestore-data", true, "Whether to preserve filestore data after installation deletion or not.")
 	serverCmd.PersistentFlags().Bool("debug", false, "Whether to output debug logs.")
@@ -97,6 +98,7 @@ var serverCmd = &cobra.Command{
 		route53ZoneID, _ := command.Flags().GetString("route53-id")
 		privateRoute53ZoneID, _ := command.Flags().GetString("private-route53-id")
 		privateDNS, _ := command.Flags().GetString("private-dns")
+		useExistingResources, _ := command.Flags().GetBool("use-existing-aws-resources")
 		keepDatabaseData, _ := command.Flags().GetBool("keep-database-data")
 		keepFilestoreData, _ := command.Flags().GetBool("keep-filestore-data")
 
@@ -118,6 +120,7 @@ var serverCmd = &cobra.Command{
 			"private-route53-id":              privateRoute53ZoneID,
 			"private-dns":                     privateDNS,
 			"cluster-resource-threshold":      clusterResourceThreshold,
+			"use-existing-aws-resources":      useExistingResources,
 			"keep-database-data":              keepDatabaseData,
 			"keep-filestore-data":             keepFilestoreData,
 			"debug":                           debug,
@@ -129,6 +132,7 @@ var serverCmd = &cobra.Command{
 			s3StateStore,
 			certificateSslARN,
 			privateDNS,
+			useExistingResources,
 			logger,
 		)
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/mattermost/mattermost-cloud/model"
+	log "github.com/sirupsen/logrus"
 )
 
 type contextHandlerFunc func(c *Context, w http.ResponseWriter, r *http.Request)
@@ -16,7 +17,7 @@ type contextHandler struct {
 func (h contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	context := h.context.Clone()
 	context.RequestID = model.NewID()
-	context.Logger = context.Logger.WithFields(map[string]interface{}{
+	context.Logger = context.Logger.WithFields(log.Fields{
 		"path":    r.URL.Path,
 		"request": context.RequestID,
 	})

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/model"
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +20,7 @@ import (
 
 // CreateClusterInstallation creates a Mattermost installation within the given cluster.
 func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation, awsClient aws.AWS) error {
-	logger := provisioner.logger.WithFields(map[string]interface{}{
+	logger := provisioner.logger.WithFields(log.Fields{
 		"cluster":      clusterInstallation.ClusterID,
 		"installation": clusterInstallation.InstallationID,
 	})
@@ -135,7 +136,7 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 // UpdateClusterInstallation updates the cluster installation spec to match the
 // installation specification.
 func (provisioner *KopsProvisioner) UpdateClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) error {
-	logger := provisioner.logger.WithFields(map[string]interface{}{
+	logger := provisioner.logger.WithFields(log.Fields{
 		"cluster":      clusterInstallation.ClusterID,
 		"installation": clusterInstallation.InstallationID,
 	})
@@ -217,7 +218,7 @@ func (provisioner *KopsProvisioner) UpdateClusterInstallation(cluster *model.Clu
 
 // DeleteClusterInstallation deletes a Mattermost installation within the given cluster.
 func (provisioner *KopsProvisioner) DeleteClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) error {
-	logger := provisioner.logger.WithFields(map[string]interface{}{
+	logger := provisioner.logger.WithFields(log.Fields{
 		"cluster":      clusterInstallation.ClusterID,
 		"installation": clusterInstallation.InstallationID,
 	})
@@ -282,7 +283,7 @@ func (provisioner *KopsProvisioner) DeleteClusterInstallation(cluster *model.Clu
 // GetClusterInstallationResource gets the cluster installation resource from
 // the kubernetes API.
 func (provisioner *KopsProvisioner) GetClusterInstallationResource(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) (*mmv1alpha1.ClusterInstallation, error) {
-	logger := provisioner.logger.WithFields(map[string]interface{}{
+	logger := provisioner.logger.WithFields(log.Fields{
 		"cluster":      clusterInstallation.ClusterID,
 		"installation": clusterInstallation.InstallationID,
 	})
@@ -331,7 +332,7 @@ func (provisioner *KopsProvisioner) ExecMattermostCLI(cluster *model.Cluster, cl
 }
 
 func (provisioner *KopsProvisioner) execCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error) {
-	logger := provisioner.logger.WithFields(map[string]interface{}{
+	logger := provisioner.logger.WithFields(log.Fields{
 		"cluster":      clusterInstallation.ClusterID,
 		"installation": clusterInstallation.InstallationID,
 	})

--- a/internal/supervisor/cluster.go
+++ b/internal/supervisor/cluster.go
@@ -72,7 +72,7 @@ func (s *ClusterSupervisor) Do() error {
 
 // Supervise schedules the required work on the given cluster.
 func (s *ClusterSupervisor) Supervise(cluster *model.Cluster) {
-	logger := s.logger.WithFields(map[string]interface{}{
+	logger := s.logger.WithFields(log.Fields{
 		"cluster": cluster.ID,
 	})
 

--- a/internal/supervisor/cluster_installation.go
+++ b/internal/supervisor/cluster_installation.go
@@ -76,7 +76,7 @@ func (s *ClusterInstallationSupervisor) Do() error {
 
 // Supervise schedules the required work on the given cluster installation.
 func (s *ClusterInstallationSupervisor) Supervise(clusterInstallation *model.ClusterInstallation) {
-	logger := s.logger.WithFields(map[string]interface{}{
+	logger := s.logger.WithFields(log.Fields{
 		"clusterInstallation": clusterInstallation.ID,
 	})
 

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -90,7 +90,7 @@ func (s *InstallationSupervisor) Do() error {
 
 // Supervise schedules the required work on the given installation.
 func (s *InstallationSupervisor) Supervise(installation *model.Installation) {
-	logger := s.logger.WithFields(map[string]interface{}{
+	logger := s.logger.WithFields(log.Fields{
 		"installation": installation.ID,
 	})
 

--- a/internal/tools/aws/ec2.go
+++ b/internal/tools/aws/ec2.go
@@ -38,7 +38,7 @@ func (a *Client) TagResource(resourceID, key, value string, logger log.FieldLogg
 		return err
 	}
 
-	logger.WithFields(map[string]interface{}{
+	logger.WithFields(log.Fields{
 		"tag-key":   key,
 		"tag-value": value,
 	}).Debugf("AWS EC2 create tag response for %s: %s", resourceID, prettyCreateTagsResponse(resp))
@@ -74,7 +74,7 @@ func (a *Client) UntagResource(resourceID, key, value string, logger log.FieldLo
 		return err
 	}
 
-	logger.WithFields(map[string]interface{}{
+	logger.WithFields(log.Fields{
 		"tag-key":   key,
 		"tag-value": value,
 	}).Debugf("AWS EC2 delete tag response for %s: %s", resourceID, prettyDeleteTagsResponse(resp))

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -63,7 +63,10 @@ func (a *Client) CreateCNAME(dnsName string, dnsEndpoints []string, logger log.F
 		return err
 	}
 
-	logger.Debugf("AWS route53 response: %s", prettyRoute53Response(resp))
+	logger.WithFields(map[string]interface{}{
+		"route53-dns-value":     dnsName,
+		"route53-dns-endpoints": dnsEndpoints,
+	}).Debugf("AWS Route53 create response: %s", prettyRoute53Response(resp))
 
 	return nil
 }
@@ -112,8 +115,6 @@ func (a *Client) DeleteCNAME(dnsName string, logger log.FieldLogger) error {
 		return nil
 	}
 
-	logger.Debugf("Attempting to delete %d DNS records", len(changes))
-
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch:  &route53.ChangeBatch{Changes: changes},
 		HostedZoneId: aws.String(a.hostedZoneID),
@@ -123,7 +124,10 @@ func (a *Client) DeleteCNAME(dnsName string, logger log.FieldLogger) error {
 		return err
 	}
 
-	logger.Debugf("AWS route53 response: %s", prettyRoute53Response(resp))
+	logger.WithFields(map[string]interface{}{
+		"route53-records-deleted": len(changes),
+		"route53-dns-value":       dnsName,
+	}).Debugf("AWS route53 delete response: %s", prettyRoute53Response(resp))
 
 	return nil
 }

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -63,7 +63,7 @@ func (a *Client) CreateCNAME(dnsName string, dnsEndpoints []string, logger log.F
 		return err
 	}
 
-	logger.WithFields(map[string]interface{}{
+	logger.WithFields(log.Fields{
 		"route53-dns-value":     dnsName,
 		"route53-dns-endpoints": dnsEndpoints,
 	}).Debugf("AWS Route53 create response: %s", prettyRoute53Response(resp))
@@ -124,7 +124,7 @@ func (a *Client) DeleteCNAME(dnsName string, logger log.FieldLogger) error {
 		return err
 	}
 
-	logger.WithFields(map[string]interface{}{
+	logger.WithFields(log.Fields{
 		"route53-records-deleted": len(changes),
 		"route53-dns-value":       dnsName,
 	}).Debugf("AWS route53 delete response: %s", prettyRoute53Response(resp))

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -36,6 +36,10 @@ func (c *Cmd) CreateCluster(name, version, ami, cloud string, clusterSize Cluste
 	if ami != "" {
 		args = append(args, arg("image", ami))
 	}
+	if cloud == "aws" {
+		args = append(args, arg("networking", "amazon-vpc-routed-eni"))
+	}
+
 	if len(privateSubnetIds) != 0 {
 		args = append(args,
 			commaArg("subnets", privateSubnetIds),
@@ -51,9 +55,6 @@ func (c *Cmd) CreateCluster(name, version, ami, cloud string, clusterSize Cluste
 	}
 	if len(workerSecurityGroups) != 0 {
 		args = append(args, commaArg("node-security-groups", workerSecurityGroups))
-	}
-	if cloud == "aws" {
-		args = append(args, arg("networking", "amazon-vpc-routed-eni"))
 	}
 
 	_, _, err := c.run(args...)

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/mattermost/mattermost-cloud/model"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,7 @@ func (s *mockWebhookStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.We
 
 func TestGetAndSendWebhooks(t *testing.T) {
 	mockStore := &mockWebhookStore{}
-	logger := testlib.MakeLogger(t).WithFields(map[string]interface{}{
+	logger := testlib.MakeLogger(t).WithFields(log.Fields{
 		"webhooks-tests": true,
 	})
 
@@ -57,7 +58,7 @@ func TestGetAndSendWebhooks(t *testing.T) {
 
 // TODO: add happy-path test.
 func TestSendWebhooks(t *testing.T) {
-	logger := testlib.MakeLogger(t).WithFields(map[string]interface{}{
+	logger := testlib.MakeLogger(t).WithFields(log.Fields{
 		"webhooks-tests": true,
 	})
 	hook := &model.Webhook{


### PR DESCRIPTION
A new flag `use-existing-aws-resources` can be used to skip the
VPC find-and-claim behavior that is used for production cluster
creation. Instead, the default kops behavior of creating a new VPC
and resources will be used.

https://mattermost.atlassian.net/browse/MM-21053