### PR TITLE
Remove DNS records regardless of their length during deletion

### DIFF
--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -133,11 +133,6 @@ func (a *Client) deleteCNAME(hostedZoneID, dnsName string, logger log.FieldLogge
 		return err
 	}
 
-	if len(dnsName) >= 64 {
-		logger.Warnf("DNS name too long, skipping since it could never have been created record-name=%s", dnsName)
-		return nil
-	}
-
 	nextRecordName := dnsName
 	var recordsets []*route53.ResourceRecordSet
 	for {


### PR DESCRIPTION
This validation step caused a deletion failure in production:
```
time="2020-01-20T14:50:15Z" level=debug msg="Released VPC vpc-02dadaa9aeb3aa41c" cluster=f9y6bdux37g4zx1jmqjfa9ocnr instance=sb1cyk7113yy7gxxyufz1twk9h
time="2020-01-20T14:50:15Z" level=info msg="Deleting Route53 DNS Record for prometheus" cluster=f9y6bdux37g4zx1jmqjfa9ocnr cluster-utility=prometheus instance=sb1cyk7113yy7gxxyufz1twk9h prometheus-action=destroy utility-group=create-handle
time="2020-01-20T14:50:16Z" level=warning msg="DNS name too long, skipping since it could never have been created record-name=f9y6bdux37g4zx1jmqjfa9ocnr.prometheus.internal.prod.cloud.mattermost.com" cluster=f9y6bdux37g4zx1jmqjfa9ocnr cluster-utility=prometheus instance=sb1cyk7113yy7gxxyufz1twk9h prometheus-action=destroy prometheus-dns-delete=f9y6bdux37g4zx1jmq
jfa9ocnr.prometheus.internal.prod.cloud.mattermost.com utility-group=create-handle
```

DNS name length validation should only be necessary or performed at creation time. At deletion time, the deletion routine should delete all DNS records associated with the resource being deleted without checking this sort of input validation, as at deletion time, the routine should no longer care whether or not the name is too long. If it exists, clearly it was short enough to be accepted by AWS in the first place.