### PR TITLE
MM-24192 Adding Teleport utility group

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -24,12 +24,14 @@ func init() {
 	clusterCreateCmd.Flags().String("fluentbit-version", model.FluentbitDefaultVersion, "The version of Fluentbit to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("nginx-version", model.NginxDefaultVersion, "The version of Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("public-nginx-version", model.PublicNginxDefaultVersion, "The version of Public Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().String("teleport-version", model.TeleportDefaultVersion, "The version of Teleport to provision. Use 'stable' to provision the latest stable version published upstream.")
 
 	clusterProvisionCmd.Flags().String("cluster", "", "The id of the cluster to be provisioned.")
 	clusterProvisionCmd.Flags().String("prometheus-version", "", "The version of Prometheus to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.Flags().String("fluentbit-version", "", "The version of Fluentbit to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.Flags().String("nginx-version", "", "The version of Nginx to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.Flags().String("public-nginx-version", "", "The version of Public Nginx to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
+	clusterProvisionCmd.Flags().String("teleport-version", "", "The version of Teleport to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.MarkFlagRequired("cluster")
 
 	clusterUpdateCmd.Flags().String("cluster", "", "The id of the cluster to be updated.")
@@ -348,6 +350,7 @@ func processUtilityFlags(command *cobra.Command) map[string]string {
 	fluentbitVersion, _ := command.Flags().GetString("fluentbit-version")
 	nginxVersion, _ := command.Flags().GetString("nginx-version")
 	publicNginxVersion, _ := command.Flags().GetString("public-nginx-version")
+	teleportVersion, _ := command.Flags().GetString("teleport-version")
 
 	utilityVersions := make(map[string]string)
 
@@ -365,6 +368,10 @@ func processUtilityFlags(command *cobra.Command) map[string]string {
 
 	if publicNginxVersion != "" {
 		utilityVersions[model.PublicNginxCanonicalName] = publicNginxVersion
+	}
+
+	if teleportVersion != "" {
+		utilityVersions[model.TeleportCanonicalName] = teleportVersion
 	}
 
 	return utilityVersions

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -16,7 +16,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			Version:                "latest",
 			Size:                   "SizeAlef500",
 			Zones:                  []string{"us-east-1a"},
-			DesiredUtilityVersions: map[string]string{"fluentbit": "2.8.7", "nginx": "1.30.0", "prometheus": "10.4.0", "public-nginx": "1.30.0", "teleport": "0.1.0"},
+			DesiredUtilityVersions: map[string]string{"fluentbit": "2.8.7", "nginx": "1.30.0", "prometheus": "10.4.0", "public-nginx": "1.30.0", "teleport": "0.2.0"},
 		}
 	}
 
@@ -69,7 +69,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"nginx":        "1.30.0",
 				"prometheus":   "10.4.0",
 				"public-nginx": "1.30.0",
-				"teleport":     "0.1.0"},
+				"teleport":     "0.2.0"},
 		}, clusterRequest)
 	})
 }

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -16,7 +16,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			Version:                "latest",
 			Size:                   "SizeAlef500",
 			Zones:                  []string{"us-east-1a"},
-			DesiredUtilityVersions: map[string]string{"fluentbit": "2.8.7", "nginx": "1.30.0", "prometheus": "10.4.0", "public-nginx": "1.30.0"},
+			DesiredUtilityVersions: map[string]string{"fluentbit": "2.8.7", "nginx": "1.30.0", "prometheus": "10.4.0", "public-nginx": "1.30.0", "teleport": "0.1.0"},
 		}
 	}
 
@@ -68,7 +68,8 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"fluentbit":    "2.8.7",
 				"nginx":        "1.30.0",
 				"prometheus":   "10.4.0",
-				"public-nginx": "1.30.0"},
+				"public-nginx": "1.30.0",
+				"teleport":     "0.1.0"},
 		}, clusterRequest)
 	})
 }

