### PR TITLE
Improved cluster delete logic

### DIFF
--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -146,7 +146,7 @@ func (a *Client) GetAndClaimVpcResources(clusterID, owner string, logger log.Fie
 		return getClusterResourcesForVPC(*clusterAlreadyClaimedVpcs[0].VpcId)
 	}
 
-	// This cluster has not alraedy claimed a VPC. Continue with claiming process.
+	// This cluster has not already claimed a VPC. Continue with claiming process.
 	totalVpcsFilter := []*ec2.Filter{
 		{
 			Name: aws.String(VpcAvailableTagKey),


### PR DESCRIPTION
This change improves the way that cluster deletion handles cleaning
up a non-stable cluster. Specifically, the deletion flow can now
skip kops or terraform cleanup separately.

I tested this with two different creation-failures and it worked fine. It
is hard to simulate all of the possible ways creation could fail, but this
should work for most/all of them.

https://mattermost.atlassian.net/browse/MM-21883