### PR TITLE
Add group API locks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/emicklei/go-restful v2.11.2+incompatible // indirect
 	github.com/go-openapi/spec v0.19.6 // indirect
 	github.com/go-openapi/swag v0.19.7 // indirect
+	github.com/golang/mock v1.3.1
 	github.com/googleapis/gnostic v0.4.1 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/jmoiron/sqlx v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -333,6 +333,7 @@ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4er
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -1103,7 +1104,6 @@ k8s.io/kubelet v0.16.7/go.mod h1:s410QQXiHs+osdFDzTfFQXvRAQcJPZILT1cRZYLbF7s=
 k8s.io/kubernetes v1.16.0/go.mod h1:nlP2zevWKRGKuaaVbKIwozU0Rjg9leVDXkL4YTtjmVs=
 k8s.io/kubernetes v1.16.2 h1:k0f/OVp6Yfv+UMTm6VYKhqjRgcvHh4QhN9coanjrito=
 k8s.io/kubernetes v1.16.2/go.mod h1:SmhGgKfQ30imqjFVj8AI+iW+zSyFsswNErKYeTfgoH0=
-k8s.io/kubernetes v1.17.3 h1:zWCppkLfHM+hoLqfbsrQ0cJnYw+4vAvedI92oQnjo/Q=
 k8s.io/legacy-cloud-providers v0.16.7/go.mod h1:E+h9WyZSgvvjpN7GboBsACNiJmrH0oSq98I12tqoEaE=
 k8s.io/metrics v0.16.7/go.mod h1:fN+mlJol+ydBJK5BX7Zk5P9x3xcBnmZyYrp+jvX0+Bw=
 k8s.io/repo-infra v0.0.0-20181204233714-00fe14e3d1a3/go.mod h1:+G1xBfZDfVFsm1Tj/HNCvg4QqWx8rJ2Fxpqr1rqp/gQ=

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -36,6 +36,8 @@ type Store interface {
 	GetGroup(groupID string) (*model.Group, error)
 	GetGroups(filter *model.GroupFilter) ([]*model.Group, error)
 	UpdateGroup(group *model.Group) error
+	LockGroup(groupID, lockerID string) (bool, error)
+	UnlockGroup(groupID, lockerID string, force bool) (bool, error)
 	DeleteGroup(groupID string) error
 
 	CreateWebhook(webhook *model.Webhook) error

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -256,51 +256,6 @@ func TestCreateGroup(t *testing.T) {
 	})
 }
 
-func TestChangeMattermostVersion(t *testing.T) {
-	logger := testlib.MakeLogger(t)
-	sqlStore := store.MakeTestSQLStore(t, logger)
-
-	router := mux.NewRouter()
-	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
-	})
-	ts := httptest.NewServer(router)
-	defer ts.Close()
-
-	client := model.NewClient(ts.URL)
-
-	group1, err := client.CreateGroup(&model.CreateGroupRequest{
-		Name:        "name",
-		Description: "description",
-		Version:     "version",
-	})
-	require.NoError(t, err)
-
-	t.Run("good request", func(t *testing.T) {
-		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/group/%s/mattermost/%s", ts.URL, group1.ID, "5.18"), nil)
-		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(httpRequest)
-		require.Equal(t, http.StatusAccepted, resp.StatusCode)
-		require.NoError(t, err)
-	})
-	t.Run("bad version", func(t *testing.T) {
-		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/group/%s/mattermost/%s", ts.URL, group1.ID, "@!#$@#"), nil)
-		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(httpRequest)
-		require.Equal(t, http.StatusNotFound, resp.StatusCode)
-		require.NoError(t, err)
-	})
-	t.Run("bad group", func(t *testing.T) {
-		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/group/%s/mattermost/%s", ts.URL, group1.ID[:len(group1.ID)-2]+"XX", "5.17"), nil)
-		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(httpRequest)
-		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		require.NoError(t, err)
-	})
-}
-
 func TestUpdateGroup(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)

--- a/model/group_request.go
+++ b/model/group_request.go
@@ -25,11 +25,9 @@ func NewCreateGroupRequestFromReader(reader io.Reader) (*CreateGroupRequest, err
 		return nil, errors.Wrap(err, "failed to decode create group request")
 	}
 
-	if createGroupRequest.Name == "" {
-		return nil, errors.New("must specify name")
-	}
-	if createGroupRequest.Version == "" {
-		return nil, errors.New("must specify version")
+	err = createGroupRequest.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid group create request")
 	}
 
 	return &createGroupRequest, nil
@@ -37,6 +35,12 @@ func NewCreateGroupRequestFromReader(reader io.Reader) (*CreateGroupRequest, err
 
 // Validate validates the values of a group create request
 func (request *CreateGroupRequest) Validate() error {
+	if request.Name == "" {
+		return errors.New("must specify name")
+	}
+	if request.Version == "" {
+		return errors.New("must specify version")
+	}
 	err := request.MattermostEnv.Validate()
 	if err != nil {
 		return errors.Wrapf(err, "bad environment variable map in create group request")
@@ -60,6 +64,11 @@ func NewPatchGroupRequestFromReader(reader io.Reader) (*PatchGroupRequest, error
 	err := json.NewDecoder(reader).Decode(&patchGroupRequest)
 	if err != nil && err != io.EOF {
 		return nil, errors.Wrap(err, "failed to decode patch group request")
+	}
+
+	err = patchGroupRequest.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid patch group request")
 	}
 
 	return &patchGroupRequest, nil


### PR DESCRIPTION
This change does the following:
 - Group update and delete API endpoints now lock the group object
   before making changes.
 - Removed group version API endpoint. The update endpoint handles
   version and other group configuration changes.
 - Refactored group request objects and streamlined validation.

https://mattermost.atlassian.net/browse/MM-23442