### PR TITLE
MM-25556: multi tenant RDS databases should be provisioned to the correct VPC in a multi cluster environment

### DIFF
--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -912,4 +912,15 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.17.0"), semver.MustParse("0.18.0"), func(e execer) error {
+		_, err := e.Exec(`
+			ALTER TABLE "MultitenantDatabase"
+			ADD COLUMN VpcID TEXT NULL;
+		`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -914,7 +914,7 @@ var migrations = []migration{
 	}},
 	{semver.MustParse("0.17.0"), semver.MustParse("0.18.0"), func(e execer) error {
 		_, err := e.Exec(`
-			ALTER TABLE "MultitenantDatabase"
+			ALTER TABLE MultitenantDatabase
 			ADD COLUMN VpcID TEXT NULL;
 		`)
 		if err != nil {

--- a/internal/store/multitenant_database.go
+++ b/internal/store/multitenant_database.go
@@ -143,7 +143,6 @@ func (sqlStore *SQLStore) UpdateMultitenantDatabase(multitenantDatabase *model.M
 			"RawInstallationIDs": multitenantDatabase.RawInstallationIDs,
 		}).
 		Where(sq.Eq{"ID": multitenantDatabase.ID}).
-		Where(sq.Eq{"VpcID": multitenantDatabase.VpcID}).
 		Where(sq.Eq{"LockAcquiredBy": *multitenantDatabase.LockAcquiredBy}),
 	)
 	if err != nil {

--- a/internal/store/multitenant_database.go
+++ b/internal/store/multitenant_database.go
@@ -14,7 +14,7 @@ var multitenantDatabaseSelect sq.SelectBuilder
 
 func init() {
 	multitenantDatabaseSelect = sq.
-		Select("ID", "RawInstallationIDs", "CreateAt", "DeleteAt", "LockAcquiredBy", "LockAcquiredAt").
+		Select("ID", "VpcID", "RawInstallationIDs", "CreateAt", "DeleteAt", "LockAcquiredBy", "LockAcquiredAt").
 		From("MultitenantDatabase")
 }
 
@@ -51,6 +51,11 @@ func (sqlStore *SQLStore) GetMultitenantDatabases(filter *model.MultitenantDatab
 		if len(filter.LockerID) > 0 {
 			builder = builder.
 				Where(sq.Eq{"LockAcquiredBy": filter.LockerID})
+		}
+
+		if len(filter.VpcID) > 0 {
+			builder = builder.
+				Where(sq.Eq{"VpcID": filter.VpcID})
 		}
 	}
 
@@ -99,6 +104,7 @@ func (sqlStore *SQLStore) CreateMultitenantDatabase(multitenantDatabase *model.M
 		Insert("MultitenantDatabase").
 		SetMap(map[string]interface{}{
 			"ID":                 multitenantDatabase.ID,
+			"VpcID":              multitenantDatabase.VpcID,
 			"RawInstallationIDs": multitenantDatabase.RawInstallationIDs,
 			"LockAcquiredBy":     nil,
 			"LockAcquiredAt":     0,
@@ -137,6 +143,7 @@ func (sqlStore *SQLStore) UpdateMultitenantDatabase(multitenantDatabase *model.M
 			"RawInstallationIDs": multitenantDatabase.RawInstallationIDs,
 		}).
 		Where(sq.Eq{"ID": multitenantDatabase.ID}).
+		Where(sq.Eq{"VpcID": multitenantDatabase.VpcID}).
 		Where(sq.Eq{"LockAcquiredBy": *multitenantDatabase.LockAcquiredBy}),
 	)
 	if err != nil {

--- a/internal/store/multitenant_database_test.go
+++ b/internal/store/multitenant_database_test.go
@@ -41,11 +41,13 @@ func (s *TestMultitenantDatabaseSuite) SetupTest() {
 	s.lockerID = s.installationID0
 
 	s.database1 = &model.MultitenantDatabase{
-		ID: "database_id0",
+		ID:    "database_id0",
+		VpcID: "vpc_id0",
 	}
 
 	s.database2 = &model.MultitenantDatabase{
-		ID: "database_id1",
+		ID:    "database_id1",
+		VpcID: "vpc_id1",
 	}
 
 	s.database1.SetInstallationIDs(model.MultitenantDatabaseInstallationIDs{s.installationID0, s.installationID1})
@@ -66,7 +68,8 @@ func TestMultitenantDatabase(t *testing.T) {
 
 func (s *TestMultitenantDatabaseSuite) TestCreate() {
 	db := model.MultitenantDatabase{
-		ID: "database_some_id",
+		ID:    "database_some_id",
+		VpcID: "database_vpc_id",
 	}
 	err := s.sqlStore.CreateMultitenantDatabase(&db)
 	s.Assert().NoError(err)
@@ -301,4 +304,24 @@ func (s *TestMultitenantDatabaseSuite) TestGetMultitenantDatabaseForInstallation
 	s.Assert().Error(err)
 	s.Assert().Nil(database)
 	s.Assert().Equal("expected exactly one multitenant database per installation (found 2)", err.Error())
+}
+
+func (s *TestMultitenantDatabaseSuite) TestGetDatabasesWithVpcIDFilter() {
+	databases, err := s.sqlStore.GetMultitenantDatabases(&model.MultitenantDatabaseFilter{
+		VpcID:                   "vpc_id0",
+		NumOfInstallationsLimit: model.NoInstallationsLimit,
+		PerPage:                 model.AllPerPage,
+	})
+	s.Assert().NoError(err)
+	s.Assert().NotNil(databases)
+	s.Assert().Equal(1, len(databases))
+
+	databases, err = s.sqlStore.GetMultitenantDatabases(&model.MultitenantDatabaseFilter{
+		VpcID:                   "does_not_exist",
+		NumOfInstallationsLimit: model.NoInstallationsLimit,
+		PerPage:                 model.AllPerPage,
+	})
+	s.Assert().NoError(err)
+	s.Assert().Nil(databases)
+	s.Assert().Equal(0, len(databases))
 }

--- a/internal/tools/aws/database_multitenant.go
+++ b/internal/tools/aws/database_multitenant.go
@@ -59,35 +59,48 @@ func (d *RDSMultitenantDatabase) Teardown(store model.InstallationDatabaseStoreI
 
 	logger.Info("Tearing down RDS database and database secret")
 
-	multitenantDatabase, err := store.GetMultitenantDatabaseForInstallationID(d.installationID)
+	multitenantDatabases, err := store.GetMultitenantDatabases(&model.MultitenantDatabaseFilter{
+		InstallationID:          d.installationID,
+		NumOfInstallationsLimit: model.NoInstallationsLimit,
+		PerPage:                 model.AllPerPage,
+	})
 	if err != nil {
-		return errors.Wrapf(err, "unable to find multitenant database for installation ID %s when tearing the multitenant database down", d.installationID)
+		return errors.Wrapf(err, "failed to find multitenant database for installation ID %s", d.installationID)
 	}
 
-	unlocked, err := d.lockMultitenantDatabase(multitenantDatabase.ID, store)
+	if len(multitenantDatabases) > 1 {
+		return errors.Errorf("teardown expected exactly one multitenant database for installation ID %s (found %d)", d.installationID, len(multitenantDatabases))
+	}
+
+	if len(multitenantDatabases) < 1 {
+		logger.Infof("No multitenant database found for installation ID %s: teardown completed.", d.installationID)
+		return nil
+	}
+
+	unlocked, err := d.lockMultitenantDatabase(multitenantDatabases[0].ID, store)
 	if err != nil {
-		return errors.Wrapf(err, "failed to lock multitenant database ID %s when tearing the multitenant database down", multitenantDatabase.ID)
+		return errors.Wrapf(err, "failed to lock multitenant database ID %s when tearing the multitenant database down", multitenantDatabases[0].ID)
 	}
 	defer unlocked(logger)
 
-	rdsCluster, err := d.describeRDSCluster(multitenantDatabase.ID)
+	rdsCluster, err := d.describeRDSCluster(multitenantDatabases[0].ID)
 	if err != nil {
-		return errors.Wrapf(err, "failed to describe multitenant database ID %s when tearing the multitenant database down", multitenantDatabase.ID)
+		return errors.Wrapf(err, "failed to describe multitenant database ID %s when tearing the multitenant database down", multitenantDatabases[0].ID)
 	}
 
 	logger = logger.WithField("rds-cluster-id", *rdsCluster.DBClusterIdentifier)
 
-	err = d.dropDatabaseAndDeleteSecret(multitenantDatabase.ID, *rdsCluster.Endpoint, databaseName, store, logger)
+	err = d.dropDatabaseAndDeleteSecret(multitenantDatabases[0].ID, *rdsCluster.Endpoint, databaseName, store, logger)
 	if err != nil {
 		return errors.Wrap(err, "unable to finish teardown of multitenant database")
 	}
 
-	err = d.updateTagCounterAndRemoveInstallationID(rdsCluster.DBClusterArn, multitenantDatabase, store, logger)
+	err = d.updateTagCounterAndRemoveInstallationID(rdsCluster.DBClusterArn, multitenantDatabases[0], store, logger)
 	if err != nil {
 		return errors.Wrap(err, "unable to finish teardown of multitenant database")
 	}
 
-	logger.Infof("Multitenant RDS database teardown complete")
+	logger.Info("Multitenant RDS database teardown complete")
 
 	return nil
 }
@@ -266,6 +279,7 @@ func (d *RDSMultitenantDatabase) validateAndLockRDSCluster(multitenantDatabases 
 func (d *RDSMultitenantDatabase) findRDSClusterForInstallation(vpcID string, store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) (*rdsClusterOutput, error) {
 	multitenantDatabases, err := store.GetMultitenantDatabases(&model.MultitenantDatabaseFilter{
 		InstallationID:          d.installationID,
+		VpcID:                   vpcID,
 		NumOfInstallationsLimit: model.NoInstallationsLimit,
 		PerPage:                 model.AllPerPage,
 	})
@@ -278,6 +292,7 @@ func (d *RDSMultitenantDatabase) findRDSClusterForInstallation(vpcID string, sto
 	if len(multitenantDatabases) == 0 {
 		multitenantDatabases, err = store.GetMultitenantDatabases(&model.MultitenantDatabaseFilter{
 			NumOfInstallationsLimit: DefaultRDSMultitenantDatabaseCountLimit,
+			VpcID:                   vpcID,
 			PerPage:                 model.AllPerPage,
 		})
 		if err != nil {
@@ -388,7 +403,8 @@ func (d *RDSMultitenantDatabase) getMultitenantDatabasesFromResourceTags(vpcID s
 
 		if rdsClusterID != nil {
 			multitenantDatabase := model.MultitenantDatabase{
-				ID: *rdsClusterID,
+				ID:    *rdsClusterID,
+				VpcID: vpcID,
 			}
 
 			err := store.CreateMultitenantDatabase(&multitenantDatabase)
@@ -446,7 +462,7 @@ func (d *RDSMultitenantDatabase) getClusterInstallationVPC(store model.Installat
 		return nil, fmt.Errorf("no cluster installations found for installation ID %s", d.installationID)
 	}
 	if clusterInstallationCount != 1 {
-		return nil, fmt.Errorf("Multitenant RDS provisioning is not currently supported for more than one cluster installation (found %d)", clusterInstallationCount)
+		return nil, fmt.Errorf("multitenant RDS provisioning is not currently supported for multiple cluster installations (found %d)", clusterInstallationCount)
 	}
 
 	vpcs, err := d.client.GetVpcsWithFilters([]*ec2.Filter{

--- a/internal/tools/aws/database_multitenant_test.go
+++ b/internal/tools/aws/database_multitenant_test.go
@@ -140,6 +140,17 @@ func (a *AWSTestSuite) TestProvisioningMultitenantDatabase() {
 				},
 			}, nil),
 
+		a.Mocks.API.RDS.EXPECT().
+			DescribeDBClusterEndpoints(gomock.Any()).
+			Return(&rds.DescribeDBClusterEndpointsOutput{
+				DBClusterEndpoints: []*rds.DBClusterEndpoint{
+					{
+						Status: aws.String("available"),
+					},
+				},
+			}, nil).
+			Times(1),
+
 		// Create the multitenant database.
 		a.Mocks.Model.DatabaseInstallationStore.EXPECT().
 			CreateMultitenantDatabase(gomock.Any()).

--- a/model/multitenant_database.go
+++ b/model/multitenant_database.go
@@ -9,6 +9,7 @@ import (
 // MultitenantDatabase represents a cluster that manages multiple databases.
 type MultitenantDatabase struct {
 	ID                 string
+	VpcID              string
 	RawInstallationIDs []byte `json:",omitempty"`
 	LockAcquiredBy     *string
 	CreateAt           int64
@@ -76,11 +77,12 @@ func (d *MultitenantDatabaseInstallationIDs) Remove(installationID string) {
 	}
 }
 
-// MultitenantDatabaseFilter filters results based on a specific installation ID and a number of
+// MultitenantDatabaseFilter filters results based on a specific installation ID, Vpc ID and a number of
 // installation's limit.
 type MultitenantDatabaseFilter struct {
 	LockerID                string
 	InstallationID          string
+	VpcID                   string
 	NumOfInstallationsLimit int
 	Page                    int
 	PerPage                 int


### PR DESCRIPTION
#### Summary
This PR fixes the issue where the provisioner tries to install a multitenant database in a RDS cluster that belongs to some other VPC.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-25556

#### Release Note
```release-note
- Fixed the issue where the provisioner tries to install a multitenant database in a RDS cluster that does not belong to the acquired VPC.
- Fixed issue where the provisioner may get stuck trying to teardown an installation id that never had a correspondent multitenant database.
```
