### PR TITLE
Add option to change cluster AMI on upgrade

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -38,8 +38,10 @@ func init() {
 
 	clusterUpgradeCmd.Flags().String("cluster", "", "The id of the cluster to be upgraded.")
 	clusterUpgradeCmd.Flags().String("version", "latest", "The Kubernetes version to target. Use 'latest' or versions such as '1.14.1'.")
+	clusterUpgradeCmd.Flags().String("kops-ami", "", "The AMI to use for the cluster hosts. Leave empty for the default kops image.")
 	clusterUpgradeCmd.MarkFlagRequired("cluster")
 	clusterUpgradeCmd.MarkFlagRequired("version")
+	clusterUpgradeCmd.MarkFlagRequired("kops-ami")
 
 	clusterResizeCmd.Flags().String("cluster", "", "The id of the cluster to be resized.")
 	clusterResizeCmd.Flags().String("size", "SizeAlef500", "The size constant describing the cluster.")
@@ -186,8 +188,12 @@ var clusterUpgradeCmd = &cobra.Command{
 
 		clusterID, _ := command.Flags().GetString("cluster")
 		version, _ := command.Flags().GetString("version")
+		kopsAMI, _ := command.Flags().GetString("kops-ami")
 
-		err := client.UpgradeCluster(clusterID, version)
+		err := client.UpgradeCluster(clusterID, &model.UpgradeClusterRequest{
+			Version: version,
+			KopsAMI: kopsAMI,
+		})
 		if err != nil {
 			return errors.Wrap(err, "failed to upgrade cluster")
 		}

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -187,12 +187,10 @@ var clusterUpgradeCmd = &cobra.Command{
 		client := model.NewClient(serverAddress)
 
 		clusterID, _ := command.Flags().GetString("cluster")
-		version, _ := command.Flags().GetString("version")
-		kopsAMI, _ := command.Flags().GetString("kops-ami")
 
-		err := client.UpgradeCluster(clusterID, &model.UpgradeClusterRequest{
-			Version: version,
-			KopsAMI: kopsAMI,
+		err := client.UpgradeCluster(clusterID, &model.PatchUpgradeClusterRequest{
+			Version: getStringFlagPointer(command, "version"),
+			KopsAMI: getStringFlagPointer(command, "kops-ami"),
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to upgrade cluster")

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -362,9 +362,7 @@ func handleUpgradeKubernetes(c *Context, w http.ResponseWriter, r *http.Request)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	if kopsMetadata.Version != upgradeClusterRequest.Version || kopsMetadata.AMI != upgradeClusterRequest.KopsAMI {
-		kopsMetadata.Version = upgradeClusterRequest.Version
-		kopsMetadata.AMI = upgradeClusterRequest.KopsAMI
+	if upgradeClusterRequest.Apply(kopsMetadata) {
 		err = cluster.SetProvisionerMetadata(kopsMetadata)
 		if err != nil {
 			c.Logger.WithError(err).Error("failed to set provisioner metadata")

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -555,7 +555,7 @@ func TestUpgradeCluster(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("unknown cluster", func(t *testing.T) {
-		err := client.UpgradeCluster(model.NewID(), &model.UpgradeClusterRequest{Version: "latest"})
+		err := client.UpgradeCluster(model.NewID(), &model.PatchUpgradeClusterRequest{Version: sToP("latest")})
 		require.EqualError(t, err, "failed with status code 404")
 	})
 
@@ -575,7 +575,7 @@ func TestUpgradeCluster(t *testing.T) {
 			require.True(t, unlocked)
 		}()
 
-		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: "latest"})
+		err = client.UpgradeCluster(cluster1.ID, &model.PatchUpgradeClusterRequest{Version: sToP("latest")})
 		require.EqualError(t, err, "failed with status code 409")
 	})
 
@@ -585,7 +585,7 @@ func TestUpgradeCluster(t *testing.T) {
 		require.NoError(t, err)
 
 		version := "latest"
-		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: version})
+		err = client.UpgradeCluster(cluster1.ID, &model.PatchUpgradeClusterRequest{Version: &version})
 		require.NoError(t, err)
 
 		cluster1, err = client.GetCluster(cluster1.ID)
@@ -604,7 +604,7 @@ func TestUpgradeCluster(t *testing.T) {
 		require.NoError(t, err)
 
 		version := "latest"
-		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: version})
+		err = client.UpgradeCluster(cluster1.ID, &model.PatchUpgradeClusterRequest{Version: &version})
 		require.NoError(t, err)
 
 		cluster1, err = client.GetCluster(cluster1.ID)
@@ -623,7 +623,7 @@ func TestUpgradeCluster(t *testing.T) {
 		require.NoError(t, err)
 
 		version := "latest"
-		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: version})
+		err = client.UpgradeCluster(cluster1.ID, &model.PatchUpgradeClusterRequest{Version: &version})
 		require.NoError(t, err)
 
 		cluster1, err = client.GetCluster(cluster1.ID)
@@ -642,7 +642,7 @@ func TestUpgradeCluster(t *testing.T) {
 		require.NoError(t, err)
 
 		version := "1.14.1"
-		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: version})
+		err = client.UpgradeCluster(cluster1.ID, &model.PatchUpgradeClusterRequest{Version: &version})
 		require.NoError(t, err)
 
 		cluster1, err = client.GetCluster(cluster1.ID)
@@ -660,7 +660,7 @@ func TestUpgradeCluster(t *testing.T) {
 		err = sqlStore.UpdateCluster(cluster1)
 		require.NoError(t, err)
 
-		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: "invalid"})
+		err = client.UpgradeCluster(cluster1.ID, &model.PatchUpgradeClusterRequest{Version: sToP("invalid")})
 		require.EqualError(t, err, "failed with status code 400")
 	})
 
