### PR TITLE
MM-22353 Add a migration to insert default values for UtilityMetadata

### DIFF
--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -606,7 +606,7 @@ var migrations = []migration{
 
 		// if there are UtilityMetadata fields that are not empty, this
 		// table has already been manually migrated
-		if numRows > 1 {
+		if numRows > 0 {
 			return nil
 		}
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -591,4 +591,29 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.12.0"), semver.MustParse("0.13.0"), func(e execer) error {
+		// Assign default values to UtilityMetadata if values do not
+		// exist, otherwise, keep existing values
+		result, err := e.Exec(`SELECT * FROM Cluster WHERE UtilityMetadata != ''`)
+		if err != nil {
+			return err
+		}
+
+		numRows, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+
+		// if there are UtilityMetadata fields that are not empty, this
+		// table has already been manually migrated
+		if numRows > 1 {
+			return nil
+		}
+
+		_, err = e.Exec(`
+				UPDATE Cluster
+				SET	UtilityMetadata = '{}';
+		 `)
+		return err
+	}},
 }

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -591,28 +591,12 @@ var migrations = []migration{
 
 		return nil
 	}},
-	{semver.MustParse("0.12.0"), semver.MustParse("0.13.0"), func(e execer) error {
+	{semver.MustParse("0.12.0"), semver.MustParse("0.12.1"), func(e execer) error {
 		// Assign default values to UtilityMetadata if values do not
 		// exist, otherwise, keep existing values
-		result, err := e.Exec(`SELECT * FROM Cluster WHERE UtilityMetadata != ''`)
-		if err != nil {
-			return err
-		}
-
-		numRows, err := result.RowsAffected()
-		if err != nil {
-			return err
-		}
-
-		// if there are UtilityMetadata fields that are not empty, this
-		// table has already been manually migrated
-		if numRows > 0 {
-			return nil
-		}
-
-		_, err = e.Exec(`
+		_, err := e.Exec(`
 				UPDATE Cluster
-				SET	UtilityMetadata = '{}';
+				SET UtilityMetadata = '{}' WHERE UtilityMetadata is NULL;
 		 `)
 		return err
 	}},


### PR DESCRIPTION
This change inserts an empty JSON structure into the Cluster table in the UtilityMetadata column to resolve the issues seen upgrading clusters in production.

To test this, I build HEAD~1 of the provisioner (database schema version .11), created a cluster, killed the provisioner, rebuilt with these changes, migrated the database from .11 to .13, restarted the provisioner, and was able to call `cloud cluster provision` against the existing cluster.

After provisioning, the utilities are pinned to stable by default. I was also able to successfully test pinning them at a specific version after the migration:
```
~/g/s/g/m/mattermost-cloud » cloud cluster provision --cluster 9q85a9ajojnu98osrrfycgj77a
```
after provision:
```
~/g/s/g/m/mattermost-cloud » cloud cluster utilities --cluster 9q85a9ajojnu98osrrfycgj77a
{
    "desiredVersions": {
        "Prometheus": "",
        "Nginx": "",
        "Fluentbit": ""
    },
    "actualVersions": {
        "Prometheus": "10.4.0",
        "Nginx": "1.30.0",
        "Fluentbit": "2.8.7"
    }
}
```
Reprovision to pin versions:
```
~/g/s/g/m/mattermost-cloud » cloud cluster provision --cluster 9q85a9ajojnu98osrrfycgj77a --prometheus-version 10.4.0 --nginx-version 1.30.0 --fluentbit-version 2.8.7
~/g/s/g/m/mattermost-cloud » cloud cluster utilities --cluster 9q85a9ajojnu98osrrfycgj77a
{
    "desiredVersions": {
        "Prometheus": "10.4.0",
        "Nginx": "1.30.0",
        "Fluentbit": "2.8.7"
    },
    "actualVersions": {
        "Prometheus": "10.4.0",
        "Nginx": "1.30.0",
        "Fluentbit": "2.8.7"
    }
}
```

Lines 596-610 should protect manually transitioned clusters from being further altered by this migration, but should receive extra attention during this review as I am not 100% certain how to test that scenario.