### PR TITLE
Add installation scaling

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -28,6 +28,7 @@ func init() {
 	installationUpdateCmd.Flags().String("installation", "", "The id of the installation to be updated.")
 	installationUpdateCmd.Flags().String("version", "stable", "The Mattermost version to target.")
 	installationUpdateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost container image to use.")
+	installationUpdateCmd.Flags().String("size", model.InstallationDefaultSize, "The size of the installation. Accepts 100users, 1000users, 5000users, 10000users, 25000users, miniSingleton, or miniHA. Defaults to 100users.")
 	installationUpdateCmd.Flags().String("license", "", "The Mattermost License to use in the server.")
 	installationUpdateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	installationUpdateCmd.MarkFlagRequired("installation")
@@ -130,6 +131,7 @@ var installationUpdateCmd = &cobra.Command{
 			&model.PatchInstallationRequest{
 				Version:       getStringFlagPointer(command, "version"),
 				Image:         getStringFlagPointer(command, "image"),
+				Size:          getStringFlagPointer(command, "size"),
 				License:       getStringFlagPointer(command, "license"),
 				MattermostEnv: envVarMap,
 			},

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -156,6 +156,7 @@ func (request *GetInstallationsRequest) ApplyToURL(u *url.URL) {
 type PatchInstallationRequest struct {
 	Version       *string
 	Image         *string
+	Size          *string
 	License       *string
 	MattermostEnv EnvVarMap
 }
@@ -167,6 +168,12 @@ func (p *PatchInstallationRequest) Validate() error {
 	}
 	if p.Image != nil && len(*p.Image) == 0 {
 		return errors.New("provided image update value was blank")
+	}
+	if p.Size != nil {
+		_, err := mmv1alpha1.GetClusterSize(*p.Size)
+		if err != nil {
+			return errors.Wrap(err, "invalid size")
+		}
 	}
 	err := p.MattermostEnv.Validate()
 	if err != nil {
@@ -187,6 +194,10 @@ func (p *PatchInstallationRequest) Apply(installation *Installation) bool {
 	if p.Image != nil && *p.Image != installation.Image {
 		applied = true
 		installation.Image = *p.Image
+	}
+	if p.Size != nil && *p.Size != installation.Size {
+		applied = true
+		installation.Size = *p.Size
 	}
 	if p.License != nil && *p.License != installation.License {
 		applied = true

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -249,6 +249,17 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 			},
 		},
 		{
+			"size only",
+			true,
+			&model.PatchInstallationRequest{
+				Size: sToP("miniSingleton"),
+			},
+			&model.Installation{},
+			&model.Installation{
+				Size: "miniSingleton",
+			},
+		},
+		{
 			"license only",
 			true,
 			&model.PatchInstallationRequest{
@@ -279,6 +290,7 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 			true,
 			&model.PatchInstallationRequest{
 				Version: sToP("patch-version"),
+				Size:    sToP("miniSingleton"),
 				MattermostEnv: model.EnvVarMap{
 					"key1": {Value: "patch-value-1"},
 				},
@@ -295,6 +307,7 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 				Version: "patch-version",
 				Image:   "image1",
 				License: "license1",
+				Size:    "miniSingleton",
 				MattermostEnv: model.EnvVarMap{
 					"key1": {Value: "patch-value-1"},
 				},


### PR DESCRIPTION
The installation update API endpoint now allows for updating the
installation size value. The cloud server will then update the
Mattermost app values for replica count and resource requests and
limits.

A few notes on installation sizing changes:
- Resource and replica changes are currently targeting the Mattermost
   app pod only. Other pods such as those managed by the MinIO and
   MySQL operator won't be updated with the current Mattermost
   Operator logic. This is intentional as those apps can have replica
   scaling issues.
 - Resizing currently ignores the installation scheduling algorithm.
   There is no good interface to determine if the new installation
   size will safely fit on the cluster. This could, in theory, be done
   when the size request change comes in on the API, but would require
   new scheduling logic. For now, take care when resizing.

https://mattermost.atlassian.net/browse/MM-25094

```release-note
Add installation scaling
```
