### PR TITLE
Refactor installation update logic

### DIFF
--- a/cmd/cloud/flags.go
+++ b/cmd/cloud/flags.go
@@ -1,0 +1,21 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func getStringFlagPointer(command *cobra.Command, s string) *string {
+	if command.Flags().Changed(s) {
+		val, _ := command.Flags().GetString(s)
+		return &val
+	}
+
+	return nil
+}
+
+func getInt64FlagPointer(command *cobra.Command, s string) *int64 {
+	if command.Flags().Changed(s) {
+		val, _ := command.Flags().GetInt64(s)
+		return &val
+	}
+
+	return nil
+}

--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -93,12 +93,7 @@ var groupCreateCmd = &cobra.Command{
 			return errors.Wrap(err, "failed to create group")
 		}
 
-		err = printJSON(group)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return printJSON(group)
 	},
 }
 
@@ -119,37 +114,20 @@ var groupUpdateCmd = &cobra.Command{
 			return err
 		}
 
-		getStringFlagPointer := func(s string) *string {
-			if command.Flags().Changed(s) {
-				val, _ := command.Flags().GetString(s)
-				return &val
-			}
-
-			return nil
-		}
-		getInt64FlagPointer := func(s string) *int64 {
-			if command.Flags().Changed(s) {
-				val, _ := command.Flags().GetInt64(s)
-				return &val
-			}
-
-			return nil
-		}
-
-		err = client.UpdateGroup(&model.PatchGroupRequest{
+		group, err := client.UpdateGroup(&model.PatchGroupRequest{
 			ID:            groupID,
-			Name:          getStringFlagPointer("name"),
-			Description:   getStringFlagPointer("description"),
-			Version:       getStringFlagPointer("version"),
-			Image:         getStringFlagPointer("image"),
-			MaxRolling:    getInt64FlagPointer("max-rolling"),
+			Name:          getStringFlagPointer(command, "name"),
+			Description:   getStringFlagPointer(command, "description"),
+			Version:       getStringFlagPointer(command, "version"),
+			Image:         getStringFlagPointer(command, "image"),
+			MaxRolling:    getInt64FlagPointer(command, "max-rolling"),
 			MattermostEnv: envVarMap,
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to update group")
 		}
 
-		return nil
+		return printJSON(group)
 	},
 }
 

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -138,7 +138,9 @@ func handleUpdateGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.Supervisor.Do()
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, group)
 }
 
 // handleDeleteGroup responds to DELETE /api/group/{group}, marking the group as deleted.

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -297,12 +297,13 @@ func TestUpdateGroup(t *testing.T) {
 	})
 
 	t.Run("unknown group", func(t *testing.T) {
-		err := client.UpdateGroup(&model.PatchGroupRequest{ID: model.NewID()})
+		group, err := client.UpdateGroup(&model.PatchGroupRequest{ID: model.NewID()})
 		require.EqualError(t, err, "failed with status code 404")
+		require.Nil(t, group)
 	})
 
 	t.Run("partial update", func(t *testing.T) {
-		err = client.UpdateGroup(&model.PatchGroupRequest{
+		updateResponseGroup, err := client.UpdateGroup(&model.PatchGroupRequest{
 			ID:      group1.ID,
 			Version: sToP("version2"),
 		})
@@ -314,11 +315,12 @@ func TestUpdateGroup(t *testing.T) {
 		require.Equal(t, "description", group1.Description)
 		require.Equal(t, "version2", group1.Version)
 		require.EqualValues(t, group1.MattermostEnv, mattermostEnvFooBar)
+		require.Equal(t, updateResponseGroup, group1)
 	})
 
 	mattermostEnvBarBaz := model.EnvVarMap{"bar": model.EnvVar{Value: "baz"}}
 	t.Run("full update", func(t *testing.T) {
-		err = client.UpdateGroup(&model.PatchGroupRequest{
+		updateResponseGroup, err := client.UpdateGroup(&model.PatchGroupRequest{
 			ID:            group1.ID,
 			Name:          sToP("name2"),
 			Description:   sToP("description2"),
@@ -334,6 +336,7 @@ func TestUpdateGroup(t *testing.T) {
 		require.Equal(t, "version2", group1.Version)
 		require.NotEqual(t, group1.MattermostEnv, mattermostEnvFooBar)
 		require.Equal(t, group1.MattermostEnv, mattermostEnvBarBaz)
+		require.Equal(t, updateResponseGroup, group1)
 	})
 }
 

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -228,7 +228,7 @@ func handleUpdateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 	installationID := vars["installation"]
 	c.Logger = c.Logger.WithField("installation", installationID)
 
-	updateInstallationRequest, err := model.NewUpdateInstallationRequestFromReader(r.Body)
+	patchInstallationRequest, err := model.NewPatchInstallationRequestFromReader(r.Body)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to decode request")
 		w.WriteHeader(http.StatusBadRequest)
@@ -250,35 +250,35 @@ func handleUpdateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	webhookPayload := &model.WebhookPayload{
-		Type:      model.TypeInstallation,
-		ID:        installation.ID,
-		NewState:  newState,
-		OldState:  installation.State,
-		Timestamp: time.Now().UnixNano(),
-	}
-	installation.State = newState
-	installation.Version = updateInstallationRequest.Version
-	installation.License = updateInstallationRequest.License
-	installation.Image = updateInstallationRequest.Image
-	installation.MattermostEnv = updateInstallationRequest.MattermostEnv
+	if patchInstallationRequest.Apply(installation) {
+		installation.State = newState
 
-	err = c.Store.UpdateInstallation(installation)
-	if err != nil {
-		c.Logger.WithError(err).Error("failed to mark installation for update")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
+		err = c.Store.UpdateInstallation(installation)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to update installation")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 
-	err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
-	if err != nil {
-		c.Logger.WithError(err).Error("Unable to process and send webhooks")
+		webhookPayload := &model.WebhookPayload{
+			Type:      model.TypeInstallation,
+			ID:        installation.ID,
+			NewState:  newState,
+			OldState:  installation.State,
+			Timestamp: time.Now().UnixNano(),
+		}
+		err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
+		if err != nil {
+			c.Logger.WithError(err).Error("Unable to process and send webhooks")
+		}
 	}
 
 	unlockOnce()
 	c.Supervisor.Do()
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
+	outputJSON(c, w, installation)
 }
 
 // handleJoinGroup responds to PUT /api/installation/{installation}/group/{group}, joining the group.

--- a/model/client.go
+++ b/model/client.go
@@ -356,20 +356,20 @@ func (c *Client) GetInstallations(request *GetInstallationsRequest) ([]*Installa
 	}
 }
 
-// UpgradeInstallation upgrades an installation.
-func (c *Client) UpgradeInstallation(installationID string, request *UpdateInstallationRequest) error {
+// UpdateInstallation updates an installation.
+func (c *Client) UpdateInstallation(installationID string, request *PatchInstallationRequest) (*Installation, error) {
 	resp, err := c.doPut(c.buildURL("/api/installation/%s/mattermost", installationID), request)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer closeBody(resp)
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return nil
+		return InstallationFromReader(resp.Body)
 
 	default:
-		return errors.Errorf("failed with status code %d", resp.StatusCode)
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
 	}
 }
 
@@ -510,19 +510,19 @@ func (c *Client) CreateGroup(request *CreateGroupRequest) (*Group, error) {
 }
 
 // UpdateGroup updates the installation group.
-func (c *Client) UpdateGroup(request *PatchGroupRequest) error {
+func (c *Client) UpdateGroup(request *PatchGroupRequest) (*Group, error) {
 	resp, err := c.doPut(c.buildURL("/api/group/%s", request.ID), request)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer closeBody(resp)
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return nil
+		return GroupFromReader(resp.Body)
 
 	default:
-		return errors.Errorf("failed with status code %d", resp.StatusCode)
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
 	}
 }
 

--- a/model/group_request.go
+++ b/model/group_request.go
@@ -121,14 +121,14 @@ func (p *PatchGroupRequest) Apply(group *Group) bool {
 // Validate validates the values of a group patch request
 func (p *PatchGroupRequest) Validate() error {
 	if p.Name != nil && len(*p.Name) == 0 {
-		return errors.New("must specify name")
+		return errors.New("provided name update value was blank")
 	}
 	if p.MaxRolling != nil && *p.MaxRolling < 1 {
 		return errors.New("max rolling must be 1 or greater")
 	}
 	err := p.MattermostEnv.Validate()
 	if err != nil {
-		return errors.Wrapf(err, "bad environment variable map in patch group request")
+		return errors.Wrap(err, "invalid env var settings")
 	}
 
 	return nil


### PR DESCRIPTION
This change does the following:
 - Changes the installation update logic to use patching like what
   is done with groups. This removes the requirement for passing
   in more installation update values than those being used to
   actually affect the installation. In doing so, the API endpoint
   is now easier to use and less error-prone.
 - Changes the installation update API endpoint to handle change
   detection better. Previously, all installation updates would
   trigger a state change. Now, only actual updates will do so.
 - Corrects installation update logging referencing only version
   updates.
 - Both the installation and group update endpoints now return
   the patched object as stored in the database for review.

https://mattermost.atlassian.net/browse/MM-23904