### PR TITLE
MM-24209: enhanced RDS encryption at rest

### DIFF
--- a/internal/tools/aws/database_test.go
+++ b/internal/tools/aws/database_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -70,15 +71,16 @@ func (a *AWSTestSuite) TestSnapshotError() {
 	a.Assert().Equal("failed to create a DB cluster snapshot: database is not stable", err.Error())
 }
 
-// TODO(gsagula): test other database use-cases.
-// Acceptance test for provisioning a RDS database.
 func (a *AWSTestSuite) TestProvisionRDS() {
 	database := RDSDatabase{
 		installationID: a.InstallationA.ID,
 		client:         a.Mocks.AWS,
 	}
 
-	a.Mocks.Log.Logger.EXPECT().Infof("Provisioning AWS RDS database with ID %s", CloudID(a.InstallationA.ID)).Return().Times(1)
+	a.Mocks.Log.Logger.EXPECT().
+		Infof("Provisioning AWS RDS database with ID %s", CloudID(a.InstallationA.ID)).
+		Return().
+		Times(1)
 
 	a.Mocks.Model.DatabaseInstallationStore.EXPECT().
 		GetClusterInstallations(gomock.Any()).
@@ -170,10 +172,19 @@ func (a *AWSTestSuite) TestProvisionRDS() {
 			Times(1))
 
 	a.Mocks.API.KMS.EXPECT().
+		DescribeKey(gomock.Any()).
+		Return(nil, awserr.New(kms.ErrCodeNotFoundException, "alias does not exist", nil)).
+		Do(func(input *kms.DescribeKeyInput) {
+			a.Assert().Equal(*input.KeyId, "alias/cloud-id000000000000000000000000a-rds")
+		}).
+		Times(1)
+
+	a.Mocks.API.KMS.EXPECT().
 		CreateKey(gomock.Any()).
 		Return(&kms.CreateKeyOutput{
 			KeyMetadata: &kms.KeyMetadata{
-				KeyId: aws.String(a.RDSEncryptionKeyID),
+				KeyId:    aws.String(a.RDSEncryptionKeyID),
+				KeyState: aws.String(kms.KeyStateEnabled),
 			},
 		}, nil).
 		Do(func(input *kms.CreateKeyInput) {
@@ -189,8 +200,555 @@ func (a *AWSTestSuite) TestProvisionRDS() {
 		}).
 		Times(1)
 
+	a.Mocks.Log.Logger.EXPECT().
+		Infof("Encrypting RDS database with key %s", "alias/cloud-id000000000000000000000000a-rds").
+		Times(1)
+
 	err := database.Provision(a.Mocks.Model.DatabaseInstallationStore, a.Mocks.Log.Logger)
 	a.Assert().NoError(err)
+}
+
+func (a *AWSTestSuite) TestProvisionRDSDescribeEncriptionKeyError() {
+	database := RDSDatabase{
+		installationID: a.InstallationA.ID,
+		client:         a.Mocks.AWS,
+	}
+
+	a.Mocks.Log.Logger.EXPECT().
+		Infof("Provisioning AWS RDS database with ID %s", CloudID(a.InstallationA.ID)).
+		Return().
+		Times(1)
+
+	a.Mocks.Model.DatabaseInstallationStore.EXPECT().
+		GetClusterInstallations(gomock.Any()).
+		Do(func(input *model.ClusterInstallationFilter) {
+			a.Assert().Equal(input.InstallationID, a.InstallationA.ID)
+		}).
+		Return([]*model.ClusterInstallation{
+			&model.ClusterInstallation{ID: a.ClusterA.ID},
+		}, nil).
+		Times(1)
+
+	a.Mocks.API.EC2.EXPECT().
+		DescribeVpcs(gomock.Any()).
+		Return(&ec2.DescribeVpcsOutput{Vpcs: []*ec2.Vpc{&ec2.Vpc{VpcId: &a.VPCa}}}, nil).
+		Times(1)
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("secret-name", RDSSecretName(CloudID(a.InstallationA.ID))).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.SecretsManager.EXPECT().
+			GetSecretValue(gomock.Any()).
+			Return(&secretsmanager.GetSecretValueOutput{SecretString: &a.SecretString}, nil).
+			Times(1))
+
+	a.Mocks.API.RDS.EXPECT().
+		DescribeDBClusters(gomock.Any()).
+		Return(nil, errors.New("db cluster does not exist")).
+		Times(1)
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("security-group-ids", []string{a.GroupID}).
+		Return(testlib.NewLoggerEntry()).Times(1).
+		After(a.Mocks.API.EC2.EXPECT().
+			DescribeSecurityGroups(gomock.Any()).
+			Return(&ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{&ec2.SecurityGroup{GroupId: &a.GroupID}},
+			}, nil))
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("db-subnet-group-name", DBSubnetGroupName(a.VPCa)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.RDS.EXPECT().
+			DescribeDBSubnetGroups(gomock.Any()).
+			Return(&rds.DescribeDBSubnetGroupsOutput{
+				DBSubnetGroups: []*rds.DBSubnetGroup{
+					&rds.DBSubnetGroup{
+						DBSubnetGroupName: aws.String(DBSubnetGroupName(a.VPCa)),
+					},
+				},
+			}, nil))
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("db-cluster-name", CloudID(a.InstallationA.ID)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1)
+
+	a.Mocks.API.RDS.EXPECT().
+		CreateDBCluster(gomock.Any()).
+		Return(nil, nil).
+		Do(func(input *rds.CreateDBClusterInput) {
+			for _, zone := range input.AvailabilityZones {
+				a.Assert().Contains(a.RDSAvailabilityZones, *zone)
+			}
+			a.Assert().Equal(*input.BackupRetentionPeriod, int64(7))
+			a.Assert().Equal(*input.DBClusterIdentifier, CloudID(a.InstallationA.ID))
+			a.Assert().Equal(*input.DatabaseName, a.DBName)
+			a.Assert().Equal(*input.VpcSecurityGroupIds[0], a.GroupID)
+		}).
+		Times(1)
+
+	a.Mocks.API.RDS.EXPECT().
+		DescribeDBInstances(gomock.Any()).
+		Return(nil, errors.New("db cluster instance does not exist")).
+		Do(func(input *rds.DescribeDBInstancesInput) {
+			a.Assert().Equal(*input.DBInstanceIdentifier, RDSMasterInstanceID(a.InstallationA.ID))
+		})
+
+	a.Mocks.Log.Logger.EXPECT().WithField("db-instance-name", RDSMasterInstanceID(a.InstallationA.ID)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.RDS.EXPECT().
+			CreateDBInstance(gomock.Any()).Return(nil, nil).
+			Do(func(input *rds.CreateDBInstanceInput) {
+				a.Assert().Equal(*input.DBClusterIdentifier, CloudID(a.InstallationA.ID))
+				a.Assert().Equal(*input.DBInstanceIdentifier, RDSMasterInstanceID(a.InstallationA.ID))
+			}).
+			Times(1))
+
+	a.Mocks.API.KMS.EXPECT().
+		DescribeKey(gomock.Any()).
+		Return(nil, awserr.New(kms.ConnectionErrorCodeTypeUserLockedOut, "unexpected error code", nil)).
+		Do(func(input *kms.DescribeKeyInput) {
+			a.Assert().Equal(*input.KeyId, "alias/cloud-id000000000000000000000000a-rds")
+		}).
+		Times(1)
+
+	a.Mocks.API.KMS.EXPECT().
+		CreateKey(gomock.Any()).
+		Times(0)
+
+	a.Mocks.API.KMS.EXPECT().
+		CreateAlias(gomock.Any()).
+		Times(0)
+
+	a.Mocks.Log.Logger.EXPECT().
+		Infof("Encrypting RDS database with key %s", "alias/cloud-id000000000000000000000000a-rds").
+		Times(0)
+
+	err := database.Provision(a.Mocks.Model.DatabaseInstallationStore, a.Mocks.Log.Logger)
+	a.Assert().Error(err)
+	a.Assert().Equal("unable to provision RDS database: unable to verify encryption key "+
+		"alias/cloud-id000000000000000000000000a-rds for the RDS cluster ID cloud-id000000000000000000000000a: "+
+		"USER_LOCKED_OUT: unexpected error code", err.Error())
+}
+
+func (a *AWSTestSuite) TestProvisionRDSEncryptionKeyCreationError() {
+	database := RDSDatabase{
+		installationID: a.InstallationA.ID,
+		client:         a.Mocks.AWS,
+	}
+
+	a.Mocks.Log.Logger.EXPECT().
+		Infof("Provisioning AWS RDS database with ID %s", CloudID(a.InstallationA.ID)).
+		Return().
+		Times(1)
+
+	a.Mocks.Model.DatabaseInstallationStore.EXPECT().
+		GetClusterInstallations(gomock.Any()).
+		Do(func(input *model.ClusterInstallationFilter) {
+			a.Assert().Equal(input.InstallationID, a.InstallationA.ID)
+		}).
+		Return([]*model.ClusterInstallation{
+			&model.ClusterInstallation{ID: a.ClusterA.ID},
+		}, nil).
+		Times(1)
+
+	a.Mocks.API.EC2.EXPECT().
+		DescribeVpcs(gomock.Any()).
+		Return(&ec2.DescribeVpcsOutput{Vpcs: []*ec2.Vpc{&ec2.Vpc{VpcId: &a.VPCa}}}, nil).
+		Times(1)
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("secret-name", RDSSecretName(CloudID(a.InstallationA.ID))).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.SecretsManager.EXPECT().
+			GetSecretValue(gomock.Any()).
+			Return(&secretsmanager.GetSecretValueOutput{SecretString: &a.SecretString}, nil).
+			Times(1))
+
+	a.Mocks.API.RDS.EXPECT().
+		DescribeDBClusters(gomock.Any()).
+		Return(nil, errors.New("db cluster does not exist")).
+		Times(1)
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("security-group-ids", []string{a.GroupID}).
+		Return(testlib.NewLoggerEntry()).Times(1).
+		After(a.Mocks.API.EC2.EXPECT().
+			DescribeSecurityGroups(gomock.Any()).
+			Return(&ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{&ec2.SecurityGroup{GroupId: &a.GroupID}},
+			}, nil))
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("db-subnet-group-name", DBSubnetGroupName(a.VPCa)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.RDS.EXPECT().
+			DescribeDBSubnetGroups(gomock.Any()).
+			Return(&rds.DescribeDBSubnetGroupsOutput{
+				DBSubnetGroups: []*rds.DBSubnetGroup{
+					&rds.DBSubnetGroup{
+						DBSubnetGroupName: aws.String(DBSubnetGroupName(a.VPCa)),
+					},
+				},
+			}, nil))
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("db-cluster-name", CloudID(a.InstallationA.ID)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1)
+
+	a.Mocks.API.RDS.EXPECT().
+		CreateDBCluster(gomock.Any()).
+		Return(nil, nil).
+		Do(func(input *rds.CreateDBClusterInput) {
+			for _, zone := range input.AvailabilityZones {
+				a.Assert().Contains(a.RDSAvailabilityZones, *zone)
+			}
+			a.Assert().Equal(*input.BackupRetentionPeriod, int64(7))
+			a.Assert().Equal(*input.DBClusterIdentifier, CloudID(a.InstallationA.ID))
+			a.Assert().Equal(*input.DatabaseName, a.DBName)
+			a.Assert().Equal(*input.VpcSecurityGroupIds[0], a.GroupID)
+		}).
+		Times(1)
+
+	a.Mocks.API.RDS.EXPECT().
+		DescribeDBInstances(gomock.Any()).
+		Return(nil, errors.New("db cluster instance does not exist")).
+		Do(func(input *rds.DescribeDBInstancesInput) {
+			a.Assert().Equal(*input.DBInstanceIdentifier, RDSMasterInstanceID(a.InstallationA.ID))
+		})
+
+	a.Mocks.Log.Logger.EXPECT().WithField("db-instance-name", RDSMasterInstanceID(a.InstallationA.ID)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.RDS.EXPECT().
+			CreateDBInstance(gomock.Any()).Return(nil, nil).
+			Do(func(input *rds.CreateDBInstanceInput) {
+				a.Assert().Equal(*input.DBClusterIdentifier, CloudID(a.InstallationA.ID))
+				a.Assert().Equal(*input.DBInstanceIdentifier, RDSMasterInstanceID(a.InstallationA.ID))
+			}).
+			Times(1))
+
+	a.Mocks.API.KMS.EXPECT().
+		DescribeKey(gomock.Any()).
+		Return(nil, awserr.New(kms.ErrCodeNotFoundException, "alias does not exist", nil)).
+		Do(func(input *kms.DescribeKeyInput) {
+			a.Assert().Equal(*input.KeyId, "alias/cloud-id000000000000000000000000a-rds")
+		}).
+		Times(1)
+
+	a.Mocks.API.KMS.EXPECT().
+		CreateKey(gomock.Any()).
+		Return(&kms.CreateKeyOutput{
+			KeyMetadata: &kms.KeyMetadata{
+				KeyId:    aws.String(a.RDSEncryptionKeyID),
+				KeyState: aws.String(kms.KeyStateEnabled),
+			},
+		}, awserr.New(kms.ErrCodeInternalException, "something went wrong", nil)).
+		Do(func(input *kms.CreateKeyInput) {
+			a.Assert().Equal(*input.Description, "Key used for encrypting RDS database")
+		}).
+		Times(1)
+
+	a.Mocks.API.KMS.EXPECT().
+		CreateAlias(gomock.Any()).
+		Times(0)
+
+	a.Mocks.Log.Logger.EXPECT().
+		Infof("Encrypting RDS database with key %s", "alias/cloud-id000000000000000000000000a-rds").
+		Times(0)
+
+	err := database.Provision(a.Mocks.Model.DatabaseInstallationStore, a.Mocks.Log.Logger)
+	a.Assert().Error(err)
+	a.Assert().Equal("unable to provision RDS database: unable to create an encryption key "+
+		"for the RDS cluster ID cloud-id000000000000000000000000a: KMSInternalException: "+
+		"something went wrong", err.Error())
+}
+
+func (a *AWSTestSuite) TestProvisionRDSEncryptionKeyAliasError() {
+	database := RDSDatabase{
+		installationID: a.InstallationA.ID,
+		client:         a.Mocks.AWS,
+	}
+
+	a.Mocks.Log.Logger.EXPECT().
+		Infof("Provisioning AWS RDS database with ID %s", CloudID(a.InstallationA.ID)).
+		Return().
+		Times(1)
+
+	a.Mocks.Model.DatabaseInstallationStore.EXPECT().
+		GetClusterInstallations(gomock.Any()).
+		Do(func(input *model.ClusterInstallationFilter) {
+			a.Assert().Equal(input.InstallationID, a.InstallationA.ID)
+		}).
+		Return([]*model.ClusterInstallation{
+			&model.ClusterInstallation{ID: a.ClusterA.ID},
+		}, nil).
+		Times(1)
+
+	a.Mocks.API.EC2.EXPECT().
+		DescribeVpcs(gomock.Any()).
+		Return(&ec2.DescribeVpcsOutput{Vpcs: []*ec2.Vpc{&ec2.Vpc{VpcId: &a.VPCa}}}, nil).
+		Times(1)
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("secret-name", RDSSecretName(CloudID(a.InstallationA.ID))).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.SecretsManager.EXPECT().
+			GetSecretValue(gomock.Any()).
+			Return(&secretsmanager.GetSecretValueOutput{SecretString: &a.SecretString}, nil).
+			Times(1))
+
+	a.Mocks.API.RDS.EXPECT().
+		DescribeDBClusters(gomock.Any()).
+		Return(nil, errors.New("db cluster does not exist")).
+		Times(1)
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("security-group-ids", []string{a.GroupID}).
+		Return(testlib.NewLoggerEntry()).Times(1).
+		After(a.Mocks.API.EC2.EXPECT().
+			DescribeSecurityGroups(gomock.Any()).
+			Return(&ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{&ec2.SecurityGroup{GroupId: &a.GroupID}},
+			}, nil))
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("db-subnet-group-name", DBSubnetGroupName(a.VPCa)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.RDS.EXPECT().
+			DescribeDBSubnetGroups(gomock.Any()).
+			Return(&rds.DescribeDBSubnetGroupsOutput{
+				DBSubnetGroups: []*rds.DBSubnetGroup{
+					&rds.DBSubnetGroup{
+						DBSubnetGroupName: aws.String(DBSubnetGroupName(a.VPCa)),
+					},
+				},
+			}, nil))
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("db-cluster-name", CloudID(a.InstallationA.ID)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1)
+
+	a.Mocks.API.RDS.EXPECT().
+		CreateDBCluster(gomock.Any()).
+		Return(nil, nil).
+		Do(func(input *rds.CreateDBClusterInput) {
+			for _, zone := range input.AvailabilityZones {
+				a.Assert().Contains(a.RDSAvailabilityZones, *zone)
+			}
+			a.Assert().Equal(*input.BackupRetentionPeriod, int64(7))
+			a.Assert().Equal(*input.DBClusterIdentifier, CloudID(a.InstallationA.ID))
+			a.Assert().Equal(*input.DatabaseName, a.DBName)
+			a.Assert().Equal(*input.VpcSecurityGroupIds[0], a.GroupID)
+		}).
+		Times(1)
+
+	a.Mocks.API.RDS.EXPECT().
+		DescribeDBInstances(gomock.Any()).
+		Return(nil, errors.New("db cluster instance does not exist")).
+		Do(func(input *rds.DescribeDBInstancesInput) {
+			a.Assert().Equal(*input.DBInstanceIdentifier, RDSMasterInstanceID(a.InstallationA.ID))
+		})
+
+	a.Mocks.Log.Logger.EXPECT().WithField("db-instance-name", RDSMasterInstanceID(a.InstallationA.ID)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.RDS.EXPECT().
+			CreateDBInstance(gomock.Any()).Return(nil, nil).
+			Do(func(input *rds.CreateDBInstanceInput) {
+				a.Assert().Equal(*input.DBClusterIdentifier, CloudID(a.InstallationA.ID))
+				a.Assert().Equal(*input.DBInstanceIdentifier, RDSMasterInstanceID(a.InstallationA.ID))
+			}).
+			Times(1))
+
+	a.Mocks.API.KMS.EXPECT().
+		DescribeKey(gomock.Any()).
+		Return(nil, awserr.New(kms.ErrCodeNotFoundException, "alias does not exist", nil)).
+		Do(func(input *kms.DescribeKeyInput) {
+			a.Assert().Equal(*input.KeyId, "alias/cloud-id000000000000000000000000a-rds")
+		}).
+		Times(1)
+
+	a.Mocks.API.KMS.EXPECT().
+		CreateKey(gomock.Any()).
+		Return(&kms.CreateKeyOutput{
+			KeyMetadata: &kms.KeyMetadata{
+				KeyId:    aws.String(a.RDSEncryptionKeyID),
+				KeyState: aws.String(kms.KeyStateEnabled),
+			},
+		}, nil).
+		Do(func(input *kms.CreateKeyInput) {
+			a.Assert().Equal(*input.Description, "Key used for encrypting RDS database")
+		}).
+		Times(1)
+
+	a.Mocks.API.KMS.EXPECT().
+		CreateAlias(gomock.Any()).
+		Return(nil, awserr.New(kms.ErrCodeIncorrectKeyException, "some random error", nil)).
+		Do(func(input *kms.CreateAliasInput) {
+			a.Assert().Equal(*input.AliasName, KMSAliasNameRDS(CloudID(a.InstallationA.ID)))
+		}).
+		Times(1)
+
+	a.Mocks.API.KMS.EXPECT().
+		ScheduleKeyDeletion(gomock.Any()).
+		Do(func(input *kms.ScheduleKeyDeletionInput) {
+			a.Assert().Equal(*input.KeyId, a.RDSEncryptionKeyID)
+		}).
+		Times(1)
+
+	a.Mocks.Log.Logger.EXPECT().
+		Infof("Encrypting RDS database with key %s", "alias/cloud-id000000000000000000000000a-rds").
+		Times(0)
+
+	err := database.Provision(a.Mocks.Model.DatabaseInstallationStore, a.Mocks.Log.Logger)
+	a.Assert().Error(err)
+	a.Assert().Equal("unable to provision RDS database: unable to create an encryption key alias "+
+		"name for the RDS cluster ID cloud-id000000000000000000000000a: IncorrectKeyException: "+
+		"some random error", err.Error())
+}
+
+func (a *AWSTestSuite) TestProvisionRDSEncryptionKeyStateError() {
+	database := RDSDatabase{
+		installationID: a.InstallationA.ID,
+		client:         a.Mocks.AWS,
+	}
+
+	a.Mocks.Log.Logger.EXPECT().
+		Infof("Provisioning AWS RDS database with ID %s", CloudID(a.InstallationA.ID)).
+		Return().
+		Times(1)
+
+	a.Mocks.Model.DatabaseInstallationStore.EXPECT().
+		GetClusterInstallations(gomock.Any()).
+		Do(func(input *model.ClusterInstallationFilter) {
+			a.Assert().Equal(input.InstallationID, a.InstallationA.ID)
+		}).
+		Return([]*model.ClusterInstallation{
+			&model.ClusterInstallation{ID: a.ClusterA.ID},
+		}, nil).
+		Times(1)
+
+	a.Mocks.API.EC2.EXPECT().
+		DescribeVpcs(gomock.Any()).
+		Return(&ec2.DescribeVpcsOutput{Vpcs: []*ec2.Vpc{&ec2.Vpc{VpcId: &a.VPCa}}}, nil).
+		Times(1)
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("secret-name", RDSSecretName(CloudID(a.InstallationA.ID))).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.SecretsManager.EXPECT().
+			GetSecretValue(gomock.Any()).
+			Return(&secretsmanager.GetSecretValueOutput{SecretString: &a.SecretString}, nil).
+			Times(1))
+
+	a.Mocks.API.RDS.EXPECT().
+		DescribeDBClusters(gomock.Any()).
+		Return(nil, errors.New("db cluster does not exist")).
+		Times(1)
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("security-group-ids", []string{a.GroupID}).
+		Return(testlib.NewLoggerEntry()).Times(1).
+		After(a.Mocks.API.EC2.EXPECT().
+			DescribeSecurityGroups(gomock.Any()).
+			Return(&ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{&ec2.SecurityGroup{GroupId: &a.GroupID}},
+			}, nil))
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("db-subnet-group-name", DBSubnetGroupName(a.VPCa)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.RDS.EXPECT().
+			DescribeDBSubnetGroups(gomock.Any()).
+			Return(&rds.DescribeDBSubnetGroupsOutput{
+				DBSubnetGroups: []*rds.DBSubnetGroup{
+					&rds.DBSubnetGroup{
+						DBSubnetGroupName: aws.String(DBSubnetGroupName(a.VPCa)),
+					},
+				},
+			}, nil))
+
+	a.Mocks.Log.Logger.EXPECT().
+		WithField("db-cluster-name", CloudID(a.InstallationA.ID)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1)
+
+	a.Mocks.API.RDS.EXPECT().
+		CreateDBCluster(gomock.Any()).
+		Return(nil, nil).
+		Do(func(input *rds.CreateDBClusterInput) {
+			for _, zone := range input.AvailabilityZones {
+				a.Assert().Contains(a.RDSAvailabilityZones, *zone)
+			}
+			a.Assert().Equal(*input.BackupRetentionPeriod, int64(7))
+			a.Assert().Equal(*input.DBClusterIdentifier, CloudID(a.InstallationA.ID))
+			a.Assert().Equal(*input.DatabaseName, a.DBName)
+			a.Assert().Equal(*input.VpcSecurityGroupIds[0], a.GroupID)
+		}).
+		Times(1)
+
+	a.Mocks.API.RDS.EXPECT().
+		DescribeDBInstances(gomock.Any()).
+		Return(nil, errors.New("db cluster instance does not exist")).
+		Do(func(input *rds.DescribeDBInstancesInput) {
+			a.Assert().Equal(*input.DBInstanceIdentifier, RDSMasterInstanceID(a.InstallationA.ID))
+		})
+
+	a.Mocks.Log.Logger.EXPECT().WithField("db-instance-name", RDSMasterInstanceID(a.InstallationA.ID)).
+		Return(testlib.NewLoggerEntry()).
+		Times(1).
+		After(a.Mocks.API.RDS.EXPECT().
+			CreateDBInstance(gomock.Any()).Return(nil, nil).
+			Do(func(input *rds.CreateDBInstanceInput) {
+				a.Assert().Equal(*input.DBClusterIdentifier, CloudID(a.InstallationA.ID))
+				a.Assert().Equal(*input.DBInstanceIdentifier, RDSMasterInstanceID(a.InstallationA.ID))
+			}).
+			Times(1))
+
+	a.Mocks.API.KMS.EXPECT().
+		DescribeKey(gomock.Any()).
+		Return(&kms.DescribeKeyOutput{
+			KeyMetadata: &kms.KeyMetadata{
+				KeyId:    aws.String(a.RDSEncryptionKeyID),
+				KeyState: aws.String(kms.KeyStatePendingDeletion),
+			},
+		}, nil).
+		Times(1)
+
+	a.Mocks.API.KMS.EXPECT().
+		CreateKey(gomock.Any()).
+		Times(0)
+
+	a.Mocks.API.KMS.EXPECT().
+		CreateAlias(gomock.Any()).
+		Times(0)
+
+	a.Mocks.API.KMS.EXPECT().
+		ScheduleKeyDeletion(gomock.Any()).
+		Times(0)
+
+	a.Mocks.Log.Logger.EXPECT().
+		Infof("Encrypting RDS database with key %s", "alias/cloud-id000000000000000000000000a-rds").
+		Times(0)
+
+	err := database.Provision(a.Mocks.Model.DatabaseInstallationStore, a.Mocks.Log.Logger)
+	a.Assert().Error(err)
+	a.Assert().Equal("unable to provision RDS database: expected encryption key "+
+		"alias/cloud-id000000000000000000000000a-rds state to be Enabled, but it was "+
+		"PendingDeletion", err.Error())
 }
 
 // WARNING:

