### PR TITLE
Enable group functionality

### DIFF
--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -23,7 +23,7 @@ type Store interface {
 
 	CreateInstallation(installation *model.Installation) error
 	GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error)
-	GetInstallations(filter *model.InstallationFilter) ([]*model.Installation, error)
+	GetInstallations(filter *model.InstallationFilter, includeGroupConfig, includeGroupConfigOverrides bool) ([]*model.Installation, error)
 	UpdateInstallation(installation *model.Installation) error
 	LockInstallation(installationID, lockerID string) (bool, error)
 	UnlockInstallation(installationID, lockerID string, force bool) (bool, error)

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -160,7 +160,7 @@ func handleDeleteGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 		Page:           0,
 		PerPage:        model.AllPerPage,
 		IncludeDeleted: false,
-	})
+	}, false, false)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to get installations in group")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -55,12 +55,12 @@ func parsePaging(u *url.URL) (int, int, bool, error) {
 }
 
 func parseGroupConfig(u *url.URL) (bool, bool, error) {
-	includeGroupConfig, err := parseBool(u, "include_group_config", false)
+	includeGroupConfig, err := parseBool(u, "include_group_config", true)
 	if err != nil {
 		return false, false, err
 	}
 
-	includeGroupConfigOverrides, err := parseBool(u, "include_group_config_overrides", false)
+	includeGroupConfigOverrides, err := parseBool(u, "include_group_config_overrides", true)
 	if err != nil {
 		return false, false, err
 	}

--- a/internal/store/group.go
+++ b/internal/store/group.go
@@ -258,7 +258,9 @@ func (sqlStore *SQLStore) UpdateGroup(group *model.Group) error {
 	if err != nil {
 		return err
 	}
-	if originalGroup.Version != group.Version || reflect.DeepEqual(originalGroup.MattermostEnv, group.MattermostEnv) {
+	if originalGroup.Version != group.Version ||
+		originalGroup.Image != group.Image ||
+		!reflect.DeepEqual(originalGroup.MattermostEnv, group.MattermostEnv) {
 		// Update the sequence number, but don't trust the group sequence number
 		// that was passed in.
 		group.Sequence = originalGroup.Sequence + 1

--- a/internal/store/group_test.go
+++ b/internal/store/group_test.go
@@ -463,7 +463,7 @@ func TestGetGroupRollingMetadata(t *testing.T) {
 		}
 		metadata, err = sqlStore.GetGroupRollingMetadata(group1.ID)
 		require.NoError(t, err)
-		require.Equal(t, expectedMetadata, metadata)
+		assert.Equal(t, expectedMetadata, metadata)
 	})
 }
 
@@ -501,6 +501,7 @@ func TestUpdateGroup(t *testing.T) {
 
 	oldSequence = group1.Sequence
 	group1.Sequence = 9001
+	group1.Version = "version4"
 
 	err = sqlStore.UpdateGroup(group1)
 	require.NoError(t, err)

--- a/internal/supervisor/cluster_installation.go
+++ b/internal/supervisor/cluster_installation.go
@@ -148,7 +148,7 @@ func (s *ClusterInstallationSupervisor) transitionClusterInstallation(clusterIns
 		return failedClusterInstallationState(clusterInstallation.State)
 	}
 
-	installation, err := s.store.GetInstallation(clusterInstallation.InstallationID, false, false)
+	installation, err := s.store.GetInstallation(clusterInstallation.InstallationID, true, false)
 	if err != nil {
 		logger.WithError(err).Warnf("Failed to query installation %s", clusterInstallation.InstallationID)
 		return clusterInstallation.State

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -58,6 +58,11 @@ func (s *mockInstallationStore) UpdateInstallationGroupSequence(installation *mo
 	return nil
 }
 
+func (s *mockInstallationStore) UpdateInstallationState(installation *model.Installation) error {
+	s.UpdateInstallationCalls++
+	return nil
+}
+
 func (s *mockInstallationStore) LockInstallation(installationID, lockerID string) (bool, error) {
 	return true, nil
 }

--- a/model/installation.go
+++ b/model/installation.go
@@ -101,6 +101,13 @@ func (i *Installation) MergeWithGroup(group *Group, includeOverrides bool) {
 		}
 		i.Version = group.Version
 	}
+	if i.Image != group.Image {
+		if includeOverrides {
+			i.GroupOverrides["Installation Image"] = i.Image
+			i.GroupOverrides["Group Image"] = group.Image
+		}
+		i.Image = group.Image
+	}
 	for key, value := range group.MattermostEnv {
 		if includeOverrides {
 			if _, ok := i.MattermostEnv[key]; ok {

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -14,6 +14,7 @@ import (
 // CreateInstallationRequest specifies the parameters for a new installation.
 type CreateInstallationRequest struct {
 	OwnerID       string
+	GroupID       string
 	Version       string
 	Image         string
 	DNS           string
@@ -102,7 +103,7 @@ func NewCreateInstallationRequestFromReader(reader io.Reader) (*CreateInstallati
 
 // GetInstallationRequest describes the parameters to request an installation.
 type GetInstallationRequest struct {
-	IncludeGroupConfig          bool `json:"include_group_config"`
+	IncludeGroupConfig          bool
 	IncludeGroupConfigOverrides bool
 }
 
@@ -112,27 +113,37 @@ func (request *GetInstallationRequest) ApplyToURL(u *url.URL) {
 		return
 	}
 	q := u.Query()
-	if request.IncludeGroupConfig {
-		q.Add("include_group_config", "true")
+	if !request.IncludeGroupConfig {
+		q.Add("include_group_config", "false")
 	}
-	if request.IncludeGroupConfigOverrides {
-		q.Add("include_group_config_overrides", "true")
+	if !request.IncludeGroupConfigOverrides {
+		q.Add("include_group_config_overrides", "false")
 	}
 	u.RawQuery = q.Encode()
 }
 
 // GetInstallationsRequest describes the parameters to request a list of installations.
 type GetInstallationsRequest struct {
-	OwnerID        string
-	Page           int
-	PerPage        int
-	IncludeDeleted bool
+	OwnerID                     string
+	GroupID                     string
+	IncludeGroupConfig          bool
+	IncludeGroupConfigOverrides bool
+	Page                        int
+	PerPage                     int
+	IncludeDeleted              bool
 }
 
 // ApplyToURL modifies the given url to include query string parameters for the request.
 func (request *GetInstallationsRequest) ApplyToURL(u *url.URL) {
 	q := u.Query()
 	q.Add("owner", request.OwnerID)
+	q.Add("group", request.GroupID)
+	if !request.IncludeGroupConfig {
+		q.Add("include_group_config", "false")
+	}
+	if !request.IncludeGroupConfigOverrides {
+		q.Add("include_group_config_overrides", "false")
+	}
 	q.Add("page", strconv.Itoa(request.Page))
 	q.Add("per_page", strconv.Itoa(request.PerPage))
 	if request.IncludeDeleted {


### PR DESCRIPTION
This change does the following:
 - Enables group configuration merging by default when creating
   and updating installations.
 - Provides API functionality for updating group config such as
   Max Rolling.
 - Provides API functionality for returning installation objects
   with or without group configuration merged in. Default setting
   is to return merged config.
 - Provides API functionality to return installations belonging to
   a single group.
 - Adds Image configuration merging logic.
 - Many, many more tests.

Note: the group supervisor which manages lazy installation updates
due to group configuration updates still defaults to not-running
with default server flags. This can be manually enabled for now
and the default will be changed later.

https://mattermost.atlassian.net/browse/MM-22506

