### PR TITLE
Require flags for 'cluster installation mattermost-cli` command

### DIFF
--- a/cmd/cloud/cluster_installation.go
+++ b/cmd/cloud/cluster_installation.go
@@ -31,6 +31,8 @@ func init() {
 
 	clusterInstallationMattermostCLICmd.Flags().String("cluster-installation", "", "The id of the cluster installation.")
 	clusterInstallationMattermostCLICmd.Flags().String("command", "", "The Mattermost CLI subcommand to run.")
+	clusterInstallationMattermostCLICmd.MarkFlagRequired("cluster-installation")
+	clusterInstallationMattermostCLICmd.MarkFlagRequired("command")
 
 	clusterInstallationCmd.AddCommand(clusterInstallationGetCmd)
 	clusterInstallationCmd.AddCommand(clusterInstallationListCmd)


### PR DESCRIPTION
These flags are always required so let's provide better feedback
if they are missing.