### PR TITLE
Update kops to 1.16.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@
 ################################################################################
 
 ## Docker Build Versions
-DOCKER_BUILD_IMAGE = golang:1.14.1
+DOCKER_BUILD_IMAGE = golang:1.14.2
 DOCKER_BASE_IMAGE = alpine:3.11
 
 ## Tool Versions
 TERRAFORM_VERSION=0.11.14
-KOPS_VERSION=1.15.0
+KOPS_VERSION=1.16.3
 HELM_VERSION=v2.14.2
-KUBECTL_VERSION=v1.15.0
+KUBECTL_VERSION=v1.18.3
 
 ################################################################################
 


### PR DESCRIPTION
This update will allow us to move to kubernetes 1.16.X.

This also includes a version bump to Go and kubectl.

Notes:
Although kops 1.17.0 is available, I will be performing additional
testing before we move to that version.

In my testing from 1.15.X to 1.16.X, I consistently ran into the
bug outlined here:
https://github.com/kubernetes/kops/issues/8771

This workaround was what I used to proceed with the upgrade:
https://github.com/kubernetes/kops/issues/8771#issuecomment-601137743

https://mattermost.atlassian.net/browse/MM-25708

```release-note
Update kops to 1.16.3
```
