### PR TITLE
Fix ineffectual debug log setting when in dev mode

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -56,8 +56,10 @@ var serverCmd = &cobra.Command{
 	RunE: func(command *cobra.Command, args []string) error {
 		command.SilenceUsage = true
 
+		devMode, _ := command.Flags().GetBool("dev")
+
 		debug, _ := command.Flags().GetBool("debug")
-		if debug {
+		if debug || (devMode && flagIsUnset(command, "debug")) {
 			logger.SetLevel(logrus.DebugLevel)
 		}
 
@@ -109,18 +111,13 @@ var serverCmd = &cobra.Command{
 			logger.WithError(err).Error("Unable to get current working directory")
 		}
 
-		dev, _ := command.Flags().GetBool("dev")
-		if dev {
+		if devMode {
 
-			if !command.Flags().Changed("debug") {
-				debug = true
-			}
-
-			if !command.Flags().Changed("keep-database-data") {
+			if flagIsUnset(command, "keep-database-data") {
 				keepDatabaseData = false
 			}
 
-			if !command.Flags().Changed("keep-filestore-data") {
+			if flagIsUnset(command, "keep-filestore-data") {
 				keepFilestoreData = false
 			}
 
@@ -139,7 +136,7 @@ var serverCmd = &cobra.Command{
 			"keep-database-data":              keepDatabaseData,
 			"keep-filestore-data":             keepFilestoreData,
 			"debug":                           debug,
-			"dev-mode":                        dev,
+			"dev-mode":                        devMode,
 		}).Info("Starting Mattermost Provisioning Server")
 
 		deprecationWarnings(logger, command)
@@ -274,4 +271,8 @@ func getHumanReadableID() string {
 	}
 
 	return strings.TrimSpace(string(output))
+}
+
+func flagIsUnset(cmd *cobra.Command, flagName string) bool {
+	return !cmd.Flags().Changed(flagName)
 }

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -59,7 +59,8 @@ var serverCmd = &cobra.Command{
 		devMode, _ := command.Flags().GetBool("dev")
 
 		debug, _ := command.Flags().GetBool("debug")
-		if debug || (devMode && flagIsUnset(command, "debug")) {
+		debugMode := debug || (devMode && flagIsUnset(command, "debug"))
+		if debugMode {
 			logger.SetLevel(logrus.DebugLevel)
 		}
 
@@ -135,7 +136,7 @@ var serverCmd = &cobra.Command{
 			"use-existing-aws-resources":      useExistingResources,
 			"keep-database-data":              keepDatabaseData,
 			"keep-filestore-data":             keepFilestoreData,
-			"debug":                           debug,
+			"debug":                           debugMode,
 			"dev-mode":                        devMode,
 		}).Info("Starting Mattermost Provisioning Server")
 


### PR DESCRIPTION
I noticed a small bug in the dev mode stuff I wrote earlier, sorry about this.

Setting `--dev` wasn't actually causing the logger to log in DEBUG mode because the logger gets created earlier in program execution.

This fixes that and also provides a little cleanup with a new helper method.
```release-note
Fixed a bug causing `--dev` to not output DEBUG logs
```