### PR TITLE
Add cluster workbench command for cloud client

### DIFF
--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -26,6 +26,7 @@ func init() {
 	rootCmd.AddCommand(groupCmd)
 	rootCmd.AddCommand(schemaCmd)
 	rootCmd.AddCommand(webhookCmd)
+	rootCmd.AddCommand(workbenchCmd)
 	rootCmd.AddCommand(completionCmd)
 }
 

--- a/cmd/cloud/workbench.go
+++ b/cmd/cloud/workbench.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/internal/tools/terraform"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	workbenchCmd.PersistentFlags().String("server", "http://localhost:8075", "The provisioning server whose API will be queried.")
+	workbenchCmd.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
+
+	workbenchClusterCmd.Flags().String("cluster", "", "The id of the cluster to work on.")
+	workbenchClusterCmd.MarkFlagRequired("cluster")
+
+	workbenchCmd.AddCommand(workbenchClusterCmd)
+}
+
+var workbenchCmd = &cobra.Command{
+	Use:   "workbench",
+	Short: "Tools for working with cloud resources",
+}
+
+var workbenchClusterCmd = &cobra.Command{
+	Use:   "cluster",
+	Short: "Export kops and terraform files into a workbench directory",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		clusterID, _ := command.Flags().GetString("cluster")
+		cluster, err := client.GetCluster(clusterID)
+		if err != nil {
+			return errors.Wrap(err, "failed to query cluster")
+		}
+		if cluster == nil {
+			return errors.Errorf("unable to find cluster %s", clusterID)
+		}
+
+		logger := logger.WithField("cluster", clusterID)
+		logger.Info("Setting up cluster workbench")
+
+		s3StateStore, _ := command.Flags().GetString("state-store")
+
+		kopsClient, err := kops.New(s3StateStore, logger)
+		if err != nil {
+			return err
+		}
+
+		err = kopsClient.ExportKubecfg(cluster.ProvisionerMetadataKops.Name)
+		if err != nil {
+			kopsClient.Close()
+			return err
+		}
+
+		err = kopsClient.UpdateCluster(cluster.ProvisionerMetadataKops.Name, kopsClient.GetOutputDirectory())
+		if err != nil {
+			kopsClient.Close()
+			return err
+		}
+
+		terraformClient, err := terraform.New(kopsClient.GetOutputDirectory(), s3StateStore, logger)
+		if err != nil {
+			kopsClient.Close()
+			return err
+		}
+
+		err = terraformClient.Init(cluster.ProvisionerMetadataKops.Name)
+		if err != nil {
+			kopsClient.Close()
+			terraformClient.Close()
+			return err
+		}
+
+		logger.Info("Cluster workbench setup complete")
+		logger.Infof("The workbench directory can be found at %s", kopsClient.GetTempDir())
+
+		return nil
+	},
+}

--- a/internal/tools/kops/cmd.go
+++ b/internal/tools/kops/cmd.go
@@ -25,14 +25,14 @@ type Cmd struct {
 
 // New creates a new instance of Cmd through which to execute kops.
 func New(s3StateStore string, logger log.FieldLogger) (*Cmd, error) {
-	tempDir, err := ioutil.TempDir("", "kops-")
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create temporary kops directory")
-	}
-
 	kopsPath, err := exec.LookPath("kops")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find kops installed on your PATH")
+	}
+
+	tempDir, err := ioutil.TempDir("", "kops-")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create temporary kops directory")
 	}
 
 	return &Cmd{


### PR DESCRIPTION
This new command can be used to create a local temporary workbench
directory for a cluster. This directory contains the kubecfg and
terraform files for that cluster. This flow replicates the process
that the provisioning server uses to manage clusters, which can be
useful for troubleshooting issues or manual cluster updates.

Note that this command still requires you configuring AWS creds
locally for accessing these resources.

Fixes https://mattermost.atlassian.net/browse/MM-26393

```release-note
Add cluster workbench command for cloud client
```
