### PR TITLE
Always log to DEBUG level from AWS session

### DIFF
--- a/internal/tools/aws/session.go
+++ b/internal/tools/aws/session.go
@@ -37,12 +37,7 @@ func NewAWSSessionWithLogger(config *aws.Config, logger log.FieldLogger) (*sessi
 				"aws-operation-name": r.Operation.Name,
 			})
 
-			if r.HTTPResponse.StatusCode >= 400 {
-				logger.Error(buffer.String())
-			}
-			if r.HTTPResponse.StatusCode < 400 {
-				logger.Debug(buffer.String())
-			}
+			logger.Debug(buffer.String())
 		}
 	})
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Changes the AWS session package to only log at DEBUG level. On `master` the behavior is such that we get ERROR level logs for any response from AWS >=400 level. While this does represent an HTTP error, there are a number of places where we expect an error from AWS under normal operation, so it becomes incorrect to bubble up these API errors as application errors.

This change changes all talk with AWS to DEBUG level so that the provisioner output only produces red error output in cases where there are application errors.

#### Ticket Link
No ticket link

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
