### PR TITLE
update helm / alpine and go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@
 ################################################################################
 
 ## Docker Build Versions
-DOCKER_BUILD_IMAGE = golang:1.14.2
-DOCKER_BASE_IMAGE = alpine:3.11
+DOCKER_BUILD_IMAGE = golang:1.14.4
+DOCKER_BASE_IMAGE = alpine:3.12
 
 ## Tool Versions
 TERRAFORM_VERSION=0.11.14
 KOPS_VERSION=v1.16.3
-HELM_VERSION=v2.16.7
+HELM_VERSION=v2.16.9
 KUBECTL_VERSION=v1.18.3
 
 ################################################################################

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # Build the mattermost cloud
-ARG DOCKER_BUILD_IMAGE=golang:1.14.1
-ARG DOCKER_BASE_IMAGE=alpine:3.11.3
+ARG DOCKER_BUILD_IMAGE=golang:1.14
+ARG DOCKER_BASE_IMAGE=alpine:3.12
 
 FROM ${DOCKER_BUILD_IMAGE} AS build
 WORKDIR /mattermost-cloud/


### PR DESCRIPTION
#### Summary
Helm release 2.16.9 to fix a security vulnerability and this PR update the helm to get that fix

also bumps go and alpine to the latest versions


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
update helm to 2.16.9 / go to 1.14.4 and alpine to 3.12
```
