### PR TITLE
update kubectl to match the kops image and bump alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@
 
 ## Docker Build Versions
 DOCKER_BUILD_IMAGE = golang:1.13
-DOCKER_BASE_IMAGE = alpine:3.10
+DOCKER_BASE_IMAGE = alpine:3.11
 
 ## Tool Versions
 TERRAFORM_VERSION=0.11.14
 KOPS_VERSION=1.15.0
 HELM_VERSION=v2.14.2
-KUBECTL_VERSION=v1.14.0
+KUBECTL_VERSION=v1.15.0
 
 ################################################################################
 


### PR DESCRIPTION
#### Summary
- bump kubectl to match the kops version
- update the alpine version 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