--- a/internal/tools/aws/kms.go
+++ b/internal/tools/aws/kms.go
@@ -3,16 +3,15 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
-	"github.com/pkg/errors"
 )
 
 // kmsCreateSymmetricKey creates a symmetric encryption key with alias.
-func (a *Client) kmsCreateSymmetricKey(awsID, keyDescription string) (*kms.KeyMetadata, error) {
+func (a *Client) kmsCreateSymmetricKey(keyDescription string) (*kms.KeyMetadata, error) {
 	createKeyOut, err := a.Service().kms.CreateKey(&kms.CreateKeyInput{
 		Description: aws.String(keyDescription),
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unabled to create encryption key for %s", awsID)
+		return nil, err
 	}
 
 	return createKeyOut.KeyMetadata, nil
@@ -26,7 +25,7 @@ func (a *Client) kmsCreateAlias(keyID, aliasName string) error {
 		TargetKeyId: aws.String(keyID),
 	})
 	if err != nil {
-		return errors.Wrapf(err, "unabled to create an alias name for encryption key %s", keyID)
+		return err
 	}
 
 	return nil
@@ -38,7 +37,7 @@ func (a *Client) kmsDisableSymmetricKey(keyID string) error {
 		KeyId: aws.String(keyID),
 	})
 	if err != nil {
-		return errors.Wrapf(err, "unabled to disable encryption key %s", keyID)
+		return err
 	}
 
 	return nil
@@ -50,7 +49,7 @@ func (a *Client) kmsGetSymmetricKey(aliasName string) (*kms.KeyMetadata, error) 
 		KeyId: aws.String(aliasName),
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unabled to describe encryption key for alias name %s", aliasName)
+		return nil, err
 	}
 
 	return describeKeyOut.KeyMetadata, nil
@@ -65,7 +64,7 @@ func (a *Client) kmsScheduleKeyDeletion(keyID string, days int64) error {
 		PendingWindowInDays: aws.Int64(days),
 	})
 	if err != nil {
-		return errors.Wrapf(err, "unable to schedule deletion of encryption key ID %s", keyID)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary

Few improvements to the tools/aws/database:

-  Added logic to check when alias name already exists and then reuse the encryption key
- Fixed bug which KMS return errors were being wrapped and then failing on awserror type assertion.
- Check state of the key before using it.
- Added more tests for different use cases involving encryption key. 

Signed-off-by: Gabriel Linden Sagula <gsagula@gmail.com>

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-24209

