### PR TITLE
Ignore multiple cloud db files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 clusters
-cloud.db
+cloud*.db
 coverage.out
 .vscode


### PR DESCRIPTION
This allows for multiple sqlite cloud database files to exist
and be ignored by git. i.e. `cloud.dev.db` is now a valid ignored
file name.
