### PR TITLE
Graceful SIGTERM shutdown

### DIFF
--- a/internal/supervisor/cluster.go
+++ b/internal/supervisor/cluster.go
@@ -56,6 +56,11 @@ func NewClusterSupervisor(store clusterStore, clusterProvisioner clusterProvisio
 	}
 }
 
+// Shutdown performs graceful shutdown tasks for the cluster supervisor.
+func (s *ClusterSupervisor) Shutdown() {
+	s.logger.Debug("Shutting down cluster supervisor")
+}
+
 // Do looks for work to be done on any pending clusters and attempts to schedule the required work.
 func (s *ClusterSupervisor) Do() error {
 	clusters, err := s.store.GetUnlockedClustersPendingWork()

--- a/internal/supervisor/cluster_installation.go
+++ b/internal/supervisor/cluster_installation.go
@@ -59,6 +59,11 @@ func NewClusterInstallationSupervisor(store clusterInstallationStore, clusterIns
 	}
 }
 
+// Shutdown performs graceful shutdown tasks for the cluster installation supervisor.
+func (s *ClusterInstallationSupervisor) Shutdown() {
+	s.logger.Debug("Shutting down cluster installation supervisor")
+}
+
 // Do looks for work to be done on any pending cluster installations and attempts to schedule the required work.
 func (s *ClusterInstallationSupervisor) Do() error {
 	clusterInstallations, err := s.store.GetUnlockedClusterInstallationsPendingWork()

--- a/internal/supervisor/doer.go
+++ b/internal/supervisor/doer.go
@@ -3,6 +3,7 @@ package supervisor
 // Doer describes an action to be done.
 type Doer interface {
 	Do() error
+	Shutdown()
 }
 
 // MultiDoer is a slice of doers.
@@ -18,4 +19,11 @@ func (md MultiDoer) Do() error {
 	}
 
 	return nil
+}
+
+// Shutdown tells each doer to perform shutdown tasks.
+func (md MultiDoer) Shutdown() {
+	for _, doer := range md {
+		doer.Shutdown()
+	}
 }

--- a/internal/supervisor/doer_test.go
+++ b/internal/supervisor/doer_test.go
@@ -18,12 +18,16 @@ func (td *testDoer) Do() error {
 	return nil
 }
 
+func (td *testDoer) Shutdown() {}
+
 type failDoer struct {
 }
 
 func (fd *failDoer) Do() error {
 	return fmt.Errorf("failed")
 }
+
+func (td *failDoer) Shutdown() {}
 
 func TestMultiDoer(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {

--- a/internal/supervisor/group.go
+++ b/internal/supervisor/group.go
@@ -40,6 +40,11 @@ func NewGroupSupervisor(store groupStore, instanceID string, logger log.FieldLog
 	}
 }
 
+// Shutdown performs graceful shutdown tasks for the group supervisor.
+func (s *GroupSupervisor) Shutdown() {
+	s.logger.Debug("Shutting down group supervisor")
+}
+
 // Do looks for work to be done on any pending groups and attempts to schedule
 // the required work.
 func (s *GroupSupervisor) Do() error {

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -89,6 +89,11 @@ func NewInstallationSupervisor(store installationStore, installationProvisioner 
 	}
 }
 
+// Shutdown performs graceful shutdown tasks for the installation supervisor.
+func (s *InstallationSupervisor) Shutdown() {
+	s.logger.Debug("Shutting down installation supervisor")
+}
+
 // Do looks for work to be done on any pending installations and attempts to schedule the required work.
 func (s *InstallationSupervisor) Do() error {
 	installations, err := s.store.GetUnlockedInstallationsPendingWork()

--- a/internal/supervisor/scheduler.go
+++ b/internal/supervisor/scheduler.go
@@ -62,6 +62,7 @@ func (s *Scheduler) run() {
 		case <-notify:
 			_ = s.doer.Do()
 		case <-s.stop:
+			s.doer.Shutdown()
 			close(s.done)
 			return
 		}


### PR DESCRIPTION
Kubernetes has a process for terminating pods as part of rolling
updates and other pod lifecycle mechanisms. One of the steps of
this process is sending a SIGTERM signal to the containers in the
pod.

The provisioner previously was not listening for SIGTERM properly,
meaning that there was a chance that supervisors could be performing
work when the container was terminated. This change handles SIGTERM
properly by attempting a graceful shutdown of the cloud server.

Also, logging has been added with a Shutdown() method for each
supervisor running in the server.

https://mattermost.atlassian.net/browse/MM-25678

```release-note
Graceful SIGTERM shutdown
```