@@ -671,9 +671,9 @@ func TestUpgradeCluster(t *testing.T) {
 
 		version := "1.14.1"
 		ami := "mattermost-os"
-		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{
-			Version: version,
-			KopsAMI: ami,
+		err = client.UpgradeCluster(cluster1.ID, &model.PatchUpgradeClusterRequest{
+			Version: &version,
+			KopsAMI: &ami,
 		})
 		require.NoError(t, err)
 
@@ -692,7 +692,7 @@ func TestUpgradeCluster(t *testing.T) {
 		err = sqlStore.UpdateCluster(cluster1)
 		require.NoError(t, err)
 
-		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: "latest"})
+		err = client.UpgradeCluster(cluster1.ID, &model.PatchUpgradeClusterRequest{Version: sToP("latest")})
 		require.EqualError(t, err, "failed with status code 400")
 	})
 }

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -555,7 +555,7 @@ func TestUpgradeCluster(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("unknown cluster", func(t *testing.T) {
-		err := client.UpgradeCluster(model.NewID(), "latest")
+		err := client.UpgradeCluster(model.NewID(), &model.UpgradeClusterRequest{Version: "latest"})
 		require.EqualError(t, err, "failed with status code 404")
 	})
 
@@ -575,7 +575,7 @@ func TestUpgradeCluster(t *testing.T) {
 			require.True(t, unlocked)
 		}()
 
-		err = client.UpgradeCluster(cluster1.ID, "latest")
+		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: "latest"})
 		require.EqualError(t, err, "failed with status code 409")
 	})
 
@@ -584,12 +584,18 @@ func TestUpgradeCluster(t *testing.T) {
 		err = sqlStore.UpdateCluster(cluster1)
 		require.NoError(t, err)
 
-		err = client.UpgradeCluster(cluster1.ID, "latest")
+		version := "latest"
+		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: version})
 		require.NoError(t, err)
 
 		cluster1, err = client.GetCluster(cluster1.ID)
 		require.NoError(t, err)
