### PR TITLE
Defining an interface for managing cluster utilities as a group

### DIFF
--- a/internal/provisioner/fluentbit.go
+++ b/internal/provisioner/fluentbit.go
@@ -1,0 +1,56 @@
+package provisioner
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	log "github.com/sirupsen/logrus"
+)
+
+type fluentbit struct {
+	provisioner *KopsProvisioner
+	kops        *kops.Cmd
+	logger      log.FieldLogger
+}
+
+func newFluentbitHandle(provisioner *KopsProvisioner, kops *kops.Cmd, logger log.FieldLogger) (*fluentbit, error) {
+	if logger == nil {
+		return nil, fmt.Errorf("cannot instantiate Fluentbit handle with nil logger")
+	}
+
+	if provisioner == nil {
+		return nil, fmt.Errorf("cannot create a connection to Fluentbit if the provisioner provided is nil")
+	}
+
+	if kops == nil {
+		return nil, fmt.Errorf("cannot create a connection to Fluentbit if the Kops command provided is nil")
+	}
+
+	return &fluentbit{
+		provisioner: provisioner,
+		kops:        kops,
+		logger:      logger.WithField("cluster-utility", "fluentbit"),
+	}, nil
+}
+
+func (f *fluentbit) Create() error {
+	elasticSearchDNS := fmt.Sprintf("elasticsearch.%s", f.provisioner.privateDNS)
+	return (&helmDeployment{
+		chartDeploymentName: "fluent-bit",
+		chartName:           "stable/fluent-bit",
+		namespace:           "fluent-bit",
+		setArgument:         fmt.Sprintf("backend.es.host=%s", elasticSearchDNS),
+		valuesPath:          "helm-charts/fluent-bit_values.yaml",
+		kopsProvisioner:     f.provisioner,
+		kops:                f.kops,
+		logger:              f.logger,
+	}).Create()
+}
+
+func (f *fluentbit) Destroy() error {
+	return nil
+}
+
+func (f *fluentbit) Upgrade() error {
+	return nil
+}

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -1,0 +1,234 @@
+package provisioner
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/mattermost/mattermost-cloud/internal/tools/k8s"
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+// helmDeployment deploys Helm charts.
+type helmDeployment struct {
+	chartDeploymentName string
+	chartName           string
+	namespace           string
+	setArgument         string
+	valuesPath          string
+
+	cluster         *model.Cluster
+	kopsProvisioner *KopsProvisioner
+	kops            *kops.Cmd
+	logger          log.FieldLogger
+}
+
+func installHelm(kops *kops.Cmd, logger log.FieldLogger) error {
+	logger.Info("Installing Helm")
+
+	err := helmSetup(logger, kops)
+	if err != nil {
+		return errors.Wrap(err, "couldn't install Helm")
+	}
+
+	wait := 120
+	logger.Infof("Waiting up to %d seconds for helm to become ready...", wait)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(wait)*time.Second)
+	defer cancel()
+	err = waitForHelmRunning(ctx, kops.GetKubeConfigPath())
+	if err != nil {
+		return errors.Wrap(err, "Helm didn't start as expected, or we couldn't detect it")
+	}
+
+	logger.Info("Updating all Helm repos.")
+	return helmRepoUpdate(logger)
+}
+
+func (d *helmDeployment) Update() error {
+	logger := d.logger.WithField("helm-update", d.chartName)
+
+	logger.Infof("Refreshing helm chart %s -- may trigger service upgrade", d.chartName)
+	err := upgradeHelmChart(*d, d.kops.GetKubeConfigPath(), logger)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("got an error trying to upgrade the helm chart %s", d.chartName))
+	}
+	return nil
+}
+
+// Create will install a given HelmDeployment in the cluster specified in that object.
+func (d *helmDeployment) Create() error {
+	logger := d.logger.WithField("helm-create", d.chartName)
+	logger.Infof("Installing helm chart %s", d.chartName)
+	return installHelmChart(*d, d.kops.GetKubeConfigPath(), logger)
+}
+
+// waitForHelmRunning is used to check when Helm is ready to install charts.
+func waitForHelmRunning(ctx context.Context, configPath string) error {
+	for {
+		cmd := exec.Command("helm", "ls", "--kubeconfig", configPath)
+		var out bytes.Buffer
+		cmd.Stderr = &out
+		cmd.Run()
+		if out.String() == "" {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "timed out waiting for helm to become ready")
+		case <-time.After(5 * time.Second):
+		}
+	}
+}
+
+// helmRepoUpdate updates the helm repos to get latest available charts
+func helmRepoUpdate(logger log.FieldLogger) error {
+	var cmd *exec.Cmd
+	arguments := []string{
+		"repo",
+		"update",
+	}
+
+	cmd = exec.Command("helm", arguments...)
+
+	logger.WithFields(log.Fields{
+		"cmd": cmd.Path,
+	}).Info("Invoking command")
+
+	err := cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, "Failed to execute Helm to update the Helm repos")
+	}
+	return nil
+}
+
+// installHelmChart is used to install Helm charts.
+func installHelmChart(chart helmDeployment, configPath string, logger log.FieldLogger) error {
+	var cmd *exec.Cmd
+	arguments := []string{
+		"--debug",
+		"install",
+		"--kubeconfig", configPath,
+		"-f", chart.valuesPath,
+		chart.chartName,
+		"--namespace", chart.namespace,
+		"--name", chart.chartDeploymentName}
+
+	if chart.setArgument != "" {
+		arguments = append(arguments, "--set", chart.setArgument)
+	}
+
+	cmd = exec.Command("helm", arguments...)
+
+	logger.WithFields(log.Fields{
+		"cmd":  cmd.Path,
+		"args": cmd.Args,
+	}).Info("Invoking command")
+
+	err := cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Couldn't execute Helm when trying to install the chart %s", chart.chartName))
+	}
+	return nil
+}
+
+// upgradeHelmChart is used to upgrade Helm deployments.
+func upgradeHelmChart(chart helmDeployment, configPath string, logger log.FieldLogger) error {
+	var cmd *exec.Cmd
+	arguments := []string{
+		"--debug",
+		"upgrade",
+		chart.chartDeploymentName,
+		chart.chartName,
+		"--kubeconfig", configPath,
+		"-f", chart.valuesPath,
+		"--namespace", chart.namespace,
+	}
+
+	if chart.setArgument != "" {
+		arguments = append(arguments, "--set", chart.setArgument)
+	}
+
+	cmd = exec.Command("helm", arguments...)
+
+	logger.WithFields(log.Fields{
+		"cmd":  cmd.Path,
+		"args": cmd.Args,
+	}).Info("Invoking command")
+
+	output, err := cmd.Output()
+	if len(output) > 0 {
+		log.Debugf("Helm output was:\n%s\n", string(output))
+	}
+
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to upgrade Helm chart %s", chart.chartName))
+	}
+	return nil
+}
+
+// helmSetup is used for the initial setup of Helm in cluster.
+func helmSetup(logger log.FieldLogger, kops *kops.Cmd) error {
+	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to set up the k8s client")
+	}
+
+	logger.Info("Initializing Helm in the cluster")
+	err = exec.Command("helm", "--debug", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--upgrade").Run()
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize Helm in the cluster")
+	}
+
+	logger.Info("Creating Tiller service account")
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "tiller"},
+	}
+
+	_, err = k8sClient.Clientset.CoreV1().ServiceAccounts("kube-system").Create(serviceAccount)
+	if err != nil {
+		return errors.Wrap(err, "failed to set up Tiller service account for Helm")
+	}
+
+	logger.Info("Successfully created Tiller service account")
+
+	logger.Info("Creating Tiller cluster role bind")
+	roleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "tiller-cluster-rule"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "tiller", Namespace: "kube-system"},
+		},
+		RoleRef: rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
+	}
+
+	_, err = k8sClient.Clientset.RbacV1().ClusterRoleBindings().Create(roleBinding)
+	if err != nil {
+		return errors.Wrap(err, "failed to create cluster role bindings")
+	}
+
+	logger.Info("Successfully created cluster role bind")
+
+	logger.Info("Upgrade Helm")
+
+	cmd := exec.Command("helm", "--debug", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--service-account", "tiller", "--upgrade")
+
+	logger.WithFields(log.Fields{
+		"cmd":  cmd.Path,
+		"args": cmd.Args,
+	}).Info("Invoking command")
+
+	err = cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, "failed to invoke Helm command")
+	}
+
+	return nil
+}

