### PR TITLE
Version should actually not be required for update

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -30,7 +30,6 @@ func init() {
 	installationUpdateCmd.Flags().String("license", "", "The Mattermost License to use in the server.")
 	installationUpdateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	installationUpdateCmd.MarkFlagRequired("installation")
-	installationUpdateCmd.MarkFlagRequired("version")
 
 	installationDeleteCmd.Flags().String("installation", "", "The id of the installation to be deleted.")
 	installationDeleteCmd.MarkFlagRequired("installation")


### PR DESCRIPTION
`--version` is marked as a required field for `cloud installation update` and it should not be, as the user may only wish to use `--mattermost-env`. Perhaps there should be a check to make sure one of the flags is used, but in any case, the tool shouldn't force you to specify `--version` in this case.

Pretty sure this was my mistake originally, whoops!