### PR TITLE
Add a make install build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,3 +87,7 @@ get-kubectl: ## Download kubectl only if it's not available. Used in the docker 
 		curl -Lo build/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl &&\
 		chmod +x build/kubectl;\
 	fi
+
+.PHONY: install
+install: build
+	go install ./...


### PR DESCRIPTION
Adds a target to the Makefile for `make install` which calls the `build` target and then `go install ./...` to place the binaries in `$GOPATH/bin`.

This is just a quality of life suggestion; I automatically look for a `make install` target in projects with Makefiles and this one does what I think folks would generally expect `make install` to do for this repository, and I wanted it for my immediate workflow so I added these lines and thought we might want to merge them upstream.