### PR TITLE
Initial installation group config inheritance

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -34,6 +34,8 @@ func init() {
 	installationDeleteCmd.MarkFlagRequired("installation")
 
 	installationGetCmd.Flags().String("installation", "", "The id of the installation to be fetched.")
+	installationGetCmd.Flags().Bool("include-group-config", false, "Whether to include group configuration in the installation or not.")
+	installationGetCmd.Flags().Bool("include-group-config-overrides", false, "Whether to include a group configuration override summary in the installation or not.")
 	installationGetCmd.MarkFlagRequired("installation")
 
 	installationListCmd.Flags().String("owner", "", "The owner by which to filter installations.")
@@ -166,7 +168,13 @@ var installationGetCmd = &cobra.Command{
 		client := model.NewClient(serverAddress)
 
 		installationID, _ := command.Flags().GetString("installation")
-		installation, err := client.GetInstallation(installationID)
+		includeGroupConfig, _ := command.Flags().GetBool("include-group-config")
+		includeGroupConfigOverrides, _ := command.Flags().GetBool("include-group-config-overrides")
+
+		installation, err := client.GetInstallation(installationID, &model.GetInstallationRequest{
+			IncludeGroupConfig:          includeGroupConfig,
+			IncludeGroupConfigOverrides: includeGroupConfigOverrides,
+		})
 		if err != nil {
 			return errors.Wrap(err, "failed to query installation")
 		}

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -22,7 +22,7 @@ type Store interface {
 	DeleteCluster(clusterID string) error
 
 	CreateInstallation(installation *model.Installation) error
-	GetInstallation(installationID string) (*model.Installation, error)
+	GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error)
 	GetInstallations(filter *model.InstallationFilter) ([]*model.Installation, error)
 	UpdateInstallation(installation *model.Installation) error
 	LockInstallation(installationID, lockerID string) (bool, error)

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -419,7 +419,7 @@ func TestDeleteGroup(t *testing.T) {
 		err = client.JoinGroup(group1.ID, installation1.ID)
 		require.NoError(t, err)
 
-		installation1, err = client.GetInstallation(installation1.ID)
+		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.NotNil(t, installation1.GroupID)
 		require.Equal(t, group1.ID, *installation1.GroupID)

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -53,3 +53,17 @@ func parsePaging(u *url.URL) (int, int, bool, error) {
 
 	return page, perPage, includeDeleted, nil
 }
+
+func parseGroupConfig(u *url.URL) (bool, bool, error) {
+	includeGroupConfig, err := parseBool(u, "include_group_config", false)
+	if err != nil {
+		return false, false, err
+	}
+
+	includeGroupConfigOverrides, err := parseBool(u, "include_group_config_overrides", false)
+	if err != nil {
+		return false, false, err
+	}
+
+	return includeGroupConfig, includeGroupConfigOverrides, nil
+}

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -34,7 +34,14 @@ func handleGetInstallation(c *Context, w http.ResponseWriter, r *http.Request) {
 	installationID := vars["installation"]
 	c.Logger = c.Logger.WithField("installation", installationID)
 
-	installation, err := c.Store.GetInstallation(installationID)
+	includeGroupConfig, includeGroupConfigOverrides, err := parseGroupConfig(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse paging parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	installation, err := c.Store.GetInstallation(installationID, includeGroupConfig, includeGroupConfigOverrides)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to query installation")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/api/lock.go
+++ b/internal/api/lock.go
@@ -45,7 +45,7 @@ func lockCluster(c *Context, clusterID string) (*model.Cluster, int, func()) {
 // lockInstallation synchronizes access to the given installation across potentially multiple provisioning
 // servers.
 func lockInstallation(c *Context, installationID string) (*model.Installation, int, func()) {
-	installation, err := c.Store.GetInstallation(installationID)
+	installation, err := c.Store.GetInstallation(installationID, false, false)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to query installation")
 		return nil, http.StatusInternalServerError, nil

--- a/internal/store/group.go
+++ b/internal/store/group.go
@@ -11,7 +11,7 @@ import (
 var groupSelect sq.SelectBuilder
 
 type rawGroup struct {
-	model.Group
+	*model.Group
 	MattermostEnvRaw []byte
 }
 
@@ -21,25 +21,18 @@ func init() {
 		From(`"Group"`)
 }
 
-func rawGroupToGroup(raw *rawGroup) (*model.Group, error) {
+func rawGroupToGroup(r *rawGroup) (*model.Group, error) {
 	var err error
 	mattermostEnv := &model.EnvVarMap{}
-	if raw.MattermostEnvRaw != nil {
-		mattermostEnv, err = model.EnvVarFromJSON(raw.MattermostEnvRaw)
+	if r.MattermostEnvRaw != nil {
+		mattermostEnv, err = model.EnvVarFromJSON(r.MattermostEnvRaw)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return &model.Group{
-		ID:            raw.ID,
-		Name:          raw.Name,
-		Description:   raw.Description,
-		Version:       raw.Version,
-		CreateAt:      raw.CreateAt,
-		DeleteAt:      raw.DeleteAt,
-		MattermostEnv: *mattermostEnv,
-	}, nil
+	r.Group.MattermostEnv = *mattermostEnv
+	return r.Group, nil
 }
 
 // GetGroup fetches the given group by id.

--- a/internal/supervisor/cluster_installation.go
+++ b/internal/supervisor/cluster_installation.go
@@ -16,7 +16,7 @@ import (
 type clusterInstallationStore interface {
 	GetCluster(clusterID string) (*model.Cluster, error)
 
-	GetInstallation(installationID string) (*model.Installation, error)
+	GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error)
 
 	GetClusterInstallation(clusterInstallationID string) (*model.ClusterInstallation, error)
 	GetUnlockedClusterInstallationsPendingWork() ([]*model.ClusterInstallation, error)
@@ -148,7 +148,7 @@ func (s *ClusterInstallationSupervisor) transitionClusterInstallation(clusterIns
 		return failedClusterInstallationState(clusterInstallation.State)
 	}
 
-	installation, err := s.store.GetInstallation(clusterInstallation.InstallationID)
+	installation, err := s.store.GetInstallation(clusterInstallation.InstallationID, false, false)
 	if err != nil {
 		logger.WithError(err).Warnf("Failed to query installation %s", clusterInstallation.InstallationID)
 		return clusterInstallation.State

--- a/internal/supervisor/cluster_installation_test.go
+++ b/internal/supervisor/cluster_installation_test.go
@@ -27,7 +27,7 @@ type mockClusterInstallationStore struct {
 func (s *mockClusterInstallationStore) GetCluster(clusterID string) (*model.Cluster, error) {
 	return s.Cluster, nil
 }
-func (s *mockClusterInstallationStore) GetInstallation(installationID string) (*model.Installation, error) {
+func (s *mockClusterInstallationStore) GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error) {
 	return s.Installation, nil
 }
 func (s *mockClusterInstallationStore) GetClusterInstallation(clusterInstallationID string) (*model.ClusterInstallation, error) {

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -19,7 +19,7 @@ type installationStore interface {
 	LockCluster(clusterID, lockerID string) (bool, error)
 	UnlockCluster(clusterID string, lockerID string, force bool) (bool, error)
 
-	GetInstallation(installationID string) (*model.Installation, error)
+	GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error)
 	GetUnlockedInstallationsPendingWork() ([]*model.Installation, error)
 	UpdateInstallation(installation *model.Installation) error
 	LockInstallation(installationID, lockerID string) (bool, error)
@@ -105,7 +105,7 @@ func (s *InstallationSupervisor) Supervise(installation *model.Installation) {
 
 	newState := s.transitionInstallation(installation, s.instanceID, logger)
 
-	installation, err := s.store.GetInstallation(installation.ID)
+	installation, err := s.store.GetInstallation(installation.ID, false, false)
 	if err != nil {
 		logger.WithError(err).Warnf("failed to get installation and thus persist state %s", newState)
 		return
@@ -251,7 +251,7 @@ func (s *InstallationSupervisor) createClusterInstallation(cluster *model.Cluste
 		if len(existingClusterInstallations) == 1 {
 			// This should be the only scenario where we need to check if the
 			// cluster installation running requires isolation or not.
-			installation, err := s.store.GetInstallation(existingClusterInstallations[0].InstallationID)
+			installation, err := s.store.GetInstallation(existingClusterInstallations[0].InstallationID, false, false)
 			if err != nil {
 				logger.WithError(err).Warn("Unable to find installation")
 				return nil
@@ -378,7 +378,7 @@ func (s *InstallationSupervisor) waitForClusterInstallationStable(installation *
 	logger.Debugf("Found %d cluster installations: %d stable, %d reconciling, %d failed, %d other", len(clusterInstallations), stable, reconciling, failed, other)
 
 	if len(clusterInstallations) == stable {
-		logger.Infof("Finished creating installation")
+		logger.Info("Finished creating cluster installation")
 		return s.configureInstallationDNS(installation, logger)
 	}
 	if failed > 0 {

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -40,7 +40,7 @@ func (s *mockInstallationStore) UnlockCluster(clusterID string, lockerID string,
 	return true, nil
 }
 
-func (s *mockInstallationStore) GetInstallation(installationID string) (*model.Installation, error) {
+func (s *mockInstallationStore) GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error) {
 	return s.Installation, nil
 }
 
@@ -232,7 +232,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	expectInstallationState := func(t *testing.T, sqlStore *store.SQLStore, installation *model.Installation, expectedState string) {
 		t.Helper()
 
-		installation, err := sqlStore.GetInstallation(installation.ID)
+		installation, err := sqlStore.GetInstallation(installation.ID, false, false)
 		require.NoError(t, err)
 		require.Equal(t, expectedState, installation.State)
 	}

--- a/model/client.go
+++ b/model/client.go
@@ -306,8 +306,15 @@ func (c *Client) RetryCreateInstallation(installationID string) error {
 }
 
 // GetInstallation fetches the specified installation from the configured provisioning server.
-func (c *Client) GetInstallation(installationID string) (*Installation, error) {
-	resp, err := c.doGet(c.buildURL("/api/installation/%s", installationID))
+func (c *Client) GetInstallation(installationID string, request *GetInstallationRequest) (*Installation, error) {
+	u, err := url.Parse(c.buildURL("/api/installation/%s", installationID))
+	if err != nil {
+		return nil, err
+	}
+
+	request.ApplyToURL(u)
+
+	resp, err := c.doGet(u.String())
 	if err != nil {
 		return nil, err
 	}

--- a/model/env.go
+++ b/model/env.go
@@ -37,7 +37,7 @@ func (em *EnvVarMap) Validate() error {
 	return nil
 }
 
-// ToEnvList returns a list of standard corev1.EnvVars
+// ToEnvList returns a list of standard corev1.EnvVars.
 func (em *EnvVarMap) ToEnvList() []corev1.EnvVar {
 	envList := []corev1.EnvVar{}
 
@@ -52,14 +52,12 @@ func (em *EnvVarMap) ToEnvList() []corev1.EnvVar {
 	return envList
 }
 
-// ToJSON converts the EnvVarMap to a JSON object represented as a
-// []byte
+// ToJSON converts the EnvVarMap to a JSON object represented as a []byte.
 func (em *EnvVarMap) ToJSON() ([]byte, error) {
 	return json.Marshal(em)
 }
 
-// EnvVarFromJSON creates a EnvVarMap from the JSON represented as a
-// []byte
+// EnvVarFromJSON creates a EnvVarMap from the JSON represented as a []byte.
 func EnvVarFromJSON(raw []byte) (*EnvVarMap, error) {
 	e := &EnvVarMap{}
 	err := json.Unmarshal(raw, e)

--- a/model/installation.go
+++ b/model/installation.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 )
 
@@ -23,6 +24,13 @@ type Installation struct {
 	DeleteAt       int64
 	LockAcquiredBy *string
 	LockAcquiredAt int64
+	GroupOverrides map[string]string `json:"GroupOverrides,omitempty"`
+
+	// configconfigMergedWithGroup is set when the installation configuration
+	// has been overridden with group configuration. This value can then be
+	// checked later to determine whether the installation is safe to save or
+	// not.
+	configMergedWithGroup bool
 }
 
 // InstallationFilter describes the parameters used to constrain a set of installations.
@@ -35,12 +43,58 @@ type InstallationFilter struct {
 }
 
 // Clone returns a deep copy the installation.
-func (c *Installation) Clone() *Installation {
+func (i *Installation) Clone() *Installation {
 	var clone Installation
-	data, _ := json.Marshal(c)
+	data, _ := json.Marshal(i)
 	json.Unmarshal(data, &clone)
 
 	return &clone
+}
+
+// IsInGroup returns if the installation is in a group or not.
+func (i *Installation) IsInGroup() bool {
+	return i.GroupID != nil
+}
+
+// ConfigMergedWithGroup returns if the installation currently has inherited
+// group configuration values.
+func (i *Installation) ConfigMergedWithGroup() bool {
+	return i.configMergedWithGroup
+}
+
+// MergeWithGroup merges an installation's configuration with that of a group.
+// An option can be provided to include a group override summary to the
+// installation.
+func (i *Installation) MergeWithGroup(group *Group, includeOverrides bool) {
+	if i.ConfigMergedWithGroup() {
+		return
+	}
+	if group == nil {
+		return
+	}
+
+	i.configMergedWithGroup = true
+	i.GroupOverrides = make(map[string]string)
+	if group.MattermostEnv != nil && i.MattermostEnv == nil {
+		i.MattermostEnv = make(EnvVarMap)
+	}
+
+	if i.Version != group.Version {
+		i.Version = group.Version
+		if includeOverrides {
+			i.GroupOverrides["Installation Version"] = i.Version
+			i.GroupOverrides["Group Version"] = group.Version
+		}
+	}
+	for key, value := range group.MattermostEnv {
+		if includeOverrides {
+			if _, ok := i.MattermostEnv[key]; ok {
+				i.GroupOverrides[fmt.Sprintf("Installation MattermostEnv[%s]", key)] = i.MattermostEnv[key].Value
+				i.GroupOverrides[fmt.Sprintf("Group MattermostEnv[%s]", key)] = value.Value
+			}
+		}
+		i.MattermostEnv[key] = value
+	}
 }
 
 // InstallationFromReader decodes a json-encoded installation from the given io.Reader.

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -96,6 +96,27 @@ func NewCreateInstallationRequestFromReader(reader io.Reader) (*CreateInstallati
 	return &createInstallationRequest, nil
 }
 
+// GetInstallationRequest describes the parameters to request an installation.
+type GetInstallationRequest struct {
+	IncludeGroupConfig          bool `json:"include_group_config"`
+	IncludeGroupConfigOverrides bool
+}
+
+// ApplyToURL modifies the given url to include query string parameters for the request.
+func (request *GetInstallationRequest) ApplyToURL(u *url.URL) {
+	if request == nil {
+		return
+	}
+	q := u.Query()
+	if request.IncludeGroupConfig {
+		q.Add("include_group_config", "true")
+	}
+	if request.IncludeGroupConfigOverrides {
+		q.Add("include_group_config_overrides", "true")
+	}
+	u.RawQuery = q.Encode()
+}
+
 // GetInstallationsRequest describes the parameters to request a list of installations.
 type GetInstallationsRequest struct {
 	OwnerID        string


### PR DESCRIPTION
This change does the following:
 - Adds foundational logic for merging installation and group
   configuration. This is only exposed via the get installation
   API endpoint for now. No supervisor logic has been altered.
 - Prevent saving installation objects once they have merged
   group config. This is to prevent errors when the provisioner
   eventually acts on group config changes.
 - Logging and group store cleanup.

https://mattermost.atlassian.net/browse/MM-22504

