### PR TITLE
Additional group database configuration

### DIFF
--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -15,8 +15,9 @@ func init() {
 	installationSelect = sq.
 		Select(
 			"ID", "OwnerID", "Version", "DNS", "Database", "Filestore", "Size",
-			"Affinity", "GroupID", "State", "License", "MattermostEnvRaw",
-			"CreateAt", "DeleteAt", "LockAcquiredBy", "LockAcquiredAt",
+			"Affinity", "GroupID", "GroupSequence", "State", "License",
+			"MattermostEnvRaw", "CreateAt", "DeleteAt", "LockAcquiredBy",
+			"LockAcquiredAt",
 		).
 		From("Installation")
 }
@@ -168,6 +169,7 @@ func (sqlStore *SQLStore) CreateInstallation(installation *model.Installation) e
 			"Size":             installation.Size,
 			"Affinity":         installation.Affinity,
 			"GroupID":          installation.GroupID,
+			"GroupSequence":    nil,
 			"State":            installation.State,
 			"CreateAt":         installation.CreateAt,
 			"License":          installation.License,

--- a/model/group.go
+++ b/model/group.go
@@ -7,13 +7,17 @@ import (
 
 // Group represents a group of Mattermost installations.
 type Group struct {
-	ID            string
-	Name          string
-	Description   string
-	Version       string
-	CreateAt      int64
-	DeleteAt      int64
-	MattermostEnv EnvVarMap
+	ID             string
+	Sequence       int64
+	Name           string
+	Description    string
+	Version        string
+	MaxRolling     int64
+	MattermostEnv  EnvVarMap
+	CreateAt       int64
+	DeleteAt       int64
+	LockAcquiredBy *string
+	LockAcquiredAt int64
 }
 
 // GroupFilter describes the parameters used to constrain a set of groups.

--- a/model/installation.go
+++ b/model/installation.go
@@ -11,6 +11,7 @@ type Installation struct {
 	ID             string
 	OwnerID        string
 	GroupID        *string
+	GroupSequence  *int64 `json:"GroupSequence,omitempty"`
 	Version        string
 	DNS            string
 	Database       string


### PR DESCRIPTION
This change adds group store configuration to prepare for group
supervisor work. The additional values will be used to properly
reconcile installation configuration when a group is updated.

https://mattermost.atlassian.net/browse/MM-23440
