### PR TITLE
Refactor CreateClusterRequest

### DIFF
--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -39,7 +39,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 		clusterRequest, err := model.NewCreateClusterRequestFromReader(bytes.NewReader([]byte(
 			`{"Provider": "azure", "Size": "SizeAlef1000", "Zones":["zone1", "zone2"]}`,
 		)))
-		require.EqualError(t, err, "unsupported provider azure")
+		require.EqualError(t, err, "create cluster request failed validation: unsupported provider azure")
 		require.Nil(t, clusterRequest)
 	})
 

--- a/model/cluster_request_test.go
+++ b/model/cluster_request_test.go
@@ -1,0 +1,33 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateClusterRequestValid(t *testing.T) {
+	var testCases = []struct {
+		testName     string
+		request      *model.CreateClusterRequest
+		requireError bool
+	}{
+		{"defaults", &model.CreateClusterRequest{}, false},
+		{"invalid provider", &model.CreateClusterRequest{Provider: "blah"}, true},
+		{"invalid version", &model.CreateClusterRequest{Version: "blah"}, true},
+		{"invalid size", &model.CreateClusterRequest{Size: "blah"}, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			tc.request.SetDefaults()
+
+			if tc.requireError {
+				assert.Error(t, tc.request.Validate())
+			} else {
+				assert.NoError(t, tc.request.Validate())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change moves logic for setting defaults and validating a
CreateClusterRequest to methods of the struct. This allows for
requests to be easily validated before sending them to the server.

https://mattermost.atlassian.net/browse/MM-21370
