### PR TITLE
MM-25664: fixed logic that constraints query for fetching Multitenant Databases

### DIFF
--- a/internal/store/multitenant_database.go
+++ b/internal/store/multitenant_database.go
@@ -74,7 +74,7 @@ func (sqlStore *SQLStore) GetMultitenantDatabases(filter *model.MultitenantDatab
 				return nil, errors.Wrap(err, "failed to query multitenant databases")
 			}
 
-			if len(installationIDs) <= int(filter.NumOfInstallationsLimit) {
+			if len(installationIDs) < int(filter.NumOfInstallationsLimit) {
 				filteredDatabases = append(filteredDatabases, database)
 			}
 		}

--- a/internal/store/multitenant_database_test.go
+++ b/internal/store/multitenant_database_test.go
@@ -110,6 +110,16 @@ func (s *TestMultitenantDatabaseSuite) TestGetLimitConstraint() {
 	})
 	s.Assert().NoError(err)
 	s.Assert().NotNil(databases)
+	s.Assert().Equal(0, len(databases))
+}
+
+func (s *TestMultitenantDatabaseSuite) TestGetLimitConstraintOne() {
+	databases, err := s.sqlStore.GetMultitenantDatabases(&model.MultitenantDatabaseFilter{
+		NumOfInstallationsLimit: 3,
+		PerPage:                 model.AllPerPage,
+	})
+	s.Assert().NoError(err)
+	s.Assert().NotNil(databases)
 	s.Assert().Equal(1, len(databases))
 	s.Assert().Equal(s.database1.ID, databases[0].ID)
 }

--- a/internal/tools/aws/database_multitenant.go
+++ b/internal/tools/aws/database_multitenant.go
@@ -588,6 +588,9 @@ func (d *RDSMultitenantDatabase) validateMultitenantDatabaseInstallations(multit
 	if err != nil {
 		return errors.Wrapf(err, "failed to get multitenant database ID %s", multitenantDatabaseID)
 	}
+	if multitenantDatabase == nil {
+		return errors.Errorf("unable to find a multitenant database ID %s", multitenantDatabaseID)
+	}
 
 	expectedInstallations, err := multitenantDatabase.GetInstallationIDs()
 	if err != nil {


### PR DESCRIPTION
#### Summary
Data store method GetMultitenantDatabases takes a filter that constraint the number of installations. This filter has the wrong logic for filtering databases based on the number of installations below the limit. It was preventing the findRDSClusterForInstallation() to proceed to function that fetches RDS clusters from AWS.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-25664

#### Release Note
```release-note
Fixed logic that constraints query for fetching Multitenant Databases
```