### PR TITLE
Add installation hibernation

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -32,9 +32,6 @@ func init() {
 	installationUpdateCmd.Flags().Bool("mattermost-env-clear", false, "Clears all env var data.")
 	installationUpdateCmd.MarkFlagRequired("installation")
 
-	installationDeleteCmd.Flags().String("installation", "", "The id of the installation to be deleted.")
-	installationDeleteCmd.MarkFlagRequired("installation")
-
 	installationGetCmd.Flags().String("installation", "", "The id of the installation to be fetched.")
 	installationGetCmd.Flags().Bool("include-group-config", true, "Whether to include group configuration in the installation or not.")
 	installationGetCmd.Flags().Bool("include-group-config-overrides", true, "Whether to include a group configuration override summary in the installation or not.")
@@ -48,9 +45,20 @@ func init() {
 	installationListCmd.Flags().Int("per-page", 100, "The number of installations to fetch per page.")
 	installationListCmd.Flags().Bool("include-deleted", false, "Whether to include deleted installations.")
 
+	installationHibernateCmd.Flags().String("installation", "", "The id of the installation to put into hibernation.")
+	installationHibernateCmd.MarkFlagRequired("installation")
+
+	installationWakeupCmd.Flags().String("installation", "", "The id of the installation to wake up from hibernation.")
+	installationWakeupCmd.MarkFlagRequired("installation")
+
+	installationDeleteCmd.Flags().String("installation", "", "The id of the installation to be deleted.")
+	installationDeleteCmd.MarkFlagRequired("installation")
+
 	installationCmd.AddCommand(installationCreateCmd)
 	installationCmd.AddCommand(installationUpdateCmd)
 	installationCmd.AddCommand(installationDeleteCmd)
+	installationCmd.AddCommand(installationHibernateCmd)
+	installationCmd.AddCommand(installationWakeupCmd)
 	installationCmd.AddCommand(installationGetCmd)
 	installationCmd.AddCommand(installationListCmd)
 	installationCmd.AddCommand(installationShowStateReport)
@@ -158,6 +166,56 @@ var installationDeleteCmd = &cobra.Command{
 		err := client.DeleteInstallation(installationID)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete installation")
+		}
+
+		return nil
+	},
+}
+
+var installationHibernateCmd = &cobra.Command{
+	Use:   "hibernate",
+	Short: "Put an installation into hibernation.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		installationID, _ := command.Flags().GetString("installation")
+
+		installation, err := client.HibernateInstallation(installationID)
+		if err != nil {
+			return errors.Wrap(err, "failed to put installation into hibernation")
+		}
+
+		err = printJSON(installation)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var installationWakeupCmd = &cobra.Command{
+	Use:   "wake-up",
+	Short: "Wake an installation from hibernation.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		installationID, _ := command.Flags().GetString("installation")
+
+		installation, err := client.WakupInstallation(installationID)
+		if err != nil {
+			return errors.Wrap(err, "failed to wake up installation")
+		}
+
+		err = printJSON(installation)
+		if err != nil {
+			return err
 		}
 
 		return nil

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -208,7 +208,7 @@ var installationWakeupCmd = &cobra.Command{
 
 		installationID, _ := command.Flags().GetString("installation")
 
-		installation, err := client.WakupInstallation(installationID)
+		installation, err := client.WakeupInstallation(installationID)
 		if err != nil {
 			return errors.Wrap(err, "failed to wake up installation")
 		}

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -176,7 +176,7 @@ func (provisioner *KopsProvisioner) HibernateClusterInstallation(cluster *model.
 
 	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to create kubernetes client")
 	}
 
 	name := makeClusterInstallationName(clusterInstallation)

--- a/manifests/operator-manifests/mattermost/crds/mm_clusterinstallation_crd.yaml
+++ b/manifests/operator-manifests/mattermost/crds/mm_clusterinstallation_crd.yaml
@@ -643,6 +643,10 @@ spec:
                     name:
                       description: Name defines the name of the deployment
                       type: string
+                    resourceLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     version:
                       description: Version defines the Docker image version that will
                         be used for the deployment. Required when BlueGreen or Canary
@@ -668,6 +672,10 @@ spec:
                     name:
                       description: Name defines the name of the deployment
                       type: string
+                    resourceLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     version:
                       description: Version defines the Docker image version that will
                         be used for the deployment. Required when BlueGreen or Canary
@@ -699,6 +707,10 @@ spec:
                     name:
                       description: Name defines the name of the deployment
                       type: string
+                    resourceLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     version:
                       description: Version defines the Docker image version that will
                         be used for the deployment. Required when BlueGreen or Canary
@@ -1186,6 +1198,10 @@ spec:
                 set by 'Size'.
               format: int32
               type: integer
+            resourceLabels:
+              additionalProperties:
+                type: string
+              type: object
             resources:
               description: Defines the resource requests and limits for the Mattermost
                 app server pods.

--- a/manifests/operator-manifests/mattermost/operator.yaml
+++ b/manifests/operator-manifests/mattermost/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: mattermost-operator
       containers:
         - name: mattermost-operator
-          image: mattermost/mattermost-operator:v1.4.0
+          image: mattermost/mattermost-operator:v1.5.0
           imagePullPolicy: IfNotPresent
           command:
           - mattermost-operator

--- a/model/client.go
+++ b/model/client.go
@@ -408,8 +408,8 @@ func (c *Client) HibernateInstallation(installationID string) (*Installation, er
 	}
 }
 
-// WakupInstallation wakes an installation from hibernation.
-func (c *Client) WakupInstallation(installationID string) (*Installation, error) {
+// WakeupInstallation wakes an installation from hibernation.
+func (c *Client) WakeupInstallation(installationID string) (*Installation, error) {
 	resp, err := c.doPost(c.buildURL("/api/installation/%s/wakeup", installationID), nil)
 	if err != nil {
 		return nil, err

--- a/model/client.go
+++ b/model/client.go
@@ -391,6 +391,40 @@ func (c *Client) UpdateInstallation(installationID string, request *PatchInstall
 	}
 }
 
+// HibernateInstallation puts an installation into hibernation.
+func (c *Client) HibernateInstallation(installationID string) (*Installation, error) {
+	resp, err := c.doPost(c.buildURL("/api/installation/%s/hibernate", installationID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return InstallationFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// WakupInstallation wakes an installation from hibernation.
+func (c *Client) WakupInstallation(installationID string) (*Installation, error) {
+	resp, err := c.doPost(c.buildURL("/api/installation/%s/wakeup", installationID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return InstallationFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // DeleteInstallation deletes the given installation and all resources contained therein.
 func (c *Client) DeleteInstallation(installationID string) error {
 	resp, err := c.doDelete(c.buildURL("/api/installation/%s", installationID))

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -22,6 +22,14 @@ const (
 	InstallationStateCreationNoCompatibleClusters = "creation-no-compatible-clusters"
 	// InstallationStateCreationFinalTasks is the final step of the installation creation.
 	InstallationStateCreationFinalTasks = "creation-final-tasks"
+	// InstallationStateHibernationRequested is an installation that is about
+	// to be put into hibernation.
+	InstallationStateHibernationRequested = "hibernation-requested"
+	// InstallationStateHibernationInProgress is an installation that is
+	// transitioning to hibernation.
+	InstallationStateHibernationInProgress = "hibernation-in-progress"
+	// InstallationStateHibernating is an installation that is hibernating.
+	InstallationStateHibernating = "hibernating"
 	// InstallationStateUpdateRequested is an installation that is about to undergo an update.
 	InstallationStateUpdateRequested = "update-requested"
 	// InstallationStateUpdateInProgress is an installation that is being updated.
@@ -57,6 +65,9 @@ var AllInstallationStates = []string{
 	InstallationStateCreationFailed,
 	InstallationStateCreationNoCompatibleClusters,
 	InstallationStateCreationFinalTasks,
+	InstallationStateHibernationRequested,
+	InstallationStateHibernationInProgress,
+	InstallationStateHibernating,
 	InstallationStateUpdateRequested,
 	InstallationStateUpdateInProgress,
 	InstallationStateUpdateFailed,
@@ -79,6 +90,8 @@ var AllInstallationStatesPendingWork = []string{
 	InstallationStateCreationNoCompatibleClusters,
 	InstallationStateCreationFinalTasks,
 	InstallationStateCreationDNS,
+	InstallationStateHibernationRequested,
+	InstallationStateHibernationInProgress,
 	InstallationStateUpdateRequested,
 	InstallationStateUpdateInProgress,
 	InstallationStateDeletionRequested,
@@ -93,6 +106,7 @@ var AllInstallationStatesPendingWork = []string{
 // API endpoint should put the installation in this state.
 var AllInstallationRequestStates = []string{
 	InstallationStateCreationRequested,
+	InstallationStateHibernationRequested,
 	InstallationStateUpdateRequested,
 	InstallationStateDeletionRequested,
 }
@@ -103,6 +117,8 @@ func (i *Installation) ValidTransitionState(newState string) bool {
 	switch newState {
 	case InstallationStateCreationRequested:
 		return validTransitionToInstallationStateCreationRequested(i.State)
+	case InstallationStateHibernationRequested:
+		return validTransitionToInstallationStateHibernationRequested(i.State)
 	case InstallationStateUpdateRequested:
 		return validTransitionToInstallationStateUpgradeRequested(i.State)
 	case InstallationStateDeletionRequested:
@@ -122,9 +138,19 @@ func validTransitionToInstallationStateCreationRequested(currentState string) bo
 	return false
 }
 
+func validTransitionToInstallationStateHibernationRequested(currentState string) bool {
+	switch currentState {
+	case InstallationStateStable:
+		return true
+	}
+
+	return false
+}
+
 func validTransitionToInstallationStateUpgradeRequested(currentState string) bool {
 	switch currentState {
 	case InstallationStateStable,
+		InstallationStateHibernating,
 		InstallationStateUpdateRequested,
 		InstallationStateUpdateFailed:
 		return true


### PR DESCRIPTION
This change adds functionality to put installations into a new state
called "hibernation". The current effect of this state is to scale
down the Mattermost app deployment so that there are no running
pods. In the future, this could be enhanced to include database
and filestore as well.

Changes:
 - Add hibernation API, states, and flows.
 - Update Mattermost operator to v1.5.0 to support new scale values.
 - Refactor installation supervisor logic around checking if
   cluster installations are stable or not.
 - Correct bad webhook state event.
 - Logging fixes.

Fixes https://mattermost.atlassian.net/browse/MM-25099

```release-note
Add installation hibernation
```
