### PR TITLE
add Https status and write the header in the correct order

### DIFF
--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -54,6 +54,7 @@ func handleGetClusters(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, clusters)
 }
 
@@ -257,6 +258,7 @@ func handleGetCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, cluster)
 }
 

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -54,7 +54,7 @@ func handleGetClusters(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, clusters)
 }
 

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -54,7 +54,7 @@ func handleGetClusters(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusAccepted)
 	outputJSON(c, w, clusters)
 }
 

--- a/internal/api/cluster_installation.go
+++ b/internal/api/cluster_installation.go
@@ -54,6 +54,7 @@ func handleGetClusterInstallations(c *Context, w http.ResponseWriter, r *http.Re
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, clusterInstallations)
 }
 
@@ -75,6 +76,7 @@ func handleGetClusterInstallation(c *Context, w http.ResponseWriter, r *http.Req
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, clusterInstallation)
 }
 

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -49,6 +49,7 @@ func handleGetGroups(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, groups)
 }
 
@@ -99,6 +100,7 @@ func handleGetGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, group)
 }
 

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -58,6 +58,7 @@ func handleGetInstallations(c *Context, w http.ResponseWriter, r *http.Request) 
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, installations)
 }
 
@@ -104,8 +105,8 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 
 	c.Supervisor.Do()
 
-	w.WriteHeader(http.StatusAccepted)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
 	outputJSON(c, w, installation)
 }
 
@@ -184,6 +185,7 @@ func handleGetInstallation(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, installation)
 }
 

--- a/internal/api/webhook.go
+++ b/internal/api/webhook.go
@@ -44,7 +44,7 @@ func handleCreateWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusAccepted)
 	outputJSON(c, w, webhook)
 }
 

--- a/internal/api/webhook.go
+++ b/internal/api/webhook.go
@@ -43,8 +43,8 @@ func handleCreateWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, webhook)
 }
 
@@ -66,6 +66,7 @@ func handleGetWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, webhook)
 }
 
@@ -99,6 +100,7 @@ func handleGetWebhooks(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, webhooks)
 }
 

--- a/model/client.go
+++ b/model/client.go
@@ -606,7 +606,7 @@ func (c *Client) CreateWebhook(request *CreateWebhookRequest) (*Webhook, error) 
 	defer closeBody(resp)
 
 	switch resp.StatusCode {
-	case http.StatusOK:
+	case http.StatusAccepted:
 		return WebhookFromReader(resp.Body)
 
 	default:


### PR DESCRIPTION
#### Summary
- add Https status for the missing API
- reorder the write of the headers otherwise, the header we are trying to add will not be added.