-		require.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
+		assert.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
+
+		metadata, err := model.NewKopsMetadata(cluster1.ProvisionerMetadata)
+		require.NoError(t, err)
+		assert.Equal(t, version, metadata.Version)
+		assert.Empty(t, metadata.AMI)
 	})
 
 	t.Run("after upgrade failed", func(t *testing.T) {
@@ -597,12 +603,18 @@ func TestUpgradeCluster(t *testing.T) {
 		err = sqlStore.UpdateCluster(cluster1)
 		require.NoError(t, err)
 
-		err = client.UpgradeCluster(cluster1.ID, "latest")
+		version := "latest"
+		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: version})
 		require.NoError(t, err)
 
 		cluster1, err = client.GetCluster(cluster1.ID)
 		require.NoError(t, err)
-		require.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
+		assert.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
+
+		metadata, err := model.NewKopsMetadata(cluster1.ProvisionerMetadata)
+		require.NoError(t, err)
+		assert.Equal(t, version, metadata.Version)
+		assert.Empty(t, metadata.AMI)
 	})
 
 	t.Run("while stable, to latest", func(t *testing.T) {
@@ -610,12 +622,18 @@ func TestUpgradeCluster(t *testing.T) {
 		err = sqlStore.UpdateCluster(cluster1)
 		require.NoError(t, err)
 
-		err = client.UpgradeCluster(cluster1.ID, "latest")
+		version := "latest"
+		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: version})
 		require.NoError(t, err)
 
 		cluster1, err = client.GetCluster(cluster1.ID)
 		require.NoError(t, err)
-		require.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
+		assert.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
+
+		metadata, err := model.NewKopsMetadata(cluster1.ProvisionerMetadata)
+		require.NoError(t, err)
+		assert.Equal(t, version, metadata.Version)
+		assert.Empty(t, metadata.AMI)
 	})
 
 	t.Run("while stable, to valid version", func(t *testing.T) {
@@ -623,12 +641,18 @@ func TestUpgradeCluster(t *testing.T) {
 		err = sqlStore.UpdateCluster(cluster1)
 		require.NoError(t, err)
 
-		err = client.UpgradeCluster(cluster1.ID, "1.14.1")
+		version := "1.14.1"
+		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: version})
 		require.NoError(t, err)
 
 		cluster1, err = client.GetCluster(cluster1.ID)
 		require.NoError(t, err)
-		require.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
+		assert.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
+
+		metadata, err := model.NewKopsMetadata(cluster1.ProvisionerMetadata)
+		require.NoError(t, err)
+		assert.Equal(t, version, metadata.Version)
+		assert.Empty(t, metadata.AMI)
 	})
 
 	t.Run("while stable, to invalid version", func(t *testing.T) {
@@ -636,8 +660,31 @@ func TestUpgradeCluster(t *testing.T) {
 		err = sqlStore.UpdateCluster(cluster1)
 		require.NoError(t, err)
 
-		err = client.UpgradeCluster(cluster1.ID, "invalid")
+		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: "invalid"})
 		require.EqualError(t, err, "failed with status code 400")
+	})
+
+	t.Run("while stable, to valid version and new AMI", func(t *testing.T) {
+		cluster1.State = model.ClusterStateStable
+		err = sqlStore.UpdateCluster(cluster1)
+		require.NoError(t, err)
+
+		version := "1.14.1"
+		ami := "mattermost-os"
+		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{
+			Version: version,
+			KopsAMI: ami,
+		})
+		require.NoError(t, err)
+
+		cluster1, err = client.GetCluster(cluster1.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
+
+		metadata, err := model.NewKopsMetadata(cluster1.ProvisionerMetadata)
+		require.NoError(t, err)
+		assert.Equal(t, version, metadata.Version)
+		assert.Equal(t, ami, metadata.AMI)
 	})
 
 	t.Run("while deleting", func(t *testing.T) {
@@ -645,7 +692,7 @@ func TestUpgradeCluster(t *testing.T) {
 		err = sqlStore.UpdateCluster(cluster1)
 		require.NoError(t, err)
 
-		err = client.UpgradeCluster(cluster1.ID, "latest")
+		err = client.UpgradeCluster(cluster1.ID, &model.UpgradeClusterRequest{Version: "latest"})
 		require.EqualError(t, err, "failed with status code 400")
 	})
 }

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -390,39 +390,9 @@ func (provisioner *KopsProvisioner) UpgradeCluster(cluster *model.Cluster) error
 		}
 	}
 
