### PR TITLE
MM-15369 Add API endpoint to allow changing version of Installation Groups

### DIFF
--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -33,7 +33,7 @@ func handleChangeMattermostVersion(c *Context, w http.ResponseWriter, r *http.Re
 
 	groupID, ok := vars["group"]
 	if !ok {
-		c.Logger.Error("couldn't get group ID from request parameters")
+		c.Logger.Error("failed to get group ID from request parameters")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -41,7 +41,7 @@ func handleChangeMattermostVersion(c *Context, w http.ResponseWriter, r *http.Re
 
 	version, ok := vars["version"]
 	if !ok {
-		c.Logger.Error("couldn't get version from request parameters")
+		c.Logger.Error("failed to get version from request parameters")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -49,13 +49,13 @@ func handleChangeMattermostVersion(c *Context, w http.ResponseWriter, r *http.Re
 
 	group, err := c.Store.GetGroup(groupID)
 	if err != nil {
-		c.Logger.WithError(err).Errorf("couldn't find group with ID %s", groupID)
+		c.Logger.WithError(err).Errorf("failed to find group with ID %s", groupID)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
 	if group == nil {
-		c.Logger.Errorf("couldn't find group with ID %s", groupID)
+		c.Logger.Errorf("failed to find group with ID %s", groupID)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -31,13 +31,13 @@ func initGroup(apiRouter *mux.Router, context *Context) {
 func handleChangeMattermostVersion(c *Context, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
-	groupId, ok := vars["group"]
+	groupID, ok := vars["group"]
 	if !ok {
 		c.Logger.Error("couldn't get group ID from request parameters")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	c.Logger = c.Logger.WithField("group", groupId)
+	c.Logger = c.Logger.WithField("group", groupID)
 
 	version, ok := vars["version"]
 	if !ok {
@@ -47,15 +47,15 @@ func handleChangeMattermostVersion(c *Context, w http.ResponseWriter, r *http.Re
 	}
 	c.Logger = c.Logger.WithField("version", version)
 
-	group, err := c.Store.GetGroup(groupId)
+	group, err := c.Store.GetGroup(groupID)
 	if err != nil {
-		c.Logger.WithError(err).Errorf("couldn't find group with ID %s", groupId)
+		c.Logger.WithError(err).Errorf("couldn't find group with ID %s", groupID)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
 	if group == nil {
-		c.Logger.Errorf("couldn't find group with ID %s", groupId)
+		c.Logger.Errorf("couldn't find group with ID %s", groupID)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -22,13 +22,13 @@ func initGroup(apiRouter *mux.Router, context *Context) {
 	groupRouter.Handle("", addContext(handleUpdateGroup)).Methods("PUT")
 	groupRouter.Handle("", addContext(handleDeleteGroup)).Methods("DELETE")
 
-	groupRouter.Handle("/mattermost/{version:[A-Za-z0-9.]+}", addContext(handleChangeMattermostVersion)).Methods("PUT")
+	groupRouter.Handle("/mattermost/{version:[A-Za-z0-9.]+}", addContext(handleChangeGroupMattermostVersion)).Methods("PUT")
 }
 
-// handleChangeMattermostVersion responds to PUT
+// handleChangeGroupMattermostVersion responds to PUT
 // /api/group/{group}/mattermost/{version}, upgrading or downgrading
 // the installation to the Mattermost version embedded in the request.
-func handleChangeMattermostVersion(c *Context, w http.ResponseWriter, r *http.Request) {
+func handleChangeGroupMattermostVersion(c *Context, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	groupID, ok := vars["group"]

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -54,6 +54,12 @@ func handleChangeMattermostVersion(c *Context, w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	if group == nil {
+		c.Logger.Errorf("couldn't find group with ID %s", groupId)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	group.Version = version
 	err = c.Store.UpdateGroup(group)
 	if err != nil {

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -253,6 +253,51 @@ func TestCreateGroup(t *testing.T) {
 	})
 }
 
+func TestChangeMattermostVersion(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	group1, err := client.CreateGroup(&model.CreateGroupRequest{
+		Name:        "name",
+		Description: "description",
+		Version:     "version",
+	})
+	require.NoError(t, err)
+
+	t.Run("good request", func(t *testing.T) {
+		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/group/%s/mattermost/%s", ts.URL, group1.ID, "5.18"), nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(httpRequest)
+		require.Equal(t, http.StatusAccepted, resp.StatusCode)
+		require.NoError(t, err)
+	})
+	t.Run("bad version", func(t *testing.T) {
+		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/group/%s/mattermost/%s", ts.URL, group1.ID, "@!#$@#"), nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(httpRequest)
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+		require.NoError(t, err)
+	})
+	t.Run("bad group", func(t *testing.T) {
+		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/group/%s/mattermost/%s", ts.URL, group1.ID[:len(group1.ID)-2], "5.17"), nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(httpRequest)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.NoError(t, err)
+	})
+}
+
 func TestUpdateGroup(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -290,7 +290,7 @@ func TestChangeMattermostVersion(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("bad group", func(t *testing.T) {
-		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/group/%s/mattermost/%s", ts.URL, group1.ID[:len(group1.ID)-2], "5.17"), nil)
+		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/group/%s/mattermost/%s", ts.URL, group1.ID[:len(group1.ID)-2]+"XX", "5.17"), nil)
 		require.NoError(t, err)
 		resp, err := http.DefaultClient.Do(httpRequest)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)


### PR DESCRIPTION
This change stores the desired Group version in the database, and exposes an API endpoint to do so. It does nothing else. 

I'm not sure if this resolves MM-15369 or not, as the story was originally written with the intent that the change would be put into effect on the Installations in question, so we can discuss what we want to do with the JIRA story for the sake of tracking.