### PR TITLE
logs: add machine readable format flag for logging

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -44,6 +44,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("keep-database-data", true, "Whether to preserve database data after installation deletion or not.")
 	serverCmd.PersistentFlags().Bool("keep-filestore-data", true, "Whether to preserve filestore data after installation deletion or not.")
 	serverCmd.PersistentFlags().Bool("debug", false, "Whether to output debug logs.")
+	serverCmd.PersistentFlags().Bool("machine-readable-logs", false, "Output the logs in machine readable format.")
 }
 
 var serverCmd = &cobra.Command{
@@ -55,6 +56,11 @@ var serverCmd = &cobra.Command{
 		debug, _ := command.Flags().GetBool("debug")
 		if debug {
 			logger.SetLevel(logrus.DebugLevel)
+		}
+
+		machineLogs, _ := command.Flags().GetBool("machine-readable-logs")
+		if machineLogs {
+			logger.SetFormatter(&logrus.JSONFormatter{})
 		}
 
 		logger := logger.WithField("instance", instanceID)


### PR DESCRIPTION
#### Summary
Add option to enable machine-readable logging format which in this case is JSON 😄
to set use `machine-readable-logs` flag
This will enable the Mattermost Cloud Monitoring to parse and read more easily the logs.

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-23236