-	instanceGroups, err := kops.GetInstanceGroupsJSON(kopsMetadata.Name)
+	err = updateKopsInstanceGroupAMIs(kops, kopsMetadata, logger)
 	if err != nil {
-		return err
-	}
-	for _, ig := range instanceGroups {
-		if ig.Spec.Image != kopsMetadata.AMI {
-			if len(kopsMetadata.AMI) == 0 {
-				// Setting the image value to "" leads kops to autoreplace it with
-				// the default image for that kubernetes release.
-				logger.Infof("Updating instance group '%s' image value the default kops image", ig.Metadata.Name)
-			} else {
-				logger.Infof("Updating instance group '%s' image value to '%s'", ig.Metadata.Name, kopsMetadata.AMI)
-			}
-
-			igManifest, err := kops.GetInstanceGroupYAML(kopsMetadata.Name, ig.Metadata.Name)
-			if err != nil {
-				return err
-			}
-			igManifest, err = grossKopsReplaceImage(igManifest, kopsMetadata.AMI)
-			if err != nil {
-				return err
-			}
-
-			igFilename := fmt.Sprintf("%s-ig.yaml", ig.Metadata.Name)
-			err = ioutil.WriteFile(path.Join(kops.GetTempDir(), igFilename), []byte(igManifest), 0600)
-			if err != nil {
-				return err
-			}
-			_, err = kops.Replace(igFilename)
-			if err != nil {
-				return err
-			}
-		}
+		return errors.Wrap(err, "failed to update kops instance group AMIs")
 	}
 
 	err = kops.UpdateCluster(kopsMetadata.Name, kops.GetOutputDirectory())

--- a/internal/provisioner/kops_utils.go
+++ b/internal/provisioner/kops_utils.go
@@ -3,6 +3,8 @@ package provisioner
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"path"
 	"regexp"
 	"time"
 
@@ -155,6 +157,45 @@ func (provisioner *KopsProvisioner) GetNGINXLoadBalancerEndpoint(cluster *model.
 		}
 	}
 	return "", errors.New("failed to get NGINX load balancer endpoint")
+}
+
+func updateKopsInstanceGroupAMIs(kops *kops.Cmd, kopsMetadata *model.KopsMetadata, logger log.FieldLogger) error {
+	instanceGroups, err := kops.GetInstanceGroupsJSON(kopsMetadata.Name)
+	if err != nil {
+		return errors.Wrap(err, "failed to get instance groups")
+	}
+	for _, ig := range instanceGroups {
+		if ig.Spec.Image != kopsMetadata.AMI {
+			if len(kopsMetadata.AMI) == 0 {
+				// Setting the image value to "" leads kops to autoreplace it with
+				// the default image for that kubernetes release.
+				logger.Infof("Updating instance group '%s' image value the default kops image", ig.Metadata.Name)
+			} else {
+				logger.Infof("Updating instance group '%s' image value to '%s'", ig.Metadata.Name, kopsMetadata.AMI)
+			}
+
+			igManifest, err := kops.GetInstanceGroupYAML(kopsMetadata.Name, ig.Metadata.Name)
+			if err != nil {
+				return errors.Wrap(err, "failed to get YAML output for instance group")
+			}
+			igManifest, err = grossKopsReplaceImage(igManifest, kopsMetadata.AMI)
+			if err != nil {
+				return errors.Wrap(err, "failed to replace image value in YAML")
+			}
+
+			igFilename := fmt.Sprintf("%s-ig.yaml", ig.Metadata.Name)
+			err = ioutil.WriteFile(path.Join(kops.GetTempDir(), igFilename), []byte(igManifest), 0600)
+			if err != nil {
+				return errors.Wrap(err, "failed to write new YAML file")
+			}
+			_, err = kops.Replace(igFilename)
+			if err != nil {
+				return errors.Wrap(err, "failed to update instance group")
+			}
+		}
+	}
+
+	return nil
 }
 
 // grossKopsReplaceSize is a manual find-and-replace flow for updating a raw

--- a/internal/provisioner/kops_utils.go
+++ b/internal/provisioner/kops_utils.go
@@ -193,3 +193,24 @@ func grossKopsReplaceSize(input, machineType, min, max string) (string, error) {
 
 	return input, nil
 }
