### PR TITLE
Add group supervisor for installation updates

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -36,6 +36,7 @@ func init() {
 	serverCmd.PersistentFlags().String("database", "sqlite://cloud.db", "The database backing the provisioning server.")
 	serverCmd.PersistentFlags().String("listen", ":8075", "The interface and port on which to listen.")
 	serverCmd.PersistentFlags().Bool("cluster-supervisor", true, "Whether this server will run a cluster supervisor or not.")
+	serverCmd.PersistentFlags().Bool("group-supervisor", false, "Whether this server will run an installation group supervisor or not.")
 	serverCmd.PersistentFlags().Bool("installation-supervisor", true, "Whether this server will run an installation supervisor or not.")
 	serverCmd.PersistentFlags().Bool("cluster-installation-supervisor", true, "Whether this server will run a cluster installation supervisor or not.")
 	serverCmd.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
@@ -90,9 +91,10 @@ var serverCmd = &cobra.Command{
 		}
 
 		clusterSupervisor, _ := command.Flags().GetBool("cluster-supervisor")
-		clusterInstallationSupervisor, _ := command.Flags().GetBool("cluster-installation-supervisor")
+		groupSupervisor, _ := command.Flags().GetBool("group-supervisor")
 		installationSupervisor, _ := command.Flags().GetBool("installation-supervisor")
-		if !clusterSupervisor && !installationSupervisor && !clusterInstallationSupervisor {
+		clusterInstallationSupervisor, _ := command.Flags().GetBool("cluster-installation-supervisor")
+		if !clusterSupervisor && !installationSupervisor && !clusterInstallationSupervisor && !groupSupervisor {
 			logger.Warn("Server will be running with no supervisors. Only API functionality will work.")
 		}
 
@@ -109,6 +111,7 @@ var serverCmd = &cobra.Command{
 
 		logger.WithFields(logrus.Fields{
 			"cluster-supervisor":              clusterSupervisor,
+			"group-supervisor":                groupSupervisor,
 			"installation-supervisor":         installationSupervisor,
 			"cluster-installation-supervisor": clusterInstallationSupervisor,
 			"store-version":                   currentVersion,
@@ -152,6 +155,9 @@ var serverCmd = &cobra.Command{
 		var multiDoer supervisor.MultiDoer
 		if clusterSupervisor {
 			multiDoer = append(multiDoer, supervisor.NewClusterSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, logger))
+		}
+		if groupSupervisor {
+			multiDoer = append(multiDoer, supervisor.NewGroupSupervisor(sqlStore, instanceID, logger))
 		}
 		if installationSupervisor {
 			multiDoer = append(multiDoer, supervisor.NewInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, clusterResourceThreshold, keepDatabaseData, keepFilestoreData, resourceUtil, logger))

--- a/internal/store/helpers.go
+++ b/internal/store/helpers.go
@@ -31,3 +31,24 @@ func (sqlStore *SQLStore) tableExists(tableName string) (bool, error) {
 
 	return tableExists, nil
 }
+
+// countResult handles differences in how count queries can be returned.
+type countResult []struct {
+	Count         int64 `db:"count"`
+	CountWildcard int64 `db:"Count (*)"`
+}
+
+// value checks the countResult and returns the correct count value.
+func (c countResult) value() (int64, error) {
+	if len(c) == 0 {
+		return 0, errors.New("no count result returned")
+	}
+	if c[0].Count != 0 {
+		return c[0].Count, nil
+	}
+	if c[0].CountWildcard != 0 {
+		return c[0].CountWildcard, nil
+	}
+
+	return 0, nil
+}

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -220,6 +220,44 @@ func (sqlStore *SQLStore) UpdateInstallation(installation *model.Installation) e
 	return nil
 }
 
+// UpdateInstallationGroupSequence updates the given installation GroupSequence
+// to the value stored in the merged group config. The provided installation must
+// have been merged with group config before passing it in.
+func (sqlStore *SQLStore) UpdateInstallationGroupSequence(installation *model.Installation) error {
+	if !installation.ConfigMergedWithGroup() {
+		return errors.New("installation is not merged with a group")
+	}
+
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Update("Installation").
+		SetMap(map[string]interface{}{
+			"GroupSequence": installation.GroupSequence,
+		}).
+		Where("ID = ?", installation.ID),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to update installation")
+	}
+
+	return nil
+}
+
+// UpdateInstallationState updates the given installation to a new state.
+func (sqlStore *SQLStore) UpdateInstallationState(id, state string) error {
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Update("Installation").
+		SetMap(map[string]interface{}{
+			"State": state,
+		}).
+		Where("ID = ?", id),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to update installation state")
+	}
+
+	return nil
+}
+
 // DeleteInstallation marks the given installation as deleted, but does not remove the record from the
 // database.
 func (sqlStore *SQLStore) DeleteInstallation(id string) error {

--- a/internal/supervisor/group.go
+++ b/internal/supervisor/group.go
@@ -1,0 +1,113 @@
+package supervisor
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+// groupStore abstracts the database operations required to query groups.
+type groupStore interface {
+	GetUnlockedGroupsPendingWork() ([]*model.Group, error)
+	GetGroupRollingMetadata(groupID string) (*store.GroupRollingMetadata, error)
+	LockGroup(groupID, lockerID string) (bool, error)
+	UnlockGroup(groupID, lockerID string, force bool) (bool, error)
+
+	GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error)
+	UpdateInstallationState(id, state string) error
+	LockInstallation(installationID, lockerID string) (bool, error)
+	UnlockInstallation(installationID, lockerID string, force bool) (bool, error)
+}
+
+// GroupSupervisor finds installations belonging to groups that need to have
+// their configuration reconciled to match a new group configuration setting.
+//
+// The degree of parallelism is controlled by a weighted semaphore, intended to
+// be shared with other clients needing to coordinate background jobs.
+type GroupSupervisor struct {
+	store      groupStore
+	instanceID string
+	logger     log.FieldLogger
+}
+
+// NewGroupSupervisor creates a new GroupSupervisor.
+func NewGroupSupervisor(store groupStore, instanceID string, logger log.FieldLogger) *GroupSupervisor {
+	return &GroupSupervisor{
+		store:      store,
+		instanceID: instanceID,
+		logger:     logger,
+	}
+}
+
+// Do looks for work to be done on any pending groups and attempts to schedule
+// the required work.
+func (s *GroupSupervisor) Do() error {
+	groups, err := s.store.GetUnlockedGroupsPendingWork()
+	if err != nil {
+		s.logger.WithError(err).Warn("Failed to query for groups")
+		return nil
+	}
+
+	for _, group := range groups {
+		s.Supervise(group)
+	}
+
+	return nil
+}
+
+// Supervise schedules the required work on the given group.
+func (s *GroupSupervisor) Supervise(group *model.Group) {
+	logger := s.logger.WithFields(log.Fields{
+		"group": group.ID,
+	})
+
+	groupLock := newGroupLock(group.ID, s.instanceID, s.store, logger)
+	if !groupLock.TryLock() {
+		return
+	}
+	defer groupLock.Unlock()
+
+	logger.Debug("Supervising group")
+
+	groupMetadata, err := s.store.GetGroupRollingMetadata(group.ID)
+	if err != nil {
+		logger.WithError(err).Error("Unable to get installations in group")
+		return
+	}
+
+	logger = logger.WithFields(log.Fields{
+		"maxRolling":            group.MaxRolling,
+		"installations-total":   groupMetadata.InstallationTotalCount,
+		"installations-rolling": groupMetadata.InstallationNonStableCount,
+	})
+
+	if int64(groupMetadata.InstallationNonStableCount) >= group.MaxRolling {
+		logger.Infof("Group already has %d rolling installations with a max of %d", groupMetadata.InstallationNonStableCount, group.MaxRolling)
+		return
+	}
+
+	var moved int64
+	for _, id := range groupMetadata.InstallationIDsToBeRolled {
+		if groupMetadata.InstallationNonStableCount+moved >= group.MaxRolling {
+			// We have bumped up against the max rolling count with the new
+			// installations added to the rolling pool.
+			break
+		}
+
+		installationLock := newInstallationLock(id, s.instanceID, s.store, logger)
+		if !installationLock.TryLock() {
+			return
+		}
+
+		err = s.store.UpdateInstallationState(id, model.InstallationStateUpdateRequested)
+		if err != nil {
+			logger.WithError(err).Error("Unable to set new installation state")
+		} else {
+			moved++
+		}
+		installationLock.Unlock()
+	}
+
+	logger.Infof("Moved %d installations to %s", moved, model.InstallationStateUpdateRequested)
+}

--- a/internal/supervisor/group_lock.go
+++ b/internal/supervisor/group_lock.go
@@ -1,0 +1,45 @@
+package supervisor
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+type groupLockStore interface {
+	LockGroup(groupID, lockerID string) (bool, error)
+	UnlockGroup(groupID, lockerID string, force bool) (bool, error)
+}
+
+type groupLock struct {
+	groupID  string
+	lockerID string
+	store    groupLockStore
+	logger   log.FieldLogger
+}
+
+func newGroupLock(groupID, lockerID string, store groupLockStore, logger log.FieldLogger) *groupLock {
+	return &groupLock{
+		groupID:  groupID,
+		lockerID: lockerID,
+		store:    store,
+		logger:   logger,
+	}
+}
+
+func (l *groupLock) TryLock() bool {
+	locked, err := l.store.LockGroup(l.groupID, l.lockerID)
+	if err != nil {
+		l.logger.WithError(err).Error("failed to lock group")
+		return false
+	}
+
+	return locked
+}
+
+func (l *groupLock) Unlock() {
+	unlocked, err := l.store.UnlockGroup(l.groupID, l.lockerID, false)
+	if err != nil {
+		l.logger.WithError(err).Error("failed to unlock group")
+	} else if unlocked != true {
+		l.logger.Error("failed to release lock for group")
+	}
+}

--- a/internal/supervisor/group_test.go
+++ b/internal/supervisor/group_test.go
@@ -1,0 +1,106 @@
+package supervisor_test
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/supervisor"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/require"
+)
+
+type mockGroupStore struct {
+	Group                     *model.Group
+	UnlockedGroupsPendingWork []*model.Group
+	GroupRollingMetadata      *store.GroupRollingMetadata
+
+	Installation *model.Installation
+
+	UnlockChan              chan interface{}
+	UpdateInstallationCalls int
+}
+
+func (s *mockGroupStore) GetUnlockedGroupsPendingWork() ([]*model.Group, error) {
+	return s.UnlockedGroupsPendingWork, nil
+}
+
+func (s *mockGroupStore) GetGroupRollingMetadata(groupID string) (*store.GroupRollingMetadata, error) {
+	return s.GroupRollingMetadata, nil
+}
+
+func (s *mockGroupStore) LockGroup(groupID, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (s *mockGroupStore) UnlockGroup(groupID, lockerID string, force bool) (bool, error) {
+	if s.UnlockChan != nil {
+		close(s.UnlockChan)
+	}
+	return true, nil
+}
+
+func (s *mockGroupStore) GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error) {
+	return s.Installation, nil
+}
+
+func (s *mockGroupStore) UpdateInstallation(installation *model.Installation) error {
+	s.UpdateInstallationCalls++
+	return nil
+}
+
+func (s *mockGroupStore) UpdateInstallationState(id, state string) error {
+	s.UpdateInstallationCalls++
+	return nil
+}
+
+func (s *mockGroupStore) LockInstallation(installationID, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (s *mockGroupStore) UnlockInstallation(installationID, lockerID string, force bool) (bool, error) {
+	if s.UnlockChan != nil {
+		close(s.UnlockChan)
+	}
+	return true, nil
+}
+
+func TestGroupSupervisorDo(t *testing.T) {
+	t.Run("no groups pending work", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		mockStore := &mockGroupStore{}
+
+		supervisor := supervisor.NewGroupSupervisor(mockStore, "instanceID", logger)
+		err := supervisor.Do()
+		require.NoError(t, err)
+
+		require.Equal(t, 0, mockStore.UpdateInstallationCalls)
+	})
+
+	t.Run("mock group and installation creation", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		mockStore := &mockGroupStore{}
+
+		mockStore.UnlockedGroupsPendingWork = []*model.Group{&model.Group{
+			ID: model.NewID(),
+		}}
+		mockStore.Group = mockStore.UnlockedGroupsPendingWork[0]
+
+		mockStore.Installation = &model.Installation{
+			ID:      model.NewID(),
+			GroupID: &mockStore.Group.ID,
+		}
+
+		mockStore.GroupRollingMetadata = &store.GroupRollingMetadata{
+			InstallationIDsToBeRolled: []string{mockStore.Installation.ID},
+		}
+		mockStore.UnlockChan = make(chan interface{})
+
+		supervisor := supervisor.NewGroupSupervisor(mockStore, "instanceID", logger)
+		err := supervisor.Do()
+		require.NoError(t, err)
+
+		<-mockStore.UnlockChan
+		require.Equal(t, 0, mockStore.UpdateInstallationCalls)
+	})
+}

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -54,6 +54,10 @@ func (s *mockInstallationStore) UpdateInstallation(installation *model.Installat
 	return nil
 }
 
+func (s *mockInstallationStore) UpdateInstallationGroupSequence(installation *model.Installation) error {
+	return nil
+}
+
 func (s *mockInstallationStore) LockInstallation(installationID, lockerID string) (bool, error) {
 	return true, nil
 }


### PR DESCRIPTION
The group supervisor is responsible for managing rolling updates
to installations when a group's configuration is updated. It does
this by moving installations in the group to an update-requested
state while respecting the group's MaxRolling setting.

Note that the cloud server still does not apply merged group config
to installations so the group supervisor is disabled by default.
This will be changed in a future commit.

This change also corrects a SQL query bug as well as a bug with
how group merged config overrides are reported.

https://mattermost.atlassian.net/browse/MM-23154

