### PR TITLE
Stale cluster and cluster installation supervisor fix

### DIFF
--- a/internal/supervisor/cluster.go
+++ b/internal/supervisor/cluster.go
@@ -83,11 +83,26 @@ func (s *ClusterSupervisor) Supervise(cluster *model.Cluster) {
 	}
 	defer lock.Unlock()
 
+	// Before working on the cluster, it is crucial that we ensure that it was
+	// not updated to a new state by another provisioning server.
+	originalState := cluster.State
+	cluster, err := s.store.GetCluster(cluster.ID)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to get refreshed cluster")
+		return
+	}
+	if cluster.State != originalState {
+		logger.WithField("oldClusterState", originalState).
+			WithField("newClusterState", cluster.State).
+			Warn("Another provisioner has worked on this cluster; skipping...")
+		return
+	}
+
 	logger.Debugf("Supervising cluster in state %s", cluster.State)
 
 	newState := s.transitionCluster(cluster, logger)
 
-	cluster, err := s.store.GetCluster(cluster.ID)
+	cluster, err = s.store.GetCluster(cluster.ID)
 	if err != nil {
 		logger.WithError(err).Warnf("failed to get cluster and thus persist state %s", newState)
 		return

--- a/internal/supervisor/cluster_installation.go
+++ b/internal/supervisor/cluster_installation.go
@@ -86,11 +86,26 @@ func (s *ClusterInstallationSupervisor) Supervise(clusterInstallation *model.Clu
 	}
 	defer lock.Unlock()
 
+	// Before working on the cluster installation, it is crucial that we ensure
+	// that it was not updated to a new state by another provisioning server.
+	originalState := clusterInstallation.State
+	clusterInstallation, err := s.store.GetClusterInstallation(clusterInstallation.ID)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to get refreshed cluster installation")
+		return
+	}
+	if clusterInstallation.State != originalState {
+		logger.WithField("oldClusterInstallationState", originalState).
+			WithField("newClusterInstallationState", clusterInstallation.State).
+			Warn("Another provisioner has worked on this cluster installation; skipping...")
+		return
+	}
+
 	logger.Debugf("Supervising cluster installation in state %s", clusterInstallation.State)
 
 	newState := s.transitionClusterInstallation(clusterInstallation, logger)
 
-	clusterInstallation, err := s.store.GetClusterInstallation(clusterInstallation.ID)
+	clusterInstallation, err = s.store.GetClusterInstallation(clusterInstallation.ID)
 	if err != nil {
 		logger.WithError(err).Warnf("failed to get cluster installation and thus persist state %s", newState)
 		return


### PR DESCRIPTION
This is a follow-up fix for the cluster and cluster installation
supervisors to prevent them from working on stale cloud resources.
The supervisors will now check if their workload contains a resource
that has already been worked on by another supervisor. If this is
detected, the supervisor will reevaluate all resources on its next
work cycle.

https://mattermost.atlassian.net/browse/MM-25628

```release-note
Stale cluster and cluster installation supervisor fix
```
