### PR TITLE
Add --install flag to helm upgrade

### DIFF
--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -162,6 +162,7 @@ func upgradeHelmChart(chart helmDeployment, configPath string, logger log.FieldL
 		"--kubeconfig", configPath,
 		"-f", chart.valuesPath,
 		"--namespace", chart.namespace,
+		"--install",
 	}
 
 	if chart.setArgument != "" {


### PR DESCRIPTION
As we discussed in the mid-sprint meeting, `helm upgrade` is more resilient when called with `--install` so I have added that flag to the `upgradeHelmChart` helper method which is called by each of the utilities in turn.

This is a small enough change that I did not write a JIRA story for it.

Example log output:
```
INFO[2020-02-06T12:12:03-06:00] Invoking command                              args="[helm --debug upgrade prometheus stable/prometheus --kubeconfig /tmp/kops-977933332/kubeconfig -f helm-charts/prometheus_values.yaml --namespace prometheus --install --set server.ingress.hosts={m8c8hw1657yhdx6drsozpzdc6r.prometheus.dev.cloud.internal.mattermost.com}]" cluster=m8c8hw1657yhdx6drsozpzdc6r cluster-utility=prometheus cmd=/home/ian/bin/helm helm-update=stable/prometheus instance=ggj6fzoqq7ftjy986iwm5mr17c utility-group=create-handle
```