### PR TITLE
MM-23550 Add DELETE permission for S3 buckets for cloud user

### DIFF
--- a/internal/tools/aws/iam.go
+++ b/internal/tools/aws/iam.go
@@ -168,6 +168,7 @@ func (a *Client) iamEnsurePolicyCreated(awsID, policyARN string, logger log.Fiel
 					"s3:PutObject",
 					"s3:ListBucket",
 					"s3:PutObjectAcl",
+					"s3:DeleteObject",
 				},
 				Resource: fmt.Sprintf("arn:aws:s3:::%s/*", awsID),
 			},


### PR DESCRIPTION
Resolves [MM-23550](https://mattermost.atlassian.net/browse/MM-23550) by adding a `DELETE` permission to the IAM user created for a cloud instance at creation time. MM-23550 was caused by a 403 issued by AWS due to the missing permission on this user.

One thing to note, that I'm not sure about, is that I am seeing a couple of error logs generated by the AWS library that I don't see without this change:

```
INFO[2020-03-30T17:13:34-05:00] Provisioning AWS S3 filestore                 installation=j5grybimefb5jqnysefxtcrhna instance=4jj1shoyn3riipqa37h7ztarbw
ERRO[2020-03-30T17:13:34-05:00] [aws] POST 404 Not Found https://iam.amazonaws.com/ {"UserName":"cloud-j5grybimefb5jqnysefxtcrhna"}  aws-operation-name=GetUser aws-service-id=IAM instance=4jj1shoyn3riipqa37h7ztarbw tools-aws=client
ERRO[2020-03-30T17:13:35-05:00] [aws] POST 404 Not Found https://iam.amazonaws.com/ {"PolicyArn":"arn:aws:iam::926412419614:policy/cloud-j5grybimefb5jqnysefxtcrhna"}  aws-operation-name=GetPolicy aws-service-id=IAM instance=4jj1shoyn3riipqa37h7ztarbw tools-aws=client
```

However, debugging shows that these come from a part of the code where we attempt to get a user to see if it exists and then the actions taken if it does not exist are part of normal execution, so these ERROR logs are themselves in error, but I'm not exactly sure how to suppress them, because they bubble up out of the `aws-sdk-go` library.