### PR TITLE
Move contents of terraform state file to Go constant

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -35,7 +35,6 @@ COPY --from=build /mattermost-cloud/build/helm /usr/local/bin/
 COPY --from=build /mattermost-cloud/build/kubectl /usr/local/bin/
 COPY --from=build /mattermost-cloud/manifests /mattermost-cloud/manifests
 COPY --from=build /mattermost-cloud/helm-charts /mattermost-cloud/helm-charts
-COPY --from=build /mattermost-cloud/terraform /mattermost-cloud/terraform
 COPY --from=build /mattermost-cloud/build/_output/bin/cloud /mattermost-cloud/cloud
 COPY --from=build /mattermost-cloud/build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/internal/tools/terraform/plan.go
+++ b/internal/tools/terraform/plan.go
@@ -22,14 +22,9 @@ type terraformOutput struct {
 
 // Init invokes terraform init.
 func (c *Cmd) Init(remoteKey string) error {
-	input, err := ioutil.ReadFile(path.Join("terraform", backendFilename))
+	err := ioutil.WriteFile(path.Join(c.dir, backendFilename), []byte(backendFile), 0644)
 	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(path.Join(c.dir, backendFilename), input, 0644)
-	if err != nil {
-		return err
+		return errors.Wrap(err, "unable to write terraform backend state file")
 	}
 
 	_, _, err = c.run(

--- a/internal/tools/terraform/state.go
+++ b/internal/tools/terraform/state.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package terraform
+
+// backendFile contains the contents of the terraform file used to configure
+// terraform remote state.
+const backendFile = `
+terraform {
+    backend "s3" {}
+}
+`

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,3 +1,0 @@
-terraform {
-    backend "s3" {}
-}


### PR DESCRIPTION
This allows commands such as `cloud workbench cluster` to be run
from outside the root directory of this repository.

```release-note
Move contents of terraform state file to Go constant
```
