### PR TITLE
Set default RDS instance to db.t3.small

### DIFF
--- a/internal/tools/aws/rds.go
+++ b/internal/tools/aws/rds.go
@@ -152,7 +152,7 @@ func (a *Client) rdsEnsureDBClusterInstanceCreated(awsID, instanceName string, l
 	_, err = svc.CreateDBInstance(&rds.CreateDBInstanceInput{
 		DBClusterIdentifier:  aws.String(awsID),
 		DBInstanceIdentifier: aws.String(instanceName),
-		DBInstanceClass:      aws.String("db.r5.large"),
+		DBInstanceClass:      aws.String("db.t3.small"),
 		Engine:               aws.String("aurora-mysql"),
 		PubliclyAccessible:   aws.Bool(false),
 	})


### PR DESCRIPTION
Because it gets the job done for cheaper.

https://mattermost.atlassian.net/browse/MM-21941
