### PR TITLE
MM-25481: enable TLS connection between services and RDS databases

### DIFF
--- a/internal/tools/aws/database_multitenant.go
+++ b/internal/tools/aws/database_multitenant.go
@@ -752,7 +752,7 @@ func (d *RDSMultitenantDatabase) connectRDSCluster(schema, endpoint, username, p
 }
 
 func (d *RDSMultitenantDatabase) createUserIfNotExist(ctx context.Context, username, password string) error {
-	_, err := d.db.QueryContext(ctx, "CREATE USER IF NOT EXISTS ?@? IDENTIFIED BY ?", username, "%", password)
+	_, err := d.db.QueryContext(ctx, "CREATE USER IF NOT EXISTS ?@? IDENTIFIED BY ? REQUIRE SSL", username, "%", password)
 	if err != nil {
 		return errors.Wrapf(err, "creating user %s", username)
 	}

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -96,13 +96,13 @@ func MattermostRDSDatabaseName(installationID string) string {
 
 // MattermostMySQLConnString formats the connection string used for accessing a Mattermost database.
 func MattermostMySQLConnString(schema, endpoint, username, password string) string {
-	return fmt.Sprintf("mysql://%s:%s@tcp(%s:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
+	return fmt.Sprintf("mysql://%s:%s@tcp(%s:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
 		username, password, endpoint, schema)
 }
 
-// RDSMySQLConnString formats the connection string used for accessing a MySql RDS cluster.
+// RDSMySQLConnString formats the connection string used for accessing a MySQL RDS cluster.
 func RDSMySQLConnString(schema, endpoint, username, password string) string {
-	return fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?interpolateParams=true&charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
+	return fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?interpolateParams=true&charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
 		username, password, endpoint, schema)
 }
 


### PR DESCRIPTION
#### Summary
This PR goes back to the very initial proposed design which was enable TLS connection with no Root CA validation for the installation's databases. This solution enables a secure connection between services (provisioner & mm-server) and the database but the Certificate Authority is not verified. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24703

#### Release Note
```release-note
* Enabled TLS for connections with RDS MySQL databases.
* Disabled Root CA verification by passing `tls=skip-verify` in the database connection string.
* Modified multi-tenant database to set require SSL when creating a user for the Mattermost installation database.
```

#### E2e manual testing (Environment: DEV)
* Create installation with a multi tenant database
* Delete installation with a multi tenant database
* Create installation with a single tenant database
* Delete installation with a single tenant database
* Attempt to connect to a single database without a secure connection