### PR TITLE
Lookup private AWS hosted zone domain name

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -44,7 +44,6 @@ func init() {
 	serverCmd.PersistentFlags().Bool("keep-database-data", true, "Whether to preserve database data after installation deletion or not.")
 	serverCmd.PersistentFlags().Bool("keep-filestore-data", true, "Whether to preserve filestore data after installation deletion or not.")
 	serverCmd.PersistentFlags().Bool("debug", false, "Whether to output debug logs.")
-	serverCmd.MarkPersistentFlagRequired("private-dns")
 }
 
 var serverCmd = &cobra.Command{
@@ -89,7 +88,6 @@ var serverCmd = &cobra.Command{
 			logger.Warn("Server will be running with no supervisors. Only API functionality will work.")
 		}
 
-		privateDNS, _ := command.Flags().GetString("private-dns")
 		s3StateStore, _ := command.Flags().GetString("state-store")
 		keepDatabaseData, _ := command.Flags().GetBool("keep-database-data")
 		keepFilestoreData, _ := command.Flags().GetBool("keep-filestore-data")
@@ -108,7 +106,6 @@ var serverCmd = &cobra.Command{
 			"store-version":                   currentVersion,
 			"state-store":                     s3StateStore,
 			"working-directory":               wd,
-			"private-dns":                     privateDNS,
 			"cluster-resource-threshold":      clusterResourceThreshold,
 			"use-existing-aws-resources":      useExistingResources,
 			"keep-database-data":              keepDatabaseData,
@@ -129,7 +126,6 @@ var serverCmd = &cobra.Command{
 		// Setup the provisioner for actually effecting changes to clusters.
 		kopsProvisioner := provisioner.NewKopsProvisioner(
 			s3StateStore,
-			privateDNS,
 			owner,
 			useExistingResources,
 			logger,
@@ -210,6 +206,11 @@ func deprecationWarnings(logger logrus.FieldLogger, cmd *cobra.Command) {
 		logger.Warn("[Deprecation] The directory './clusters' was found; this is no longer used by the kops provisioner")
 		logger.Warn("[Deprecation] Any remaining terraform in this directory should be manually moved to remote state")
 		logger.Warn("[Deprecation] Instructions for doing this can be found in the README")
+	}
+
+	privateDNS, _ := cmd.Flags().GetString("private-dns")
+	if privateDNS != "" {
+		logger.Warn("[Deprecation] The `private-dns` flag is deprecated and won't be used")
 	}
 }
 

--- a/internal/provisioner/fluentbit.go
+++ b/internal/provisioner/fluentbit.go
@@ -3,38 +3,53 @@ package provisioner
 import (
 	"fmt"
 
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
 type fluentbit struct {
 	provisioner *KopsProvisioner
+	awsClient   aws.AWS
 	kops        *kops.Cmd
 	logger      log.FieldLogger
 }
 
-func newFluentbitHandle(provisioner *KopsProvisioner, kops *kops.Cmd, logger log.FieldLogger) (*fluentbit, error) {
+func newFluentbitHandle(provisioner *KopsProvisioner, awsClient aws.AWS, kops *kops.Cmd, logger log.FieldLogger) (*fluentbit, error) {
 	if logger == nil {
-		return nil, fmt.Errorf("cannot instantiate Fluentbit handle with nil logger")
+		return nil, errors.New("cannot instantiate Fluentbit handle with nil logger")
 	}
 
 	if provisioner == nil {
-		return nil, fmt.Errorf("cannot create a connection to Fluentbit if the provisioner provided is nil")
+		return nil, errors.New("cannot create a connection to Fluentbit if the provisioner provided is nil")
+	}
+
+	if awsClient == nil {
+		return nil, errors.New("cannot create a connection to Fluentbit if the awsClient provided is nil")
 	}
 
 	if kops == nil {
-		return nil, fmt.Errorf("cannot create a connection to Fluentbit if the Kops command provided is nil")
+		return nil, errors.New("cannot create a connection to Fluentbit if the Kops command provided is nil")
 	}
 
 	return &fluentbit{
 		provisioner: provisioner,
+		awsClient:   awsClient,
 		kops:        kops,
 		logger:      logger.WithField("cluster-utility", "fluentbit"),
 	}, nil
 }
 
 func (f *fluentbit) Create() error {
-	elasticSearchDNS := fmt.Sprintf("elasticsearch.%s", f.provisioner.privateDNS)
+	logger := f.logger.WithField("fluentbit-action", "create")
+
+	privateDomainName, err := f.awsClient.GetPrivateZoneDomainName(logger)
+	if err != nil {
+		logger.WithError(err).Error("unable to lookup private zone name")
+	}
+	elasticSearchDNS := fmt.Sprintf("elasticsearch.%s", privateDomainName)
+
 	return (&helmDeployment{
 		chartDeploymentName: "fluent-bit",
 		chartName:           "stable/fluent-bit",

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -27,17 +27,15 @@ type KopsProvisioner struct {
 	s3StateStore            string
 	privateSubnetIds        string
 	publicSubnetIds         string
-	privateDNS              string
 	useExistingAWSResources bool
 	logger                  log.FieldLogger
 	owner                   string
 }
 
 // NewKopsProvisioner creates a new KopsProvisioner.
-func NewKopsProvisioner(s3StateStore, privateDNS, owner string, useExistingAWSResources bool, logger log.FieldLogger) *KopsProvisioner {
+func NewKopsProvisioner(s3StateStore, owner string, useExistingAWSResources bool, logger log.FieldLogger) *KopsProvisioner {
 	return &KopsProvisioner{
 		s3StateStore:            s3StateStore,
-		privateDNS:              privateDNS,
 		useExistingAWSResources: useExistingAWSResources,
 		logger:                  logger,
 		owner:                   owner,

--- a/internal/provisioner/nginx.go
+++ b/internal/provisioner/nginx.go
@@ -1,9 +1,8 @@
 package provisioner
 
 import (
-	"fmt"
-
 	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -15,15 +14,15 @@ type nginx struct {
 
 func newNginxHandle(provisioner *KopsProvisioner, kops *kops.Cmd, logger log.FieldLogger) (*nginx, error) {
 	if logger == nil {
-		return nil, fmt.Errorf("cannot instantiate NGINX handle with nil logger")
+		return nil, errors.New("cannot instantiate NGINX handle with nil logger")
 	}
 
 	if provisioner == nil {
-		return nil, fmt.Errorf("Cannot create a connection to Nginx if the provisioner provided is nil")
+		return nil, errors.New("cannot create a connection to Nginx if the provisioner provided is nil")
 	}
 
 	if kops == nil {
-		return nil, fmt.Errorf("Cannot create a connection to Nginx if the Kops command provided is nil")
+		return nil, errors.New("cannot create a connection to Nginx if the Kops command provided is nil")
 	}
 
 	return &nginx{

--- a/internal/provisioner/prometheus.go
+++ b/internal/provisioner/prometheus.go
@@ -25,19 +25,19 @@ func newPrometheusHandle(cluster *model.Cluster, provisioner *KopsProvisioner, a
 	}
 
 	if cluster == nil {
-		return nil, fmt.Errorf("Cannot create a connection to Prometheus if the cluster provided is nil")
+		return nil, errors.New("cannot create a connection to Prometheus if the cluster provided is nil")
 	}
 
 	if provisioner == nil {
-		return nil, fmt.Errorf("Cannot create a connection to Prometheus if the provisioner provided is nil")
+		return nil, errors.New("cannot create a connection to Prometheus if the provisioner provided is nil")
 	}
 
 	if awsClient == nil {
-		return nil, fmt.Errorf("Cannot create a connection to Prometheus if the awsClient provided is nil")
+		return nil, errors.New("cannot create a connection to Prometheus if the awsClient provided is nil")
 	}
 
 	if kops == nil {
-		return nil, fmt.Errorf("Cannot create a connection to Prometheus if the Kops command provided is nil")
+		return nil, errors.New("cannot create a connection to Prometheus if the Kops command provided is nil")
 	}
 
 	return &prometheus{
@@ -57,8 +57,13 @@ func (p *prometheus) Create() error {
 
 	logger := p.logger.WithField("prometheus-action", "create")
 
+	privateDomainName, err := p.awsClient.GetPrivateZoneDomainName(logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to lookup private zone name")
+	}
+
 	app := "prometheus"
-	dns := fmt.Sprintf("%s.%s.%s", p.cluster.ID, app, p.provisioner.privateDNS)
+	dns := fmt.Sprintf("%s.%s.%s", p.cluster.ID, app, privateDomainName)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120)
 	defer cancel()
@@ -78,11 +83,17 @@ func (p *prometheus) Create() error {
 }
 
 func (p *prometheus) Destroy() error {
-	app := "prometheus"
 	logger := p.logger.WithField("prometheus-action", "destroy")
+
+	privateDomainName, err := p.awsClient.GetPrivateZoneDomainName(logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to lookup private zone name")
+	}
+	app := "prometheus"
+	dns := fmt.Sprintf("%s.%s.%s", p.cluster.ID, app, privateDomainName)
+
 	logger.Infof("Deleting Route53 DNS Record for %s", app)
-	dns := fmt.Sprintf("%s.%s.%s", p.cluster.ID, app, p.provisioner.privateDNS)
-	err := p.awsClient.DeletePrivateCNAME(dns, logger.WithField("prometheus-dns-delete", dns))
+	err = p.awsClient.DeletePrivateCNAME(dns, logger.WithField("prometheus-dns-delete", dns))
 	if err != nil {
 		return errors.Wrap(err, "failed to delete Route53 DNS record")
 	}
@@ -95,7 +106,12 @@ func (p *prometheus) Upgrade() error {
 }
 
 func (p *prometheus) NewHelmDeployment() *helmDeployment {
-	prometheusDNS := fmt.Sprintf("%s.prometheus.%s", p.cluster.ID, p.provisioner.privateDNS)
+	privateDomainName, err := p.awsClient.GetPrivateZoneDomainName(p.logger)
+	if err != nil {
+		p.logger.WithError(err).Error("unable to lookup private zone name")
+	}
+	prometheusDNS := fmt.Sprintf("%s.prometheus.%s", p.cluster.ID, privateDomainName)
+
 	return &helmDeployment{
 		chartDeploymentName: "prometheus",
 		chartName:           "stable/prometheus",

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -41,7 +41,7 @@ func newUtilityGroupHandle(kops *kops.Cmd, provisioner *KopsProvisioner, cluster
 		return nil, errors.Wrap(err, "failed to get handle for Prometheus")
 	}
 
-	fluentbit, err := newFluentbitHandle(provisioner, kops, logger)
+	fluentbit, err := newFluentbitHandle(provisioner, awsClient, kops, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get handle for Fluentbit")
 	}

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -152,6 +152,10 @@ func (a *mockAWS) ReleaseVpc(clusterID string, logger log.FieldLogger) error {
 	return nil
 }
 
+func (a *mockAWS) GetPrivateZoneDomainName(logger log.FieldLogger) (string, error) {
+	return "test.domain", nil
+}
+
 func (a *mockAWS) CreatePrivateCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error {
 	return nil
 }

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -15,6 +15,7 @@ type AWS interface {
 	GetAndClaimVpcResources(clusterID, owner string, logger log.FieldLogger) (ClusterResources, error)
 	ReleaseVpc(clusterID string, logger log.FieldLogger) error
 
+	GetPrivateZoneDomainName(logger log.FieldLogger) (string, error)
 	CreatePrivateCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error
 	CreatePublicCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error
 


### PR DESCRIPTION
This change removes the requirement to provide the private DNS
setting on server startup. Instead, the domain name is now looked
up on demand. This removes the requirement to provide a matching
DNS entry to the private zone that is looked up via tags.

https://mattermost.atlassian.net/browse/MM-21937
