### PR TITLE
MM-24373 Add --dev flag to enable development mode

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -47,6 +47,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("keep-filestore-data", true, "Whether to preserve filestore data after installation deletion or not.")
 	serverCmd.PersistentFlags().Bool("debug", false, "Whether to output debug logs.")
 	serverCmd.PersistentFlags().Bool("machine-readable-logs", false, "Output the logs in machine readable format.")
+	serverCmd.PersistentFlags().Bool("dev", false, "Set sane defaults for development")
 }
 
 var serverCmd = &cobra.Command{
@@ -108,6 +109,23 @@ var serverCmd = &cobra.Command{
 			logger.WithError(err).Error("Unable to get current working directory")
 		}
 
+		dev, _ := command.Flags().GetBool("dev")
+		if dev {
+
+			if !command.Flags().Changed("debug") {
+				debug = true
+			}
+
+			if !command.Flags().Changed("keep-database-data") {
+				keepDatabaseData = false
+			}
+
+			if !command.Flags().Changed("keep-filestore-data") {
+				keepFilestoreData = false
+			}
+
+		}
+
 		logger.WithFields(logrus.Fields{
 			"cluster-supervisor":              clusterSupervisor,
 			"group-supervisor":                groupSupervisor,
@@ -121,6 +139,7 @@ var serverCmd = &cobra.Command{
 			"keep-database-data":              keepDatabaseData,
 			"keep-filestore-data":             keepFilestoreData,
 			"debug":                           debug,
+			"dev-mode":                        dev,
 		}).Info("Starting Mattermost Provisioning Server")
 
 		deprecationWarnings(logger, command)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Adds a flag `--dev` that will set `debug=true`, `keep-filestore-data=false`, and `keep-database-data=false`. All of these options can additionally be specified at the command line and the specified value will be respected even if `--dev` is specified.

For instance, you could run in developer mode (accept all other developer mode defaults) but keep your filestore data explicitly:

```
~/g/s/g/m/mattermost-cloud » cloud server --state-store $KOPS_STATE_STORE --database postgres://postgres@localhost:5434/cloud --keep-filestore-data=true --dev

INFO[2020-04-21T15:19:27-05:00] Starting Mattermost Provisioning Server       cluster-installation-supervisor=true cluster-resource-threshold=80 cluster-supervisor=true debug=true dev-mode=true group-supervisor=false installation-supervisor=true instance=m58qhymhypg7x8kfwi5egjspmw keep-database-data=false keep-filestore-data=true state-store="s3://ian-new-kops-state" store-version=0.16.0 use-existing-aws-resources=true working-directory=/home/ian/go/src/github.com/mattermost/mattermost-cloud
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24373

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added `--dev` flag for a development mode with sane defaults for running the provisioner server during development
```
