### PR TITLE
Check if group is deleted before joining installations

### DIFF
--- a/model/cluster_installation_test.go
+++ b/model/cluster_installation_test.go
@@ -126,7 +126,7 @@ func TestClusterInstallationsFromReader(t *testing.T) {
 		]`)))
 		require.NoError(t, err)
 		require.Equal(t, []*ClusterInstallation{
-			&ClusterInstallation{
+			{
 				ID:             "id1",
 				ClusterID:      "cluster_id1",
 				InstallationID: "installation_id1",
@@ -137,7 +137,7 @@ func TestClusterInstallationsFromReader(t *testing.T) {
 				LockAcquiredBy: nil,
 				LockAcquiredAt: 0,
 			},
-			&ClusterInstallation{
+			{
 				ID:             "id2",
 				ClusterID:      "cluster_id2",
 				InstallationID: "installation_id2",

--- a/model/cluster_test.go
+++ b/model/cluster_test.go
@@ -107,8 +107,8 @@ func TestClustersFromReader(t *testing.T) {
 		)))
 		require.NoError(t, err)
 		require.Equal(t, []*Cluster{
-			&Cluster{ID: "id1", Provider: "aws"},
-			&Cluster{ID: "id2", Provider: "aws"},
+			{ID: "id1", Provider: "aws"},
+			{ID: "id2", Provider: "aws"},
 		}, cluster)
 	})
 }

--- a/model/group.go
+++ b/model/group.go
@@ -29,12 +29,17 @@ type GroupFilter struct {
 }
 
 // Clone returns a deep copy the group.
-func (c *Group) Clone() *Group {
+func (g *Group) Clone() *Group {
 	var clone Group
-	data, _ := json.Marshal(c)
+	data, _ := json.Marshal(g)
 	json.Unmarshal(data, &clone)
 
 	return &clone
+}
+
+// IsDeleted returns whether the group is deleted or not.
+func (g *Group) IsDeleted() bool {
+	return g.DeleteAt != 0
 }
 
 // GroupFromReader decodes a json-encoded group from the given io.Reader.

--- a/model/group_test.go
+++ b/model/group_test.go
@@ -24,6 +24,22 @@ func TestGroupClone(t *testing.T) {
 	require.NotEqual(t, group, clone)
 }
 
+func TestGroupIsDeleted(t *testing.T) {
+	group := &Group{
+		DeleteAt: 0,
+	}
+
+	t.Run("not deleted", func(t *testing.T) {
+		require.False(t, group.IsDeleted())
+	})
+
+	group.DeleteAt = 1
+
+	t.Run("deleted", func(t *testing.T) {
+		require.True(t, group.IsDeleted())
+	})
+}
+
 func TestGroupFromReader(t *testing.T) {
 	t.Run("empty request", func(t *testing.T) {
 		group, err := GroupFromReader(bytes.NewReader([]byte(
@@ -149,7 +165,7 @@ func TestGroupsFromReader(t *testing.T) {
 		]`)))
 		require.NoError(t, err)
 		require.Equal(t, []*Group{
-			&Group{
+			{
 				ID:          "id1",
 				Name:        "name1",
 				Description: "description1",
@@ -158,7 +174,7 @@ func TestGroupsFromReader(t *testing.T) {
 				CreateAt:    10,
 				DeleteAt:    20,
 			},
-			&Group{
+			{
 				ID:          "id2",
 				Name:        "name2",
 				Description: "description2",

--- a/model/webhook_test.go
+++ b/model/webhook_test.go
@@ -111,14 +111,14 @@ func TestWebhooksFromReader(t *testing.T) {
 		]`))
 		require.NoError(t, err)
 		require.Equal(t, []*Webhook{
-			&Webhook{
+			{
 				ID:       "id1",
 				OwnerID:  "owner1",
 				URL:      "https://domain1.com",
 				CreateAt: 10,
 				DeleteAt: 20,
 			},
-			&Webhook{
+			{
 				ID:       "id2",
 				OwnerID:  "owner2",
 				URL:      "https://domain2.com",


### PR DESCRIPTION
We were already checking that groups had no installation members
before deleting them, but this change ensures groups are not
deleted before joining an installation to them.

https://mattermost.atlassian.net/browse/MM-24163

Release Note:
```release-note
Check group deletion state before joining installation
```