### PR TITLE
MM-22391 Run helm init during provision

### DIFF
--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -284,7 +284,22 @@ func helmSetup(logger log.FieldLogger, kops *kops.Cmd) error {
 		return errors.Wrap(err, "failed to create cluster role bindings")
 	}
 
+	err = helmInit(logger, kops)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// helmInit calls helm init and doesn't do anything fancy
+func helmInit(logger log.FieldLogger, kops *kops.Cmd) error {
 	logger.Info("Upgrading Helm")
+	helmClient, err := helm.New(logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to create helm wrapper")
+	}
+	defer helmClient.Close()
 
 	err = helmClient.RunGenericCommand("--debug", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--service-account", "tiller", "--upgrade")
 	if err != nil {

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -135,7 +135,7 @@ func (group utilityGroup) UpgradeUtilityGroup() error {
 	logger := group.provisioner.logger.WithField("helm-init", "UpgradeUtilityGroup")
 	err := helmInit(logger, group.kops)
 	if err != nil {
-		logger.WithError(err).Errorf("couldn't re-initialize Helm in the cluster")
+		logger.WithError(err).Error("couldn't re-initialize Helm in the cluster")
 	}
 
 	for _, utility := range group.utilities {

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -132,6 +132,12 @@ func (group utilityGroup) DestroyUtilityGroup() error {
 
 // UpgradeUtilityGroup reapplies the chart for the UtilityGroup. This will cause services to upgrade to a new version, if one is available.
 func (group utilityGroup) UpgradeUtilityGroup() error {
+	logger := group.provisioner.logger.WithField("helm-init", "UpgradeUtilityGroup")
+	err := helmInit(logger, group.kops)
+	if err != nil {
+		logger.WithError(err).Errorf("couldn't re-initialize Helm in the cluster")
+	}
+
 	for _, utility := range group.utilities {
 		err := utility.Upgrade()
 		if err != nil {


### PR DESCRIPTION
To resolve the issues seen when reprovisioning a cluster with a provisioner whose pod has been restarted, the easiest / simplest / lowest-complexity approach is to simply run `helm init` during `provision` as well as during `create`, before other Helm operations.

Running `helm init` adds little execution time cost and is a no-op on a cluster where re-initializing the tool is unnecessary, so adding it to `UpgradeUtilityGroup`, which is called when `cloud cluster provision` is called, should ensure that Helm is initialized properly before `provision` is called.