### PR TITLE
add new field - ExtraData

### DIFF
--- a/internal/supervisor/cluster_installation.go
+++ b/internal/supervisor/cluster_installation.go
@@ -111,6 +111,7 @@ func (s *ClusterInstallationSupervisor) Supervise(clusterInstallation *model.Clu
 	webhookPayload := &model.WebhookPayload{
 		Type:      model.TypeClusterInstallation,
 		ID:        clusterInstallation.ID,
+		ClusterID: clusterInstallation.ClusterID,
 		NewState:  newState,
 		OldState:  oldState,
 		Timestamp: time.Now().UnixNano(),

--- a/internal/supervisor/cluster_installation.go
+++ b/internal/supervisor/cluster_installation.go
@@ -111,10 +111,10 @@ func (s *ClusterInstallationSupervisor) Supervise(clusterInstallation *model.Clu
 	webhookPayload := &model.WebhookPayload{
 		Type:      model.TypeClusterInstallation,
 		ID:        clusterInstallation.ID,
-		ClusterID: clusterInstallation.ClusterID,
 		NewState:  newState,
 		OldState:  oldState,
 		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"ClusterID": clusterInstallation.ClusterID},
 	}
 	err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -71,10 +71,10 @@ func TestSendWebhooks(t *testing.T) {
 	payload := &model.WebhookPayload{
 		Type:      "type",
 		ID:        model.NewID(),
-		ClusterID: model.NewID(),
 		NewState:  "new_state",
 		OldState:  "old_state",
 		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"ClusterID": model.NewID()},
 	}
 
 	err := sendWebhook(hook, payload, logger)

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -71,6 +71,7 @@ func TestSendWebhooks(t *testing.T) {
 	payload := &model.WebhookPayload{
 		Type:      "type",
 		ID:        model.NewID(),
+		ClusterID: model.NewID(),
 		NewState:  "new_state",
 		OldState:  "old_state",
 		Timestamp: time.Now().UnixNano(),

--- a/model/webhook.go
+++ b/model/webhook.go
@@ -36,6 +36,7 @@ type WebhookFilter struct {
 type WebhookPayload struct {
 	Timestamp int64  `json:"timestamp"`
 	ID        string `json:"id"`
+	ClusterID string `json:"cluster_id,omitempty"`
 	Type      string `json:"type"`
 	NewState  string `json:"new_state"`
 	OldState  string `json:"old_state"`

--- a/model/webhook.go
+++ b/model/webhook.go
@@ -34,12 +34,12 @@ type WebhookFilter struct {
 
 // WebhookPayload is the payload sent in every webhook.
 type WebhookPayload struct {
-	Timestamp int64  `json:"timestamp"`
-	ID        string `json:"id"`
-	ClusterID string `json:"cluster_id,omitempty"`
-	Type      string `json:"type"`
-	NewState  string `json:"new_state"`
-	OldState  string `json:"old_state"`
+	Timestamp int64             `json:"timestamp"`
+	ID        string            `json:"id"`
+	Type      string            `json:"type"`
+	NewState  string            `json:"new_state"`
+	OldState  string            `json:"old_state"`
+	ExtraData map[string]string `json:"extra_data,omitempty"`
 }
 
 // IsDeleted returns whether the webhook was marked as deleted or not.


### PR DESCRIPTION
#### Summary
Adding a bit more info in the webhook to help when need to drill down

but the idea is to have the cluster ID when posting messages, like when we receive in the `cloud-test-installation-states` channel

Please let me know if is missing something else.