### PR TITLE
abort if dns name is too long

### DIFF
--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -269,6 +269,16 @@ func TestCreateInstallation(t *testing.T) {
 		require.EqualError(t, err, "failed with status code 400")
 	})
 
+	t.Run("dns too long", func(t *testing.T) {
+		_, err := client.CreateInstallation(&model.CreateInstallationRequest{
+			OwnerID:  "owner",
+			Version:  "version",
+			DNS:      "xoxo-serverwithverylongnametoexposeissuesrelatedtolengthofkeystha",
+			Affinity: model.InstallationAffinityIsolated,
+		})
+		require.EqualError(t, err, "failed with status code 400")
+	})
+
 	t.Run("invalid dns", func(t *testing.T) {
 		_, err := client.CreateInstallation(&model.CreateInstallationRequest{
 			OwnerID:  "owner",

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -78,6 +78,11 @@ func (a *Client) DeleteCNAME(dnsName string, logger log.FieldLogger) error {
 		return err
 	}
 
+	if len(dnsName) >= 64 {
+		logger.Warnf("DNS name too long, skipping since it could never have been created record-name=%s", dnsName)
+		return nil
+	}
+
 	nextRecordName := dnsName
 	var recordsets []*route53.ResourceRecordSet
 	for {

--- a/internal/tools/aws/route53_test.go
+++ b/internal/tools/aws/route53_test.go
@@ -120,6 +120,13 @@ func TestDeleteCNAME(t *testing.T) {
 			false,
 			true,
 		},
+		{
+			"dns name too long should skip",
+			"xoxo-serverwithverylongnametoexposeissuesrelatedtolengthofkeystha",
+			nil,
+			false,
+			false,
+		},
 	}
 
 	logger := logrus.New()

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -50,6 +50,9 @@ func (request *CreateInstallationRequest) Validate() error {
 	if request.DNS == "" {
 		return errors.New("must specify DNS")
 	}
+	if len(request.DNS) >= 64 {
+		return errors.Errorf("DNS names must be less than 64 characters, but name was %d long. DNS=%s", len(request.DNS), request.DNS)
+	}
 	_, err := mmv1alpha1.GetClusterSize(request.Size)
 	if err != nil {
 		return errors.Wrap(err, "invalid size")


### PR DESCRIPTION
#### Summary
- abort the cluster installation creation if the dns is too long
- and skip the deletion of the route53 entry is too long, since this never should happen if we are blocking in the creating, but will fix some cases that we already have

