### PR TITLE
MM-20995 Add ability to upgrade cluster utilities

### DIFF
--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -25,6 +25,7 @@ type helmDeployment struct {
 	namespace           string
 	setArgument         string
 	valuesPath          string
+	version             string
 
 	cluster         *model.Cluster
 	kopsProvisioner *KopsProvisioner
@@ -126,6 +127,10 @@ func installHelmChart(chart helmDeployment, configPath string, logger log.FieldL
 		arguments = append(arguments, "--set", chart.setArgument)
 	}
 
+	if chart.version != "" {
+		arguments = append(arguments, "--version", chart.version)
+	}
+
 	cmd = exec.Command("helm", arguments...)
 
 	logger.WithFields(log.Fields{
@@ -155,6 +160,10 @@ func upgradeHelmChart(chart helmDeployment, configPath string, logger log.FieldL
 
 	if chart.setArgument != "" {
 		arguments = append(arguments, "--set", chart.setArgument)
+	}
+
+	if chart.version != "" {
+		arguments = append(arguments, "--version", chart.version)
 	}
 
 	cmd = exec.Command("helm", arguments...)

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -15,7 +15,7 @@ func init() {
 		Select(
 			"ID", "Provider", "Provisioner", "ProviderMetadata", "ProvisionerMetadata",
 			"Version", "Size", "State", "AllowInstallations", "CreateAt", "DeleteAt",
-			"LockAcquiredBy", "LockAcquiredAt",
+			"LockAcquiredBy", "LockAcquiredAt", "PrometheusVersion", "FluentbitVersion", "NginxVersion",
 		).
 		From("Cluster")
 }
@@ -106,6 +106,9 @@ func (sqlStore *SQLStore) CreateCluster(cluster *model.Cluster) error {
 			"DeleteAt":            0,
 			"LockAcquiredBy":      nil,
 			"LockAcquiredAt":      0,
+			"PrometheusVersion":   cluster.PrometheusVersion,
+			"FluentbitVersion":    cluster.FluentbitVersion,
+			"NginxVersion":        cluster.NginxVersion,
 		}),
 	)
 	if err != nil {
@@ -128,6 +131,10 @@ func (sqlStore *SQLStore) UpdateCluster(cluster *model.Cluster) error {
 			"Size":                cluster.Size,
 			"State":               cluster.State,
 			"AllowInstallations":  cluster.AllowInstallations,
+
+			"PrometheusVersion": cluster.PrometheusVersion,
+			"FluentbitVersion":  cluster.FluentbitVersion,
+			"NginxVersion":      cluster.NginxVersion,
 		}).
 		Where("ID = ?", cluster.ID),
 	)

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -580,4 +580,67 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.11.0"), semver.MustParse("0.12.0"), func(e execer) error {
+		// Add version columns for all of the utilities.
+		// Also convert SQLite char/varchar columns to type TEXT to match PG.
+		_, err := e.Exec(`ALTER TABLE Cluster RENAME TO ClusterTemp;`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+				CREATE TABLE Cluster (
+					ID                   TEXT PRIMARY KEY,
+					Provider             TEXT NOT NULL,
+					Provisioner          TEXT NOT NULL,
+					ProviderMetadata     BYTEA NULL,
+					ProvisionerMetadata  BYTEA NULL,
+					Version              TEXT NOT NULL,
+					Size                 TEXT NOT NULL,
+					State                TEXT NOT NULL,
+					AllowInstallations   BOOLEAN NOT NULL,
+					CreateAt             BIGINT NOT NULL,
+					DeleteAt             BIGINT NOT NULL,
+					LockAcquiredBy       TEXT NULL,
+					LockAcquiredAt       BIGINT NOT NULL,
+					PrometheusVersion    TEXT NOT NULL,
+					FluentbitVersion     TEXT NOT NULL,
+					NginxVersion         TEXT NOT NULL
+				);
+			`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+				INSERT INTO Cluster
+				SELECT
+					ID,
+					Provider,
+					Provisioner,
+					ProviderMetadata,
+					ProvisionerMetadata,
+					Version,
+					Size,
+					State,
+					AllowInstallations,
+					CreateAt,
+					DeleteAt,
+					LockAcquiredBy,
+					LockAcquiredAt,
+					"","",""
+				FROM
+					ClusterTemp;
+			`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`DROP TABLE ClusterTemp;`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/model/client.go
+++ b/model/client.go
@@ -142,9 +142,10 @@ func (c *Client) RetryCreateCluster(clusterID string) error {
 	}
 }
 
-// ProvisionCluster provisions k8s operators on a cluster from the configured provisioning server.
-func (c *Client) ProvisionCluster(clusterID string) error {
-	resp, err := c.doPost(c.buildURL("/api/cluster/%s/provision", clusterID), nil)
+// ProvisionCluster provisions k8s operators and Helm charts on a
+// cluster from the configured provisioning server.
+func (c *Client) ProvisionCluster(clusterID string, request *ProvisionClusterRequest) error {
+	resp, err := c.doPost(c.buildURL("/api/cluster/%s/provision", clusterID), request)
 	if err != nil {
 		return err
 	}

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -23,6 +23,10 @@ type Cluster struct {
 	DeleteAt            int64
 	LockAcquiredBy      *string
 	LockAcquiredAt      int64
+
+	PrometheusVersion string
+	NginxVersion      string
+	FluentbitVersion  string
 }
 
 // Clone returns a deep copy the cluster.
@@ -104,4 +108,24 @@ var clusterVersionMatcher = regexp.MustCompile(`^(([0-9]{1,3}.[0-9]{1,3}.[0-9]{1
 // or a valid k8s version number.
 func ValidClusterVersion(name string) bool {
 	return clusterVersionMatcher.MatchString(name)
+}
+
+// UpdateUtilityVersions expects a map of cluster name to version
+// string and finds valid ones in the map and adds them to the cluster
+// object throws away invalid entries in order to avoid becoming an
+// impure function that needs to return an error type as a possible
+// side effect, as this complicates usage
+func (c *Cluster) UpdateUtilityVersions(versions map[string]string) {
+	for utility, version := range versions {
+		switch utility {
+		case "prometheus":
+			c.PrometheusVersion = version
+		case "nginx":
+			c.NginxVersion = version
+		case "fluentbit":
+			c.FluentbitVersion = version
+		default:
+			continue
+		}
+	}
 }

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -11,12 +11,13 @@ import (
 
 // CreateClusterRequest specifies the parameters for a new cluster.
 type CreateClusterRequest struct {
-	Provider           string   `json:"provider,omitempty"`
-	Version            string   `json:"version,omitempty"`
-	KopsAMI            string   `json:"kops-ami,omitempty"`
-	Size               string   `json:"size,omitempty"`
-	Zones              []string `json:"zones,omitempty"`
-	AllowInstallations bool     `json:"allow-installations,omitempty"`
+	Provider           string            `json:"provider,omitempty"`
+	Version            string            `json:"version,omitempty"`
+	KopsAMI            string            `json:"kops-ami,omitempty"`
+	Size               string            `json:"size,omitempty"`
+	Zones              []string          `json:"zones,omitempty"`
+	AllowInstallations bool              `json:"allow-installations,omitempty"`
+	UtilityVersions    map[string]string `json:"utility-versions,omitempty"`
 }
 
 // SetDefaults sets the default values for a cluster create request.
@@ -99,6 +100,19 @@ func NewUpdateClusterRequestFromReader(reader io.Reader) (*UpdateClusterRequest,
 	if err != nil && err != io.EOF {
 		return nil, errors.Wrap(err, "failed to decode update cluster request")
 	}
-
 	return &updateClusterRequest, nil
+}
+
+type ProvisionClusterRequest struct {
+	UtilityVersions map[string]string `json:"utility-versions,omitempty"`
+}
+
+// NewUpdateClusterRequestFromReader will create an UpdateClusterRequest from an io.Reader with JSON data.
+func NewProvisionClusterRequestFromReader(reader io.Reader) (*ProvisionClusterRequest, error) {
+	var provisionClusterRequest ProvisionClusterRequest
+	err := json.NewDecoder(reader).Decode(&provisionClusterRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode provision cluster request")
+	}
+	return &provisionClusterRequest, nil
 }


### PR DESCRIPTION
This is just a WIP right now but if you have feedback feel free to leave it, the code is in a working state and the remainder to do is listed below.


Working:

- Able to install normally without specifying version
- Able to specify a version after install
- Boilerplate in place to do the same for Fluentbit and Nginx

TODO:

- Ability to go back to "latest" from specified version
- Actually enable Provision() for Nginx and Fluentbit, the rest of the
  scaffolding is there already
- Uncomment the new API endpoint to allow specifying an upgrade to just one utility
  without calling the whole Provision process (after testing it of course)

