### PR TITLE
installation: add option to set a custom image when creating/updating

### DIFF
--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -12,6 +12,7 @@ func init() {
 	groupCreateCmd.Flags().String("name", "", "A unique name describing this group of installations.")
 	groupCreateCmd.Flags().String("description", "", "An optional description for this group of installations.")
 	groupCreateCmd.Flags().String("version", "stable", "The Mattermost version for installations in this group to target.")
+	groupCreateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost Container image to use.")
 	groupCreateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	groupCreateCmd.MarkFlagRequired("name")
 
@@ -19,6 +20,7 @@ func init() {
 	groupUpdateCmd.Flags().String("name", "", "A unique name describing this group of installations.")
 	groupUpdateCmd.Flags().String("description", "", "An optional description for this group of installations.")
 	groupUpdateCmd.Flags().String("version", "", "The Mattermost version for installations in this group to target.")
+	groupUpdateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost Container image to use.")
 	groupUpdateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	groupUpdateCmd.MarkFlagRequired("group")
 
@@ -64,6 +66,7 @@ var groupCreateCmd = &cobra.Command{
 		client := model.NewClient(serverAddress)
 
 		name, _ := command.Flags().GetString("name")
+		image, _ := command.Flags().GetString("image")
 		description, _ := command.Flags().GetString("description")
 		version, _ := command.Flags().GetString("version")
 		mattermostEnv, _ := command.Flags().GetStringArray("mattermost-env")
@@ -77,6 +80,7 @@ var groupCreateCmd = &cobra.Command{
 			Name:          name,
 			Description:   description,
 			Version:       version,
+			Image:         image,
 			MattermostEnv: envVarMap,
 		})
 
@@ -106,6 +110,7 @@ var groupUpdateCmd = &cobra.Command{
 		name, _ := command.Flags().GetString("name")
 		description, _ := command.Flags().GetString("description")
 		version, _ := command.Flags().GetString("version")
+		image, _ := command.Flags().GetString("image")
 		mattermostEnv, _ := command.Flags().GetStringArray("mattermost-env")
 
 		envVarMap, err := parseEnvVarInput(mattermostEnv)
@@ -126,6 +131,7 @@ var groupUpdateCmd = &cobra.Command{
 			Name:          patchPointer(name),
 			Description:   patchPointer(description),
 			Version:       patchPointer(version),
+			Image:         patchPointer(image),
 			MattermostEnv: envVarMap,
 		})
 		if err != nil {

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -13,7 +13,7 @@ func init() {
 
 	installationCreateCmd.Flags().String("owner", "", "An opaque identifier describing the owner of the installation.")
 	installationCreateCmd.Flags().String("version", "stable", "The Mattermost version to install.")
-	installationCreateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost Container iamge to use.")
+	installationCreateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost Container image to use.")
 	installationCreateCmd.Flags().String("dns", "", "The URL at which the Mattermost server will be available.")
 	installationCreateCmd.Flags().String("size", model.InstallationDefaultSize, "The size of the installation. Accepts 100users, 1000users, 5000users, 10000users, 25000users, miniSingleton, or miniHA. Defaults to 100users.")
 	installationCreateCmd.Flags().String("affinity", model.InstallationAffinityIsolated, "How other installations may be co-located in the same cluster.")
@@ -26,6 +26,7 @@ func init() {
 
 	installationUpdateCmd.Flags().String("installation", "", "The id of the installation to be updated.")
 	installationUpdateCmd.Flags().String("version", "stable", "The Mattermost version to target.")
+	installationUpdateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost Container image to use.")
 	installationUpdateCmd.Flags().String("license", "", "The Mattermost License to use in the server.")
 	installationUpdateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	installationUpdateCmd.MarkFlagRequired("installation")

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -13,6 +13,7 @@ func init() {
 
 	installationCreateCmd.Flags().String("owner", "", "An opaque identifier describing the owner of the installation.")
 	installationCreateCmd.Flags().String("version", "stable", "The Mattermost version to install.")
+	installationCreateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost Container iamge to use.")
 	installationCreateCmd.Flags().String("dns", "", "The URL at which the Mattermost server will be available.")
 	installationCreateCmd.Flags().String("size", model.InstallationDefaultSize, "The size of the installation. Accepts 100users, 1000users, 5000users, 10000users, 25000users, miniSingleton, or miniHA. Defaults to 100users.")
 	installationCreateCmd.Flags().String("affinity", model.InstallationAffinityIsolated, "How other installations may be co-located in the same cluster.")
@@ -67,6 +68,7 @@ var installationCreateCmd = &cobra.Command{
 
 		ownerID, _ := command.Flags().GetString("owner")
 		version, _ := command.Flags().GetString("version")
+		image, _ := command.Flags().GetString("image")
 		size, _ := command.Flags().GetString("size")
 		dns, _ := command.Flags().GetString("dns")
 		affinity, _ := command.Flags().GetString("affinity")
@@ -83,6 +85,7 @@ var installationCreateCmd = &cobra.Command{
 		installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
 			OwnerID:       ownerID,
 			Version:       version,
+			Image:         image,
 			Size:          size,
 			DNS:           dns,
 			License:       license,
@@ -115,6 +118,7 @@ var installationUpdateCmd = &cobra.Command{
 
 		installationID, _ := command.Flags().GetString("installation")
 		version, _ := command.Flags().GetString("version")
+		image, _ := command.Flags().GetString("image")
 		license, _ := command.Flags().GetString("license")
 		mattermostEnv, _ := command.Flags().GetStringArray("mattermost-env")
 
@@ -125,6 +129,7 @@ var installationUpdateCmd = &cobra.Command{
 
 		updateRequest := &model.UpdateInstallationRequest{
 			Version:       version,
+			Image:         image,
 			License:       license,
 			MattermostEnv: envVarMap,
 		}

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -88,6 +88,7 @@ func handleCreateGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 		Name:          createGroupRequest.Name,
 		Description:   createGroupRequest.Description,
 		Version:       createGroupRequest.Version,
+		Image:         createGroupRequest.Image,
 		MattermostEnv: createGroupRequest.MattermostEnv,
 	}
 

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -244,12 +244,14 @@ func TestCreateGroup(t *testing.T) {
 			Name:          "name",
 			Description:   "description",
 			Version:       "version",
+			Image:         "sample/image",
 			MattermostEnv: mattermostEnvFooBar,
 		})
 		require.NoError(t, err)
 		require.Equal(t, "name", group.Name)
 		require.Equal(t, "description", group.Description)
 		require.Equal(t, "version", group.Version)
+		require.Equal(t, "sample/image", group.Image)
 		require.NotEqual(t, 0, group.CreateAt)
 		require.EqualValues(t, 0, group.DeleteAt)
 		require.EqualValues(t, group.MattermostEnv, mattermostEnvFooBar)
@@ -277,6 +279,7 @@ func TestUpdateGroup(t *testing.T) {
 		Name:          "name",
 		Description:   "description",
 		Version:       "version",
+		Image:         "sample/image",
 		MattermostEnv: mattermostEnvFooBar,
 	})
 	require.NoError(t, err)
@@ -359,6 +362,7 @@ func TestDeleteGroup(t *testing.T) {
 		Name:        "name",
 		Description: "description",
 		Version:     "version",
+		Image:       "sample/image",
 	})
 	require.NoError(t, err)
 

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -104,6 +104,7 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 	installation := model.Installation{
 		OwnerID:       createInstallationRequest.OwnerID,
 		Version:       createInstallationRequest.Version,
+		Image:         createInstallationRequest.Image,
 		DNS:           createInstallationRequest.DNS,
 		Database:      createInstallationRequest.Database,
 		Filestore:     createInstallationRequest.Filestore,
@@ -236,6 +237,7 @@ func handleUpdateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 	installation.State = newState
 	installation.Version = updateInstallationRequest.Version
 	installation.License = updateInstallationRequest.License
+	installation.Image = updateInstallationRequest.Image
 	installation.MattermostEnv = updateInstallationRequest.MattermostEnv
 
 	err = c.Store.UpdateInstallation(installation)

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -341,7 +341,29 @@ func TestCreateInstallation(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "owner", installation.OwnerID)
 		require.Equal(t, "version", installation.Version)
+		require.Equal(t, "mattermost/mattermost-enterprise-edition", installation.Image)
 		require.Equal(t, "dns.example.com", installation.DNS)
+		require.Equal(t, model.InstallationAffinityIsolated, installation.Affinity)
+		require.Equal(t, model.InstallationStateCreationRequested, installation.State)
+		require.Empty(t, installation.LockAcquiredBy)
+		require.EqualValues(t, 0, installation.LockAcquiredAt)
+		require.NotEqual(t, 0, installation.CreateAt)
+		require.EqualValues(t, 0, installation.DeleteAt)
+	})
+
+	t.Run("valid with custom image", func(t *testing.T) {
+		installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
+			OwnerID:  "owner1",
+			Version:  "version",
+			Image:    "custom-image",
+			DNS:      "dns1.example.com",
+			Affinity: model.InstallationAffinityIsolated,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "owner1", installation.OwnerID)
+		require.Equal(t, "version", installation.Version)
+		require.Equal(t, "custom-image", installation.Image)
+		require.Equal(t, "dns1.example.com", installation.DNS)
 		require.Equal(t, model.InstallationAffinityIsolated, installation.Affinity)
 		require.Equal(t, model.InstallationStateCreationRequested, installation.State)
 		require.Empty(t, installation.LockAcquiredBy)
@@ -512,6 +534,7 @@ func TestUpdateInstallation(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpdateRequested, installation1.State)
 		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
+		require.Equal(t, "mattermost/mattermost-enterprise-edition", installation1.Image)
 	})
 
 	t.Run("after upgrade failed", func(t *testing.T) {

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -653,12 +653,14 @@ func TestJoinGroup(t *testing.T) {
 	group1, err := client.CreateGroup(&model.CreateGroupRequest{
 		Name:    "name1",
 		Version: "version1",
+		Image:   "sample/image1",
 	})
 	require.NoError(t, err)
 
 	group2, err := client.CreateGroup(&model.CreateGroupRequest{
 		Name:    "name2",
 		Version: "version2",
+		Image:   "sample/image2",
 	})
 	require.NoError(t, err)
 
@@ -745,6 +747,7 @@ func TestLeaveGroup(t *testing.T) {
 	group1, err := client.CreateGroup(&model.CreateGroupRequest{
 		Name:    "name1",
 		Version: "version1",
+		Image:   "sample/image1",
 	})
 	require.NoError(t, err)
 

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -73,6 +73,7 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 		Spec: mmv1alpha1.ClusterInstallationSpec{
 			Size:                   installation.Size,
 			Version:                translateMattermostVersion(installation.Version),
+			Image:                  installation.Image,
 			IngressName:            installation.DNS,
 			UseServiceLoadBalancer: true,
 			MattermostEnv:          installation.MattermostEnv.ToEnvList(),
@@ -187,6 +188,11 @@ func (provisioner *KopsProvisioner) UpdateClusterInstallation(cluster *model.Clu
 		logger.Infof("Cluster installation already on version %s", version)
 	}
 	cr.Spec.Version = version
+
+	if cr.Spec.Image == installation.Image {
+		logger.Infof("Cluster installation already on Image %s", installation.Image)
+	}
+	cr.Spec.Image = installation.Image
 
 	cr.Spec.MattermostLicenseSecret = ""
 	secretName := fmt.Sprintf("%s-license", name)

--- a/internal/store/group.go
+++ b/internal/store/group.go
@@ -20,7 +20,7 @@ type rawGroups []*rawGroup
 
 func init() {
 	groupSelect = sq.
-		Select("ID", "Name", "Description", "Version", "Sequence", "CreateAt",
+		Select("ID", "Name", "Description", "Version", "Image", "Sequence", "CreateAt",
 			"DeleteAt", "MattermostEnvRaw", "MaxRolling", "LockAcquiredBy",
 			"LockAcquiredAt").
 		From(`"Group"`)
@@ -232,6 +232,7 @@ func (sqlStore *SQLStore) CreateGroup(group *model.Group) error {
 			"ID":               group.ID,
 			"Sequence":         0,
 			"Name":             group.Name,
+			"Image":            group.Image,
 			"Description":      group.Description,
 			"Version":          group.Version,
 			"MattermostEnvRaw": envVarMap,
@@ -273,6 +274,7 @@ func (sqlStore *SQLStore) UpdateGroup(group *model.Group) error {
 			"Name":             group.Name,
 			"Description":      group.Description,
 			"Version":          group.Version,
+			"Image":            group.Image,
 			"MattermostEnvRaw": envVarMap,
 			"MaxRolling":       group.MaxRolling,
 		}).

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -14,7 +14,7 @@ var installationSelect sq.SelectBuilder
 func init() {
 	installationSelect = sq.
 		Select(
-			"ID", "OwnerID", "Version", "DNS", "Database", "Filestore", "Size",
+			"ID", "OwnerID", "Version", "Image", "DNS", "Database", "Filestore", "Size",
 			"Affinity", "GroupID", "GroupSequence", "State", "License",
 			"MattermostEnvRaw", "CreateAt", "DeleteAt", "LockAcquiredBy",
 			"LockAcquiredAt",
@@ -163,6 +163,7 @@ func (sqlStore *SQLStore) CreateInstallation(installation *model.Installation) e
 			"ID":               installation.ID,
 			"OwnerID":          installation.OwnerID,
 			"Version":          installation.Version,
+			"Image":            installation.Image,
 			"DNS":              installation.DNS,
 			"Database":         installation.Database,
 			"Filestore":        installation.Filestore,
@@ -201,6 +202,7 @@ func (sqlStore *SQLStore) UpdateInstallation(installation *model.Installation) e
 		SetMap(map[string]interface{}{
 			"OwnerID":          installation.OwnerID,
 			"Version":          installation.Version,
+			"Image":            installation.Image,
 			"DNS":              installation.DNS,
 			"Database":         installation.Database,
 			"Filestore":        installation.Filestore,

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -52,6 +52,7 @@ func TestInstallations(t *testing.T) {
 	installation2 := &model.Installation{
 		OwnerID:   ownerID1,
 		Version:   "version2",
+		Image:     "custom-image",
 		DNS:       "dns2.example.com",
 		Database:  model.InstallationDatabaseMysqlOperator,
 		Filestore: model.InstallationFilestoreMinioOperator,
@@ -554,6 +555,7 @@ func TestUpdateInstallation(t *testing.T) {
 		OwnerID:   ownerID1,
 		Version:   "version2",
 		DNS:       "dns4.example.com",
+		Image:     "custom-image",
 		Database:  model.InstallationDatabaseMysqlOperator,
 		Filestore: model.InstallationFilestoreMinioOperator,
 		Size:      mmv1alpha1.Size100String,

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -22,6 +22,7 @@ func TestInstallations(t *testing.T) {
 
 	group1 := &model.Group{
 		Version: "group1-version",
+		Image:   "custom/image",
 		MattermostEnv: model.EnvVarMap{
 			"Key1": model.EnvVar{Value: "Value1"},
 		},
@@ -498,6 +499,7 @@ func TestUpdateInstallation(t *testing.T) {
 
 	group1 := &model.Group{
 		Version: "group1-version",
+		Image:   "custom/image",
 		MattermostEnv: model.EnvVarMap{
 			"Key1": model.EnvVar{Value: "Value1"},
 		},
@@ -555,7 +557,7 @@ func TestUpdateInstallation(t *testing.T) {
 		OwnerID:   ownerID1,
 		Version:   "version2",
 		DNS:       "dns4.example.com",
-		Image:     "custom-image",
+		Image:     "custom/image",
 		Database:  model.InstallationDatabaseMysqlOperator,
 		Filestore: model.InstallationFilestoreMinioOperator,
 		Size:      mmv1alpha1.Size100String,
@@ -569,6 +571,7 @@ func TestUpdateInstallation(t *testing.T) {
 
 	installation1.OwnerID = ownerID2
 	installation1.Version = "version3"
+	installation1.Version = "custom/image"
 	installation1.DNS = "dns5.example.com"
 	installation1.Size = mmv1alpha1.Size1000String
 	installation1.Affinity = model.InstallationAffinityIsolated

--- a/model/group.go
+++ b/model/group.go
@@ -12,6 +12,7 @@ type Group struct {
 	Name           string
 	Description    string
 	Version        string
+	Image          string
 	MaxRolling     int64
 	MattermostEnv  EnvVarMap
 	CreateAt       int64

--- a/model/group_request.go
+++ b/model/group_request.go
@@ -14,6 +14,7 @@ type CreateGroupRequest struct {
 	Name          string
 	Description   string
 	Version       string
+	Image         string
 	MattermostEnv EnvVarMap
 }
 
@@ -28,6 +29,9 @@ func NewCreateGroupRequestFromReader(reader io.Reader) (*CreateGroupRequest, err
 	err = createGroupRequest.Validate()
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid group create request")
+	}
+	if createGroupRequest.Image == "" {
+		return nil, errors.New("must specify image")
 	}
 
 	return &createGroupRequest, nil
@@ -55,6 +59,7 @@ type PatchGroupRequest struct {
 	Name          *string
 	Description   *string
 	Version       *string
+	Image         *string
 	MattermostEnv EnvVarMap
 }
 
@@ -89,6 +94,10 @@ func (p *PatchGroupRequest) Apply(group *Group) bool {
 	if p.Version != nil && *p.Version != group.Version {
 		applied = true
 		group.Version = *p.Version
+	}
+	if p.Image != nil && *p.Image != group.Image {
+		applied = true
+		group.Image = *p.Image
 	}
 
 	if p.MattermostEnv != nil {

--- a/model/group_test.go
+++ b/model/group_test.go
@@ -11,6 +11,7 @@ func TestGroupClone(t *testing.T) {
 	group := &Group{
 		ID:          "id",
 		Name:        "name",
+		Image:       "sample/image",
 		Description: "description",
 		Version:     "version",
 	}
@@ -44,6 +45,7 @@ func TestGroupFromReader(t *testing.T) {
 		group, err := GroupFromReader(bytes.NewReader([]byte(`{
 			"ID":"id",
 			"Name":"name",
+			"Image":"sample/image",
 			"Description":"description",
 			"Version":"version",
 			"CreateAt":10,
@@ -56,6 +58,7 @@ func TestGroupFromReader(t *testing.T) {
 			Name:        "name",
 			Description: "description",
 			Version:     "version",
+			Image:       "sample/image",
 			CreateAt:    10,
 			DeleteAt:    20,
 			MattermostEnv: EnvVarMap{
@@ -73,6 +76,7 @@ func TestGroupFromReader(t *testing.T) {
 			"Name":"name",
 			"Description":"description",
 			"Version":"version",
+			"Image":"sample/image",
 			"CreateAt":10,
 			"DeleteAt":20
 		}`)))
@@ -82,6 +86,7 @@ func TestGroupFromReader(t *testing.T) {
 			Name:          "name",
 			Description:   "description",
 			Version:       "version",
+			Image:         "sample/image",
 			CreateAt:      10,
 			DeleteAt:      20,
 			MattermostEnv: nil,
@@ -95,6 +100,7 @@ func TestGroupFromReader(t *testing.T) {
 			"Name":"name",
 			"Description":"description",
 			"Version":"version",
+			"Image":"sample/image",
 			"CreateAt":10,
 			"DeleteAt":20
 			"MattermostEnv": {
@@ -127,6 +133,7 @@ func TestGroupsFromReader(t *testing.T) {
 				"Name":"name1",
 				"Description":"description1",
 				"Version":"version1",
+				"Image":"sample/image1",
 				"CreateAt":10,
 				"DeleteAt":20
 			},
@@ -135,6 +142,7 @@ func TestGroupsFromReader(t *testing.T) {
 				"Name":"name2",
 				"Description":"description2",
 				"Version":"version2",
+				"Image":"sample/image2",
 				"CreateAt":30,
 				"DeleteAt":40
 			}
@@ -146,6 +154,7 @@ func TestGroupsFromReader(t *testing.T) {
 				Name:        "name1",
 				Description: "description1",
 				Version:     "version1",
+				Image:       "sample/image1",
 				CreateAt:    10,
 				DeleteAt:    20,
 			},
@@ -154,6 +163,7 @@ func TestGroupsFromReader(t *testing.T) {
 				Name:        "name2",
 				Description: "description2",
 				Version:     "version2",
+				Image:       "sample/image2",
 				CreateAt:    30,
 				DeleteAt:    40,
 			},

--- a/model/installation.go
+++ b/model/installation.go
@@ -13,6 +13,7 @@ type Installation struct {
 	GroupID        *string
 	GroupSequence  *int64 `json:"GroupSequence,omitempty"`
 	Version        string
+	Image          string
 	DNS            string
 	Database       string
 	Filestore      string

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -15,6 +15,7 @@ import (
 type CreateInstallationRequest struct {
 	OwnerID       string
 	Version       string
+	Image         string
 	DNS           string
 	License       string
 	Size          string
@@ -28,6 +29,9 @@ type CreateInstallationRequest struct {
 func (request *CreateInstallationRequest) SetDefaults() {
 	if request.Version == "" {
 		request.Version = "stable"
+	}
+	if request.Image == "" {
+		request.Image = "mattermost/mattermost-enterprise-edition"
 	}
 	if request.Size == "" {
 		request.Size = InstallationDefaultSize
@@ -140,13 +144,16 @@ func (request *GetInstallationsRequest) ApplyToURL(u *url.URL) {
 // UpdateInstallationRequest specifies the parameters for an updated installation.
 type UpdateInstallationRequest struct {
 	Version       string
+	Image         string
 	License       string
 	MattermostEnv EnvVarMap
 }
 
 // SetDefaults sets the default values for an installation update request.
 func (request *UpdateInstallationRequest) SetDefaults() {
-	// Currently a no-op.
+	if request.Image == "" {
+		request.Image = "mattermost/mattermost-enterprise-edition"
+	}
 }
 
 // Validate validates the values of an installation update request.


### PR DESCRIPTION
#### Summary
Add option to set a custom image when creating and/or updating a MM installation
For some context please see [here](https://github.com/mattermost/mattermost-server/pull/14044)

Also, this is a good addition in case we have a customer that wants to use a custom MM image


