### PR TITLE
trying to fix the OpenSSL SSL_read: SSL_ERROR_SYSCALL issue we see in 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ LDFLAGS += -X "github.com/mattermost/mattermost-cloud/model.BuildHash=$(BUILD_HA
 
 export GO111MODULE=on
 
+# force a new connection to be used try to fix the errors we see in circleci when downloading the dependencies
+export CURLOPT_FRESH_CONNECT=1
+
 ## Checks the code style, tests, builds and bundles.
 all: check-style dist
 


### PR DESCRIPTION
#### Summary
set `CURLOPT_FRESH_CONNECT` that forces a new connection for curl because we saw several failures due to the issue `curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 104` and searching over the internet found some people saying using that fixed the issue.

triggering the pipeline multiple times during the day to observe if we still see the issue


#### Ticket Link
n/a

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
