### PR TITLE
Refactor cluster metadata handling

### DIFF
--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -591,11 +591,8 @@ func TestUpgradeCluster(t *testing.T) {
 		cluster1, err = client.GetCluster(cluster1.ID)
 		require.NoError(t, err)
 		assert.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
-
-		metadata, err := model.NewKopsMetadata(cluster1.ProvisionerMetadata)
-		require.NoError(t, err)
-		assert.Equal(t, version, metadata.Version)
-		assert.Empty(t, metadata.AMI)
+		assert.Equal(t, version, cluster1.ProvisionerMetadataKops.Version)
+		assert.Empty(t, cluster1.ProvisionerMetadataKops.AMI)
 	})
 
 	t.Run("after upgrade failed", func(t *testing.T) {
@@ -610,11 +607,8 @@ func TestUpgradeCluster(t *testing.T) {
 		cluster1, err = client.GetCluster(cluster1.ID)
 		require.NoError(t, err)
 		assert.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
-
-		metadata, err := model.NewKopsMetadata(cluster1.ProvisionerMetadata)
-		require.NoError(t, err)
-		assert.Equal(t, version, metadata.Version)
-		assert.Empty(t, metadata.AMI)
+		assert.Equal(t, version, cluster1.ProvisionerMetadataKops.Version)
+		assert.Empty(t, cluster1.ProvisionerMetadataKops.AMI)
 	})
 
 	t.Run("while stable, to latest", func(t *testing.T) {
@@ -629,11 +623,8 @@ func TestUpgradeCluster(t *testing.T) {
 		cluster1, err = client.GetCluster(cluster1.ID)
 		require.NoError(t, err)
 		assert.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
-
-		metadata, err := model.NewKopsMetadata(cluster1.ProvisionerMetadata)
-		require.NoError(t, err)
-		assert.Equal(t, version, metadata.Version)
-		assert.Empty(t, metadata.AMI)
+		assert.Equal(t, version, cluster1.ProvisionerMetadataKops.Version)
+		assert.Empty(t, cluster1.ProvisionerMetadataKops.AMI)
 	})
 
 	t.Run("while stable, to valid version", func(t *testing.T) {
@@ -648,11 +639,8 @@ func TestUpgradeCluster(t *testing.T) {
 		cluster1, err = client.GetCluster(cluster1.ID)
 		require.NoError(t, err)
 		assert.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
-
-		metadata, err := model.NewKopsMetadata(cluster1.ProvisionerMetadata)
-		require.NoError(t, err)
-		assert.Equal(t, version, metadata.Version)
-		assert.Empty(t, metadata.AMI)
+		assert.Equal(t, version, cluster1.ProvisionerMetadataKops.Version)
+		assert.Empty(t, cluster1.ProvisionerMetadataKops.AMI)
 	})
 
 	t.Run("while stable, to invalid version", func(t *testing.T) {
@@ -680,11 +668,8 @@ func TestUpgradeCluster(t *testing.T) {
 		cluster1, err = client.GetCluster(cluster1.ID)
 		require.NoError(t, err)
 		assert.Equal(t, model.ClusterStateUpgradeRequested, cluster1.State)
-
-		metadata, err := model.NewKopsMetadata(cluster1.ProvisionerMetadata)
-		require.NoError(t, err)
-		assert.Equal(t, version, metadata.Version)
-		assert.Equal(t, ami, metadata.AMI)
+		assert.Equal(t, version, cluster1.ProvisionerMetadataKops.Version)
+		assert.Equal(t, ami, cluster1.ProvisionerMetadataKops.AMI)
 	})
 
 	t.Run("while deleting", func(t *testing.T) {

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -32,12 +32,7 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 	}
 	defer kops.Close()
 
-	kopsMetadata, err := model.NewKopsMetadata(cluster.ProvisionerMetadata)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse provisioner metadata")
-	}
-
-	err = kops.ExportKubecfg(kopsMetadata.Name)
+	err = kops.ExportKubecfg(cluster.ProvisionerMetadataKops.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to export kubecfg")
 	}
@@ -163,17 +158,12 @@ func (provisioner *KopsProvisioner) UpdateClusterInstallation(cluster *model.Clu
 	}
 	defer kops.Close()
 
-	kopsMetadata, err := model.NewKopsMetadata(cluster.ProvisionerMetadata)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse provisioner metadata")
-	}
-
-	if kopsMetadata.Name == "" {
+	if cluster.ProvisionerMetadataKops.Name == "" {
 		logger.Infof("Cluster %s has no name, assuming cluster installation never existed.", cluster.ID)
 		return nil
 	}
 
-	err = kops.ExportKubecfg(kopsMetadata.Name)
+	err = kops.ExportKubecfg(cluster.ProvisionerMetadataKops.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to export kubecfg")
 	}
@@ -281,17 +271,12 @@ func (provisioner *KopsProvisioner) DeleteClusterInstallation(cluster *model.Clu
 	}
 	defer kops.Close()
 
-	kopsMetadata, err := model.NewKopsMetadata(cluster.ProvisionerMetadata)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse provisioner metadata")
-	}
-
-	if kopsMetadata.Name == "" {
+	if cluster.ProvisionerMetadataKops.Name == "" {
 		logger.Infof("Cluster %s has no name, assuming cluster installation never existed.", cluster.ID)
 		return nil
 	}
 
-	err = kops.ExportKubecfg(kopsMetadata.Name)
+	err = kops.ExportKubecfg(cluster.ProvisionerMetadataKops.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to export kubecfg")
 	}
@@ -346,17 +331,12 @@ func (provisioner *KopsProvisioner) GetClusterInstallationResource(cluster *mode
 	}
 	defer kops.Close()
 
-	kopsMetadata, err := model.NewKopsMetadata(cluster.ProvisionerMetadata)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse provisioner metadata")
-	}
-
-	if kopsMetadata.Name == "" {
+	if cluster.ProvisionerMetadataKops.Name == "" {
 		logger.Infof("Cluster %s has no name, assuming cluster installation never existed.", cluster.ID)
 		return nil, nil
 	}
 
-	err = kops.ExportKubecfg(kopsMetadata.Name)
+	err = kops.ExportKubecfg(cluster.ProvisionerMetadataKops.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to export kubecfg")
 	}
@@ -395,12 +375,7 @@ func (provisioner *KopsProvisioner) execCLI(cluster *model.Cluster, clusterInsta
 	}
 	defer kops.Close()
 
-	kopsMetadata, err := model.NewKopsMetadata(cluster.ProvisionerMetadata)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse provisioner metadata")
-	}
-
-	err = kops.ExportKubecfg(kopsMetadata.Name)
+	err = kops.ExportKubecfg(cluster.ProvisionerMetadataKops.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to export kubecfg")
 	}

--- a/internal/provisioner/kops_utils.go
+++ b/internal/provisioner/kops_utils.go
@@ -127,12 +127,7 @@ func (provisioner *KopsProvisioner) GetNGINXLoadBalancerEndpoint(cluster *model.
 	}
 	defer kops.Close()
 
-	kopsMetadata, err := model.NewKopsMetadata(cluster.ProvisionerMetadata)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to parse provisioner metadata")
-	}
-
-	err = kops.ExportKubecfg(kopsMetadata.Name)
+	err = kops.ExportKubecfg(cluster.ProvisionerMetadataKops.Name)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to export kubecfg")
 	}

--- a/internal/store/cluster_test.go
+++ b/internal/store/cluster_test.go
@@ -24,25 +24,25 @@ func TestClusters(t *testing.T) {
 		sqlStore := MakeTestSQLStore(t, logger)
 
 		cluster1 := &model.Cluster{
-			Provider:            "aws",
-			Provisioner:         "kops",
-			ProviderMetadata:    []byte(`{"provider": "test1"}`),
-			ProvisionerMetadata: []byte(`{"provisioner": "test1"}`),
-			Size:                model.SizeAlef500,
-			State:               model.ClusterStateCreationRequested,
-			AllowInstallations:  false,
-			UtilityMetadata:     []byte(`{}`),
+			Provider:                "aws",
+			Provisioner:             "kops",
+			ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
+			ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
+			UtilityMetadata:         &model.UtilityMetadata{},
+			Size:                    model.SizeAlef500,
+			State:                   model.ClusterStateCreationRequested,
+			AllowInstallations:      false,
 		}
 
 		cluster2 := &model.Cluster{
-			Provider:            "azure",
-			Provisioner:         "cluster-api",
-			ProviderMetadata:    []byte(`{"provider": "test2"}`),
-			ProvisionerMetadata: []byte(`{"provisioner": "test2"}`),
-			Size:                model.SizeAlef500,
-			State:               model.ClusterStateStable,
-			AllowInstallations:  true,
-			UtilityMetadata:     []byte(`{}`),
+			Provider:                "azure",
+			Provisioner:             "cluster-api",
+			ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
+			ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
+			UtilityMetadata:         &model.UtilityMetadata{},
+			Size:                    model.SizeAlef500,
+			State:                   model.ClusterStateStable,
+			AllowInstallations:      true,
 		}
 
 		err := sqlStore.CreateCluster(cluster1)
@@ -91,25 +91,25 @@ func TestClusters(t *testing.T) {
 		sqlStore := MakeTestSQLStore(t, logger)
 
 		cluster1 := &model.Cluster{
-			Provider:            "aws",
-			Provisioner:         "kops",
-			ProviderMetadata:    []byte(`{"provider": "test1"}`),
-			ProvisionerMetadata: []byte(`{"provisioner": "test1"}`),
-			Size:                model.SizeAlef500,
-			State:               model.ClusterStateCreationRequested,
-			AllowInstallations:  false,
-			UtilityMetadata:     []byte(`{}`),
+			Provider:                "aws",
+			Provisioner:             "kops",
+			ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
+			ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
+			UtilityMetadata:         &model.UtilityMetadata{},
+			Size:                    model.SizeAlef500,
+			State:                   model.ClusterStateCreationRequested,
+			AllowInstallations:      false,
 		}
 
 		cluster2 := &model.Cluster{
-			Provider:            "azure",
-			Provisioner:         "cluster-api",
-			ProviderMetadata:    []byte(`{"provider": "test2"}`),
-			ProvisionerMetadata: []byte(`{"provisioner": "test2"}`),
-			Size:                model.SizeAlef500,
-			State:               model.ClusterStateStable,
-			AllowInstallations:  true,
-			UtilityMetadata:     []byte(`{}`),
+			Provider:                "azure",
+			Provisioner:             "cluster-api",
+			ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
+			ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
+			UtilityMetadata:         &model.UtilityMetadata{},
+			Size:                    model.SizeAlef500,
+			State:                   model.ClusterStateStable,
+			AllowInstallations:      true,
 		}
 
 		err := sqlStore.CreateCluster(cluster1)
@@ -120,8 +120,8 @@ func TestClusters(t *testing.T) {
 
 		cluster1.Provider = "azure"
 		cluster1.Provisioner = "cluster-api"
-		cluster1.ProviderMetadata = []byte(`{"provider": "updated-test1"}`)
-		cluster1.ProvisionerMetadata = []byte(`{"provisioner": "updated-test1"}`)
+		cluster1.ProviderMetadataAWS = &model.AWSMetadata{Zones: []string{"zone2"}}
+		cluster1.ProvisionerMetadataKops = &model.KopsMetadata{Version: "version2"}
 		cluster1.Size = model.SizeAlef1000
 		cluster1.State = model.ClusterStateDeletionRequested
 		cluster1.AllowInstallations = true
@@ -143,21 +143,21 @@ func TestClusters(t *testing.T) {
 		sqlStore := MakeTestSQLStore(t, logger)
 
 		cluster1 := &model.Cluster{
-			Provider:            "aws",
-			Provisioner:         "kops",
-			ProviderMetadata:    []byte(`{"provider": "test1"}`),
-			ProvisionerMetadata: []byte(`{"provisioner": "test1"}`),
-			AllowInstallations:  false,
-			UtilityMetadata:     []byte(`{}`),
+			Provider:                "aws",
+			Provisioner:             "kops",
+			ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
+			ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
+			UtilityMetadata:         &model.UtilityMetadata{},
+			AllowInstallations:      false,
 		}
 
 		cluster2 := &model.Cluster{
-			Provider:            "azure",
-			Provisioner:         "cluster-api",
-			ProviderMetadata:    []byte(`{"provider": "test2"}`),
-			ProvisionerMetadata: []byte(`{"provisioner": "test2"}`),
-			AllowInstallations:  true,
-			UtilityMetadata:     []byte(`{}`),
+			Provider:                "azure",
+			Provisioner:             "cluster-api",
+			ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
+			ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
+			UtilityMetadata:         &model.UtilityMetadata{},
+			AllowInstallations:      true,
 		}
 
 		err := sqlStore.CreateCluster(cluster1)
@@ -219,10 +219,7 @@ func TestGetUnlockedClustersPendingWork(t *testing.T) {
 	sqlStore := MakeTestSQLStore(t, logger)
 
 	creationRequestedCluster := &model.Cluster{
-		ProviderMetadata:    []byte(`{"provider": "test1"}`),
-		ProvisionerMetadata: []byte(`{"provisioner": "test1"}`),
-		State:               model.ClusterStateCreationRequested,
-		UtilityMetadata:     []byte(`{}`),
+		State: model.ClusterStateCreationRequested,
 	}
 	err := sqlStore.CreateCluster(creationRequestedCluster)
 	require.NoError(t, err)
@@ -230,10 +227,7 @@ func TestGetUnlockedClustersPendingWork(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 
 	upgradeRequestedCluster := &model.Cluster{
-		ProviderMetadata:    []byte(`{"provider": "test1"}`),
-		ProvisionerMetadata: []byte(`{"provisioner": "test1"}`),
-		State:               model.ClusterStateUpgradeRequested,
-		UtilityMetadata:     []byte(`{}`),
+		State: model.ClusterStateUpgradeRequested,
 	}
 	err = sqlStore.CreateCluster(upgradeRequestedCluster)
 	require.NoError(t, err)
@@ -241,10 +235,7 @@ func TestGetUnlockedClustersPendingWork(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 
 	deletionRequestedCluster := &model.Cluster{
-		ProviderMetadata:    []byte(`{"provider": "test1"}`),
-		ProvisionerMetadata: []byte(`{"provisioner": "test1"}`),
-		State:               model.ClusterStateDeletionRequested,
-		UtilityMetadata:     []byte(`{}`),
+		State: model.ClusterStateDeletionRequested,
 	}
 	err = sqlStore.CreateCluster(deletionRequestedCluster)
 	require.NoError(t, err)

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -189,7 +189,7 @@ func (sqlStore *SQLStore) CreateInstallation(installation *model.Installation) e
 
 	envJSON, err := json.Marshal(installation.MattermostEnv)
 	if err != nil {
-		errors.Wrap(err, "unable to marshal MattermostEnv")
+		return errors.Wrap(err, "unable to marshal MattermostEnv")
 	}
 
 	_, err = sqlStore.execBuilder(sqlStore.db, sq.

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -58,8 +58,8 @@ func (s *mockClusterStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.We
 
 type mockClusterProvisioner struct{}
 
-func (p *mockClusterProvisioner) PrepareCluster(cluster *model.Cluster) (bool, error) {
-	return true, nil
+func (p *mockClusterProvisioner) PrepareCluster(cluster *model.Cluster) bool {
+	return true
 }
 
 func (p *mockClusterProvisioner) CreateCluster(cluster *model.Cluster, aws aws.AWS) error {

--- a/model/aws_metadata.go
+++ b/model/aws_metadata.go
@@ -8,14 +8,14 @@ type AWSMetadata struct {
 }
 
 // NewAWSMetadata creates an instance of AWSMetadata given the raw provider metadata.
-func NewAWSMetadata(providerMetadata []byte) (*AWSMetadata, error) {
-	awsMetadata := AWSMetadata{}
-
-	if providerMetadata == nil {
-		return &awsMetadata, nil
+func NewAWSMetadata(metadataBytes []byte) (*AWSMetadata, error) {
+	if metadataBytes == nil || string(metadataBytes) == "null" {
+		// TODO: remove "null" check after sqlite is gone.
+		return nil, nil
 	}
 
-	err := json.Unmarshal(providerMetadata, &awsMetadata)
+	var awsMetadata AWSMetadata
+	err := json.Unmarshal(metadataBytes, &awsMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/model/aws_metadata_test.go
+++ b/model/aws_metadata_test.go
@@ -11,7 +11,7 @@ func TestNewAWSMetadata(t *testing.T) {
 	t.Run("nil payload", func(t *testing.T) {
 		awsMetadata, err := model.NewAWSMetadata(nil)
 		require.NoError(t, err)
-		require.Empty(t, awsMetadata.Zones)
+		require.Nil(t, awsMetadata)
 	})
 
 	t.Run("invalid payload", func(t *testing.T) {

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -4,26 +4,24 @@ import (
 	"encoding/json"
 	"io"
 	"regexp"
-
-	"github.com/pkg/errors"
 )
 
 // Cluster represents a Kubernetes cluster.
 type Cluster struct {
-	ID                  string
-	Provider            string
-	Provisioner         string
-	ProviderMetadata    []byte `json:",omitempty"`
-	ProvisionerMetadata []byte `json:",omitempty"`
-	AllowInstallations  bool
-	Version             string
-	Size                string
-	State               string
-	CreateAt            int64
-	DeleteAt            int64
-	LockAcquiredBy      *string
-	LockAcquiredAt      int64
-	UtilityMetadata     []byte `json:",omitempty"`
+	ID                      string
+	State                   string
+	Provider                string
+	ProviderMetadataAWS     *AWSMetadata
+	Provisioner             string
+	ProvisionerMetadataKops *KopsMetadata
+	UtilityMetadata         *UtilityMetadata
+	AllowInstallations      bool
+	Version                 string
+	Size                    string
+	CreateAt                int64
+	DeleteAt                int64
+	LockAcquiredBy          *string
+	LockAcquiredAt          int64
 }
 
 // Clone returns a deep copy the cluster.
@@ -33,38 +31,6 @@ func (c *Cluster) Clone() *Cluster {
 	json.Unmarshal(data, &clone)
 
 	return &clone
-}
-
-// SetProviderMetadata is a helper method to encode an interface{} as the corresponding bytes.
-func (c *Cluster) SetProviderMetadata(data interface{}) error {
-	if data == nil {
-		c.ProviderMetadata = nil
-		return nil
-	}
-
-	providerMetadata, err := json.Marshal(data)
-	if err != nil {
-		return errors.Wrap(err, "failed to set provider metadata")
-	}
-
-	c.ProviderMetadata = providerMetadata
-	return nil
-}
-
-// SetProvisionerMetadata is a helper method to encode an interface{} as the corresponding bytes.
-func (c *Cluster) SetProvisionerMetadata(data interface{}) error {
-	if data == nil {
-		c.ProvisionerMetadata = nil
-		return nil
-	}
-
-	provisionerMetadata, err := json.Marshal(data)
-	if err != nil {
-		return errors.Wrap(err, "failed to set provisioner metadata")
-	}
-
-	c.ProvisionerMetadata = provisionerMetadata
-	return nil
 }
 
 // ClusterFromReader decodes a json-encoded cluster from the given io.Reader.

--- a/model/cluster_test.go
+++ b/model/cluster_test.go
@@ -10,52 +10,20 @@ import (
 
 func TestClusterClone(t *testing.T) {
 	cluster := &Cluster{
-		Provider:            "aws",
-		Provisioner:         "kops",
-		ProviderMetadata:    []byte(`{"provider": "test1"}`),
-		ProvisionerMetadata: []byte(`{"provisioner": "test1"}`),
-		AllowInstallations:  false,
+		Provider:                "aws",
+		Provisioner:             "kops",
+		ProviderMetadataAWS:     &AWSMetadata{Zones: []string{"zone1"}},
+		ProvisionerMetadataKops: &KopsMetadata{Version: "version1"},
+		AllowInstallations:      false,
 	}
 
 	clone := cluster.Clone()
 	require.Equal(t, cluster, clone)
 
 	// Verify changing pointers in the clone doesn't affect the original.
-	clone.ProviderMetadata = []byte("override")
-	clone.ProvisionerMetadata = []byte("override")
+	clone.ProviderMetadataAWS = &AWSMetadata{Zones: []string{"zone2"}}
+	clone.ProvisionerMetadataKops = &KopsMetadata{Version: "version2"}
 	require.NotEqual(t, cluster, clone)
-}
-
-func TestSetProviderMetadata(t *testing.T) {
-	t.Run("set nil", func(t *testing.T) {
-		cluster := Cluster{}
-		err := cluster.SetProviderMetadata(nil)
-		require.NoError(t, err)
-		require.Nil(t, cluster.ProviderMetadata)
-	})
-
-	t.Run("set data", func(t *testing.T) {
-		cluster := Cluster{}
-		err := cluster.SetProviderMetadata(struct{ Test string }{"test"})
-		require.NoError(t, err)
-		require.Equal(t, `{"Test":"test"}`, string(cluster.ProviderMetadata))
-	})
-}
-
-func TestSetProvisionerMetadata(t *testing.T) {
-	t.Run("set nil", func(t *testing.T) {
-		cluster := Cluster{}
-		err := cluster.SetProvisionerMetadata(nil)
-		require.NoError(t, err)
-		require.Nil(t, cluster.ProvisionerMetadata)
-	})
-
-	t.Run("set data", func(t *testing.T) {
-		cluster := Cluster{}
-		err := cluster.SetProvisionerMetadata(struct{ Test string }{"test"})
-		require.NoError(t, err)
-		require.Equal(t, `{"Test":"test"}`, string(cluster.ProvisionerMetadata))
-	})
 }
 
 func TestClusterFromReader(t *testing.T) {

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,39 +40,27 @@ func TestGetUtilityVersion(t *testing.T) {
 }
 
 func TestSetActualVersion(t *testing.T) {
-	c := &Cluster{
-		Provider:            "aws",
-		Provisioner:         "kops",
-		ProviderMetadata:    []byte(`{"provider": "test1"}`),
-		ProvisionerMetadata: []byte(`{"provisioner": "test1"}`),
-		AllowInstallations:  false,
-	}
+	c := &Cluster{}
 
-	assert.Equal(t, c.UtilityMetadata, []byte(nil))
+	assert.Nil(t, c.UtilityMetadata)
 	err := c.SetUtilityActualVersion(NginxCanonicalName, "1.9.9")
 	require.NoError(t, err)
-	assert.NotEqual(t, []byte(nil), c.UtilityMetadata)
+	assert.NotNil(t, c.UtilityMetadata)
 	version, err := c.ActualUtilityVersion(NginxCanonicalName)
 	require.NoError(t, err)
 	assert.Equal(t, "1.9.9", version)
 }
 
 func TestSetDesired(t *testing.T) {
-	c := &Cluster{
-		Provider:            "aws",
-		Provisioner:         "kops",
-		ProviderMetadata:    []byte(`{"provider": "test1"}`),
-		ProvisionerMetadata: []byte(`{"provisioner": "test1"}`),
-		AllowInstallations:  false,
-	}
+	c := &Cluster{}
 
-	assert.Equal(t, c.UtilityMetadata, []byte(nil))
+	assert.Nil(t, c.UtilityMetadata)
 	err := c.SetUtilityDesiredVersions(map[string]string{
 		NginxCanonicalName: "1.9.9",
 	})
 	require.NoError(t, err)
 
-	assert.NotEqual(t, []byte(nil), c.UtilityMetadata)
+	assert.NotNil(t, c.UtilityMetadata)
 
 	version, err := c.DesiredUtilityVersion(NginxCanonicalName)
 	require.NoError(t, err)
@@ -82,39 +69,25 @@ func TestSetDesired(t *testing.T) {
 	version, err = c.DesiredUtilityVersion(PrometheusCanonicalName)
 	require.NoError(t, err)
 	assert.Equal(t, "", version)
-
 }
 
 func TestGetActualVersion(t *testing.T) {
-	um := &UtilityMetadata{
-		DesiredVersions: utilityVersions{
-			Prometheus:  "",
-			Nginx:       "10.3",
-			Fluentbit:   "1337",
-			PublicNginx: "1234",
-		},
-		ActualVersions: utilityVersions{
-			Prometheus:  "prometheus-10.3",
-			Nginx:       "nginx-10.2",
-			Fluentbit:   "fluent-bit-0.9",
-			PublicNginx: "nginx-10.2",
-		},
-	}
-
-	b, err := json.Marshal(um)
-	require.NoError(t, err)
-	assert.NotEqual(t, 0, len(b))
-
 	c := &Cluster{
-		Provider:            "aws",
-		Provisioner:         "kops",
-		ProviderMetadata:    []byte(`{"provider": "test1"}`),
-		ProvisionerMetadata: []byte(`{"provisioner": "test1"}`),
-		AllowInstallations:  false,
-		UtilityMetadata:     b,
+		UtilityMetadata: &UtilityMetadata{
+			DesiredVersions: utilityVersions{
+				Prometheus:  "",
+				Nginx:       "10.3",
+				Fluentbit:   "1337",
+				PublicNginx: "1234",
+			},
+			ActualVersions: utilityVersions{
+				Prometheus:  "prometheus-10.3",
+				Nginx:       "nginx-10.2",
+				Fluentbit:   "fluent-bit-0.9",
+				PublicNginx: "nginx-10.2",
+			},
+		},
 	}
-
-	require.NotEqual(t, 0, len(c.UtilityMetadata))
 
 	version, err := c.ActualUtilityVersion(PrometheusCanonicalName)
 	assert.NoError(t, err)
@@ -138,35 +111,22 @@ func TestGetActualVersion(t *testing.T) {
 }
 
 func TestGetDesiredVersion(t *testing.T) {
-	um := &UtilityMetadata{
-		DesiredVersions: utilityVersions{
-			Prometheus:  "",
-			Nginx:       "10.3",
-			Fluentbit:   "1337",
-			PublicNginx: "1234",
-		},
-		ActualVersions: utilityVersions{
-			Prometheus:  "prometheus-10.3",
-			Nginx:       "nginx-10.2",
-			Fluentbit:   "fluent-bit-0.9",
-			PublicNginx: "nginx-10.2",
-		},
-	}
-
-	b, err := json.Marshal(um)
-	require.NoError(t, err)
-	assert.NotEqual(t, 0, len(b))
-
 	c := &Cluster{
-		Provider:            "aws",
-		Provisioner:         "kops",
-		ProviderMetadata:    []byte(`{"provider": "test1"}`),
-		ProvisionerMetadata: []byte(`{"provisioner": "test1"}`),
-		AllowInstallations:  false,
-		UtilityMetadata:     b,
+		UtilityMetadata: &UtilityMetadata{
+			DesiredVersions: utilityVersions{
+				Prometheus:  "",
+				Nginx:       "10.3",
+				Fluentbit:   "1337",
+				PublicNginx: "1234",
+			},
+			ActualVersions: utilityVersions{
+				Prometheus:  "prometheus-10.3",
+				Nginx:       "nginx-10.2",
+				Fluentbit:   "fluent-bit-0.9",
+				PublicNginx: "nginx-10.2",
+			},
+		},
 	}
-
-	assert.NotEqual(t, 0, len(c.UtilityMetadata))
 
 	version, err := c.DesiredUtilityVersion(PrometheusCanonicalName)
 	assert.NoError(t, err)

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -12,17 +12,17 @@ type KopsMetadata struct {
 }
 
 // NewKopsMetadata creates an instance of KopsMetadata given the raw provisioner metadata.
-func NewKopsMetadata(provisionerMetadata []byte) (*KopsMetadata, error) {
-	kopsMetadata := KopsMetadata{}
-
+func NewKopsMetadata(metadataBytes []byte) (*KopsMetadata, error) {
 	// Check if length of metadata is 0 as opposed to if the value is nil. This
 	// is done to avoid an issue encountered where the metadata value provided
 	// had a length of 0, but had non-zero capacity.
-	if len(provisionerMetadata) == 0 {
-		return &kopsMetadata, nil
+	if len(metadataBytes) == 0 || string(metadataBytes) == "null" {
+		// TODO: remove "null" check after sqlite is gone.
+		return nil, nil
 	}
 
-	err := json.Unmarshal(provisionerMetadata, &kopsMetadata)
+	kopsMetadata := KopsMetadata{}
+	err := json.Unmarshal(metadataBytes, &kopsMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/model/kops_metadata_test.go
+++ b/model/kops_metadata_test.go
@@ -11,7 +11,7 @@ func TestNewKopsMetadata(t *testing.T) {
 	t.Run("nil payload", func(t *testing.T) {
 		kopsMetadata, err := model.NewKopsMetadata(nil)
 		require.NoError(t, err)
-		require.Equal(t, "", kopsMetadata.Name)
+		require.Nil(t, kopsMetadata)
 	})
 
 	t.Run("invalid payload", func(t *testing.T) {


### PR DESCRIPTION
This change alters the behavior of accessing cluster metadata.
Before, it was presented in the cluster object in raw format which
required marshaling and unmarshaling to access and update. This
logic is now handled directly on the store level so the returned
clusters now have metadata in their actual types. When cluster
updates are made, the store will marshal these types back into
their raw format before being stored.

Note: further work and cleanup on some of the utility metadata
logic will be made in a follow-up PR.

https://mattermost.atlassian.net/browse/MM-25793

```release-note
Refactor cluster metadata handling
```
