### PR TITLE
server: add missing syscal to trap the shutdown

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,6 +11,7 @@ RUN make build
 
 # Final Image
 FROM ${DOCKER_BASE_IMAGE}
+
 LABEL name="Mattermost Cloud" \
   maintainer="cloud-team@mattermost.com" \
   vendor="Mattermost" \
@@ -37,6 +38,8 @@ COPY --from=build /mattermost-cloud/build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 WORKDIR /mattermost-cloud/
 
-ENTRYPOINT ["/usr/local/bin/entrypoint"]
-
 USER ${USER_UID}
+
+EXPOSE 8075
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	sdkAWS "github.com/aws/aws-sdk-go/aws"
@@ -228,6 +229,8 @@ var serverCmd = &cobra.Command{
 		//  - SIGTERM (Ctrl+/) (Kubernetes pod rolling termination)
 		// SIGKILL and SIGQUIT will not be caught.
 		signal.Notify(c, os.Interrupt)
+		// SIGTERM signal sent from kubernetes
+		signal.Notify(c, syscall.SIGTERM)
 		// Important:
 		// There are long-lived serial processes in the supervisors (especially
 		// the cluster supervisor). It is quite possible that these will still


### PR DESCRIPTION
#### Summary
The docker image implements the correct approach and create the process in the PID 1 
```
PID   USER     TIME  COMMAND
    1 cloud     0:00 /mattermost-cloud/cloud server --debug --machine-readable-
   15 cloud     0:00 ps aux
```
It needs to be in PID 1 so we can receive the SIGX call to shut down the process gracefully

The missing part was the code `signal.Notify(c, syscall.SIGTERM)` which receives a syscall which is the way that kubernetes send the SIGTERM / SIGKILL signals. The `signal.Notify(c, os.Interrupt)` only works for command-line interrupts and k8s does not send in the shell.

using this we can see we got the signal correctly 

```
{"instance":"ejt374ddxjd43mz45jjq94x4so","level":"warning","msg":"Server will be running with no supervisors. Only API functionality will work.","time":"2020-06-05T08:20:57Z"}
{"cluster-installation-supervisor":false,"cluster-resource-threshold":80,"cluster-supervisor":false,"debug":true,"dev-mode":false,"group-supervisor":false,"installation-supervisor":false,"instance":"ejt374ddxjd43mz45jjq94x4so","keep-database-data":false,"keep-filestore-data":false,"level":"info","msg":"Starting Mattermost Provisioning Server","state-store":"mattermost-kops-state-test","store-version":"0.18.0","time":"2020-06-05T08:20:57Z","use-existing-aws-resources":true,"working-directory":"/mattermost-cloud"}
{"level":"debug","msg":"Couldn't determine username of developer with which to tag infrastructure due to error: exec: \"git\": executable file not found in $PATH","time":"2020-06-05T08:20:57Z"}
{"addr":":8075","instance":"ejt374ddxjd43mz45jjq94x4so","level":"info","msg":"Listening","time":"2020-06-05T08:20:57Z"}
.....
{"instance":"ejt374ddxjd43mz45jjq94x4so","level":"info","msg":"Shutting down","shutdown-signal":"terminated","time":"2020-06-05T08:21:27Z"}
```


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
server: add missing syscal to trap the shutdown
```
