### PR TITLE
MM-23741 Only run Helm once during install

### DIFF
--- a/internal/provisioner/certmanager.go
+++ b/internal/provisioner/certmanager.go
@@ -54,18 +54,7 @@ func (n *certManager) updateVersion(h *helmDeployment) error {
 	return nil
 }
 
-func (n *certManager) Create() error {
-	h := n.NewHelmDeployment()
-	err := h.Create()
-	if err != nil {
-		return err
-	}
-
-	err = n.updateVersion(h)
-	return err
-}
-
-func (n *certManager) Upgrade() error {
+func (n *certManager) CreateOrUpgrade() error {
 	h := n.NewHelmDeployment()
 	err := h.Update()
 	if err != nil {

--- a/internal/provisioner/fluentbit.go
+++ b/internal/provisioner/fluentbit.go
@@ -47,23 +47,11 @@ func newFluentbitHandle(version string, provisioner *KopsProvisioner, awsClient 
 	}, nil
 }
 
-func (f *fluentbit) Create() error {
-	logger := f.logger.WithField("fluentbit-action", "create")
-	h := f.NewHelmDeployment(logger)
-	err := h.Create()
-	if err != nil {
-		return err
-	}
-
-	err = f.updateVersion(h)
-	return err
-}
-
 func (f *fluentbit) Destroy() error {
 	return nil
 }
 
-func (f *fluentbit) Upgrade() error {
+func (f *fluentbit) CreateOrUpgrade() error {
 	logger := f.logger.WithField("fluentbit-action", "upgrade")
 	h := f.NewHelmDeployment(logger)
 	err := h.Update()

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -271,18 +271,6 @@ func helmSetup(logger log.FieldLogger, kops *kops.Cmd) error {
 		return errors.Wrap(err, "failed to set up the k8s client")
 	}
 
-	helmClient, err := helm.New(logger)
-	if err != nil {
-		return errors.Wrap(err, "unable to create helm wrapper")
-	}
-	defer helmClient.Close()
-
-	logger.Info("Initializing Helm in the cluster")
-	err = helmClient.RunGenericCommand("--debug", "--kubeconfig", kops.GetKubeConfigPath(), "init", "--upgrade")
-	if err != nil {
-		return errors.Wrap(err, "failed to initialize Helm in the cluster")
-	}
-
 	logger.Info("Creating Tiller service account")
 	serviceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{Name: "tiller"},

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -66,13 +66,6 @@ func (d *helmDeployment) Update() error {
 	return nil
 }
 
-// Create will install a given HelmDeployment in the cluster specified in that object.
-func (d *helmDeployment) Create() error {
-	logger := d.logger.WithField("helm-create", d.chartName)
-	logger.Infof("Installing helm chart %s", d.chartName)
-	return installHelmChart(*d, d.kops.GetKubeConfigPath(), logger)
-}
-
 // waitForHelmRunning is used to check when Helm is ready to install charts.
 func waitForHelmRunning(ctx context.Context, configPath string) error {
 	for {

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -342,7 +342,7 @@ func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster, aws
 		return errors.Wrap(err, "failed to create new cluster utility group handle")
 	}
 
-	err = ugh.UpgradeUtilityGroup()
+	err = ugh.ProvisionUtilityGroup()
 	if err != nil {
 		return errors.Wrap(err, "failed to upgrade all services in utility group")
 	}

--- a/internal/provisioner/nginx.go
+++ b/internal/provisioner/nginx.go
@@ -49,18 +49,7 @@ func (n *nginx) updateVersion(h *helmDeployment) error {
 	return nil
 }
 
-func (n *nginx) Create() error {
-	h := n.NewHelmDeployment()
-	err := h.Create()
-	if err != nil {
-		return err
-	}
-
-	err = n.updateVersion(h)
-	return err
-}
-
-func (n *nginx) Upgrade() error {
+func (n *nginx) CreateOrUpgrade() error {
 	h := n.NewHelmDeployment()
 	err := h.Update()
 	if err != nil {

--- a/internal/provisioner/prometheus.go
+++ b/internal/provisioner/prometheus.go
@@ -3,7 +3,6 @@ package provisioner
 import (
 	"context"
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
@@ -79,12 +78,12 @@ func (p *prometheus) CreateOrUpgrade() error {
 
 	app := "prometheus"
 	dns := fmt.Sprintf("%s.%s.%s", p.cluster.ID, app, privateDomainName)
-	_, err = net.LookupNS(dns)
-	if err == nil {
-		// if we can resolve this domain then the domain is already provisioned
+	if p.awsClient.IsProvisionedPrivateCNAME(dns, p.logger) {
+		p.logger.Debugln("CNAME was already provisioned for prometheus")
 		return nil
 	}
 
+	p.logger.Debugln("CNAME was not provisioned for prometheus")
 	ctx, cancel := context.WithTimeout(context.Background(), 120)
 	defer cancel()
 

--- a/internal/provisioner/public_nginx.go
+++ b/internal/provisioner/public_nginx.go
@@ -49,18 +49,7 @@ func (n *publicNginx) updateVersion(h *helmDeployment) error {
 	return nil
 }
 
-func (n *publicNginx) Create() error {
-	h := n.NewHelmDeployment()
-	err := h.Create()
-	if err != nil {
-		return err
-	}
-
-	err = n.updateVersion(h)
-	return err
-}
-
-func (n *publicNginx) Upgrade() error {
+func (n *publicNginx) CreateOrUpgrade() error {
 	h := n.NewHelmDeployment()
 	err := h.Update()
 	if err != nil {

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -156,12 +156,6 @@ func (group utilityGroup) ProvisionUtilityGroup() error {
 		return errors.Wrap(err, "failed to set up Helm as a prerequisite to installing the cluster utilities")
 	}
 
-	logger = group.provisioner.logger.WithField("helm-init", "ProvisionUtilityGroup")
-	err = helmInit(logger, group.kops)
-	if err != nil {
-		logger.WithError(err).Error("couldn't re-initialize Helm in the cluster")
-	}
-
 	logger.Info("Adding new Helm repos.")
 	for repoName, repoURL := range helmRepos {
 		err = helmRepoAdd(repoName, repoURL, logger)

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -121,20 +121,6 @@ func (group utilityGroup) CreateUtilityGroup() error {
 		return errors.Wrap(err, "failed to deploy Cert Manager manifests")
 	}
 
-	// TODO remove this when Helm is removed as a dependency
-	err = installHelm(group.kops, helmRepos, group.provisioner.logger)
-	if err != nil {
-		return errors.Wrap(err, "failed to set up Helm as a prerequisite to installing the cluster utilities")
-	}
-
-	logger.Info("Adding new Helm repos.")
-	for repoName, repoURL := range helmRepos {
-		err = helmRepoAdd(repoName, repoURL, logger)
-		if err != nil {
-			return errors.Wrap(err, "unable to add helm repos")
-		}
-	}
-
 	return nil
 }
 
@@ -165,7 +151,12 @@ func (group utilityGroup) ProvisionUtilityGroup() error {
 		return errors.Wrap(err, "failed to deploy Cert Manager manifests")
 	}
 
-	logger = group.provisioner.logger.WithField("helm-init", "UpgradeUtilityGroup")
+	err = installHelm(group.kops, helmRepos, group.provisioner.logger.WithField("helm-install", "ProvisionUtilityGroup"))
+	if err != nil {
+		return errors.Wrap(err, "failed to set up Helm as a prerequisite to installing the cluster utilities")
+	}
+
+	logger = group.provisioner.logger.WithField("helm-init", "ProvisionUtilityGroup")
 	err = helmInit(logger, group.kops)
 	if err != nil {
 		logger.WithError(err).Error("couldn't re-initialize Helm in the cluster")

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -184,6 +184,10 @@ func (a *mockAWS) CreatePublicCNAME(dnsName string, dnsEndpoints []string, logge
 	return nil
 }
 
+func (a *mockAWS) IsProvisionedPrivateCNAME(dnsName string, logger log.FieldLogger) bool {
+	return false
+}
+
 func (a *mockAWS) DeletePrivateCNAME(dnsName string, logger log.FieldLogger) error {
 	return nil
 }

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -38,6 +38,7 @@ type AWS interface {
 	CreatePrivateCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error
 	CreatePublicCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error
 
+	IsProvisionedPrivateCNAME(dnsName string, logger log.FieldLogger) bool
 	DeletePrivateCNAME(dnsName string, logger log.FieldLogger) error
 	DeletePublicCNAME(dnsName string, logger log.FieldLogger) error
 

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -128,6 +128,8 @@ func (a *Client) createCNAME(hostedZoneID, dnsName string, dnsEndpoints []string
 	return nil
 }
 
+// IsProvisionedPrivateCNAME returns true if a record has been
+// registered for the given CNAME (full FQDN required as input)
 func (a *Client) IsProvisionedPrivateCNAME(dnsName string, logger log.FieldLogger) bool {
 	id, err := a.getHostedZoneIDWithTag(Tag{
 		Key:   DefaultCloudDNSTagKey,

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -167,7 +167,7 @@ func (a *Client) deleteCNAME(hostedZoneID, dnsName string, logger log.FieldLogge
 			return err
 		}
 
-		recordsets = append(recordsets, recordList.ResourceRecordSets...)
+		recordSets = append(recordSets, recordList.ResourceRecordSets...)
 
 		if !*recordList.IsTruncated {
 			break
@@ -179,11 +179,11 @@ func (a *Client) deleteCNAME(hostedZoneID, dnsName string, logger log.FieldLogge
 	}
 
 	var changes []*route53.Change
-	for _, recordset := range recordsets {
-		if strings.Trim(*recordset.Name, ".") == dnsName {
+	for _, recordSet := range recordSets {
+		if strings.Trim(*recordSet.Name, ".") == dnsName {
 			changes = append(changes, &route53.Change{
 				Action:            aws.String("DELETE"),
-				ResourceRecordSet: recordset,
+				ResourceRecordSet: recordSet,
 			})
 		}
 	}


### PR DESCRIPTION
### Summary
<!--
A description of what this pull request does.
-->
This pull request simplifies the UtilityGroup creation process by moving the `helm upgrade` commands to the `provision` step. This does several things:

1) `helm install` is no longer called during the cluster creation step. Only preliminary one-time setup for the Utilities is now called in CreateUtilityGroup. The actual Helm charts are not installed during this step.

2) `helm upgrade --install` is called during the provision step. This installs the utilities during `cloud cluster create` and updates them during `cloud cluster provision`.

3) Utilities are now responsible for independently figuring out if they are being reprovisioned or installed for the first time, during `CreateOrUpgrade`. Right now, only Prometheus does one-time setup during Create and it was easy to gate this behavior so it only runs if necessary. In the future, new Utilities will be expected to follow this pattern. The other existing utilities had identical creation/upgrade routines.

`UpgradeUtilityGroup` is also changed to `ProvisionUtilityGroup` to better indicate the fact that this method is called during provision. It's also now responsible for both deploying and upgrading the UtilityGroup, so the name change makes sense to reflect that as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23741

#### Testing

Manually I've created/destroyed a few clusters, and I also tried wiping `$HELM_HOME` and could still `create` without it. I also tried running `create`, then killing the provisioner server, wiping `$HELM_HOME`, and was able to re-`provision` the existing cluster without a problem after restarting the provisioner server.

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Optimized UtilityGroup installation at cluster creation time
```