--- a/internal/provisioner/kops_utils.go
+++ b/internal/provisioner/kops_utils.go
@@ -1,20 +1,15 @@
 package provisioner
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/mattermost/mattermost-cloud/internal/tools/k8s"
-	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
 	"github.com/mattermost/mattermost-cloud/internal/tools/terraform"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -86,24 +81,6 @@ func waitForNamespacesDeleted(ctx context.Context, namespaces []string, k8sClien
 	}
 }
 
-// waitForHelmRunning is used to check when Helm is ready to install charts.
-func waitForHelmRunning(ctx context.Context, configPath string) error {
-	for {
-		cmd := exec.Command("helm", "ls", "--kubeconfig", configPath)
-		var out bytes.Buffer
-		cmd.Stderr = &out
-		cmd.Run()
-		if out.String() == "" {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return errors.Wrap(ctx.Err(), "timed out waiting for helm to become ready")
-		case <-time.After(5 * time.Second):
-		}
-	}
-}
-
 // getLoadBalancerEndpoint is used to get the endpoint of the internal ingress.
 func getLoadBalancerEndpoint(ctx context.Context, namespace string, logger log.FieldLogger, configPath string) (string, error) {
 	k8sClient, err := k8s.New(configPath, logger)
@@ -132,106 +109,4 @@ func getLoadBalancerEndpoint(ctx context.Context, namespace string, logger log.F
 		case <-time.After(5 * time.Second):
 		}
 	}
