### PR TITLE
validate if the request has spaces in some fields

### DIFF
--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -81,7 +82,31 @@ func (request *CreateInstallationRequest) Validate() error {
 		return errors.Wrap(err, "invalid env var settings")
 	}
 
+	return checkSpaces(request)
+}
+
+func checkSpaces(request *CreateInstallationRequest) error {
+	if hasWhiteSpace(request.DNS) != -1 {
+		return errors.Errorf("cannot have spaces in dns field. DNS=%s", request.DNS)
+	}
+	if hasWhiteSpace(request.Version) != -1 {
+		return errors.Errorf("cannot have spaces in version field. Version=%s", request.Version)
+	}
+	if hasWhiteSpace(request.Image) != -1 {
+		return errors.Errorf("cannot have spaces in image field. Image=%s", request.Image)
+	}
+	if hasWhiteSpace(request.License) != -1 {
+		return errors.Errorf("cannot have spaces in license field. License=%s", request.License)
+	}
+	if hasWhiteSpace(request.GroupID) != -1 {
+		return errors.Errorf("cannot have spaces in group field. Group=%s", request.GroupID)
+	}
+
 	return nil
+}
+
+func hasWhiteSpace(value string) int {
+	return strings.IndexAny(value, " ")
 }
 
 // NewCreateInstallationRequestFromReader will create a CreateInstallationRequest from an io.Reader with JSON data.

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -92,6 +92,25 @@ func TestCreateInstallationRequestValid(t *testing.T) {
 				},
 			},
 		},
+		{
+			"dns has space",
+			true,
+			&model.CreateInstallationRequest{
+				OwnerID: "owner1",
+				DNS:     "domain.com ",
+			},
+		},
+		{
+			"Group/Database/filestore is blank should not fail validation",
+			false,
+			&model.CreateInstallationRequest{
+				OwnerID:   "owner1",
+				DNS:       "domain.com",
+				GroupID:   "",
+				Filestore: "",
+				Database:  "",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
#### Summary
If we create an installation and the dns name have spaces in the end of the string, for example, we cannot create and then cannot complete the deletion of the installation because we receive this error:

```json
{"aws-operation-name":"ListResourceRecordSets","aws-service-id":"Route 53","instance":"pbkueecpu7nb8peosk8j3b41gy","level":"debug","msg":"[aws] GET 400 Bad Request https://route53.amazonaws.com/2013-04-01/hostedzone/Z1KG2H35T59O81/rrset?name=ee-demo.staging.cloud.mattermost.com%20 {\"HostedZoneId\":\"Z1KG2H35T59O81\",\"MaxItems\":null,\"StartRecordIdentifier\":null,\"StartRecordName\":\"ee-demo.staging.cloud.mattermost.com \",\"StartRecordType\":null}","time":"2020-06-11T14:56:47Z","tools-aws":"client"}
{"error":"InvalidInput: FATAL problem: UnsupportedCharacter (Value contains unsupported characters) encountered with ' '\n\tstatus code: 400, request id: 7c4f461b-b27b-404b-9656-c9431f1a4c80","installation":"9ifr3zjx6fyojkriqmtthyfx8y","instance":"pbkueecpu7nb8peosk8j3b41gy","level":"error","msg":"Failed to delete installation DNS","time":"2020-06-11T14:56:47Z"}
```


#### Ticket Link

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
validate if the request has spaces in some fields
```
