### PR TITLE
MM-23151: changed multi-tenant database's  locking pattern

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -157,7 +157,7 @@ var serverCmd = &cobra.Command{
 			MaxRetries: sdkAWS.Int(toolsAWS.DefaultAWSClientRetries),
 		}, logger)
 
-		resourceUtil := utils.NewResourceUtil(awsClient)
+		resourceUtil := utils.NewResourceUtil(instanceID, awsClient)
 
 		// Setup the provisioner for actually effecting changes to clusters.
 		kopsProvisioner := provisioner.NewKopsProvisioner(

--- a/internal/store/multitenant_database.go
+++ b/internal/store/multitenant_database.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"fmt"
 
-	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-cloud/model"
+
+	sq "github.com/Masterminds/squirrel"
 	"github.com/pkg/errors"
 )
 
@@ -44,7 +45,7 @@ func (sqlStore *SQLStore) GetMultitenantDatabases(filter *model.MultitenantDatab
 	if filter != nil {
 		if len(filter.InstallationID) > 0 {
 			builder = builder.
-				Where("RawInstallationIDs LIKE ?", fmt.Sprint("%", filter.InstallationID, "%"))
+				Where(sq.Like{"RawInstallationIDs": fmt.Sprint("%", filter.InstallationID, "%")})
 		}
 
 		if len(filter.LockerID) > 0 {
@@ -135,8 +136,8 @@ func (sqlStore *SQLStore) UpdateMultitenantDatabase(multitenantDatabase *model.M
 		SetMap(map[string]interface{}{
 			"RawInstallationIDs": multitenantDatabase.RawInstallationIDs,
 		}).
-		Where("ID = ?", multitenantDatabase.ID).
-		Where("LockAcquiredBy = ?", *multitenantDatabase.LockAcquiredBy),
+		Where(sq.Eq{"ID": multitenantDatabase.ID}).
+		Where(sq.Eq{"LockAcquiredBy": *multitenantDatabase.LockAcquiredBy}),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to update multitenant database")

--- a/internal/store/multitenant_database.go
+++ b/internal/store/multitenant_database.go
@@ -236,11 +236,11 @@ func (sqlStore *SQLStore) GetMultitenantDatabaseForInstallationID(installationID
 }
 
 // LockMultitenantDatabase marks the database cluster as locked for exclusive use by the caller.
-func (sqlStore *SQLStore) LockMultitenantDatabase(multitenantDatabaseID, installationID string) (bool, error) {
-	return sqlStore.lockRows("MultitenantDatabase", []string{multitenantDatabaseID}, installationID)
+func (sqlStore *SQLStore) LockMultitenantDatabase(multitenantDatabaseID, instanceID string) (bool, error) {
+	return sqlStore.lockRows("MultitenantDatabase", []string{multitenantDatabaseID}, instanceID)
 }
 
 // UnlockMultitenantDatabase releases a lock previously acquired against a caller.
-func (sqlStore *SQLStore) UnlockMultitenantDatabase(multitenantDatabaseID, installationID string, force bool) (bool, error) {
-	return sqlStore.unlockRows("MultitenantDatabase", []string{multitenantDatabaseID}, installationID, force)
+func (sqlStore *SQLStore) UnlockMultitenantDatabase(multitenantDatabaseID, instanceID string, force bool) (bool, error) {
+	return sqlStore.unlockRows("MultitenantDatabase", []string{multitenantDatabaseID}, instanceID, force)
 }

--- a/internal/tools/aws/client_test.go
+++ b/internal/tools/aws/client_test.go
@@ -54,6 +54,8 @@ type AWSTestSuite struct {
 	InstallationA *model.Installation
 	InstallationB *model.Installation
 
+	InstanceID string
+
 	ClusterA *model.Cluster
 	ClusterB *model.Cluster
 
@@ -143,6 +145,7 @@ func NewAWSTestSuite(t *testing.T) *AWSTestSuite {
 		CertifcateARN:        "arn:aws:certificate::123456789012",
 		ResourceARN:          "arn:aws:kms:us-east-1:526412419611:key/10cbe864-7411-4cda-bd28-3355218d0995",
 		RDSResourceARN:       "arn:aws:rds:us-east-1:926412419614:cluster:rds-cluster-multitenant-09d44077df9934f96-97670d43",
+		InstanceID:           "WSxaaqafXCgeaZers2qergasdgsw1dC",
 
 		EndpointsA: []string{"example1.mattermost.com", "example2.mattermost.com"},
 		EndpointsB: []string{"example1.mattermost.com"},

--- a/internal/tools/aws/database_multitenant_test.go
+++ b/internal/tools/aws/database_multitenant_test.go
@@ -20,6 +20,7 @@ import (
 func (a *AWSTestSuite) TestProvisioningMultitenantDatabase() {
 	database := RDSMultitenantDatabase{
 		installationID: a.InstallationA.ID,
+		instanceID:     a.InstanceID,
 		client:         a.Mocks.AWS,
 	}
 
@@ -42,16 +43,6 @@ func (a *AWSTestSuite) TestProvisioningMultitenantDatabase() {
 		a.Mocks.API.EC2.EXPECT().DescribeVpcs(gomock.Any()).
 			Return(&ec2.DescribeVpcsOutput{Vpcs: []*ec2.Vpc{{VpcId: &a.VPCa}}}, nil).
 			Times(1),
-
-		// Get multitenant databases from the datastore to check if any is locked.
-		a.Mocks.Model.DatabaseInstallationStore.EXPECT().
-			GetMultitenantDatabases(gomock.Any()).
-			Do(func(input *model.MultitenantDatabaseFilter) {
-				a.Assert().Equal(input.LockerID, a.InstallationA.ID)
-				a.Assert().Equal(input.NumOfInstallationsLimit, model.NoInstallationsLimit)
-				a.Assert().Equal(input.PerPage, model.AllPerPage)
-			}).
-			Return(make([]*model.MultitenantDatabase, 0), nil),
 
 		// Get multitenant databases from the datastore to check if any belongs to the installation ID.
 		a.Mocks.Model.DatabaseInstallationStore.EXPECT().
@@ -159,7 +150,7 @@ func (a *AWSTestSuite) TestProvisioningMultitenantDatabase() {
 			Times(1),
 
 		a.Mocks.Model.DatabaseInstallationStore.EXPECT().
-			LockMultitenantDatabase(a.RDSClusterID, a.InstallationA.ID).
+			LockMultitenantDatabase(a.RDSClusterID, a.InstanceID).
 			Return(true, nil).
 			Times(1),
 
@@ -202,7 +193,7 @@ func (a *AWSTestSuite) TestProvisioningMultitenantDatabase() {
 			Times(1),
 
 		a.Mocks.Model.DatabaseInstallationStore.EXPECT().
-			UnlockMultitenantDatabase(a.RDSClusterID, a.InstallationA.ID, true).
+			UnlockMultitenantDatabase(a.RDSClusterID, a.InstanceID, true).
 			Return(true, nil).
 			Times(1),
 	)

--- a/internal/tools/utils/utils.go
+++ b/internal/tools/utils/utils.go
@@ -82,13 +82,15 @@ func copyFile(source string, dest string) error {
 
 // ResourceUtil is used for calling any filestore type.
 type ResourceUtil struct {
-	awsClient *aws.Client
+	awsClient  *aws.Client
+	instanceID string
 }
 
 // NewResourceUtil returns a new instance of ResourceUtil.
-func NewResourceUtil(awsClient *aws.Client) *ResourceUtil {
+func NewResourceUtil(instanceID string, awsClient *aws.Client) *ResourceUtil {
 	return &ResourceUtil{
-		awsClient: awsClient,
+		awsClient:  awsClient,
+		instanceID: instanceID,
 	}
 }
 
@@ -114,7 +116,7 @@ func (r *ResourceUtil) GetDatabase(installation *model.Installation) model.Datab
 	case model.InstallationDatabaseSingleTenantRDS:
 		return aws.NewRDSDatabase(installation.ID, r.awsClient)
 	case model.InstallationDatabaseMultiTenantRDS:
-		return aws.NewRDSMultitenantDatabase(installation.ID, r.awsClient)
+		return aws.NewRDSMultitenantDatabase(r.instanceID, installation.ID, r.awsClient)
 	}
 
 	// Warning: we should never get here as it would mean that we didn't match


### PR DESCRIPTION
#### Summary
This PR changes the multi-tenant database locking mechanism to be consistent with the same locking pattern used in other parts of the code. Prior to this change, multi-tenant database was using the installation id for locking a table row. This can be a problem when multiple provisioners operate simultaneously and for this reason we favour the usage of an instance id to acquire any lock. The same PR also gets rid of a part of the code that was being used to release a row that got stuck in the locked state.

#### Related Issue
https://github.com/mattermost/mattermost-cloud/pull/209

#### Release Note
```release-note
 * Changed the multi-tenant database logic to acquire locks using the instance ID instead of the installation ID.
 * Removed the logic used by the multi-tenant database to auto-release rows in a permanent locked state. This should be done manually by the operator. 
```


Signed-off-by: Gabriel Linden Sagula <gsagula@gmail.com>