### PR TITLE
MM-23607: Enhanced AWS session HTTP handler

### DIFF
--- a/internal/tools/aws/session.go
+++ b/internal/tools/aws/session.go
@@ -1,6 +1,9 @@
 package aws
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -14,9 +17,26 @@ func NewAWSSessionWithLogger(config *aws.Config, logger log.FieldLogger) (*sessi
 		return nil, err
 	}
 
-	awsSession.Handlers.Send.PushFront(func(r *request.Request) {
-		logger.Debugf("%s: %s%s\n%s", r.HTTPRequest.Method, r.HTTPRequest.URL.Host, r.HTTPRequest.URL.RawPath, r.Params)
+	awsSession.Handlers.Complete.PushFront(func(r *request.Request) {
+		loggingMessage := fmt.Sprintf("%s.%s %s %s: %s%s  %q", r.ClientInfo.ServiceID, r.Operation.Name, r.HTTPRequest.Method,
+			r.HTTPResponse.Status, r.HTTPRequest.URL.Host, r.HTTPRequest.URL.RawPath, marshallParams(r.Params))
+
+		if r.HTTPResponse.StatusCode >= 400 {
+			logger.Error(loggingMessage)
+		}
+
+		if r.HTTPResponse.StatusCode < 400 {
+			logger.Debug(loggingMessage)
+		}
 	})
 
 	return awsSession, nil
+}
+
+func marshallParams(v interface{}) string {
+	paramBytes, err := json.Marshal(v)
+	if err != nil {
+		return err.Error()
+	}
+	return string(paramBytes)
 }

--- a/internal/tools/aws/session.go
+++ b/internal/tools/aws/session.go
@@ -19,23 +19,25 @@ func NewAWSSessionWithLogger(config *aws.Config, logger log.FieldLogger) (*sessi
 	}
 
 	awsSession.Handlers.Complete.PushFront(func(r *request.Request) {
-		var buffer bytes.Buffer
-		buffer.WriteString(fmt.Sprintf("%s.%s %s %s: %s%s  ", r.ClientInfo.ServiceID, r.Operation.Name, r.HTTPRequest.Method,
-			r.HTTPResponse.Status, r.HTTPRequest.URL.Host, r.HTTPRequest.URL.RawPath))
+		if r.HTTPResponse != nil && r.HTTPRequest != nil {
+			var buffer bytes.Buffer
+			buffer.WriteString(fmt.Sprintf("%s.%s %s %s: %s%s  ", r.ClientInfo.ServiceID, r.Operation.Name, r.HTTPRequest.Method,
+				r.HTTPResponse.Status, r.HTTPRequest.URL.Host, r.HTTPRequest.URL.RawPath))
 
-		paramBytes, err := json.Marshal(r.Params)
-		if err != nil {
-			buffer.WriteString(err.Error())
-		} else {
-			buffer.Write(paramBytes)
-		}
+			paramBytes, err := json.Marshal(r.Params)
+			if err != nil {
+				buffer.WriteString(err.Error())
+			} else {
+				buffer.Write(paramBytes)
+			}
 
-		if r.HTTPResponse.StatusCode >= 400 {
-			logger.Error(buffer.String())
-		}
+			if r.HTTPResponse.StatusCode >= 400 {
+				logger.Error(buffer.String())
+			}
 
-		if r.HTTPResponse.StatusCode < 400 {
-			logger.Debug(buffer.String())
+			if r.HTTPResponse.StatusCode < 400 {
+				logger.Debug(buffer.String())
+			}
 		}
 	})
 


### PR DESCRIPTION
#### Summary
This PR changes tools/session handler to log HTTP errors as well as successful calls to AWS. It also remove new lines that could potentially break consumers.

New logging messages will look like this:
```
ERROR[2020-03-26T13:41:26-07:00] [aws] GET 404 Not Found: https://route53.amazonaws.com/2013-04-01/hostedzone/ZWI3O6O6N782C/rrset?name=gsagula-stuff4-test.dev.cloud.mattermost.com aws-operation-name=ListResourceRecordSets aws-service-id="Route 53" instance=dyhzb81a5injzk65nn5okuusda tools-aws=client

DEBUG[2020-03-26T13:41:27-07:00] [aws] POST 200 OK: https://route53.amazonaws.com/2013-04-01/hostedzone/ZWI3O6O6N782C/rrset/ {"ChangeBatch":{"Changes":[{"Action":"DELETE","ResourceRecordSet":{"AliasTarget":null,"Failover":null,"GeoLocation":null,"HealthCheckId":null,"MultiValueAnswer":null,"Name":"gsagula-stuff4-test.dev.cloud.mattermost.com.","Region":null,"ResourceRecords":[{"Value":"ac4cb1f8bd1b043a9869331c1a4c3a37-97467332.us-east-1.elb.amazonaws.com"}],"SetIdentifier":"gsagula-stuff4-test.dev.cloud.mattermost.com","TTL":60,"TrafficPolicyInstanceId":null,"Type":"CNAME","Weight":1}}],"Comment":null},"HostedZoneId":"ZWI3O6O6N782C"}  aws-operation-name=ChangeResourceRecordSets aws-service-id="Route 53" instance=dyhzb81a5injzk65nn5okuusda tools-aws=client
```

Fixes:  https://mattermost.atlassian.net/browse/MM-23607