### PR TITLE
Allow for empty image and/or version group values

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -14,7 +14,7 @@ func init() {
 	installationCreateCmd.Flags().String("owner", "", "An opaque identifier describing the owner of the installation.")
 	installationCreateCmd.Flags().String("group", "", "The id of the group to join")
 	installationCreateCmd.Flags().String("version", "stable", "The Mattermost version to install.")
-	installationCreateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost Container image to use.")
+	installationCreateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost container image to use.")
 	installationCreateCmd.Flags().String("dns", "", "The URL at which the Mattermost server will be available.")
 	installationCreateCmd.Flags().String("size", model.InstallationDefaultSize, "The size of the installation. Accepts 100users, 1000users, 5000users, 10000users, 25000users, miniSingleton, or miniHA. Defaults to 100users.")
 	installationCreateCmd.Flags().String("affinity", model.InstallationAffinityIsolated, "How other installations may be co-located in the same cluster.")
@@ -27,7 +27,7 @@ func init() {
 
 	installationUpdateCmd.Flags().String("installation", "", "The id of the installation to be updated.")
 	installationUpdateCmd.Flags().String("version", "stable", "The Mattermost version to target.")
-	installationUpdateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost Container image to use.")
+	installationUpdateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost container image to use.")
 	installationUpdateCmd.Flags().String("license", "", "The Mattermost License to use in the server.")
 	installationUpdateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	installationUpdateCmd.MarkFlagRequired("installation")

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -89,6 +89,7 @@ func handleCreateGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 		Description:   createGroupRequest.Description,
 		Version:       createGroupRequest.Version,
 		Image:         createGroupRequest.Image,
+		MaxRolling:    createGroupRequest.MaxRolling,
 		MattermostEnv: createGroupRequest.MattermostEnv,
 	}
 

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -230,14 +230,6 @@ func TestCreateGroup(t *testing.T) {
 		require.EqualError(t, err, "failed with status code 400")
 	})
 
-	t.Run("missing version", func(t *testing.T) {
-		_, err := client.CreateGroup(&model.CreateGroupRequest{
-			Name:        "name",
-			Description: "description",
-		})
-		require.EqualError(t, err, "failed with status code 400")
-	})
-
 	mattermostEnvFooBar := model.EnvVarMap{"foo": model.EnvVar{Value: "bar"}}
 	t.Run("valid", func(t *testing.T) {
 		group, err := client.CreateGroup(&model.CreateGroupRequest{
@@ -245,6 +237,7 @@ func TestCreateGroup(t *testing.T) {
 			Description:   "description",
 			Version:       "version",
 			Image:         "sample/image",
+			MaxRolling:    2,
 			MattermostEnv: mattermostEnvFooBar,
 		})
 		require.NoError(t, err)
@@ -252,9 +245,10 @@ func TestCreateGroup(t *testing.T) {
 		require.Equal(t, "description", group.Description)
 		require.Equal(t, "version", group.Version)
 		require.Equal(t, "sample/image", group.Image)
+		require.Equal(t, int64(2), group.MaxRolling)
+		require.EqualValues(t, group.MattermostEnv, mattermostEnvFooBar)
 		require.NotEqual(t, 0, group.CreateAt)
 		require.EqualValues(t, 0, group.DeleteAt)
-		require.EqualValues(t, group.MattermostEnv, mattermostEnvFooBar)
 	})
 }
 

--- a/model/group_request.go
+++ b/model/group_request.go
@@ -28,14 +28,8 @@ func (request *CreateGroupRequest) SetDefaults() {
 
 // Validate validates the values of a group create request.
 func (request *CreateGroupRequest) Validate() error {
-	if request.Name == "" {
+	if len(request.Name) == 0 {
 		return errors.New("must specify name")
-	}
-	if request.Version == "" {
-		return errors.New("must specify version")
-	}
-	if request.Image == "" {
-		return errors.New("must specify image")
 	}
 	if request.MaxRolling < 1 {
 		return errors.New("max rolling must be 1 or greater")
@@ -126,6 +120,9 @@ func (p *PatchGroupRequest) Apply(group *Group) bool {
 
 // Validate validates the values of a group patch request
 func (p *PatchGroupRequest) Validate() error {
+	if p.Name != nil && len(*p.Name) == 0 {
+		return errors.New("must specify name")
+	}
 	if p.MaxRolling != nil && *p.MaxRolling < 1 {
 		return errors.New("max rolling must be 1 or greater")
 	}

--- a/model/installation.go
+++ b/model/installation.go
@@ -94,14 +94,14 @@ func (i *Installation) MergeWithGroup(group *Group, includeOverrides bool) {
 		i.MattermostEnv = make(EnvVarMap)
 	}
 
-	if i.Version != group.Version {
+	if len(group.Version) != 0 && i.Version != group.Version {
 		if includeOverrides {
 			i.GroupOverrides["Installation Version"] = i.Version
 			i.GroupOverrides["Group Version"] = group.Version
 		}
 		i.Version = group.Version
 	}
-	if i.Image != group.Image {
+	if len(group.Image) != 0 && i.Image != group.Image {
 		if includeOverrides {
 			i.GroupOverrides["Installation Image"] = i.Image
 			i.GroupOverrides["Group Image"] = group.Image


### PR DESCRIPTION
This opens up groups to be used for specific purposes such as only
setting environment variables for the installations in the group.

This change also fixes a bug on group creation where max rolling
was not set correctly.

https://mattermost.atlassian.net/browse/MM-23840
