### PR TITLE
fix error when existing installation does not have the mm env

### DIFF
--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -30,9 +30,13 @@ type rawInstallations []*rawInstallation
 
 func (r *rawInstallation) toInstallation() (*model.Installation, error) {
 	// We only need to set values that are converted from a raw database format.
-	mattermostEnv, err := envVarFromJSON(r.MattermostEnvRaw)
-	if err != nil {
-		return nil, err
+	var err error
+	mattermostEnv := model.EnvVarMap{}
+	if r.MattermostEnvRaw != nil {
+		mattermostEnv, err = envVarFromJSON(r.MattermostEnvRaw)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	r.Installation.MattermostEnv = mattermostEnv

--- a/model/env.go
+++ b/model/env.go
@@ -5,7 +5,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// EnvVar contains the value source for a given environement variable.
+// EnvVar contains the value source for a given environment variable.
 type EnvVar struct {
 	Value     string               `json:"value,omitempty"`
 	ValueFrom *corev1.EnvVarSource `json:"valueFrom,omitempty"`


### PR DESCRIPTION
#### Summary
Getting this error to list existing installations that do not have MM env

```
ERRO[2020-02-24T12:42:10+01:00] failed to query installations                 error="unexpected end of JSON input" instance=huq3m1wsytg3mn7fzacp76phhe path=/api/installations request=qtrkgwkz7bnd5mk4y94kbqz8ah
```

this PR fix this issue

related to: https://github.com/mattermost/mattermost-cloud/pull/161

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

