### PR TITLE
MM-22054 Create new storageclass with volumeBindingMode: WaitForFirstConsumer option

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -168,6 +168,18 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 
 	logger.WithField("name", kopsMetadata.Name).Info("Successfully deployed kubernetes")
 
+	logger.WithField("name", kopsMetadata.Name).Info("Updating VolumeBindingMode in default storage class")
+	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	if err != nil {
+		return err
+	}
+
+	_, err = k8sClient.UpdateStorageClassVolumeBindingMode("gp2")
+	if err != nil {
+		return err
+	}
+	logger.WithField("name", kopsMetadata.Name).Info("Successfully updated storage class")
+
 	ugh, err := newUtilityGroupHandle(kops, provisioner, cluster, awsClient, logger)
 	if err != nil {
 		return err

--- a/internal/tools/k8s/storage_class.go
+++ b/internal/tools/k8s/storage_class.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// UpdateStorageClassVolumeBindingMode updates the storage class volume binding mode from immediate to WaitForFirstCustomer.
+// UpdateStorageClassVolumeBindingMode updates the storage class volume binding mode from immediate to WaitForFirstConsumer.
 func (kc *KubeClient) UpdateStorageClassVolumeBindingMode(class string) (metav1.Object, error) {
 
 	storageClass, err := kc.Clientset.StorageV1beta1().StorageClasses().Get(class, metav1.GetOptions{})

--- a/internal/tools/k8s/storage_class.go
+++ b/internal/tools/k8s/storage_class.go
@@ -1,0 +1,25 @@
+package k8s
+
+import (
+	"k8s.io/api/storage/v1beta1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// UpdateStorageClassVolumeBindingMode updates the storage class volume binding mode from immediate to WaitForFirstCustomer.
+func (kc *KubeClient) UpdateStorageClassVolumeBindingMode(class string) (metav1.Object, error) {
+
+	storageClass, err := kc.Clientset.StorageV1beta1().StorageClasses().Get(class, metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
+		return nil, err
+	}
+	bindingMode := v1beta1.VolumeBindingWaitForFirstConsumer
+	storageClass.VolumeBindingMode = &bindingMode
+	storageClass.ResourceVersion = ""
+
+	err = kc.Clientset.StorageV1beta1().StorageClasses().Delete(class, &metav1.DeleteOptions{})
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return nil, err
+	}
+	return kc.Clientset.StorageV1beta1().StorageClasses().Create(storageClass)
+}

--- a/internal/tools/k8s/storage_class.go
+++ b/internal/tools/k8s/storage_class.go
@@ -8,7 +8,6 @@ import (
 
 // UpdateStorageClassVolumeBindingMode updates the storage class volume binding mode from immediate to WaitForFirstConsumer.
 func (kc *KubeClient) UpdateStorageClassVolumeBindingMode(class string) (metav1.Object, error) {
-
 	storageClass, err := kc.Clientset.StorageV1beta1().StorageClasses().Get(class, metav1.GetOptions{})
 	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err

--- a/internal/tools/k8s/storage_class_test.go
+++ b/internal/tools/k8s/storage_class_test.go
@@ -1,0 +1,27 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/storage/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestStorageClass(t *testing.T) {
+	testClient := newTestKubeClient()
+	storageClass := &v1beta1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "gp2"},
+	}
+	class := "gp2"
+
+	t.Run("update storageclass", func(t *testing.T) {
+		testClient.Clientset.StorageV1beta1().StorageClasses().Create(storageClass)
+		result, err := testClient.UpdateStorageClassVolumeBindingMode(class)
+		fmt.Println(err)
+		require.NoError(t, err)
+		require.Equal(t, storageClass.GetName(), result.GetName())
+	})
+
+}

--- a/internal/tools/k8s/storage_class_test.go
+++ b/internal/tools/k8s/storage_class_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,7 +18,6 @@ func TestStorageClass(t *testing.T) {
 	t.Run("update storageclass", func(t *testing.T) {
 		testClient.Clientset.StorageV1beta1().StorageClasses().Create(storageClass)
 		result, err := testClient.UpdateStorageClassVolumeBindingMode(class)
-		fmt.Println(err)
 		require.NoError(t, err)
 		require.Equal(t, storageClass.GetName(), result.GetName())
 	})


### PR DESCRIPTION
#### Summary
Create new storageclass with volumeBindingMode: WaitForFirstConsumer option
This is to replace the existing storageclass deployed by Kops during the cluster creation.
The process is : 
 - Get the existing storage class
 - Update the BindingMode
 - Delete the existing storage class
 - Deploy new storage class.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22054