+
+// grossKopsReplaceImage is a manual find-and-replace flow for updating a raw
+// kops instance group YAML manifest with a new image value.
+// TODO: remove once new `kops set instancegroup` functionality is available.
+//
+// Example Manifest:
+//
+// apiVersion: kops.k8s.io/v1alpha2
+// kind: InstanceGroup
+// spec:
+//   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
+func grossKopsReplaceImage(input, image string) (string, error) {
+	imageRE := regexp.MustCompile(`  image: .*\n`)
+	imageMatches := len(imageRE.FindAllStringIndex(input, -1))
+	if imageMatches != 1 {
+		return "", errors.Errorf("expected to find one image match, but found %d", imageMatches)
+	}
+	input = imageRE.ReplaceAllString(input, fmt.Sprintf("  image: %s\n", image))
+
+	return input, nil
+}

--- a/internal/provisioner/kops_utils_test.go
+++ b/internal/provisioner/kops_utils_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGrossReplace(t *testing.T) {
+func TestGrossReplaceSize(t *testing.T) {
 	testManifest := `
 apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
@@ -153,6 +153,95 @@ spec:
 
 	t.Run("no machineType", func(t *testing.T) {
 		replaced, err := grossKopsReplaceSize(testManifest, "raspberry.pi", "1337", "1337")
+		assert.Error(t, err)
+		assert.Empty(t, replaced)
+	})
+}
+
+func TestGrossReplaceImage(t *testing.T) {
+	testManifest := `
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2020-03-19T20:33:45Z"
+  labels:
+    kops.k8s.io/cluster: 1nx98f8ykbbz9ern94reuodqpe-kops.k8s.local
+  name: nodes
+spec:
+  additionalSecurityGroups:
+  - sg-08bc68b2c11d412fc
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: m5.large
+  maxSize: 26
+  minSize: 26
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  subnets:
+  - us-east-1a
+  - us-east-1b
+  - us-east-1c
+  - us-east-1d
+  - us-east-1e
+`
+
+	expectedManifest := `
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2020-03-19T20:33:45Z"
+  labels:
+    kops.k8s.io/cluster: 1nx98f8ykbbz9ern94reuodqpe-kops.k8s.local
+  name: nodes
+spec:
+  additionalSecurityGroups:
+  - sg-08bc68b2c11d412fc
+  image: mattermost-os-amd128
+  machineType: m5.large
+  maxSize: 26
+  minSize: 26
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  subnets:
+  - us-east-1a
+  - us-east-1b
+  - us-east-1c
+  - us-east-1d
+  - us-east-1e
+`
+	t.Run("valid replace", func(t *testing.T) {
+		replaced, err := grossKopsReplaceImage(testManifest, "mattermost-os-amd128")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedManifest, replaced)
+	})
+
+	testManifest = `
+	apiVersion: kops.k8s.io/v1alpha2
+	kind: InstanceGroup
+	metadata:
+		creationTimestamp: "2020-03-19T20:33:45Z"
+		labels:
+			kops.k8s.io/cluster: 1nx98f8ykbbz9ern94reuodqpe-kops.k8s.local
+		name: nodes
+	spec:
+		additionalSecurityGroups:
+		- sg-08bc68b2c11d412fc
+		machineType: m5.large
+		maxSize: 26
+		minSize: 26
+		nodeLabels:
+			kops.k8s.io/instancegroup: nodes
+		role: Node
+		subnets:
+		- us-east-1a
+		- us-east-1b
+		- us-east-1c
+		- us-east-1d
+		- us-east-1e
+	`
+	t.Run("no image", func(t *testing.T) {
+		replaced, err := grossKopsReplaceImage(testManifest, "mattermost-os-amd128")
 		assert.Error(t, err)
 		assert.Empty(t, replaced)
 	})

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -188,25 +188,6 @@ func (c *Cmd) GetCluster(name string) (string, error) {
 	return trimmed, nil
 }
 
-// GetInstanceGroupYAML invokes kops get instancegroup, using the context of the
-// created Cmd, and returns the YAML stdout.
-func (c *Cmd) GetInstanceGroupYAML(clusterName, igName string) (string, error) {
-	stdout, _, err := c.run(
-		"get",
-		"instancegroup",
-		arg("name", clusterName),
-		arg("state", "s3://", c.s3StateStore),
-		igName,
-		arg("output", "yaml"),
-	)
-	trimmed := strings.TrimSuffix(string(stdout), "\n")
-	if err != nil {
-		return trimmed, errors.Wrap(err, "failed to invoke kops get instancegroup")
-	}
-
-	return trimmed, nil
-}
-
 // Replace invokes kops replace, using the context of the created Cmd, and
 // returns the stdout. The filename passed in is expected to be in the root temp
 // dir of this kops command.

--- a/internal/tools/kops/instance_groups.go
+++ b/internal/tools/kops/instance_groups.go
@@ -1,0 +1,77 @@
+package kops
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// InstanceGroup is a kops instance group.
+type InstanceGroup struct {
+	Metadata InstanceGroupMetadata `json:"metadata"`
+	Spec     InstanceGroupSpec     `json:"spec"`
+}
+
+// InstanceGroupMetadata is the metadata of a kops instance group.
+type InstanceGroupMetadata struct {
+	Name string `json:"name"`
+}
+
+// InstanceGroupSpec is the spec of a kops instance group.
+type InstanceGroupSpec struct {
+	Image string `json:"image"`
+}
+
+// GetInstanceGroupsJSON invokes kops get instancegroup, using the context of the
+// created Cmd, and returns the unmarshaled response as []InstanceGroup.
+func (c *Cmd) GetInstanceGroupsJSON(clusterName string) ([]InstanceGroup, error) {
+	stdout, _, err := c.run(
+		"get",
+		"instancegroup",
+		arg("name", clusterName),
+		arg("state", "s3://", c.s3StateStore),
+		arg("output", "json"),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to invoke kops get instancegroup")
+	}
+
+	var instanceGroupList []InstanceGroup
+	err = json.Unmarshal(stdout, &instanceGroupList)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal JSON output from kops get instancegroup")
+	}
+	if len(instanceGroupList) == 0 {
+		return nil, errors.New("expected at least one instance group, but found none")
+	}
+	for _, ig := range instanceGroupList {
+		if len(ig.Metadata.Name) == 0 {
+			return nil, errors.New("an instance group name value was empty")
+		}
+		if len(ig.Spec.Image) == 0 {
+			return nil, errors.New("an instance group image value was empty")
+		}
+	}
+
+	return instanceGroupList, nil
+}
+
+// GetInstanceGroupYAML invokes kops get instancegroup, using the context of the
+// created Cmd, and returns the YAML stdout.
+func (c *Cmd) GetInstanceGroupYAML(clusterName, igName string) (string, error) {
+	stdout, _, err := c.run(
+		"get",
+		"instancegroup",
+		arg("name", clusterName),
+		arg("state", "s3://", c.s3StateStore),
+		igName,
+		arg("output", "yaml"),
+	)
+	trimmed := strings.TrimSuffix(string(stdout), "\n")
+	if err != nil {
+		return trimmed, errors.Wrap(err, "failed to invoke kops get instancegroup")
+	}
+
+	return trimmed, nil
+}

--- a/model/client.go
+++ b/model/client.go
@@ -238,8 +238,8 @@ func (c *Client) UpdateCluster(clusterID string, request *UpdateClusterRequest) 
 }
 
 // UpgradeCluster upgrades a cluster to the latest recommended production ready k8s version.
-func (c *Client) UpgradeCluster(clusterID, version string) error {
-	resp, err := c.doPut(c.buildURL("/api/cluster/%s/kubernetes/%s", clusterID, version), nil)
+func (c *Client) UpgradeCluster(clusterID string, request *UpgradeClusterRequest) error {
+	resp, err := c.doPut(c.buildURL("/api/cluster/%s/kubernetes", clusterID), request)
 	if err != nil {
 		return err
 	}

--- a/model/client.go
+++ b/model/client.go
@@ -238,7 +238,7 @@ func (c *Client) UpdateCluster(clusterID string, request *UpdateClusterRequest) 
 }
 
 // UpgradeCluster upgrades a cluster to the latest recommended production ready k8s version.
-func (c *Client) UpgradeCluster(clusterID string, request *UpgradeClusterRequest) error {
+func (c *Client) UpgradeCluster(clusterID string, request *PatchUpgradeClusterRequest) error {
 	resp, err := c.doPut(c.buildURL("/api/cluster/%s/kubernetes", clusterID), request)
 	if err != nil {
 		return err

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -118,6 +118,37 @@ func NewUpdateClusterRequestFromReader(reader io.Reader) (*UpdateClusterRequest,
 	return &updateClusterRequest, nil
 }
 
+// UpgradeClusterRequest specifies the parameters upgrading a cluster.
+type UpgradeClusterRequest struct {
+	Version string `json:"version,omitempty"`
+	KopsAMI string `json:"kops-ami,omitempty"`
+}
+
+// Validate validates the values of a cluster upgrade request.
+func (request *UpgradeClusterRequest) Validate() error {
+	if !ValidClusterVersion(request.Version) {
+		return errors.Errorf("unsupported cluster version %s", request.Version)
+	}
+
+	return nil
+}
+
+// NewUpgradeClusterRequestFromReader will create an UpgradeClusterRequest from an io.Reader with JSON data.
+func NewUpgradeClusterRequestFromReader(reader io.Reader) (*UpgradeClusterRequest, error) {
+	var upgradeClusterRequest UpgradeClusterRequest
+	err := json.NewDecoder(reader).Decode(&upgradeClusterRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode upgrade cluster request")
+	}
+
+	err = upgradeClusterRequest.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "upgrade cluster request failed validation")
+	}
+
+	return &upgradeClusterRequest, nil
+}
+
 // ProvisionClusterRequest contains metadata related to changing the installed cluster state.
 type ProvisionClusterRequest struct {
 	DesiredUtilityVersions map[string]string `json:"utility-versions,omitempty"`

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -118,24 +118,40 @@ func NewUpdateClusterRequestFromReader(reader io.Reader) (*UpdateClusterRequest,
 	return &updateClusterRequest, nil
 }
 
-// UpgradeClusterRequest specifies the parameters upgrading a cluster.
-type UpgradeClusterRequest struct {
-	Version string `json:"version,omitempty"`
-	KopsAMI string `json:"kops-ami,omitempty"`
+// PatchUpgradeClusterRequest specifies the parameters upgrading a cluster.
+type PatchUpgradeClusterRequest struct {
+	Version *string `json:"version,omitempty"`
+	KopsAMI *string `json:"kops-ami,omitempty"`
 }
 
 // Validate validates the values of a cluster upgrade request.
-func (request *UpgradeClusterRequest) Validate() error {
-	if !ValidClusterVersion(request.Version) {
-		return errors.Errorf("unsupported cluster version %s", request.Version)
+func (p *PatchUpgradeClusterRequest) Validate() error {
+	if p.Version != nil && !ValidClusterVersion(*p.Version) {
+		return errors.Errorf("unsupported cluster version %s", *p.Version)
 	}
 
 	return nil
 }
 
+// Apply applies the patch to the given installation.
+func (p *PatchUpgradeClusterRequest) Apply(metadata *KopsMetadata) bool {
+	var applied bool
+
+	if p.Version != nil && *p.Version != metadata.Version {
+		applied = true
+		metadata.Version = *p.Version
+	}
+	if p.KopsAMI != nil && *p.KopsAMI != metadata.AMI {
+		applied = true
+		metadata.AMI = *p.KopsAMI
+	}
+
+	return applied
+}
+
 // NewUpgradeClusterRequestFromReader will create an UpgradeClusterRequest from an io.Reader with JSON data.
-func NewUpgradeClusterRequestFromReader(reader io.Reader) (*UpgradeClusterRequest, error) {
-	var upgradeClusterRequest UpgradeClusterRequest
+func NewUpgradeClusterRequestFromReader(reader io.Reader) (*PatchUpgradeClusterRequest, error) {
+	var upgradeClusterRequest PatchUpgradeClusterRequest
 	err := json.NewDecoder(reader).Decode(&upgradeClusterRequest)
 	if err != nil && err != io.EOF {
 		return nil, errors.Wrap(err, "failed to decode upgrade cluster request")

--- a/model/cluster_request_test.go
+++ b/model/cluster_request_test.go
@@ -35,12 +35,13 @@ func TestCreateClusterRequestValid(t *testing.T) {
 func TestUpgradeClusterRequestValid(t *testing.T) {
 	var testCases = []struct {
 		testName     string
-		request      *model.UpgradeClusterRequest
+		request      *model.PatchUpgradeClusterRequest
 		requireError bool
 	}{
-		{"valid version", &model.UpgradeClusterRequest{Version: "1.15.2"}, false},
-		{"invalid version", &model.UpgradeClusterRequest{Version: "invalid"}, true},
-		{"blank version", &model.UpgradeClusterRequest{}, true},
+		{"empty payload", &model.PatchUpgradeClusterRequest{}, false},
+		{"valid version", &model.PatchUpgradeClusterRequest{Version: sToP("1.15.2")}, false},
+		{"invalid version", &model.PatchUpgradeClusterRequest{Version: sToP("invalid")}, true},
+		{"blank version", &model.PatchUpgradeClusterRequest{Version: sToP("")}, true},
 	}
 
 	for _, tc := range testCases {
@@ -50,6 +51,69 @@ func TestUpgradeClusterRequestValid(t *testing.T) {
 			} else {
 				assert.NoError(t, tc.request.Validate())
 			}
+		})
+	}
+}
+
+func TestUpgradeClusterRequestApply(t *testing.T) {
+	var testCases = []struct {
+		testName         string
+		expectApply      bool
+		request          *model.PatchUpgradeClusterRequest
+		metadata         *model.KopsMetadata
+		expectedMetadata *model.KopsMetadata
+	}{
+		{
+			"empty",
+			false,
+			&model.PatchUpgradeClusterRequest{},
+			&model.KopsMetadata{},
+			&model.KopsMetadata{},
+		},
+		{
+			"version only",
+			true,
+			&model.PatchUpgradeClusterRequest{
+				Version: sToP("version1"),
+			},
+			&model.KopsMetadata{},
+			&model.KopsMetadata{
+				Version: "version1",
+			},
+		},
+		{
+			"ami only",
+			true,
+			&model.PatchUpgradeClusterRequest{
+				KopsAMI: sToP("image1"),
+			},
+			&model.KopsMetadata{},
+			&model.KopsMetadata{
+				AMI: "image1",
+			},
+		},
+		{
+			"version and ami",
+			true,
+			&model.PatchUpgradeClusterRequest{
+				Version: sToP("version1"),
+				KopsAMI: sToP("image1"),
+			},
+			&model.KopsMetadata{
+				Version: "old-version",
+			},
+			&model.KopsMetadata{
+				Version: "version1",
+				AMI:     "image1",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			apply := tc.request.Apply(tc.metadata)
+			assert.Equal(t, tc.expectApply, apply)
+			assert.Equal(t, tc.expectedMetadata, tc.metadata)
 		})
 	}
 }

--- a/model/cluster_request_test.go
+++ b/model/cluster_request_test.go
@@ -31,3 +31,25 @@ func TestCreateClusterRequestValid(t *testing.T) {
 		})
 	}
 }
+
+func TestUpgradeClusterRequestValid(t *testing.T) {
+	var testCases = []struct {
+		testName     string
+		request      *model.UpgradeClusterRequest
+		requireError bool
+	}{
+		{"valid version", &model.UpgradeClusterRequest{Version: "1.15.2"}, false},
+		{"invalid version", &model.UpgradeClusterRequest{Version: "invalid"}, true},
+		{"blank version", &model.UpgradeClusterRequest{}, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			if tc.requireError {
+				assert.Error(t, tc.request.Validate())
+			} else {
+				assert.NoError(t, tc.request.Validate())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This new functionality allows the cloud provisioner to update the
various instance groups in a cluster to use a new AMI for the nodes.
Upgrades can now handle an update to the kubernetes version, AMI,
or both simultaneously. Passing in an empty value for the AMI will
use the default kops AMI for that kubernetes version.

Tested manually by updating a cluster with 3 master and 2 worker
nodes.

As a follow-up, I may change the wording around `upgrade` as that
can be misleading when only updating the AMI or if we actually want
to downgrade.

https://mattermost.atlassian.net/browse/MM-24641

```release-note
Add option to change cluster AMI on upgrade
```
