### PR TITLE
Add installation and group env var patching logic

### DIFF
--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -24,6 +24,7 @@ func init() {
 	groupUpdateCmd.Flags().String("image", "", "The Mattermost container image to use.")
 	groupUpdateCmd.Flags().Int64("max-rolling", 0, "The maximum number of installations that can be updated at one time when a group is updated")
 	groupUpdateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
+	groupUpdateCmd.Flags().Bool("mattermost-env-clear", false, "Clears all env var data.")
 	groupUpdateCmd.MarkFlagRequired("group")
 
 	groupDeleteCmd.Flags().String("group", "", "The id of the group to be deleted.")
@@ -75,7 +76,7 @@ var groupCreateCmd = &cobra.Command{
 		maxRolling, _ := command.Flags().GetInt64("max-rolling")
 		mattermostEnv, _ := command.Flags().GetStringArray("mattermost-env")
 
-		envVarMap, err := parseEnvVarInput(mattermostEnv)
+		envVarMap, err := parseEnvVarInput(mattermostEnv, false)
 		if err != nil {
 			return err
 		}
@@ -108,8 +109,9 @@ var groupUpdateCmd = &cobra.Command{
 
 		groupID, _ := command.Flags().GetString("group")
 		mattermostEnv, _ := command.Flags().GetStringArray("mattermost-env")
+		mattermostEnvClear, _ := command.Flags().GetBool("mattermost-env-clear")
 
-		envVarMap, err := parseEnvVarInput(mattermostEnv)
+		envVarMap, err := parseEnvVarInput(mattermostEnv, mattermostEnvClear)
 		if err != nil {
 			return err
 		}

--- a/cmd/cloud/utils.go
+++ b/cmd/cloud/utils.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+func parseEnvVarInput(rawInput []string, clear bool) (model.EnvVarMap, error) {
+	if len(rawInput) != 0 && clear {
+		return nil, errors.New("both mattermost-env and mattermost-env-clear were set; use one or the other")
+	}
+	if clear {
+		// An empty non-nil map is what the API expects for a full env wipe.
+		return make(model.EnvVarMap), nil
+	}
+	if len(rawInput) == 0 {
+		return nil, nil
+	}
+
+	envVarMap := make(model.EnvVarMap)
+
+	for _, env := range rawInput {
+		// Split the input once by "=" to allow for multiple "="s to be in the
+		// value. Expect there to still be one key and value.
+		kv := strings.SplitN(env, "=", 2)
+		if len(kv) != 2 || len(kv[0]) == 0 {
+			return nil, errors.Errorf("%s is not in a valid env format; expecting KEY_NAME=VALUE", env)
+		}
+
+		if _, ok := envVarMap[kv[0]]; ok {
+			return nil, errors.Errorf("env var %s was defined more than once", kv[0])
+		}
+
+		envVarMap[kv[0]] = model.EnvVar{Value: kv[1]}
+	}
+
+	return envVarMap, nil
+}

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -334,8 +334,8 @@ func TestUpdateGroup(t *testing.T) {
 		require.Equal(t, "name2", group1.Name)
 		require.Equal(t, "description2", group1.Description)
 		require.Equal(t, "version2", group1.Version)
-		require.NotEqual(t, group1.MattermostEnv, mattermostEnvFooBar)
-		require.Equal(t, group1.MattermostEnv, mattermostEnvBarBaz)
+		require.True(t, mattermostEnvFooBar.ClearOrPatch(&mattermostEnvBarBaz))
+		require.Equal(t, group1.MattermostEnv, mattermostEnvFooBar)
 		require.Equal(t, updateResponseGroup, group1)
 	})
 }

--- a/model/env.go
+++ b/model/env.go
@@ -47,15 +47,20 @@ func (em *EnvVarMap) Validate() error {
 //  - If the new EnvVarMap is empty, clear the existing EnvVarMap completely.
 //  - If the new EnvVarMap is not empty, apply normal patch logic.
 func (em *EnvVarMap) ClearOrPatch(new *EnvVarMap) bool {
+	if *em == nil {
+		if len(*new) == 0 {
+			return false
+		}
+
+		*em = *new
+		return true
+	}
+
 	if len(*new) == 0 {
 		orginalEmpty := len(*em) != 0
 		*em = nil
 
-		if orginalEmpty {
-			return true
-		}
-
-		return false
+		return orginalEmpty
 	}
 
 	return em.Patch(*new)

--- a/model/env_test.go
+++ b/model/env_test.go
@@ -68,6 +68,24 @@ func TestEnvClearOrPatch(t *testing.T) {
 		expectedEnvVarMap model.EnvVarMap
 	}{
 		{
+			"nil old and new EnvVarMap",
+			false,
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"nil old EnvVarMap",
+			true,
+			nil,
+			model.EnvVarMap{
+				"key1": {Value: "value1"},
+			},
+			model.EnvVarMap{
+				"key1": {Value: "value1"},
+			},
+		},
+		{
 			"nil new EnvVarMap",
 			true,
 			model.EnvVarMap{
@@ -215,7 +233,7 @@ func TestEnvPatch(t *testing.T) {
 			model.EnvVarMap{},
 		},
 		{
-			"delete nonexistant keys",
+			"delete nonexistent keys",
 			false,
 			model.EnvVarMap{
 				"key1": {Value: "value1"},

--- a/model/group_request.go
+++ b/model/group_request.go
@@ -70,22 +70,6 @@ type PatchGroupRequest struct {
 	MattermostEnv EnvVarMap
 }
 
-// NewPatchGroupRequestFromReader will create a PatchGroupRequest from an io.Reader with JSON data.
-func NewPatchGroupRequestFromReader(reader io.Reader) (*PatchGroupRequest, error) {
-	var patchGroupRequest PatchGroupRequest
-	err := json.NewDecoder(reader).Decode(&patchGroupRequest)
-	if err != nil && err != io.EOF {
-		return nil, errors.Wrap(err, "failed to decode patch group request")
-	}
-
-	err = patchGroupRequest.Validate()
-	if err != nil {
-		return nil, errors.Wrap(err, "invalid patch group request")
-	}
-
-	return &patchGroupRequest, nil
-}
-
 // Apply applies the patch to the given group.
 func (p *PatchGroupRequest) Apply(group *Group) bool {
 	var applied bool
@@ -111,8 +95,14 @@ func (p *PatchGroupRequest) Apply(group *Group) bool {
 		group.MaxRolling = *p.MaxRolling
 	}
 	if p.MattermostEnv != nil {
-		applied = true
-		group.MattermostEnv = p.MattermostEnv
+		if group.MattermostEnv != nil {
+			if group.MattermostEnv.ClearOrPatch(&p.MattermostEnv) {
+				applied = true
+			}
+		} else {
+			applied = true
+			group.MattermostEnv = p.MattermostEnv
+		}
 	}
 
 	return applied
@@ -126,12 +116,26 @@ func (p *PatchGroupRequest) Validate() error {
 	if p.MaxRolling != nil && *p.MaxRolling < 1 {
 		return errors.New("max rolling must be 1 or greater")
 	}
-	err := p.MattermostEnv.Validate()
-	if err != nil {
-		return errors.Wrap(err, "invalid env var settings")
-	}
+	// EnvVarMap validation is skipped as all configurations of this now imply
+	// a specific patch action should be taken.
 
 	return nil
+}
+
+// NewPatchGroupRequestFromReader will create a PatchGroupRequest from an io.Reader with JSON data.
+func NewPatchGroupRequestFromReader(reader io.Reader) (*PatchGroupRequest, error) {
+	var patchGroupRequest PatchGroupRequest
+	err := json.NewDecoder(reader).Decode(&patchGroupRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode patch group request")
+	}
+
+	err = patchGroupRequest.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid patch group request")
+	}
+
+	return &patchGroupRequest, nil
 }
 
 // GetGroupsRequest describes the parameters to request a list of groups.

--- a/model/group_request.go
+++ b/model/group_request.go
@@ -95,13 +95,8 @@ func (p *PatchGroupRequest) Apply(group *Group) bool {
 		group.MaxRolling = *p.MaxRolling
 	}
 	if p.MattermostEnv != nil {
-		if group.MattermostEnv != nil {
-			if group.MattermostEnv.ClearOrPatch(&p.MattermostEnv) {
-				applied = true
-			}
-		} else {
+		if group.MattermostEnv.ClearOrPatch(&p.MattermostEnv) {
 			applied = true
-			group.MattermostEnv = p.MattermostEnv
 		}
 	}
 

--- a/model/group_request_test.go
+++ b/model/group_request_test.go
@@ -1,0 +1,302 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateGroupRequestValid(t *testing.T) {
+	var testCases = []struct {
+		testName     string
+		requireError bool
+		request      *model.CreateGroupRequest
+	}{
+		{
+			"defaults",
+			false,
+			&model.CreateGroupRequest{
+				Name:       "group1",
+				MaxRolling: 1,
+			},
+		},
+		{
+			"no name",
+			true,
+			&model.CreateGroupRequest{
+				MaxRolling: 1,
+			},
+		},
+		{
+			"negative max rolling",
+			true,
+			&model.CreateGroupRequest{
+				Name:       "group1",
+				MaxRolling: -1,
+			},
+		},
+		{
+			"invalid mattermost env",
+			true,
+			&model.CreateGroupRequest{
+				Name:       "group1",
+				MaxRolling: 1,
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: ""},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			tc.request.SetDefaults()
+
+			if tc.requireError {
+				assert.Error(t, tc.request.Validate())
+			} else {
+				assert.NoError(t, tc.request.Validate())
+			}
+		})
+	}
+}
+
+func TestPatchGroupRequestValid(t *testing.T) {
+	var testCases = []struct {
+		testName    string
+		expectError bool
+		request     *model.PatchGroupRequest
+	}{
+		{
+			"empty",
+			false,
+			&model.PatchGroupRequest{},
+		},
+		{
+			"version only",
+			false,
+			&model.PatchGroupRequest{
+				Name: sToP("group1"),
+			},
+		},
+		{
+			"invalid name only",
+			true,
+			&model.PatchGroupRequest{
+				Name: sToP(""),
+			},
+		},
+		{
+			"max rolling only",
+			false,
+			&model.PatchGroupRequest{
+				MaxRolling: i64oP(1),
+			},
+		},
+		{
+			"invalid max rolling only",
+			true,
+			&model.PatchGroupRequest{
+				MaxRolling: i64oP(-1),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			if tc.expectError {
+				assert.Error(t, tc.request.Validate())
+				return
+			}
+
+			assert.NoError(t, tc.request.Validate())
+		})
+	}
+}
+
+func TestPatchGroupRequestApply(t *testing.T) {
+	var testCases = []struct {
+		testName             string
+		expectApply          bool
+		request              *model.PatchGroupRequest
+		installation         *model.Group
+		expectedInstallation *model.Group
+	}{
+		{
+			"empty",
+			false,
+			&model.PatchGroupRequest{},
+			&model.Group{},
+			&model.Group{},
+		},
+		{
+			"name only",
+			true,
+			&model.PatchGroupRequest{
+				Name: sToP("group1"),
+			},
+			&model.Group{},
+			&model.Group{
+				Name: "group1",
+			},
+		},
+		{
+			"description only",
+			true,
+			&model.PatchGroupRequest{
+				Description: sToP("group1 description"),
+			},
+			&model.Group{},
+			&model.Group{
+				Description: "group1 description",
+			},
+		},
+		{
+			"version only",
+			true,
+			&model.PatchGroupRequest{
+				Version: sToP("version1"),
+			},
+			&model.Group{},
+			&model.Group{
+				Version: "version1",
+			},
+		},
+		{
+			"image only",
+			true,
+			&model.PatchGroupRequest{
+				Image: sToP("image1"),
+			},
+			&model.Group{},
+			&model.Group{
+				Image: "image1",
+			},
+		},
+		{
+			"max rolling only",
+			true,
+			&model.PatchGroupRequest{
+				MaxRolling: i64oP(5),
+			},
+			&model.Group{},
+			&model.Group{
+				MaxRolling: 5,
+			},
+		},
+		{
+			"mattermost env only, no group env",
+			true,
+			&model.PatchGroupRequest{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+			&model.Group{},
+			&model.Group{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+		},
+		{
+			"mattermost env only, patch group env with no changes",
+			false,
+			&model.PatchGroupRequest{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+			&model.Group{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+			&model.Group{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+		},
+		{
+			"mattermost env only, patch group env with changes",
+			true,
+			&model.PatchGroupRequest{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+			&model.Group{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value2"},
+				},
+			},
+			&model.Group{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+		},
+		{
+			"mattermost env only, patch group env with new key",
+			true,
+			&model.PatchGroupRequest{
+				MattermostEnv: model.EnvVarMap{
+					"key2": {Value: "value1"},
+				},
+			},
+			&model.Group{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+			&model.Group{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+					"key2": {Value: "value1"},
+				},
+			},
+		},
+		{
+			"complex",
+			true,
+			&model.PatchGroupRequest{
+				Version: sToP("patch-version"),
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "patch-value-1"},
+					"key3": {Value: "patch-value-3"},
+				},
+			},
+			&model.Group{
+				Version: "version1",
+				Image:   "image1",
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+					"key2": {Value: "value2"},
+				},
+			},
+			&model.Group{
+				Version: "patch-version",
+				Image:   "image1",
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "patch-value-1"},
+					"key2": {Value: "value2"},
+					"key3": {Value: "patch-value-3"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			apply := tc.request.Apply(tc.installation)
+			assert.Equal(t, tc.expectApply, apply)
+			assert.Equal(t, tc.expectedInstallation, tc.installation)
+		})
+	}
+}
+
+func i64oP(i int64) *int64 {
+	return &i
+}

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -202,13 +202,8 @@ func (p *PatchInstallationRequest) Apply(installation *Installation) bool {
 		installation.License = *p.License
 	}
 	if p.MattermostEnv != nil {
-		if installation.MattermostEnv != nil {
-			if installation.MattermostEnv.ClearOrPatch(&p.MattermostEnv) {
-				applied = true
-			}
-		} else {
+		if installation.MattermostEnv.ClearOrPatch(&p.MattermostEnv) {
 			applied = true
-			installation.MattermostEnv = p.MattermostEnv
 		}
 	}
 

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -175,10 +175,8 @@ func (p *PatchInstallationRequest) Validate() error {
 			return errors.Wrap(err, "invalid size")
 		}
 	}
-	err := p.MattermostEnv.Validate()
-	if err != nil {
-		return errors.Wrap(err, "invalid env var settings")
-	}
+	// EnvVarMap validation is skipped as all configurations of this now imply
+	// a specific patch action should be taken.
 
 	return nil
 }
@@ -204,8 +202,14 @@ func (p *PatchInstallationRequest) Apply(installation *Installation) bool {
 		installation.License = *p.License
 	}
 	if p.MattermostEnv != nil {
-		applied = true
-		installation.MattermostEnv = p.MattermostEnv
+		if installation.MattermostEnv != nil {
+			if installation.MattermostEnv.ClearOrPatch(&p.MattermostEnv) {
+				applied = true
+			}
+		} else {
+			applied = true
+			installation.MattermostEnv = p.MattermostEnv
+		}
 	}
 
 	return applied

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -188,15 +188,6 @@ func TestPatchInstallationRequestValid(t *testing.T) {
 				Image: sToP(""),
 			},
 		},
-		{
-			"invalid mattermost env",
-			true,
-			&model.PatchInstallationRequest{
-				MattermostEnv: model.EnvVarMap{
-					"key1": {Value: ""},
-				},
-			},
-		},
 	}
 
 	for _, tc := range testCases {
@@ -271,7 +262,7 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 			},
 		},
 		{
-			"mattermost env only",
+			"mattermost env only, no installation env",
 			true,
 			&model.PatchInstallationRequest{
 				MattermostEnv: model.EnvVarMap{
@@ -286,6 +277,64 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 			},
 		},
 		{
+			"mattermost env only, patch installation env with no changes",
+			false,
+			&model.PatchInstallationRequest{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+			&model.Installation{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+			&model.Installation{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+		},
+		{
+			"mattermost env only, patch installation env with changes",
+			true,
+			&model.PatchInstallationRequest{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+			&model.Installation{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value2"},
+				},
+			},
+			&model.Installation{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+		},
+		{
+			"mattermost env only, patch installation env with new key",
+			true,
+			&model.PatchInstallationRequest{
+				MattermostEnv: model.EnvVarMap{
+					"key2": {Value: "value1"},
+				},
+			},
+			&model.Installation{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+			&model.Installation{
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+					"key2": {Value: "value1"},
+				},
+			},
+		},
+		{
 			"complex",
 			true,
 			&model.PatchInstallationRequest{
@@ -293,6 +342,7 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 				Size:    sToP("miniSingleton"),
 				MattermostEnv: model.EnvVarMap{
 					"key1": {Value: "patch-value-1"},
+					"key3": {Value: "patch-value-3"},
 				},
 			},
 			&model.Installation{
@@ -301,6 +351,7 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 				License: "license1",
 				MattermostEnv: model.EnvVarMap{
 					"key1": {Value: "value1"},
+					"key2": {Value: "value2"},
 				},
 			},
 			&model.Installation{
@@ -310,6 +361,8 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 				Size:    "miniSingleton",
 				MattermostEnv: model.EnvVarMap{
 					"key1": {Value: "patch-value-1"},
+					"key2": {Value: "value2"},
+					"key3": {Value: "patch-value-3"},
 				},
 			},
 		},


### PR DESCRIPTION
This change replaces the original env var update logic from
complete-replacement behavior to flexible patching behavior. The
new logic is as follows:
 - New EnvVarMap is nil: empty patch so no updates.
 - New EnvVarMap is empty: clear existing map completely.
 - New EnvVarMap has new keys and values: add new keys and values
   to existing map.
 - New EnvVarMap has new values for old keys: update old keys with
   new values.
 - NewEnvVarMap has empty values for old keys: delete the old keys.

https://mattermost.atlassian.net/browse/MM-25338

```release-note
Add installation and group env var patching logic
```
