### PR TITLE
Prevent group deletion with installation members

### DIFF
--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -417,7 +417,7 @@ func handleDeleteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if len(clusterInstallations) != 0 {
 		c.Logger.Errorf("unable to delete cluster while it still has %d cluster installations", len(clusterInstallations))
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusForbidden)
 		return
 	}
 

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -77,6 +77,9 @@ func (sqlStore *SQLStore) GetInstallations(filter *model.InstallationFilter) ([]
 	if filter.OwnerID != "" {
 		builder = builder.Where("OwnerID = ?", filter.OwnerID)
 	}
+	if filter.GroupID != "" {
+		builder = builder.Where("GroupID = ?", filter.GroupID)
+	}
 	if !filter.IncludeDeleted {
 		builder = builder.Where("DeleteAt = 0")
 	}

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -85,10 +85,6 @@ func TestInstallations(t *testing.T) {
 
 	err = sqlStore.CreateInstallation(installation4)
 	require.NoError(t, err)
-	err = sqlStore.DeleteInstallation(installation4.ID)
-	require.NoError(t, err)
-	installation4, err = sqlStore.GetInstallation(installation4.ID)
-	require.NoError(t, err)
 
 	t.Run("get unknown installation", func(t *testing.T) {
 		installation, err := sqlStore.GetInstallation("unknown")
@@ -106,6 +102,23 @@ func TestInstallations(t *testing.T) {
 		installation, err := sqlStore.GetInstallation(installation2.ID)
 		require.NoError(t, err)
 		require.Equal(t, installation2, installation)
+	})
+
+	t.Run("get installation 3", func(t *testing.T) {
+		installation, err := sqlStore.GetInstallation(installation3.ID)
+		require.NoError(t, err)
+		require.Equal(t, installation3, installation)
+	})
+
+	t.Run("get and delete installation 4", func(t *testing.T) {
+		installation, err := sqlStore.GetInstallation(installation4.ID)
+		require.NoError(t, err)
+		require.Equal(t, installation4, installation)
+
+		err = sqlStore.DeleteInstallation(installation4.ID)
+		require.NoError(t, err)
+		installation4, err = sqlStore.GetInstallation(installation4.ID)
+		require.NoError(t, err)
 	})
 
 	testCases := []struct {
@@ -188,6 +201,27 @@ func TestInstallations(t *testing.T) {
 				IncludeDeleted: true,
 			},
 			[]*model.Installation{installation3, installation4},
+		},
+		{
+			"group 1",
+			&model.InstallationFilter{
+				GroupID:        groupID1,
+				Page:           0,
+				PerPage:        10,
+				IncludeDeleted: true,
+			},
+			[]*model.Installation{installation1, installation3},
+		},
+		{
+			"owner 2, group 2, include deleted",
+			&model.InstallationFilter{
+				OwnerID:        ownerID2,
+				GroupID:        groupID2,
+				Page:           0,
+				PerPage:        10,
+				IncludeDeleted: true,
+			},
+			[]*model.Installation{installation4},
 		},
 	}
 

--- a/model/installation.go
+++ b/model/installation.go
@@ -27,6 +27,7 @@ type Installation struct {
 // InstallationFilter describes the parameters used to constrain a set of installations.
 type InstallationFilter struct {
 	OwnerID        string
+	GroupID        string
 	Page           int
 	PerPage        int
 	IncludeDeleted bool


### PR DESCRIPTION
This corrects group deletion behavior so that only empty groups
can be deleted. Also, the installation filter is now able to filter
installations based on their group ID.

https://mattermost.atlassian.net/browse/MM-22252