### PR TITLE
MM-23742 Moving DNS registration step before installation creation and adding check for certificate approve status

### DIFF
--- a/internal/provisioner/kops_utils.go
+++ b/internal/provisioner/kops_utils.go
@@ -156,8 +156,8 @@ func (provisioner *KopsProvisioner) GetNGINXLoadBalancerEndpoint(cluster *model.
 	return "", errors.New("failed to get NGINX load balancer endpoint")
 }
 
-// WaitForCertApproved checks if installations certificate is approved.
-func (provisioner *KopsProvisioner) WaitForCertApproved(cluster *model.Cluster, namespace, certName string) (string, error) {
+// GetCertStatus gets the status of a CertManager Certificate.
+func (provisioner *KopsProvisioner) GetCertStatus(cluster *model.Cluster, namespace, certName string) (string, error) {
 	logger := provisioner.logger.WithFields(log.Fields{
 		"cluster":   cluster.ID,
 		"namespace": namespace,

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -1,6 +1,8 @@
 package supervisor
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
@@ -46,6 +48,7 @@ type installationProvisioner interface {
 	GetClusterInstallationResource(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) (*mmv1alpha1.ClusterInstallation, error)
 	GetClusterResources(cluster *model.Cluster, onlySchedulable bool) (*k8s.ClusterResources, error)
 	GetNGINXLoadBalancerEndpoint(cluster *model.Cluster, namespace string) (string, error)
+	WaitForCertApproved(cluster *model.Cluster, namespace, certName string) (string, error)
 }
 
 // InstallationSupervisor finds installations pending work and effects the required changes.
@@ -165,6 +168,9 @@ func (s *InstallationSupervisor) transitionInstallation(installation *model.Inst
 
 	case model.InstallationStateCreationInProgress:
 		return s.waitForClusterInstallationStable(installation, instanceID, logger)
+
+	case model.InstallationStateCreationFinalTasks:
+		return s.finalCreationTasks(installation, logger)
 
 	case model.InstallationStateCreationDNS:
 		return s.configureInstallationDNS(installation, logger)
@@ -354,8 +360,7 @@ func (s *InstallationSupervisor) preProvisionInstallation(installation *model.In
 	}
 
 	logger.Info("Installation pre-provisioning complete")
-
-	return s.waitForClusterInstallationStable(installation, instanceID, logger)
+	return model.InstallationStateCreationDNS
 }
 
 func (s *InstallationSupervisor) waitForClusterInstallationStable(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
@@ -394,7 +399,7 @@ func (s *InstallationSupervisor) waitForClusterInstallationStable(installation *
 
 	if len(clusterInstallations) == stable {
 		logger.Info("Finished creating cluster installation")
-		return s.configureInstallationDNS(installation, logger)
+		return model.InstallationStateCreationFinalTasks
 	}
 	if failed > 0 {
 		logger.Infof("Found %d failed cluster installations", failed)
@@ -442,8 +447,7 @@ func (s *InstallationSupervisor) configureInstallationDNS(installation *model.In
 	}
 
 	logger.Infof("Successfully configured DNS %s", installation.DNS)
-
-	return model.InstallationStateStable
+	return model.InstallationStateCreationInProgress
 }
 
 func (s *InstallationSupervisor) updateInstallation(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
@@ -684,4 +688,37 @@ func (s *InstallationSupervisor) finalDeletionCleanup(installation *model.Instal
 	logger.Info("Finished deleting installation")
 
 	return model.InstallationStateDeleted
+}
+
+func (s *InstallationSupervisor) finalCreationTasks(installation *model.Installation, logger log.FieldLogger) string {
+	clusterInstallations, err := s.store.GetClusterInstallations(&model.ClusterInstallationFilter{
+		InstallationID: installation.ID,
+		PerPage:        model.AllPerPage,
+	})
+	if err != nil {
+		logger.WithError(err).Warn("Failed to find cluster installations")
+		return model.InstallationStateCreationFinalTasks
+	}
+
+	for _, clusterInstallation := range clusterInstallations {
+		cluster, err := s.store.GetCluster(clusterInstallation.ClusterID)
+		if err != nil {
+			logger.WithError(err).Warnf("Failed to query cluster %s", clusterInstallation.ClusterID)
+			return model.InstallationStateCreationFinalTasks
+		}
+
+		certName := fmt.Sprintf("%s-tls-cert", strings.Replace(installation.DNS, ".", "-", -1))
+		status, err := s.provisioner.WaitForCertApproved(cluster, installation.ID, certName)
+		if err != nil {
+			logger.WithError(err).Error("Couldn't get the certificate status")
+			return model.InstallationStateCreationFinalTasks
+		}
+		if status == "False" {
+			logger.Infof("Certificate %s not approved yet", certName)
+			return model.InstallationStateCreationFinalTasks
+		}
+		logger.Infof("Certificate %s approved", certName)
+	}
+	logger.Info("Finished final creation tasks")
+	return model.InstallationStateStable
 }

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -153,7 +153,7 @@ func (p *mockInstallationProvisioner) GetNGINXLoadBalancerEndpoint(cluster *mode
 }
 
 func (p *mockInstallationProvisioner) GetCertStatus(cluster *model.Cluster, namespace, certName string) (string, error) {
-	return "False", nil
+	return "True", nil
 }
 
 // TODO(gsagula): this can be replaced with /internal/mocks/aws-tools/AWS.go so that inputs and other variants
@@ -452,11 +452,11 @@ func TestInstallationSupervisor(t *testing.T) {
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
-		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationDNS)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationInProgress)
 		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateReconciling)
 	})
 
-	t.Run("creation DNS, cluster installations reconciling", func(t *testing.T) {
+	t.Run("creation requested, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, &utils.ResourceUtil{}, logger)
@@ -474,7 +474,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			Size:     mmv1alpha1.Size100String,
 			Affinity: model.InstallationAffinityIsolated,
 			GroupID:  &groupID,
-			State:    model.InstallationStateCreationDNS,
+			State:    model.InstallationStateCreationRequested,
 		}
 
 		err = sqlStore.CreateInstallation(installation)
@@ -532,7 +532,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationRequested)
 	})
 
-	t.Run("creation in progress, cluster installations stable", func(t *testing.T) {
+	t.Run("creation requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, &utils.ResourceUtil{}, logger)
@@ -550,7 +550,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			Size:     mmv1alpha1.Size100String,
 			Affinity: model.InstallationAffinityIsolated,
 			GroupID:  &groupID,
-			State:    model.InstallationStateCreationInProgress,
+			State:    model.InstallationStateCreationRequested,
 		}
 
 		err = sqlStore.CreateInstallation(installation)
@@ -566,7 +566,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
-		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationFinalTasks)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateStable)
 		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateStable)
 	})
 