-}
-
-// helmRepoUpdate updates the helm repos to get latest available charts
-func helmRepoUpdate(logger log.FieldLogger) error {
-	var cmd *exec.Cmd
-	arguments := []string{
-		"repo",
-		"update",
-	}
-
-	cmd = exec.Command("helm", arguments...)
-
-	logger.WithFields(log.Fields{
-		"cmd": cmd.Path,
-	}).Info("Invoking command")
-
-	err := cmd.Run()
-	return err
-}
-
-// installHelmChart is used to install Helm charts.
-func installHelmChart(chart helmDeployment, configPath string, logger log.FieldLogger) error {
-	var cmd *exec.Cmd
-	arguments := []string{
-		"--debug",
-		"install",
-		"--kubeconfig", configPath,
-		"-f", chart.valuesPath,
-		chart.chartName,
-		"--namespace", chart.namespace,
-		"--name", chart.chartDeploymentName}
-
-	if chart.setArgument != "" {
-		arguments = append(arguments, "--set", chart.setArgument)
-	}
-
-	cmd = exec.Command("helm", arguments...)
-
-	logger.WithFields(log.Fields{
-		"cmd":  cmd.Path,
-		"args": cmd.Args,
-	}).Info("Invoking command")
-
-	err := cmd.Run()
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// helmSetup is used for the initial setup of Helm in cluster.
-func helmSetup(logger log.FieldLogger, kops *kops.Cmd) error {
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
-	if err != nil {
-		return err
-	}
-
-	logger.Info("Initializing Helm in the cluster")
-	err = exec.Command("helm", "--debug", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--upgrade").Run()
-	if err != nil {
-		return err
-	}
-
-	logger.Info("Creating Tiller service account")
-	serviceAccount := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{Name: "tiller"},
-	}
-	_, err = k8sClient.Clientset.CoreV1().ServiceAccounts("kube-system").Create(serviceAccount)
-	if err != nil {
-		return err
-	}
-	logger.Info("Successfully created Tiller service account")
-
-	logger.Info("Creating Tiller cluster role bind")
-	roleBinding := &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{Name: "tiller-cluster-rule"},
-		Subjects: []rbacv1.Subject{
-			{Kind: "ServiceAccount", Name: "tiller", Namespace: "kube-system"},
-		},
-		RoleRef: rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
-	}
-
-	_, err = k8sClient.Clientset.RbacV1().ClusterRoleBindings().Create(roleBinding)
-	if err != nil {
-		return err
-	}
-	logger.Info("Successfully created cluster role bind")
-
-	logger.Info("Upgrade Helm")
-
-	cmd := exec.Command("helm", "--debug", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--service-account", "tiller", "--upgrade")
-
-	logger.WithFields(log.Fields{
-		"cmd":  cmd.Path,
-		"args": cmd.Args,
-	}).Info("Invoking command")
-
-	err = cmd.Run()
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/internal/provisioner/nginx.go
+++ b/internal/provisioner/nginx.go
@@ -1,0 +1,56 @@
+package provisioner
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	log "github.com/sirupsen/logrus"
+)
+
+type nginx struct {
+	provisioner *KopsProvisioner
+	kops        *kops.Cmd
+	logger      log.FieldLogger
+}
+
+func newNginxHandle(provisioner *KopsProvisioner, kops *kops.Cmd, logger log.FieldLogger) (*nginx, error) {
+	if logger == nil {
+		return nil, fmt.Errorf("cannot instantiate NGINX handle with nil logger")
+	}
+
+	if provisioner == nil {
+		return nil, fmt.Errorf("Cannot create a connection to Nginx if the provisioner provided is nil")
+	}
+
+	if kops == nil {
+		return nil, fmt.Errorf("Cannot create a connection to Nginx if the Kops command provided is nil")
+	}
+
+	return &nginx{
+		provisioner: provisioner,
+		kops:        kops,
+		logger:      logger.WithField("cluster-utility", "nginx"),
+	}, nil
+
+}
+
+func (n *nginx) Create() error {
+	return (&helmDeployment{
+		chartDeploymentName: "private-nginx",
+		chartName:           "stable/nginx-ingress",
+		namespace:           "internal-nginx",
+		setArgument:         "",
+		valuesPath:          "helm-charts/private-nginx_values.yaml",
+		kopsProvisioner:     n.provisioner,
+		kops:                n.kops,
+		logger:              n.logger,
+	}).Create()
+}
+
+func (n *nginx) Upgrade() error {
+	return nil
+}
+
+func (n *nginx) Destroy() error {
+	return nil
+}

--- a/internal/provisioner/prometheus.go
+++ b/internal/provisioner/prometheus.go
@@ -1,0 +1,109 @@
+package provisioner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type prometheus struct {
+	awsClient   aws.AWS
+	cluster     *model.Cluster
+	kops        *kops.Cmd
+	logger      log.FieldLogger
+	provisioner *KopsProvisioner
+}
+
+func newPrometheusHandle(cluster *model.Cluster, provisioner *KopsProvisioner, awsClient aws.AWS, kops *kops.Cmd, logger log.FieldLogger) (*prometheus, error) {
+	if logger == nil {
+		return nil, fmt.Errorf("cannot instantiate Prometheus handle with nil logger")
+	}
+
+	if cluster == nil {
+		return nil, fmt.Errorf("Cannot create a connection to Prometheus if the cluster provided is nil")
+	}
+
+	if provisioner == nil {
+		return nil, fmt.Errorf("Cannot create a connection to Prometheus if the provisioner provided is nil")
+	}
+
+	if awsClient == nil {
+		return nil, fmt.Errorf("Cannot create a connection to Prometheus if the awsClient provided is nil")
+	}
+
+	if kops == nil {
+		return nil, fmt.Errorf("Cannot create a connection to Prometheus if the Kops command provided is nil")
+	}
+
+	return &prometheus{
+		cluster:     cluster,
+		provisioner: provisioner,
+		awsClient:   awsClient,
+		kops:        kops,
+		logger:      logger.WithField("cluster-utility", "prometheus"),
+	}, nil
+}
+
+func (p *prometheus) Create() error {
+	err := p.NewHelmDeployment().Create()
+	if err != nil {
+		return errors.Wrap(err, "failed to create the Prometheus Helm deployment")
+	}
+
+	logger := p.logger.WithField("prometheus-action", "create")
+
+	app := "prometheus"
+	dns := fmt.Sprintf("%s.%s.%s", p.cluster.ID, app, p.provisioner.privateDNS)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120)
+	defer cancel()
+
+	endpoint, err := getLoadBalancerEndpoint(ctx, "internal-nginx", logger.WithField("prometheus-action", "create"), p.kops.GetKubeConfigPath())
+	if err != nil {
+		return errors.Wrap(err, "couldn't get the load balancer endpoint (nginx) for Prometheus")
+	}
+
+	logger.Infof("Registering DNS %s for %s", dns, app)
+	err = p.awsClient.CreatePrivateCNAME(dns, []string{endpoint}, logger.WithField("prometheus-dns-create", dns))
+	if err != nil {
+		return errors.Wrap(err, "failed to create a CNAME to point to Prometheus")
+	}
+
+	return nil
+}
+
+func (p *prometheus) Destroy() error {
+	app := "prometheus"
+	logger := p.logger.WithField("prometheus-action", "destroy")
+	logger.Infof("Deleting Route53 DNS Record for %s", app)
+	dns := fmt.Sprintf("%s.%s.%s", p.cluster.ID, app, p.provisioner.privateDNS)
+	err := p.awsClient.DeletePrivateCNAME(dns, logger.WithField("prometheus-dns-delete", dns))
+	if err != nil {
+		return errors.Wrap(err, "failed to delete Route53 DNS record")
+	}
+
+	return nil
+}
+
+func (p *prometheus) Upgrade() error {
+	return p.NewHelmDeployment().Update()
+}
+
+func (p *prometheus) NewHelmDeployment() *helmDeployment {
+	prometheusDNS := fmt.Sprintf("%s.prometheus.%s", p.cluster.ID, p.provisioner.privateDNS)
+	return &helmDeployment{
+		chartDeploymentName: "prometheus",
+		chartName:           "stable/prometheus",
+		namespace:           "prometheus",
+		setArgument:         fmt.Sprintf("server.ingress.hosts={%s}", prometheusDNS),
+		valuesPath:          "helm-charts/prometheus_values.yaml",
+		kopsProvisioner:     p.provisioner,
+		kops:                p.kops,
+		logger:              p.logger,
+	}
+}

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -1,0 +1,99 @@
+package provisioner
+
+import (
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// A Utility is a service that runs one per cluster but is not part of
+// k8s  itself,  nor  is  it  part  of  a  ClusterInstallation  or  an
+// Installation
+type Utility interface {
+	Create() error
+	Upgrade() error
+	Destroy() error
+}
+
+// utilityGroup  holds  the  metadata  needed  to  manage  a  specific
+// utilityGroup,  and therefore  uniquely identifies  one, and  can be
+// thought  of as  a handle  to the  real group  of utilities  running
+// inside of the cluster
+type utilityGroup struct {
+	utilities   []Utility
+	kops        *kops.Cmd
+	provisioner *KopsProvisioner
+}
+
+func newUtilityGroupHandle(kops *kops.Cmd, provisioner *KopsProvisioner, cluster *model.Cluster, awsClient aws.AWS, parentLogger log.FieldLogger) (*utilityGroup, error) {
+	logger := parentLogger.WithField("utility-group", "create-handle")
+
+	nginx, err := newNginxHandle(provisioner, kops, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get handle for NGINX")
+	}
+
+	prometheus, err := newPrometheusHandle(cluster, provisioner, awsClient, kops, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get handle for Prometheus")
+	}
+
+	fluentbit, err := newFluentbitHandle(provisioner, kops, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get handle for Fluentbit")
+	}
+
+	return &utilityGroup{
+		utilities:   []Utility{nginx, prometheus, fluentbit},
+		kops:        kops,
+		provisioner: provisioner,
+	}, nil
+
+}
+
+// CreateUtilityGroup  creates  and  starts  all of  the  third  party
+// services needed to run a cluster.
+func (group utilityGroup) CreateUtilityGroup() error {
+	// TODO remove this when Helm is removed as a dependency
+	err := installHelm(group.kops, group.provisioner.logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to set up Helm as a prerequisite to installing the cluster utilities")
+	}
+
+	for _, utility := range group.utilities {
+		err := utility.Create()
+		if err != nil {
+			return errors.Wrap(err, "failed to provision one of the cluster utilities")
+		}
+	}
+
+	return nil
+}
+
+// DestroyUtilityGroup tears down all of the third party services in a
+// UtilityGroup
+func (group utilityGroup) DestroyUtilityGroup() error {
+	for _, utility := range group.utilities {
+		err := utility.Destroy()
+		if err != nil {
+			return errors.Wrap(err, "failed to destroy one of the cluster utilities")
+		}
+	}
+
+	return nil
+}
+
+// UpgradeUtilityGroup reapplies the chart for the UtilityGroup. This will cause services to upgrade to a new version, if one is available.
+func (group utilityGroup) UpgradeUtilityGroup() error {
+	for _, utility := range group.utilities {
+		err := utility.Upgrade()
+		if err != nil {
+			return errors.Wrap(err, "failed to upgrade one of the cluster utilities")
+		}
+	}
+
+	return nil
+}

--- a/internal/supervisor/cluster.go
+++ b/internal/supervisor/cluster.go
@@ -26,7 +26,7 @@ type clusterStore interface {
 type clusterProvisioner interface {
 	PrepareCluster(cluster *model.Cluster) (bool, error)
 	CreateCluster(cluster *model.Cluster, aws aws.AWS) error
-	ProvisionCluster(cluster *model.Cluster) error
+	ProvisionCluster(cluster *model.Cluster, aws aws.AWS) error
 	UpgradeCluster(cluster *model.Cluster) error
 	DeleteCluster(cluster *model.Cluster, aws aws.AWS) error
 	GetClusterVersion(cluster *model.Cluster) (string, error)
@@ -157,7 +157,7 @@ func (s *ClusterSupervisor) createCluster(cluster *model.Cluster, logger log.Fie
 		return model.ClusterStateCreationFailed
 	}
 
-	err = s.provisioner.ProvisionCluster(cluster)
+	err = s.provisioner.ProvisionCluster(cluster, s.aws)
 	if err != nil {
 		logger.WithError(err).Error("Failed to provision cluster")
 		return model.ClusterStateProvisioningFailed
@@ -183,7 +183,7 @@ func (s *ClusterSupervisor) createCluster(cluster *model.Cluster, logger log.Fie
 }
 
 func (s *ClusterSupervisor) provisionCluster(cluster *model.Cluster, logger log.FieldLogger) string {
-	err := s.provisioner.ProvisionCluster(cluster)
+	err := s.provisioner.ProvisionCluster(cluster, s.aws)
 	if err != nil {
 		logger.WithError(err).Error("Failed to provision cluster")
 		return model.ClusterStateProvisioningFailed

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -66,7 +66,7 @@ func (p *mockClusterProvisioner) CreateCluster(cluster *model.Cluster, aws aws.A
 	return nil
 }
 
-func (p *mockClusterProvisioner) ProvisionCluster(cluster *model.Cluster) error {
+func (p *mockClusterProvisioner) ProvisionCluster(cluster *model.Cluster, aws aws.AWS) error {
 	return nil
 }
 


### PR DESCRIPTION
This is a large change, ~still a work in progress,~ but it's ready to receive feedback while I continue fleshing out the details. Sorry that it is so large! It got away from me, a bit.

What's changed:
1) Moves helm-related utilities to their own file, all in one place
2) Defines an interface for creating, deleting, and updating cluster utility services that is agnostic to how the utility is deployed. Today those are all created with Helm but it should be possible to change these services to use Operators without updating `kops_provisioner_cluster.go` now, and without affecting the services that use Helm. Additional services can also be added cleanly using this interface.
3) Breaks out each of the existing utility services (nginx, Prometheus, and Fluentbit) into their own files for organizational purposes, and redefines their actions so that they satisfy the new interface.
4) Calls `helm upgrade` on Prometheus when `cloud cluster provision` is called.

To do:
~I am still working on how to properly call `helm upgrade` during Provision so that calling `cloud cluster provision` will upgrade the services. Currently `UpgradeUtilityGroup` is defined and called but it doesn't do anything.~

To resolve [MM-20995](https://mattermost.atlassian.net/browse/MM-20995) it should be possible, after this change, to add just the API endpoint and call, from within it, `Upgrade` on the Prometheus singleton object created as a part of this change, once I have the `helm upgrade` call worked out.

Some other notes:
~Commits from the other PRs I opened before the holiday are still in the history. They are isolated to 2 files though and should easily be ignored (`Makefile` and `internal/supervisor/cluster_installation.go`). If we merge those PRs the changes should disappear from this diff after I rebase.~

Also, all of my work in progress history is in the commit history. I obviously intend to squash the history before merging :)