### PR TITLE
public-nginx: remove nginx version from the responses

### DIFF
--- a/helm-charts/public-nginx_values.yaml
+++ b/helm-charts/public-nginx_values.yaml
@@ -45,6 +45,8 @@ controller:
     # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
     ssl-redirect: "false"
     force-ssl-redirect: "false"
+    # remove the version of nginx from the responses
+    server-tokens: "false"
     server-snippet: |
       listen 8000;
       if ( $server_port = 80 ) {


### PR DESCRIPTION
#### Summary
with this setting, it removes the Nginx version from the response

we need to reprovision the cluster to get that

Before:
```
curl -D- XXXXXXXX
HTTP/1.1 308 Permanent Redirect
Server: nginx/1.17.10
Date: Fri, 26 Jun 2020 08:44:25 GMT
Content-Type: text/html
Content-Length: 172
Connection: keep-alive

<html>
<head><title>308 Permanent Redirect</title></head>
<body>
<center><h1>308 Permanent Redirect</h1></center>
<hr><center>nginx/1.17.10</center>
</body>
</html>
```

After

```
curl -D- CCCC
HTTP/1.1 308 Permanent Redirect
Date: Fri, 26 Jun 2020 09:03:20 GMT
Content-Type: text/html
Content-Length: 164
Connection: keep-alive

<html>
<head><title>308 Permanent Redirect</title></head>
<body>
<center><h1>308 Permanent Redirect</h1></center>
<hr><center>nginx</center>
</body>
</html>
```


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
Jira: https://mattermost.atlassian.net/browse/MM-26510

```release-note
public-nginx: remove nginx version from the responses
```