@@ -604,11 +604,11 @@ func TestInstallationSupervisor(t *testing.T) {
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
-		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationDNS)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationInProgress)
 		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationRequested)
 	})
 
-	t.Run("creation in progress, cluster installations failed", func(t *testing.T) {
+	t.Run("creation requested, cluster installations failed", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, false, false, &utils.ResourceUtil{}, logger)
@@ -626,7 +626,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			Size:     mmv1alpha1.Size100String,
 			Affinity: model.InstallationAffinityIsolated,
 			GroupID:  &groupID,
-			State:    model.InstallationStateCreationInProgress,
+			State:    model.InstallationStateCreationPreProvisioning,
 		}
 
 		err = sqlStore.CreateInstallation(installation)
@@ -718,7 +718,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
-		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationFinalTasks)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateStable)
 		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateStable)
 	})
 
@@ -794,7 +794,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
-		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationFinalTasks)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateStable)
 		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateStable)
 	})
 
@@ -886,7 +886,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
-		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationDNS)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationInProgress)
 		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationRequested)
 	})
 
@@ -1182,7 +1182,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			require.NoError(t, err)
 
 			supervisor.Supervise(installation)
-			expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationDNS)
+			expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationInProgress)
 			expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationRequested)
 			expectClusterInstallationsOnCluster(t, sqlStore, cluster, 1)
 		})
@@ -1214,7 +1214,7 @@ func TestInstallationSupervisor(t *testing.T) {
 					require.NoError(t, err)
 
 					supervisor.Supervise(installation)
-					expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationDNS)
+					expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationInProgress)
 					expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationRequested)
 					expectClusterInstallationsOnCluster(t, sqlStore, cluster, i)
 				})
@@ -1246,7 +1246,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			require.NoError(t, err)
 
 			supervisor.Supervise(isolatedInstallation)
