### PR TITLE
Gracefully succeed if S3 bucket is already deleted

### DIFF
--- a/internal/tools/aws/filestore.go
+++ b/internal/tools/aws/filestore.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
+	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 )
 
 // S3Filestore is a filestore backed by AWS S3.
@@ -143,7 +143,7 @@ func s3FilestoreTeardown(installationID string, keepData bool, logger log.FieldL
 	}
 
 	if !keepData {
-		err = a.s3EnsureBucketDeleted(awsID)
+		err = a.s3EnsureBucketDeleted(awsID, logger)
 		if err != nil {
 			return err
 		}

--- a/internal/tools/aws/s3.go
+++ b/internal/tools/aws/s3.go
@@ -2,10 +2,12 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 func (a *Client) s3EnsureBucketCreated(bucketName string) error {
@@ -35,17 +37,29 @@ func (a *Client) s3EnsureBucketCreated(bucketName string) error {
 	return nil
 }
 
-func (a *Client) s3EnsureBucketDeleted(bucketName string) error {
+func (a *Client) s3EnsureBucketDeleted(bucketName string, logger log.FieldLogger) error {
 	svc := s3.New(session.New())
+
+	// First check if bucket still exists. There isn't a "GetBucket" so we will
+	// try to get the bucket policy instead.
+	_, err := svc.GetBucketPolicy(&s3.GetBucketPolicyInput{
+		Bucket: aws.String(bucketName),
+	})
+	if aerr, ok := err.(awserr.Error); ok {
+		if aerr.Code() == s3.ErrCodeNoSuchBucket {
+			logger.WithField("s3-bucket-name", bucketName).Warn("AWS S3 bucket could not be found; assuming already deleted")
+			return nil
+		}
+	}
 
 	// AWS forces S3 buckets to be empty before they can be deleted.
 	iter := s3manager.NewDeleteListIterator(svc, &s3.ListObjectsInput{
 		Bucket: aws.String(bucketName),
 	})
 
-	err := s3manager.NewBatchDeleteWithClient(svc).Delete(aws.BackgroundContext(), iter)
+	err = s3manager.NewBatchDeleteWithClient(svc).Delete(aws.BackgroundContext(), iter)
 	if err != nil {
-		return errors.Wrap(err, "unable to delete bucket objects")
+		return errors.Wrap(err, "unable to delete bucket contents")
 	}
 
 	_, err = svc.DeleteBucket(&s3.DeleteBucketInput{


### PR DESCRIPTION
This improves S3 bucket cleanup so that if the bucket was already
deleted then the provisioner will continue without error.

https://mattermost.atlassian.net/browse/MM-21767

