### PR TITLE
Add RDS cluster logic

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -126,6 +126,11 @@ var serverCmd = &cobra.Command{
 			"debug":                           debug,
 		}).Info("Starting Mattermost Provisioning Server")
 
+		// Warn on settings we consider to be non-production.
+		if !useExistingResources {
+			logger.Warn("[DEV] Server is configured to not use cluster VPC claim functionality")
+		}
+
 		// Setup the provisioner for actually effecting changes to clusters.
 		kopsProvisioner := provisioner.NewKopsProvisioner(
 			clusterRootDir,

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/internal/tools/k8s"
 	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"github.com/mattermost/mattermost-cloud/model"
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	"github.com/pkg/errors"
@@ -97,7 +98,7 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 		logger.Debug("Cluster installation configured with a Mattermost license")
 	}
 
-	databaseSpec, databaseSecret, err := installation.GetDatabase().GenerateDatabaseSpecAndSecret(logger)
+	databaseSpec, databaseSecret, err := utils.GetDatabase(installation).GenerateDatabaseSpecAndSecret(logger)
 	if err != nil {
 		return err
 	}
@@ -110,7 +111,7 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 		mattermostInstallation.Spec.Database = *databaseSpec
 	}
 
-	filestoreSpec, filestoreSecret, err := installation.GetFilestore().GenerateFilestoreSpecAndSecret(logger)
+	filestoreSpec, filestoreSecret, err := utils.GetFilestore(installation).GenerateFilestoreSpecAndSecret(logger)
 	if err != nil {
 		return err
 	}

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/internal/tools/k8s"
+	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"github.com/mattermost/mattermost-cloud/internal/webhook"
 	"github.com/mattermost/mattermost-cloud/model"
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
@@ -141,12 +142,14 @@ func (s *InstallationSupervisor) Supervise(installation *model.Installation) {
 func (s *InstallationSupervisor) transitionInstallation(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
 	switch installation.State {
 	case model.InstallationStateCreationRequested,
-		model.InstallationStateCreationPreProvisioning:
-		return s.preProvisionInstallation(installation, instanceID, logger)
-
-	case model.InstallationStateCreationInProgress,
 		model.InstallationStateCreationNoCompatibleClusters:
 		return s.createInstallation(installation, instanceID, logger)
+
+	case model.InstallationStateCreationPreProvisioning:
+		return s.preProvisionInstallation(installation, instanceID, logger)
+
+	case model.InstallationStateCreationInProgress:
+		return s.waitForClusterInstallationStable(installation, instanceID, logger)
 
 	case model.InstallationStateCreationDNS:
 		return s.configureInstallationDNS(installation, logger)
@@ -170,24 +173,6 @@ func (s *InstallationSupervisor) transitionInstallation(installation *model.Inst
 	}
 }
 
-func (s *InstallationSupervisor) preProvisionInstallation(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
-	err := installation.GetDatabase().Provision(logger)
-	if err != nil {
-		logger.WithError(err).Error("Failed to provision installation database")
-		return model.InstallationStateCreationPreProvisioning
-	}
-
-	err = installation.GetFilestore().Provision(logger)
-	if err != nil {
-		logger.WithError(err).Error("Failed to provision installation filestore")
-		return model.InstallationStateCreationPreProvisioning
-	}
-
-	logger.Info("Installation pre-provisioning complete")
-
-	return s.createInstallation(installation, instanceID, logger)
-}
-
 func (s *InstallationSupervisor) createInstallation(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
 	clusterInstallations, err := s.store.GetClusterInstallations(&model.ClusterInstallationFilter{
 		InstallationID: installation.ID,
@@ -195,57 +180,28 @@ func (s *InstallationSupervisor) createInstallation(installation *model.Installa
 	})
 	if err != nil {
 		logger.WithError(err).Warn("Failed to find cluster installations")
-		return installation.State
+		return model.InstallationStateCreationRequested
 	}
 
-	// If we've previously created one or more cluster installations, consider the
-	// installation to be stable once all cluster installations are stable. Or, if
-	// some cluster installations have failed, mark the installation as failed.
 	if len(clusterInstallations) > 0 {
-		var stable, reconciling, failed, other int
-		for _, clusterInstallation := range clusterInstallations {
-			switch clusterInstallation.State {
-			case model.ClusterInstallationStateStable:
-				stable++
-			case model.ClusterInstallationStateReconciling:
-				reconciling++
-			case model.ClusterInstallationStateCreationFailed:
-				failed++
-			default:
-				other++
-			}
-		}
-
-		logger.Debugf("Found %d cluster installations: %d stable, %d reconciling, %d failed, %d other", len(clusterInstallations), stable, reconciling, failed, other)
-
-		if len(clusterInstallations) == stable {
-			logger.Infof("Finished creating installation")
-			return s.configureInstallationDNS(installation, logger)
-		}
-		if failed > 0 {
-			logger.Infof("Found %d failed cluster installations", failed)
-			return model.InstallationStateCreationFailed
-		}
-
-		return model.InstallationStateCreationInProgress
+		logger.Warnf("Expected no cluster installations, but found %d", len(clusterInstallations))
+		return s.preProvisionInstallation(installation, instanceID, logger)
 	}
 
-	// Otherwise proceed to requesting cluster installation creation on any available clusters.
+	// Proceed to requesting cluster installation creation on any available clusters.
 	clusters, err := s.store.GetClusters(&model.ClusterFilter{
 		PerPage:        model.AllPerPage,
 		IncludeDeleted: false,
 	})
 	if err != nil {
 		logger.WithError(err).Warn("Failed to query clusters")
-		return installation.State
+		return model.InstallationStateCreationRequested
 	}
 
 	for _, cluster := range clusters {
 		clusterInstallation := s.createClusterInstallation(cluster, installation, instanceID, logger)
 		if clusterInstallation != nil {
-			// Once created, preserve the existing state until the cluster installation
-			// stabilizes.
-			return model.InstallationStateCreationInProgress
+			return s.preProvisionInstallation(installation, instanceID, logger)
 		}
 	}
 
@@ -367,6 +323,70 @@ func (s *InstallationSupervisor) createClusterInstallation(cluster *model.Cluste
 	logger.Infof("Requested creation of cluster installation on cluster %s. Expected resource load: CPU=%d%%, Memory=%d%%", cluster.ID, cpuPercent, memoryPercent)
 
 	return clusterInstallation
+}
+
+func (s *InstallationSupervisor) preProvisionInstallation(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
+	err := utils.GetDatabase(installation).Provision(s.store, logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed to provision installation database")
+		return model.InstallationStateCreationPreProvisioning
+	}
+
+	err = utils.GetFilestore(installation).Provision(logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed to provision installation filestore")
+		return model.InstallationStateCreationPreProvisioning
+	}
+
+	logger.Info("Installation pre-provisioning complete")
+
+	return s.waitForClusterInstallationStable(installation, instanceID, logger)
+}
+
+func (s *InstallationSupervisor) waitForClusterInstallationStable(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
+	clusterInstallations, err := s.store.GetClusterInstallations(&model.ClusterInstallationFilter{
+		InstallationID: installation.ID,
+		PerPage:        model.AllPerPage,
+	})
+	if err != nil {
+		logger.WithError(err).Warn("Failed to find cluster installations")
+		return model.InstallationStateCreationInProgress
+	}
+
+	// Consider the installation to be stable once all cluster installations are
+	// stable. Or, if some cluster installations have failed, mark the
+	// installation as failed.
+	if len(clusterInstallations) == 0 {
+		logger.Error("Expected 1 cluster installations to be created, but found none")
+		return model.InstallationStateCreationFailed
+	}
+
+	var stable, reconciling, failed, other int
+	for _, clusterInstallation := range clusterInstallations {
+		switch clusterInstallation.State {
+		case model.ClusterInstallationStateStable:
+			stable++
+		case model.ClusterInstallationStateReconciling:
+			reconciling++
+		case model.ClusterInstallationStateCreationFailed:
+			failed++
+		default:
+			other++
+		}
+	}
+
+	logger.Debugf("Found %d cluster installations: %d stable, %d reconciling, %d failed, %d other", len(clusterInstallations), stable, reconciling, failed, other)
+
+	if len(clusterInstallations) == stable {
+		logger.Infof("Finished creating installation")
+		return s.configureInstallationDNS(installation, logger)
+	}
+	if failed > 0 {
+		logger.Infof("Found %d failed cluster installations", failed)
+		return model.InstallationStateCreationFailed
+	}
+
+	return model.InstallationStateCreationInProgress
 }
 
 func (s *InstallationSupervisor) configureInstallationDNS(installation *model.Installation, logger log.FieldLogger) string {
@@ -628,13 +648,13 @@ func (s *InstallationSupervisor) finalDeletionCleanup(installation *model.Instal
 		return model.InstallationStateDeletionFinalCleanup
 	}
 
-	err = installation.GetDatabase().Teardown(s.keepDatabaseData, logger)
+	err = utils.GetDatabase(installation).Teardown(s.keepDatabaseData, logger)
 	if err != nil {
 		logger.WithError(err).Error("Failed to delete database")
 		return model.InstallationStateDeletionFinalCleanup
 	}
 
-	err = installation.GetFilestore().Teardown(s.keepFilestoreData, logger)
+	err = utils.GetFilestore(installation).Teardown(s.keepFilestoreData, logger)
 	if err != nil {
 		logger.WithError(err).Error("Failed to delete filestore")
 		return model.InstallationStateDeletionFinalCleanup

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -596,6 +596,196 @@ func TestInstallationSupervisor(t *testing.T) {
 		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateStable)
 	})
 
+	t.Run("pre provisioning requested, cluster installations reconciling", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
+
+		cluster := standardStableTestCluster()
+		err := sqlStore.CreateCluster(cluster)
+		require.NoError(t, err)
+
+		owner := model.NewID()
+		groupID := model.NewID()
+		installation := &model.Installation{
+			OwnerID:  owner,
+			Version:  "version",
+			DNS:      "dns.example.com",
+			Size:     mmv1alpha1.Size100String,
+			Affinity: model.InstallationAffinityIsolated,
+			GroupID:  &groupID,
+			State:    model.InstallationStateCreationPreProvisioning,
+		}
+
+		err = sqlStore.CreateInstallation(installation)
+		require.NoError(t, err)
+
+		clusterInstallation := &model.ClusterInstallation{
+			ClusterID:      cluster.ID,
+			InstallationID: installation.ID,
+			Namespace:      "namespace",
+			State:          model.ClusterInstallationStateCreationRequested,
+		}
+		err = sqlStore.CreateClusterInstallation(clusterInstallation)
+		require.NoError(t, err)
+
+		supervisor.Supervise(installation)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationInProgress)
+		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationRequested)
+	})
+
+	t.Run("creation requested, cluster installations failed", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
+
+		cluster := standardStableTestCluster()
+		err := sqlStore.CreateCluster(cluster)
+		require.NoError(t, err)
+
+		owner := model.NewID()
+		groupID := model.NewID()
+		installation := &model.Installation{
+			OwnerID:  owner,
+			Version:  "version",
+			DNS:      "dns.example.com",
+			Size:     mmv1alpha1.Size100String,
+			Affinity: model.InstallationAffinityIsolated,
+			GroupID:  &groupID,
+			State:    model.InstallationStateCreationPreProvisioning,
+		}
+
+		err = sqlStore.CreateInstallation(installation)
+		require.NoError(t, err)
+
+		clusterInstallation := &model.ClusterInstallation{
+			ClusterID:      cluster.ID,
+			InstallationID: installation.ID,
+			Namespace:      "namespace",
+			State:          model.ClusterInstallationStateCreationFailed,
+		}
+		err = sqlStore.CreateClusterInstallation(clusterInstallation)
+		require.NoError(t, err)
+
+		supervisor.Supervise(installation)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationFailed)
+		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationFailed)
+	})
+
+	t.Run("creation in progress, cluster installations reconciling", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
+
+		cluster := standardStableTestCluster()
+		err := sqlStore.CreateCluster(cluster)
+		require.NoError(t, err)
+
+		owner := model.NewID()
+		groupID := model.NewID()
+		installation := &model.Installation{
+			OwnerID:  owner,
+			Version:  "version",
+			DNS:      "dns.example.com",
+			Size:     mmv1alpha1.Size100String,
+			Affinity: model.InstallationAffinityIsolated,
+			GroupID:  &groupID,
+			State:    model.InstallationStateCreationInProgress,
+		}
+
+		err = sqlStore.CreateInstallation(installation)
+		require.NoError(t, err)
+
+		clusterInstallation := &model.ClusterInstallation{
+			ClusterID:      cluster.ID,
+			InstallationID: installation.ID,
+			Namespace:      "namespace",
+			State:          model.ClusterInstallationStateCreationRequested,
+		}
+		err = sqlStore.CreateClusterInstallation(clusterInstallation)
+		require.NoError(t, err)
+
+		supervisor.Supervise(installation)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationInProgress)
+		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationRequested)
+	})
+
+	t.Run("creation in progress, cluster installations stable", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
+
+		cluster := standardStableTestCluster()
+		err := sqlStore.CreateCluster(cluster)
+		require.NoError(t, err)
+
+		owner := model.NewID()
+		groupID := model.NewID()
+		installation := &model.Installation{
+			OwnerID:  owner,
+			Version:  "version",
+			DNS:      "dns.example.com",
+			Size:     mmv1alpha1.Size100String,
+			Affinity: model.InstallationAffinityIsolated,
+			GroupID:  &groupID,
+			State:    model.InstallationStateCreationInProgress,
+		}
+
+		err = sqlStore.CreateInstallation(installation)
+		require.NoError(t, err)
+
+		clusterInstallation := &model.ClusterInstallation{
+			ClusterID:      cluster.ID,
+			InstallationID: installation.ID,
+			Namespace:      "namespace",
+			State:          model.ClusterInstallationStateStable,
+		}
+		err = sqlStore.CreateClusterInstallation(clusterInstallation)
+		require.NoError(t, err)
+
+		supervisor.Supervise(installation)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateStable)
+		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateStable)
+	})
+
+	t.Run("creation in progress, cluster installations failed", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, logger)
+
+		cluster := standardStableTestCluster()
+		err := sqlStore.CreateCluster(cluster)
+		require.NoError(t, err)
+
+		owner := model.NewID()
+		groupID := model.NewID()
+		installation := &model.Installation{
+			OwnerID:  owner,
+			Version:  "version",
+			DNS:      "dns.example.com",
+			Size:     mmv1alpha1.Size100String,
+			Affinity: model.InstallationAffinityIsolated,
+			GroupID:  &groupID,
+			State:    model.InstallationStateCreationInProgress,
+		}
+
+		err = sqlStore.CreateInstallation(installation)
+		require.NoError(t, err)
+
+		clusterInstallation := &model.ClusterInstallation{
+			ClusterID:      cluster.ID,
+			InstallationID: installation.ID,
+			Namespace:      "namespace",
+			State:          model.ClusterInstallationStateCreationFailed,
+		}
+		err = sqlStore.CreateClusterInstallation(clusterInstallation)
+		require.NoError(t, err)
+
+		supervisor.Supervise(installation)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationFailed)
+		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationFailed)
+	})
+
 	t.Run("creation dns requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/mattermost/mattermost-cloud/model"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -22,6 +23,7 @@ type AWS interface {
 type Client struct {
 	hostedZoneID string
 	api          api
+	store        model.InstallationDatabaseStoreInterface
 }
 
 // api mocks out the AWS API calls for testing.
@@ -41,4 +43,14 @@ func New(hostedZoneID string) *Client {
 		hostedZoneID: hostedZoneID,
 		api:          &apiInterface{},
 	}
+}
+
+// AddSQLStore adds SQLStore functionality to the AWS client.
+func (c *Client) AddSQLStore(store model.InstallationDatabaseStoreInterface) {
+	c.store = store
+}
+
+// HasSQLStore returns whether the AWS client has a SQL store or not.
+func (c *Client) HasSQLStore() bool {
+	return c.store != nil
 }

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -45,6 +45,17 @@ const (
 	// Note: This needs to be manually created before RDS databases can be used.
 	DefaultDBSecurityGroupTagValue = "MYSQL/Aurora"
 
+	// DefaultDBSubnetGroupTagKey is the default DB subnet group tag key that is
+	// used to find subnet groups to use in configuration of the RDS database.
+	// Note: This needs to be manually created before RDS databases can be used.
+	DefaultDBSubnetGroupTagKey = "tag:MattermostCloudInstallationDatabase"
+
+	// DefaultDBSubnetGroupTagValue is the default DB subnet group tag value
+	// that is used to find subnet groups to use in configuration of the RDS
+	// database.
+	// Note: This needs to be manually created before RDS databases can be used.
+	DefaultDBSubnetGroupTagValue = "MYSQL/Aurora"
+
 	// cloudIDPrefix is the prefix value used when creating AWS resource names.
 	// Warning:
 	// changing this value will break the connection to AWS resources for

--- a/internal/tools/aws/database.go
+++ b/internal/tools/aws/database.go
@@ -3,9 +3,12 @@ package aws
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/mattermost/mattermost-cloud/model"
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,8 +27,11 @@ func NewRDSDatabase(installationID string) *RDSDatabase {
 }
 
 // Provision completes all the steps necessary to provision a RDS database.
-func (d *RDSDatabase) Provision(logger log.FieldLogger) error {
-	err := rdsDatabaseProvision(d.installationID, logger)
+func (d *RDSDatabase) Provision(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	awsClient := New("n/a")
+	awsClient.AddSQLStore(store)
+
+	err := rdsDatabaseProvision(d.installationID, awsClient, logger)
 	if err != nil {
 		return errors.Wrap(err, "unable to provision RDS database")
 	}
@@ -82,24 +88,65 @@ func (d *RDSDatabase) GenerateDatabaseSpecAndSecret(logger log.FieldLogger) (*mm
 	return databaseSpec, databaseSecret, nil
 }
 
-func rdsDatabaseProvision(installationID string, logger log.FieldLogger) error {
-	logger.Info("Provisioning AWS RDS database")
-
-	a := New("n/a")
+func rdsDatabaseProvision(installationID string, awsClient *Client, logger log.FieldLogger) error {
 	awsID := CloudID(installationID)
+	logger.Infof("Provisioning AWS RDS database with ID %s", awsID)
 
-	rdsSecret, err := a.secretsManagerEnsureRDSSecretCreated(awsID, logger)
+	// To properly provision the database we need a SQL client to lookup which
+	// cluster(s) the installation is running on.
+	if !awsClient.HasSQLStore() {
+		return errors.New("the provided AWS client does not have SQL store access")
+	}
+
+	clusterInstallations, err := awsClient.store.GetClusterInstallations(&model.ClusterInstallationFilter{
+		PerPage:        model.AllPerPage,
+		InstallationID: installationID,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "unable to lookup cluster installations for installation %s", installationID)
+	}
+
+	clusterInstallationCount := len(clusterInstallations)
+	if clusterInstallationCount == 0 {
+		return fmt.Errorf("no cluster installations found for %s", installationID)
+	}
+	if clusterInstallationCount != 1 {
+		return fmt.Errorf("RDS provisioning is not currently supported for multiple cluster installations (found %d)", clusterInstallationCount)
+	}
+
+	clusterID := clusterInstallations[0].ClusterID
+	vpcFilters := []*ec2.Filter{
+		{
+			Name:   aws.String(VpcClusterIDTagKey),
+			Values: []*string{aws.String(clusterID)},
+		},
+		{
+			Name:   aws.String(VpcAvailableTagKey),
+			Values: []*string{aws.String(VpcAvailableTagValueFalse)},
+		},
+	}
+	vpcs, err := GetVpcsWithFilters(vpcFilters)
+	if err != nil {
+		return err
+	}
+	if len(vpcs) != 1 {
+		return fmt.Errorf("expected 1 VPC for cluster %s, but got %d", clusterID, len(vpcs))
+	}
+
+	vpcID := *vpcs[0].VpcId
+
+	rdsSecret, err := awsClient.secretsManagerEnsureRDSSecretCreated(awsID, logger)
 	if err != nil {
 		return err
 	}
 
-	err = a.rdsEnsureDBClusterCreated(awsID, rdsSecret.MasterUsername, rdsSecret.MasterPassword, logger)
+	err = awsClient.rdsEnsureDBClusterCreated(awsID, vpcID, rdsSecret.MasterUsername, rdsSecret.MasterPassword, logger)
 	if err != nil {
 		return err
 	}
 
 	masterInstanceName := fmt.Sprintf("%s-master", awsID)
-	err = a.rdsEnsureDBClusterInstanceCreated(awsID, masterInstanceName, logger)
+	err = awsClient.rdsEnsureDBClusterInstanceCreated(awsID, masterInstanceName, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/aws/database_test.go
+++ b/internal/tools/aws/database_test.go
@@ -20,22 +20,19 @@ func TestDatabaseProvision(t *testing.T) {
 	}
 
 	logger := logrus.New()
-
 	database := NewRDSDatabase(id)
 
-	err := database.Provision(logger)
+	err := database.Provision(nil, logger)
 	require.NoError(t, err)
 }
 
 func TestDatabaseTeardown(t *testing.T) {
-
 	id := os.Getenv("SUPER_AWS_DATABASE_TEST")
 	if id == "" {
 		return
 	}
 
 	logger := logrus.New()
-
 	database := NewRDSDatabase(id)
 
 	err := database.Teardown(false, logger)

--- a/internal/tools/aws/filestore.go
+++ b/internal/tools/aws/filestore.go
@@ -6,10 +6,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-
-	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 )
 
 // S3Filestore is a filestore backed by AWS S3.
@@ -75,6 +74,7 @@ func (f *S3Filestore) GenerateFilestoreSpecAndSecret(logger log.FieldLogger) (*m
 	return filestoreSpec, filestoreSecret, nil
 }
 
+// s3FilestoreProvision provisions an S3 filestore for an installation.
 func s3FilestoreProvision(installationID string, logger log.FieldLogger) error {
 	logger.Info("Provisioning AWS S3 filestore")
 

--- a/internal/tools/aws/filestore_test.go
+++ b/internal/tools/aws/filestore_test.go
@@ -20,24 +20,24 @@ func TestFilestoreProvision(t *testing.T) {
 	}
 
 	logger := logrus.New()
-
 	filestore := NewS3Filestore(id)
+
+	logger.Warnf("Provisioning down AWS filestore %s", id)
 
 	err := filestore.Provision(logger)
 	require.NoError(t, err)
 }
 
 func TestFilestoreTeardown(t *testing.T) {
-
 	id := os.Getenv("SUPER_AWS_FILESTORE_TEST")
 	if id == "" {
 		return
 	}
 
 	logger := logrus.New()
-	logger.Warnf("Tearing down S3 bucket %s", id)
-
 	filestore := NewS3Filestore(id)
+
+	logger.Warnf("Tearing down AWS filestore %s", id)
 
 	err := filestore.Teardown(false, logger)
 	require.NoError(t, err)

--- a/internal/tools/aws/secrets_manager.go
+++ b/internal/tools/aws/secrets_manager.go
@@ -135,6 +135,7 @@ func (a *Client) secretsManagerEnsureRDSSecretCreated(awsID string, logger log.F
 	return rdsSecretPayload, nil
 }
 
+// secretsManagerGetIAMAccessKey returns the AccessKey for an IAM account.
 func secretsManagerGetIAMAccessKey(awsID string) (*IAMAccessKey, error) {
 	svc := secretsmanager.New(session.New())
 

--- a/internal/tools/utils/utils.go
+++ b/internal/tools/utils/utils.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/model"
 )
 
 // CopyDirectory copy the entire directory to another destination
@@ -69,4 +72,32 @@ func copyFile(source string, dest string) error {
 	}
 
 	return nil
+}
+
+// GetFilestore returns the Filestore interface that matches the installation.
+func GetFilestore(i *model.Installation) model.Filestore {
+	switch i.Filestore {
+	case model.InstallationFilestoreMinioOperator:
+		return model.NewMinioOperatorFilestore()
+	case model.InstallationFilestoreAwsS3:
+		return aws.NewS3Filestore(i.ID)
+	}
+
+	// Warning: we should never get here as it would mean that we didn't match
+	// our filestore type.
+	return model.NewMinioOperatorFilestore()
+}
+
+// GetDatabase returns the Database interface that matches the installation.
+func GetDatabase(i *model.Installation) model.Database {
+	switch i.Database {
+	case model.InstallationDatabaseMysqlOperator:
+		return model.NewMysqlOperatorDatabase()
+	case model.InstallationDatabaseAwsRDS:
+		return aws.NewRDSDatabase(i.ID)
+	}
+
+	// Warning: we should never get here as it would mean that we didn't match
+	// our database type.
+	return model.NewMysqlOperatorDatabase()
 }

--- a/model/installation_database.go
+++ b/model/installation_database.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -16,9 +15,15 @@ const (
 
 // Database is the interface for managing Mattermost databases.
 type Database interface {
-	Provision(logger log.FieldLogger) error
+	Provision(store InstallationDatabaseStoreInterface, logger log.FieldLogger) error
 	Teardown(keepData bool, logger log.FieldLogger) error
 	GenerateDatabaseSpecAndSecret(logger log.FieldLogger) (*mmv1alpha1.Database, *corev1.Secret, error)
+}
+
+// InstallationDatabaseStoreInterface is the interface necessary for SQLStore
+// functionality to correlate an installation to a cluster for database creation.
+type InstallationDatabaseStoreInterface interface {
+	GetClusterInstallations(filter *ClusterInstallationFilter) ([]*ClusterInstallation, error)
 }
 
 // MysqlOperatorDatabase is a database backed by the MySQL operator.
@@ -30,7 +35,7 @@ func NewMysqlOperatorDatabase() *MysqlOperatorDatabase {
 }
 
 // Provision completes all the steps necessary to provision a MySQL operator database.
-func (d *MysqlOperatorDatabase) Provision(logger log.FieldLogger) error {
+func (d *MysqlOperatorDatabase) Provision(store InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
 	logger.Info("MySQL operator database requires no pre-provisioning; skipping...")
 
 	return nil
@@ -50,20 +55,6 @@ func (d *MysqlOperatorDatabase) Teardown(keepData bool, logger log.FieldLogger) 
 // accessing the MySQL operator database.
 func (d *MysqlOperatorDatabase) GenerateDatabaseSpecAndSecret(logger log.FieldLogger) (*mmv1alpha1.Database, *corev1.Secret, error) {
 	return nil, nil, nil
-}
-
-// GetDatabase returns the Database interface that matches the installation.
-func (i *Installation) GetDatabase() Database {
-	switch i.Database {
-	case InstallationDatabaseMysqlOperator:
-		return NewMysqlOperatorDatabase()
-	case InstallationDatabaseAwsRDS:
-		return aws.NewRDSDatabase(i.ID)
-	}
-
-	// Warning: we should never get here as it would mean that we didn't match
-	// our database type.
-	return NewMysqlOperatorDatabase()
 }
 
 // InternalDatabase returns true if the installation's database is internal

--- a/model/installation_filestore.go
+++ b/model/installation_filestore.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	log "github.com/sirupsen/logrus"
 
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
@@ -51,20 +50,6 @@ func (f *MinioOperatorFilestore) Teardown(keepData bool, logger log.FieldLogger)
 // accessing the MinIO operator filestore.
 func (f *MinioOperatorFilestore) GenerateFilestoreSpecAndSecret(logger log.FieldLogger) (*mmv1alpha1.Minio, *corev1.Secret, error) {
 	return nil, nil, nil
-}
-
-// GetFilestore returns the Filestore interface that matches the installation.
-func (i *Installation) GetFilestore() Filestore {
-	switch i.Filestore {
-	case InstallationFilestoreMinioOperator:
-		return NewMinioOperatorFilestore()
-	case InstallationFilestoreAwsS3:
-		return aws.NewS3Filestore(i.ID)
-	}
-
-	// Warning: we should never get here as it would mean that we didn't match
-	// our filestore type.
-	return NewMinioOperatorFilestore()
 }
 
 // InternalFilestore returns true if the installation's filestore is internal


### PR DESCRIPTION
This change does the following:
 - Adds AWS logic to correctly find the necessary resources for
   configuring an installation RDS database. These resources are
   selected based on the cluster that the installation will be
   scheduled onto.
 - Alter the installation state machine to accommodate the new
   creation flow.
 - Logging improvements.

https://mattermost.atlassian.net/browse/MM-21113