-			expectInstallationState(t, sqlStore, isolatedInstallation, model.InstallationStateCreationDNS)
+			expectInstallationState(t, sqlStore, isolatedInstallation, model.InstallationStateCreationInProgress)
 			expectClusterInstallations(t, sqlStore, isolatedInstallation, 1, model.ClusterInstallationStateCreationRequested)
 			expectClusterInstallationsOnCluster(t, sqlStore, cluster, 1)
 

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -152,6 +152,10 @@ func (p *mockInstallationProvisioner) GetNGINXLoadBalancerEndpoint(cluster *mode
 	return "example.elb.us-east-1.amazonaws.com", nil
 }
 
+func (p *mockInstallationProvisioner) WaitForCertApproved(cluster *model.Cluster, namespace, certName string) (string, error) {
+	return "False", nil
+}
+
 // TODO(gsagula): this can be replaced with /internal/mocks/aws-tools/AWS.go so that inputs and other variants
 // can be tested.
 type mockAWS struct{}

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -152,7 +152,7 @@ func (p *mockInstallationProvisioner) GetNGINXLoadBalancerEndpoint(cluster *mode
 	return "example.elb.us-east-1.amazonaws.com", nil
 }
 
-func (p *mockInstallationProvisioner) WaitForCertApproved(cluster *model.Cluster, namespace, certName string) (string, error) {
+func (p *mockInstallationProvisioner) GetCertStatus(cluster *model.Cluster, namespace, certName string) (string, error) {
 	return "False", nil
 }
 

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -20,6 +20,8 @@ const (
 	// InstallationStateCreationNoCompatibleClusters is an installation that
 	// can't be fully created because there are no compatible clusters.
 	InstallationStateCreationNoCompatibleClusters = "creation-no-compatible-clusters"
+	// InstallationStateCreationFinalTasks is the final step of the installation creation
+	InstallationStateCreationFinalTasks = "creation-final-tasks"
 	// InstallationStateUpdateRequested is an installation that is about to undergo an update.
 	InstallationStateUpdateRequested = "update-requested"
 	// InstallationStateUpdateInProgress is an installation that is being updated.
@@ -54,6 +56,7 @@ var AllInstallationStates = []string{
 	InstallationStateCreationDNS,
 	InstallationStateCreationFailed,
 	InstallationStateCreationNoCompatibleClusters,
+	InstallationStateCreationFinalTasks,
 	InstallationStateUpdateRequested,
 	InstallationStateUpdateInProgress,
 	InstallationStateUpdateFailed,
@@ -74,6 +77,7 @@ var AllInstallationStatesPendingWork = []string{
 	InstallationStateCreationPreProvisioning,
 	InstallationStateCreationInProgress,
 	InstallationStateCreationNoCompatibleClusters,
+	InstallationStateCreationFinalTasks,
 	InstallationStateCreationDNS,
 	InstallationStateUpdateRequested,
 	InstallationStateUpdateInProgress,
@@ -137,6 +141,7 @@ func validTransitionToInstallationStateDeletionRequested(currentState string) bo
 		InstallationStateCreationInProgress,
 		InstallationStateCreationDNS,
 		InstallationStateCreationNoCompatibleClusters,
+		InstallationStateCreationFinalTasks,
 		InstallationStateCreationFailed,
 		InstallationStateUpdateRequested,
 		InstallationStateUpdateInProgress,

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -20,7 +20,7 @@ const (
 	// InstallationStateCreationNoCompatibleClusters is an installation that
 	// can't be fully created because there are no compatible clusters.
 	InstallationStateCreationNoCompatibleClusters = "creation-no-compatible-clusters"
-	// InstallationStateCreationFinalTasks is the final step of the installation creation
+	// InstallationStateCreationFinalTasks is the final step of the installation creation.
 	InstallationStateCreationFinalTasks = "creation-final-tasks"
 	// InstallationStateUpdateRequested is an installation that is about to undergo an update.
 	InstallationStateUpdateRequested = "update-requested"


### PR DESCRIPTION
#### Summary

This PR moves the DNS registration step before the installation creation and adds a check for the certificate approval.

#### Release Note 

```release-note
1. Moves the DNS Registration as a first step in the process. The reason is to give the Cert Manager a head start to register the installation certificate.
2. Adds a InstallationStateCreationFinalTasks state, which handles checks needed before setting the installation to stable. Currently there is a single check to make sure that the SSL certificate is approved.
3. Adapts tests to the state changes
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-23742