### PR TITLE
add build hash info when start the server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ LOGRUS_VERSION := $(shell find go.mod -type f -exec cat {} + | grep ${LOGRUS_URL
 AWS_SDK_PATH := $(GOPATH)/pkg/mod/${AWS_SDK_URL}\@${AWS_SDK_VERSION}
 LOGRUS_PATH := $(GOPATH)/pkg/mod/${LOGRUS_URL}\@${LOGRUS_VERSION}
 
+BUILD_HASH = $(shell git rev-parse HEAD)
+
+LDFLAGS += -X "github.com/mattermost/mattermost-cloud/model.BuildHash=$(BUILD_HASH)"
+
 export GO111MODULE=on
 
 ## Checks the code style, tests, builds and bundles.
@@ -64,7 +68,7 @@ dist:	build
 .PHONY: build
 build: ## Build the mattermost-cloud
 	@echo Building Mattermost-Cloud
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -gcflags all=-trimpath=$(PWD) -asmflags all=-trimpath=$(PWD) -a -installsuffix cgo -o build/_output/bin/cloud  ./cmd/cloud
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -ldflags '$(LDFLAGS)' -gcflags all=-trimpath=$(PWD) -asmflags all=-trimpath=$(PWD) -a -installsuffix cgo -o build/_output/bin/cloud  ./cmd/cloud
 
 build-image:  ## Build the docker image for mattermost-cloud
 	@echo Building Mattermost-cloud Docker Image

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -126,6 +126,7 @@ var serverCmd = &cobra.Command{
 		}
 
 		logger.WithFields(logrus.Fields{
+			"build-hash":                      model.BuildHash,
 			"cluster-supervisor":              clusterSupervisor,
 			"group-supervisor":                groupSupervisor,
 			"installation-supervisor":         installationSupervisor,

--- a/model/version.go
+++ b/model/version.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+// BuildHash holds the git commit hash when we build the server
+var BuildHash string


### PR DESCRIPTION
#### Summary
Sometimes (lot of times :) ) I need to know which code is running in test and today there is no way to discover that.
So adding a git hash will make my life a bit easier.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add git commit hash
```
