### PR TITLE
Set logging output default to stdout

### DIFF
--- a/cmd/cloud/logger.go
+++ b/cmd/cloud/logger.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -11,6 +13,8 @@ func init() {
 	logger.SetFormatter(&log.TextFormatter{
 		FullTimestamp: true,
 	})
+	// Output to stdout instead of the default stderr.
+	log.SetOutput(os.Stdout)
 }
 
 type logrusWriter struct {


### PR DESCRIPTION
This changes logging from using stderr for all output. Switching
between stdout and stderr depending on log level is currently not
directly supported.

There are numerous issues and PRs against logrus to add log
output auto-switching, but they have all been closed.

Fixes https://mattermost.atlassian.net/browse/MM-25688

```release-note
Set logging output default to stdout
```