--- a/internal/provisioner/teleport.go
+++ b/internal/provisioner/teleport.go
@@ -114,7 +114,7 @@ func getEnvironment(awsClient aws.AWS) (string, error) {
 		return "", errors.New("Account Alias not defined")
 	}
 	for _, alias := range accountAliases.AccountAliases {
-		if strings.HasPrefix(*alias, "mattermost-cloud") {
+		if strings.HasPrefix(*alias, "mattermost-cloud") && len(strings.Split(*alias, "-")) == 3 {
 			return strings.Split(*alias, "-")[2], nil
 		}
 	}

--- a/internal/provisioner/teleport.go
+++ b/internal/provisioner/teleport.go
@@ -1,0 +1,122 @@
+package provisioner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type teleport struct {
+	environment    string
+	provisioner    *KopsProvisioner
+	kops           *kops.Cmd
+	cluster        *model.Cluster
+	logger         log.FieldLogger
+	desiredVersion string
+	actualVersion  string
+}
+
+func newTeleportHandle(cluster *model.Cluster, desiredVersion string, provisioner *KopsProvisioner, awsClient aws.AWS, kops *kops.Cmd, logger log.FieldLogger) (*teleport, error) {
+	if logger == nil {
+		return nil, errors.New("cannot instantiate Teleport handle with nil logger")
+	}
+
+	if provisioner == nil {
+		return nil, errors.New("cannot create a connection to Teleport if the provisioner provided is nil")
+	}
+
+	if kops == nil {
+		return nil, errors.New("cannot create a connection to Teleport if the Kops command provided is nil")
+	}
+
+	environment, err := getEnvironment(awsClient)
+	if err != nil {
+		return nil, err
+	}
+
+	if environment == "" {
+		return nil, errors.New("cannot create a connection to Teleport if the environment is empty")
+	}
+
+	return &teleport{
+		environment:    environment,
+		provisioner:    provisioner,
+		kops:           kops,
+		cluster:        cluster,
+		logger:         logger.WithField("cluster-utility", model.TeleportCanonicalName),
+		desiredVersion: desiredVersion,
+	}, nil
+
+}
+
+func (n *teleport) updateVersion(h *helmDeployment) error {
+	actualVersion, err := h.Version()
+	if err != nil {
+		return err
+	}
+
+	n.actualVersion = actualVersion
+	return nil
+}
+
+func (n *teleport) CreateOrUpgrade() error {
+	h := n.NewHelmDeployment()
+	err := h.Update()
+	if err != nil {
+		return err
+	}
+
+	err = n.updateVersion(h)
+	return err
+}
+
+func (n *teleport) DesiredVersion() string {
+	return n.desiredVersion
+}
+
+func (n *teleport) ActualVersion() string {
+	return strings.TrimPrefix(n.actualVersion, "teleport-")
+}
+
+func (n *teleport) Destroy() error {
+	return nil
+}
+
+func (n *teleport) NewHelmDeployment() *helmDeployment {
+	return &helmDeployment{
+		chartDeploymentName: "teleport",
+		chartName:           "chartmuseum/teleport",
+		namespace:           "teleport",
+		setArgument:         fmt.Sprintf("config.auth_service.cluster_name=cloud-%s-%s", n.environment, n.cluster.ID),
+		valuesPath:          "helm-charts/teleport_values.yaml",
+		kopsProvisioner:     n.provisioner,
+		kops:                n.kops,
+		logger:              n.logger,
+		desiredVersion:      n.desiredVersion,
+	}
+}
+
+func (n *teleport) Name() string {
+	return model.TeleportCanonicalName
+}
+
+func getEnvironment(awsClient aws.AWS) (string, error) {
+	accountAliases, err := awsClient.GetAccountAliases()
+	if err != nil {
+		return "", err
+	}
+	if len(accountAliases.AccountAliases) < 1 {
+		return "", errors.New("Account Alias not defined")
+	}
+	for _, alias := range accountAliases.AccountAliases {
+		if strings.HasPrefix(*alias, "mattermost-cloud") {
+			return strings.Split(*alias, "-")[2], nil
+		}
+	}
+	return "", errors.New("Account environment was not obtained")
+}

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -48,7 +48,6 @@ type utilityGroup struct {
 
 // List of repos to add during helm setup
 var helmRepos = map[string]string{
-	"jetstack":    "https://charts.jetstack.io",
 	"stable":      "https://kubernetes-charts.storage.googleapis.com",
 	"chartmuseum": "https://chartmuseum.internal.core.cloud.mattermost.com",
 }

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/supervisor"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
@@ -193,6 +194,10 @@ func (p *mockInstallationProvisioner) GetNGINXLoadBalancerEndpoint(cluster *mode
 type mockAWS struct{}
 
 func (a *mockAWS) GetCertificateSummaryByTag(key, value string, logger log.FieldLogger) (*acm.CertificateSummary, error) {
+	return nil, nil
+}
+
+func (a *mockAWS) GetAccountAliases() (*iam.ListAccountAliasesOutput, error) {
 	return nil, nil
 }
 

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -45,6 +45,8 @@ type AWS interface {
 	TagResource(resourceID, key, value string, logger log.FieldLogger) error
 	UntagResource(resourceID, key, value string, logger log.FieldLogger) error
 	IsValidAMI(AMIImage string, logger log.FieldLogger) (bool, error)
+
+	GetAccountAliases() (*iam.ListAccountAliasesOutput, error)
 }
 
 // NewAWSClientWithConfig returns a new instance of Client with a custom configuration.

--- a/internal/tools/aws/iam.go
+++ b/internal/tools/aws/iam.go
@@ -235,3 +235,12 @@ func (a *Client) iamEnsureAccessKeyCreated(awsID string, logger log.FieldLogger)
 
 	return createResult.AccessKey, nil
 }
+
+// GetAccountAliases returns the AWS account name aliases.
+func (a *Client) GetAccountAliases() (*iam.ListAccountAliasesOutput, error) {
+	accountAliases, err := a.Service().iam.ListAccountAliases(&iam.ListAccountAliasesInput{})
+	if err != nil {
+		return nil, err
+	}
+	return accountAliases, nil
+}

--- a/internal/tools/aws/iam.go
+++ b/internal/tools/aws/iam.go
@@ -240,7 +240,7 @@ func (a *Client) iamEnsureAccessKeyCreated(awsID string, logger log.FieldLogger)
 func (a *Client) GetAccountAliases() (*iam.ListAccountAliasesOutput, error) {
 	accountAliases, err := a.Service().iam.ListAccountAliases(&iam.ListAccountAliasesInput{})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to get AWS account name aliases")
 	}
 	return accountAliases, nil
 }

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -49,6 +49,9 @@ func (request *CreateClusterRequest) SetDefaults() {
 	if _, ok := request.DesiredUtilityVersions[PublicNginxCanonicalName]; !ok {
 		request.DesiredUtilityVersions[PublicNginxCanonicalName] = PublicNginxDefaultVersion
 	}
+	if _, ok := request.DesiredUtilityVersions[TeleportCanonicalName]; !ok {
+		request.DesiredUtilityVersions[TeleportCanonicalName] = TeleportDefaultVersion
+	}
 }
 
 // Validate validates the values of a cluster create request.

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -16,6 +16,8 @@ const (
 	FluentbitCanonicalName = "fluentbit"
 	// PublicNginxCanonicalName is the canonical string representation of public nginx
 	PublicNginxCanonicalName = "public-nginx"
+	// TeleportCanonicalName is the canonical string representation of teleport
+	TeleportCanonicalName = "teleport"
 )
 
 const (
@@ -27,6 +29,8 @@ const (
 	FluentbitDefaultVersion = "2.8.7"
 	// PublicNginxDefaultVersion defines the default version for the Helm chart
 	PublicNginxDefaultVersion = "1.30.0"
+	// TeleportDefaultVersion defines the default version for the Helm chart
+	TeleportDefaultVersion = "0.2.0"
 )
 
 // UtilityMetadata is a container struct for any metadata related to
@@ -41,6 +45,7 @@ type utilityVersions struct {
 	Nginx       string
 	Fluentbit   string
 	PublicNginx string
+	Teleport    string
 }
 
 // SetUtilityActualVersion stores the provided version for the
@@ -162,6 +167,8 @@ func getUtilityVersion(versions *utilityVersions, utility string) string {
 		return versions.Fluentbit
 	case PublicNginxCanonicalName:
 		return versions.PublicNginx
+	case TeleportCanonicalName:
+		return versions.Teleport
 	}
 
 	return ""
@@ -181,5 +188,7 @@ func setUtilityVersion(versions *utilityVersions, utility, desiredVersion string
 		versions.Fluentbit = desiredVersion
 	case PublicNginxCanonicalName:
 		versions.PublicNginx = desiredVersion
+	case TeleportCanonicalName:
+		versions.Teleport = desiredVersion
 	}
 }

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,7 +73,6 @@ func TestSetDesired(t *testing.T) {
 }
 
 func TestGetActualVersion(t *testing.T) {
-<<<<<<< HEAD
 	um := &UtilityMetadata{
 		DesiredVersions: utilityVersions{
 			Prometheus:  "",
@@ -94,8 +94,6 @@ func TestGetActualVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, 0, len(b))
 
-=======
->>>>>>> 62b815b34d5e4ca4539265fd5864c1e938d88806
 	c := &Cluster{
 		UtilityMetadata: &UtilityMetadata{
 			DesiredVersions: utilityVersions{
@@ -139,7 +137,6 @@ func TestGetActualVersion(t *testing.T) {
 }
 
 func TestGetDesiredVersion(t *testing.T) {
-<<<<<<< HEAD
 	um := &UtilityMetadata{
 		DesiredVersions: utilityVersions{
 			Prometheus:  "",
@@ -161,8 +158,6 @@ func TestGetDesiredVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, 0, len(b))
 
-=======
->>>>>>> 62b815b34d5e4ca4539265fd5864c1e938d88806
 	c := &Cluster{
 		UtilityMetadata: &UtilityMetadata{
 			DesiredVersions: utilityVersions{

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -99,7 +99,7 @@ func TestGetActualVersion(t *testing.T) {
 			Nginx:       "nginx-10.2",
 			Fluentbit:   "fluent-bit-0.9",
 			PublicNginx: "nginx-10.2",
-			Teleport:    "teleport-0.1.0",
+			Teleport:    "teleport-0.2.0",
 		},
 	}
 
@@ -136,7 +136,7 @@ func TestGetActualVersion(t *testing.T) {
 
 	version, err = c.ActualUtilityVersion(TeleportCanonicalName)
 	assert.NoError(t, err)
-	assert.Equal(t, "teleport-0.1.0", version)
+	assert.Equal(t, "teleport-0.2.0", version)
 
 	version, err = c.ActualUtilityVersion("something else that doesn't exist")
 	assert.NoError(t, err)
@@ -157,7 +157,7 @@ func TestGetDesiredVersion(t *testing.T) {
 			Nginx:       "nginx-10.2",
 			Fluentbit:   "fluent-bit-0.9",
 			PublicNginx: "nginx-10.2",
-			Teleport:    "teleport-0.1.0",
+			Teleport:    "teleport-0.2.0",
 		},
 	}
 

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -92,12 +92,14 @@ func TestGetActualVersion(t *testing.T) {
 			Nginx:       "10.3",
 			Fluentbit:   "1337",
 			PublicNginx: "1234",
+			Teleport:    "12345",
 		},
 		ActualVersions: utilityVersions{
 			Prometheus:  "prometheus-10.3",
 			Nginx:       "nginx-10.2",
 			Fluentbit:   "fluent-bit-0.9",
 			PublicNginx: "nginx-10.2",
+			Teleport:    "teleport-0.1.0",
 		},
 	}
 
@@ -132,6 +134,10 @@ func TestGetActualVersion(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "nginx-10.2", version)
 
+	version, err = c.ActualUtilityVersion(TeleportCanonicalName)
+	assert.NoError(t, err)
+	assert.Equal(t, "teleport-0.1.0", version)
+
 	version, err = c.ActualUtilityVersion("something else that doesn't exist")
 	assert.NoError(t, err)
 	assert.Equal(t, "", version)
@@ -144,12 +150,14 @@ func TestGetDesiredVersion(t *testing.T) {
 			Nginx:       "10.3",
 			Fluentbit:   "1337",
 			PublicNginx: "1234",
+			Teleport:    "12345",
 		},
 		ActualVersions: utilityVersions{
 			Prometheus:  "prometheus-10.3",
 			Nginx:       "nginx-10.2",
 			Fluentbit:   "fluent-bit-0.9",
 			PublicNginx: "nginx-10.2",
+			Teleport:    "teleport-0.1.0",
 		},
 	}
 
@@ -183,6 +191,10 @@ func TestGetDesiredVersion(t *testing.T) {
 	version, err = c.DesiredUtilityVersion(PublicNginxCanonicalName)
 	assert.NoError(t, err)
 	assert.Equal(t, "1234", version)
+
+	version, err = c.DesiredUtilityVersion(TeleportCanonicalName)
+	assert.NoError(t, err)
+	assert.Equal(t, "12345", version)
 
 	version, err = c.DesiredUtilityVersion("something else that doesn't exist")
 	assert.NoError(t, err)

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,27 +72,6 @@ func TestSetDesired(t *testing.T) {
 }
 
 func TestGetActualVersion(t *testing.T) {
-	um := &UtilityMetadata{
-		DesiredVersions: utilityVersions{
-			Prometheus:  "",
-			Nginx:       "10.3",
-			Fluentbit:   "1337",
-			PublicNginx: "1234",
-			Teleport:    "12345",
-		},
-		ActualVersions: utilityVersions{
-			Prometheus:  "prometheus-10.3",
-			Nginx:       "nginx-10.2",
-			Fluentbit:   "fluent-bit-0.9",
-			PublicNginx: "nginx-10.2",
-			Teleport:    "teleport-0.2.0",
-		},
-	}
-
-	b, err := json.Marshal(um)
-	require.NoError(t, err)
-	assert.NotEqual(t, 0, len(b))
-
 	c := &Cluster{
 		UtilityMetadata: &UtilityMetadata{
 			DesiredVersions: utilityVersions{
@@ -101,12 +79,14 @@ func TestGetActualVersion(t *testing.T) {
 				Nginx:       "10.3",
 				Fluentbit:   "1337",
 				PublicNginx: "1234",
+				Teleport:    "12345",
 			},
 			ActualVersions: utilityVersions{
 				Prometheus:  "prometheus-10.3",
 				Nginx:       "nginx-10.2",
 				Fluentbit:   "fluent-bit-0.9",
 				PublicNginx: "nginx-10.2",
+				Teleport:    "teleport-0.2.0",
 			},
 		},
 	}
@@ -137,27 +117,6 @@ func TestGetActualVersion(t *testing.T) {
 }
 
 func TestGetDesiredVersion(t *testing.T) {
-	um := &UtilityMetadata{
-		DesiredVersions: utilityVersions{
-			Prometheus:  "",
-			Nginx:       "10.3",
-			Fluentbit:   "1337",
-			PublicNginx: "1234",
-			Teleport:    "12345",
-		},
-		ActualVersions: utilityVersions{
-			Prometheus:  "prometheus-10.3",
-			Nginx:       "nginx-10.2",
-			Fluentbit:   "fluent-bit-0.9",
-			PublicNginx: "nginx-10.2",
-			Teleport:    "teleport-0.2.0",
-		},
-	}
-
-	b, err := json.Marshal(um)
-	require.NoError(t, err)
-	assert.NotEqual(t, 0, len(b))
-
 	c := &Cluster{
 		UtilityMetadata: &UtilityMetadata{
 			DesiredVersions: utilityVersions{
@@ -165,12 +124,14 @@ func TestGetDesiredVersion(t *testing.T) {
 				Nginx:       "10.3",
 				Fluentbit:   "1337",
 				PublicNginx: "1234",
+				Teleport:    "12345",
 			},
 			ActualVersions: utilityVersions{
 				Prometheus:  "prometheus-10.3",
 				Nginx:       "nginx-10.2",
 				Fluentbit:   "fluent-bit-0.9",
 				PublicNginx: "nginx-10.2",
+				Teleport:    "teleport-0.2.0",
 			},
 		},
 	}


### PR DESCRIPTION
#### Summary
This PR adds:
- Teleport Utility Group 
- Function to get Account name Aliases

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24192

#### Release Note
```release-note
Adds teleport utility group
```
