### PR TITLE
MM-23707 Add support for new helm repos

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -319,7 +319,7 @@ func processUtilityFlags(command *cobra.Command) map[string]string {
 	fluentbitVersion, _ := command.Flags().GetString("fluentbit-version")
 	nginxVersion, _ := command.Flags().GetString("nginx-version")
 	publicnginxVersion, _ := command.Flags().GetString("public-nginx-version")
-	certmanagerVersion, _ := command.Flags().GetString("cert-manager-version")
+	certManagerVersion, _ := command.Flags().GetString("cert-manager-version")
 
 	utilityVersions := make(map[string]string)
 

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -23,11 +23,15 @@ func init() {
 	clusterCreateCmd.Flags().String("prometheus-version", model.PrometheusDefaultVersion, "The version of Prometheus to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("fluentbit-version", model.FluentbitDefaultVersion, "The version of Fluentbit to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("nginx-version", model.NginxDefaultVersion, "The version of Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().String("publicnginx-version", model.PublicNginxDefaultVersion, "The version of Public Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().String("certmanager-version", model.CertManagerDefaultVersion, "The version of Cert Manager to provision. Use 'stable' to provision the latest stable version published upstream.")
 
 	clusterProvisionCmd.Flags().String("cluster", "", "The id of the cluster to be provisioned.")
 	clusterProvisionCmd.Flags().String("prometheus-version", "", "The version of Prometheus to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.Flags().String("fluentbit-version", "", "The version of Fluentbit to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.Flags().String("nginx-version", "", "The version of Nginx to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
+	clusterProvisionCmd.Flags().String("publicnginx-version", "", "The version of Public Nginx to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
+	clusterProvisionCmd.Flags().String("certmanager-version", "", "The version of Cert Manager to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.MarkFlagRequired("cluster")
 
 	clusterUpdateCmd.Flags().String("cluster", "", "The id of the cluster to be updated.")
@@ -314,6 +318,8 @@ func processUtilityFlags(command *cobra.Command) map[string]string {
 	prometheusVersion, _ := command.Flags().GetString("prometheus-version")
 	fluentbitVersion, _ := command.Flags().GetString("fluentbit-version")
 	nginxVersion, _ := command.Flags().GetString("nginx-version")
+	publicnginxVersion, _ := command.Flags().GetString("publicnginx-version")
+	certmanagerVersion, _ := command.Flags().GetString("certmanager-version")
 
 	utilityVersions := make(map[string]string)
 
@@ -327,6 +333,14 @@ func processUtilityFlags(command *cobra.Command) map[string]string {
 
 	if nginxVersion != "" {
 		utilityVersions[model.NginxCanonicalName] = nginxVersion
+	}
+
+	if publicnginxVersion != "" {
+		utilityVersions[model.PublicNginxCanonicalName] = publicnginxVersion
+	}
+
+	if certmanagerVersion != "" {
+		utilityVersions[model.CertManagerCanonicalName] = certmanagerVersion
 	}
 
 	return utilityVersions

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -318,7 +318,7 @@ func processUtilityFlags(command *cobra.Command) map[string]string {
 	prometheusVersion, _ := command.Flags().GetString("prometheus-version")
 	fluentbitVersion, _ := command.Flags().GetString("fluentbit-version")
 	nginxVersion, _ := command.Flags().GetString("nginx-version")
-	publicnginxVersion, _ := command.Flags().GetString("public-nginx-version")
+	publicNginxVersion, _ := command.Flags().GetString("public-nginx-version")
 	certManagerVersion, _ := command.Flags().GetString("cert-manager-version")
 
 	utilityVersions := make(map[string]string)

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -335,12 +335,12 @@ func processUtilityFlags(command *cobra.Command) map[string]string {
 		utilityVersions[model.NginxCanonicalName] = nginxVersion
 	}
 
-	if publicnginxVersion != "" {
-		utilityVersions[model.PublicNginxCanonicalName] = publicnginxVersion
+	if publicNginxVersion != "" {
+		utilityVersions[model.PublicNginxCanonicalName] = publicNginxVersion
 	}
 
-	if certmanagerVersion != "" {
-		utilityVersions[model.CertManagerCanonicalName] = certmanagerVersion
+	if certManagerVersion != "" {
+		utilityVersions[model.CertManagerCanonicalName] = certManagerVersion
 	}
 
 	return utilityVersions

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -23,15 +23,15 @@ func init() {
 	clusterCreateCmd.Flags().String("prometheus-version", model.PrometheusDefaultVersion, "The version of Prometheus to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("fluentbit-version", model.FluentbitDefaultVersion, "The version of Fluentbit to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("nginx-version", model.NginxDefaultVersion, "The version of Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
-	clusterCreateCmd.Flags().String("publicnginx-version", model.PublicNginxDefaultVersion, "The version of Public Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
-	clusterCreateCmd.Flags().String("certmanager-version", model.CertManagerDefaultVersion, "The version of Cert Manager to provision. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().String("public-nginx-version", model.PublicNginxDefaultVersion, "The version of Public Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().String("cert-manager-version", model.CertManagerDefaultVersion, "The version of Cert Manager to provision. Use 'stable' to provision the latest stable version published upstream.")
 
 	clusterProvisionCmd.Flags().String("cluster", "", "The id of the cluster to be provisioned.")
 	clusterProvisionCmd.Flags().String("prometheus-version", "", "The version of Prometheus to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.Flags().String("fluentbit-version", "", "The version of Fluentbit to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.Flags().String("nginx-version", "", "The version of Nginx to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
-	clusterProvisionCmd.Flags().String("publicnginx-version", "", "The version of Public Nginx to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
-	clusterProvisionCmd.Flags().String("certmanager-version", "", "The version of Cert Manager to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
+	clusterProvisionCmd.Flags().String("public-nginx-version", "", "The version of Public Nginx to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
+	clusterProvisionCmd.Flags().String("cert-manager-version", "", "The version of Cert Manager to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.MarkFlagRequired("cluster")
 
 	clusterUpdateCmd.Flags().String("cluster", "", "The id of the cluster to be updated.")
@@ -318,8 +318,8 @@ func processUtilityFlags(command *cobra.Command) map[string]string {
 	prometheusVersion, _ := command.Flags().GetString("prometheus-version")
 	fluentbitVersion, _ := command.Flags().GetString("fluentbit-version")
 	nginxVersion, _ := command.Flags().GetString("nginx-version")
-	publicnginxVersion, _ := command.Flags().GetString("publicnginx-version")
-	certmanagerVersion, _ := command.Flags().GetString("certmanager-version")
+	publicnginxVersion, _ := command.Flags().GetString("public-nginx-version")
+	certmanagerVersion, _ := command.Flags().GetString("cert-manager-version")
 
 	utilityVersions := make(map[string]string)
 

--- a/internal/provisioner/certmanager.go
+++ b/internal/provisioner/certmanager.go
@@ -152,9 +152,9 @@ func deployClusterIssuer(kops *kops.Cmd, logger log.FieldLogger) error {
 		logger.Infof("Successfully deployed cert-manager-webhook pod %q", pod.Name)
 	}
 
-	maxRetries := 5
+	maxRetries := 10
 	logger.Infof("Trying up to %d times for cluster issuer to be deployed", maxRetries)
-	err = utils.Retry(maxRetries, time.Second, func() error {
+	err = utils.Retry(maxRetries, time.Second*2, func() error {
 		files := []k8s.ManifestFile{
 			{
 				Path:            "certmanager-manifests/cluster-issuer.yaml",

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -35,7 +35,7 @@ type helmDeployment struct {
 	logger          log.FieldLogger
 }
 
-func installHelm(kops *kops.Cmd, logger log.FieldLogger) error {
+func installHelm(kops *kops.Cmd, repos map[string]string, logger log.FieldLogger) error {
 	logger.Info("Installing Helm")
 
 	err := helmSetup(logger, kops)
@@ -53,6 +53,13 @@ func installHelm(kops *kops.Cmd, logger log.FieldLogger) error {
 	}
 
 	logger.Info("Updating all Helm repos.")
+	for repoName, repoURL := range repos {
+		err = helmRepoAdd(repoName, repoURL, logger)
+
+	}
+	if err != nil {
+		return errors.Wrap(err, "unable to add helm repos")
+	}
 	return helmRepoUpdate(logger)
 }
 
@@ -90,6 +97,30 @@ func waitForHelmRunning(ctx context.Context, configPath string) error {
 		case <-time.After(5 * time.Second):
 		}
 	}
+}
+
+// helmRepoAdd adds new helm repos
+func helmRepoAdd(repoName, repoURL string, logger log.FieldLogger) error {
+	logger.Infof("Adding helm repo %s", repoName)
+	arguments := []string{
+		"repo",
+		"add",
+		repoName,
+		repoURL,
+	}
+
+	helmClient, err := helm.New(logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to create helm wrapper")
+	}
+	defer helmClient.Close()
+
+	err = helmClient.RunGenericCommand(arguments...)
+	if err != nil {
+		return errors.Wrapf(err, "unable to add repo %s", repoName)
+	}
+
+	return nil
 }
 
 // helmRepoUpdate updates the helm repos to get latest available charts

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -55,7 +55,6 @@ func installHelm(kops *kops.Cmd, repos map[string]string, logger log.FieldLogger
 	logger.Info("Updating all Helm repos.")
 	for repoName, repoURL := range repos {
 		err = helmRepoAdd(repoName, repoURL, logger)
-
 	}
 	if err != nil {
 		return errors.Wrap(err, "unable to add helm repos")

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -118,8 +118,13 @@ func (group utilityGroup) CreateUtilityGroup() error {
 		return errors.Wrap(err, "failed to deploy Cert Manager manifests")
 	}
 
+	// List of repos to add during helm setup
+	var helmRepos = map[string]string{
+		"jetstack": "https://charts.jetstack.io",
+	}
+
 	// TODO remove this when Helm is removed as a dependency
-	err = installHelm(group.kops, group.provisioner.logger)
+	err = installHelm(group.kops, helmRepos, group.provisioner.logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to set up Helm as a prerequisite to installing the cluster utilities")
 	}

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -121,6 +121,7 @@ func (group utilityGroup) CreateUtilityGroup() error {
 	// List of repos to add during helm setup
 	var helmRepos = map[string]string{
 		"jetstack": "https://charts.jetstack.io",
+		"stable":   "https://kubernetes-charts.storage.googleapis.com",
 	}
 
 	// TODO remove this when Helm is removed as a dependency

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -88,14 +88,18 @@ func TestSetDesired(t *testing.T) {
 func TestGetActualVersion(t *testing.T) {
 	um := &UtilityMetadata{
 		DesiredVersions: utilityVersions{
-			Prometheus: "",
-			Nginx:      "10.3",
-			Fluentbit:  "1337",
+			Prometheus:  "",
+			Nginx:       "10.3",
+			Fluentbit:   "1337",
+			PublicNginx: "1234",
+			CertManager: "56.3",
 		},
 		ActualVersions: utilityVersions{
-			Prometheus: "prometheus-10.3",
-			Nginx:      "nginx-10.2",
-			Fluentbit:  "fluent-bit-0.9",
+			Prometheus:  "prometheus-10.3",
+			Nginx:       "nginx-10.2",
+			Fluentbit:   "fluent-bit-0.9",
+			PublicNginx: "nginx-10.2",
+			CertManager: "cert-manager-11.2",
 		},
 	}
 
@@ -126,6 +130,14 @@ func TestGetActualVersion(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "fluent-bit-0.9", version)
 
+	version, err = c.ActualUtilityVersion(PublicNginxCanonicalName)
+	assert.NoError(t, err)
+	assert.Equal(t, "nginx-10.2", version)
+
+	version, err = c.ActualUtilityVersion(CertManagerCanonicalName)
+	assert.NoError(t, err)
+	assert.Equal(t, "cert-manager-11.2", version)
+
 	version, err = c.ActualUtilityVersion("something else that doesn't exist")
 	assert.NoError(t, err)
 	assert.Equal(t, "", version)
@@ -134,14 +146,18 @@ func TestGetActualVersion(t *testing.T) {
 func TestGetDesiredVersion(t *testing.T) {
 	um := &UtilityMetadata{
 		DesiredVersions: utilityVersions{
-			Prometheus: "",
-			Nginx:      "10.3",
-			Fluentbit:  "1337",
+			Prometheus:  "",
+			Nginx:       "10.3",
+			Fluentbit:   "1337",
+			PublicNginx: "1234",
+			CertManager: "56.3",
 		},
 		ActualVersions: utilityVersions{
-			Prometheus: "prometheus-10.3",
-			Nginx:      "nginx-10.2",
-			Fluentbit:  "fluent-bit-0.9",
+			Prometheus:  "prometheus-10.3",
+			Nginx:       "nginx-10.2",
+			Fluentbit:   "fluent-bit-0.9",
+			PublicNginx: "nginx-10.2",
+			CertManager: "cert-manager-11.2",
 		},
 	}
 
@@ -171,6 +187,14 @@ func TestGetDesiredVersion(t *testing.T) {
 	version, err = c.DesiredUtilityVersion(FluentbitCanonicalName)
 	assert.NoError(t, err)
 	assert.Equal(t, "1337", version)
+
+	version, err = c.DesiredUtilityVersion(PublicNginxCanonicalName)
+	assert.NoError(t, err)
+	assert.Equal(t, "1234", version)
+
+	version, err = c.DesiredUtilityVersion(CertManagerCanonicalName)
+	assert.NoError(t, err)
+	assert.Equal(t, "56.3", version)
 
 	version, err = c.DesiredUtilityVersion("something else that doesn't exist")
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR:

- Adds support to add new helm repos
- Adds flags for cert manager and public nginx helm charts
- Fixes utility group test
- Increases the number of attempts to deploy clusterissuer to cover edge cases