### PR TITLE
helm: bump helm to v2.16.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_BASE_IMAGE = alpine:3.11
 ## Tool Versions
 TERRAFORM_VERSION=0.11.14
 KOPS_VERSION=v1.16.3
-HELM_VERSION=v2.14.2
+HELM_VERSION=v2.16.6
 KUBECTL_VERSION=v1.18.3
 
 ################################################################################


### PR DESCRIPTION
#### Summary
the k8s 1.16 does not support extensions/v1beta1 anymore and the current helm version deploy the tiller using this API version blocking new cluster to come up

```release-note
helm: upgrade helm to v2.16.6
```
