### PR TITLE
Cleanup multitenant database logging

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -125,7 +125,7 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 
 	databaseSpec, databaseSecret, err := provisioner.resourceUtil.GetDatabase(installation).GenerateDatabaseSpecAndSecret(provisioner.store, logger)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to generate database configuration")
 	}
 
 	if databaseSpec != nil {
@@ -138,7 +138,7 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 
 	filestoreSpec, filestoreSecret, err := provisioner.resourceUtil.GetFilestore(installation).GenerateFilestoreSpecAndSecret(logger)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to generate filestore configuration")
 	}
 
 	if filestoreSecret != nil {

--- a/internal/store/multitenant_database_test.go
+++ b/internal/store/multitenant_database_test.go
@@ -244,8 +244,8 @@ func (s *TestMultitenantDatabaseSuite) TestUpdateInvalidRawInstallations() {
 		LockAcquiredBy:     &s.lockerID,
 	})
 	s.Assert().Error(err)
-	s.Assert().Equal("failed to parse raw installation ids: failed to get installation ids:"+
-		" invalid character 'b' looking for beginning of value", err.Error())
+	s.Assert().Equal("failed to parse raw installation ids: failed to unmarshal installation IDs: "+
+		"invalid character 'b' looking for beginning of value", err.Error())
 }
 
 func (s *TestMultitenantDatabaseSuite) TestUpdateNotLockedError() {

--- a/internal/tools/aws/acm_test.go
+++ b/internal/tools/aws/acm_test.go
@@ -17,10 +17,10 @@ func (a *AWSTestSuite) TestGetCertificateSummaryByTag() {
 			ListCertificates(gomock.Any()).
 			Return(&acm.ListCertificatesOutput{
 				CertificateSummaryList: []*acm.CertificateSummary{
-					&acm.CertificateSummary{
+					{
 						CertificateArn: aws.String(a.CertifcateARN + "a"),
 					},
-					&acm.CertificateSummary{
+					{
 						CertificateArn: aws.String(a.CertifcateARN + "b"),
 					},
 				},
@@ -37,7 +37,7 @@ func (a *AWSTestSuite) TestGetCertificateSummaryByTag() {
 			ListCertificates(gomock.Any()).
 			Return(&acm.ListCertificatesOutput{
 				CertificateSummaryList: []*acm.CertificateSummary{
-					&acm.CertificateSummary{
+					{
 						CertificateArn: aws.String(a.CertifcateARN),
 					},
 				},
@@ -47,7 +47,7 @@ func (a *AWSTestSuite) TestGetCertificateSummaryByTag() {
 		a.Mocks.API.ACM.EXPECT().
 			ListTagsForCertificate(gomock.Any()).
 			Return(&acm.ListTagsForCertificateOutput{
-				Tags: []*acm.Tag{&acm.Tag{
+				Tags: []*acm.Tag{{
 					Key:   aws.String("MattermostCloudInstallationCertificates"),
 					Value: aws.String("value"),
 				}},
@@ -67,10 +67,10 @@ func (a *AWSTestSuite) TestGetCertificateSummaryByTagNotFound() {
 			ListCertificates(gomock.Any()).
 			Return(&acm.ListCertificatesOutput{
 				CertificateSummaryList: []*acm.CertificateSummary{
-					&acm.CertificateSummary{
+					{
 						CertificateArn: aws.String(a.CertifcateARN + "a"),
 					},
-					&acm.CertificateSummary{
+					{
 						CertificateArn: aws.String(a.CertifcateARN + "b"),
 					},
 				},
@@ -80,7 +80,7 @@ func (a *AWSTestSuite) TestGetCertificateSummaryByTagNotFound() {
 		a.Mocks.API.ACM.EXPECT().
 			ListTagsForCertificate(gomock.Any()).
 			Return(&acm.ListTagsForCertificateOutput{
-				Tags: []*acm.Tag{&acm.Tag{
+				Tags: []*acm.Tag{{
 					Key:   aws.String("MattermostCloudInstallationCertificates"),
 					Value: aws.String("value"),
 				}},
@@ -116,10 +116,10 @@ func (a *AWSTestSuite) TestGetCertificateSummaryByTagListTagsError() {
 			ListCertificates(gomock.Any()).
 			Return(&acm.ListCertificatesOutput{
 				CertificateSummaryList: []*acm.CertificateSummary{
-					&acm.CertificateSummary{
+					{
 						CertificateArn: aws.String(a.CertifcateARN + "a"),
 					},
-					&acm.CertificateSummary{
+					{
 						CertificateArn: aws.String(a.CertifcateARN + "b"),
 					},
 				},

--- a/internal/tools/aws/database_multitenant.go
+++ b/internal/tools/aws/database_multitenant.go
@@ -78,7 +78,7 @@ func (d *RDSMultitenantDatabase) Teardown(store model.InstallationDatabaseStoreI
 	numDatabases := len(multitenantDatabases)
 	switch {
 	case (numDatabases > 1):
-		return errors.Errorf("expected 1 or less multitenant databases from query, but found %d", len(multitenantDatabases))
+		return errors.Errorf("expected 1 or less multitenant databases from query, but found %d", numDatabases)
 	case (numDatabases < 1):
 		logger.Debug("No multitenant databases found for this installation; skipping...")
 	default:

--- a/internal/tools/aws/database_multitenant_test.go
+++ b/internal/tools/aws/database_multitenant_test.go
@@ -215,6 +215,6 @@ func (a *AWSTestSuite) TestProvisioningMultitenantDatabase() {
 
 	err := database.Provision(a.Mocks.Model.DatabaseInstallationStore, a.Mocks.Log.Logger)
 	a.Assert().Error(err)
-	a.Assert().Equal("unable to create schema in multitenant RDS cluster ID rds-cluster-multitenant-09d44077df9934f96-97670d43: "+
-		"creating database name cloud_id000000000000000000000000a: dial tcp: lookup aws.rds.com/mattermost: no such host", err.Error())
+	a.Assert().Equal("failed to create schema in multitenant RDS cluster rds-cluster-multitenant-09d44077df9934f96-97670d43: "+
+		"failed to run create database SQL command: dial tcp: lookup aws.rds.com/mattermost: no such host", err.Error())
 }

--- a/internal/tools/aws/ec2.go
+++ b/internal/tools/aws/ec2.go
@@ -25,7 +25,7 @@ func (a *Client) TagResource(resourceID, key, value string, logger log.FieldLogg
 			aws.String(resourceID),
 		},
 		Tags: []*ec2.Tag{
-			&ec2.Tag{
+			{
 				Key:   aws.String(key),
 				Value: aws.String(value),
 			},
@@ -54,7 +54,7 @@ func (a *Client) UntagResource(resourceID, key, value string, logger log.FieldLo
 			aws.String(resourceID),
 		},
 		Tags: []*ec2.Tag{
-			&ec2.Tag{
+			{
 				Key:   aws.String(key),
 				Value: aws.String(value),
 			},

--- a/internal/tools/aws/rds_test.go
+++ b/internal/tools/aws/rds_test.go
@@ -126,7 +126,7 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterCreatedSubnetError() {
 		After(a.Mocks.API.EC2.EXPECT().
 			DescribeSecurityGroups(gomock.Any()).
 			Return(&ec2.DescribeSecurityGroupsOutput{
-				SecurityGroups: []*ec2.SecurityGroup{&ec2.SecurityGroup{GroupId: &a.GroupID}},
+				SecurityGroups: []*ec2.SecurityGroup{{GroupId: &a.GroupID}},
 			}, nil))
 
 	a.Mocks.Log.Logger.EXPECT().
@@ -154,7 +154,7 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterCreatedError() {
 		After(a.Mocks.API.EC2.EXPECT().
 			DescribeSecurityGroups(gomock.Any()).
 			Return(&ec2.DescribeSecurityGroupsOutput{
-				SecurityGroups: []*ec2.SecurityGroup{&ec2.SecurityGroup{GroupId: &a.GroupID}},
+				SecurityGroups: []*ec2.SecurityGroup{{GroupId: &a.GroupID}},
 			}, nil))
 
 	a.Mocks.Log.Logger.EXPECT().

--- a/internal/tools/aws/route53_test.go
+++ b/internal/tools/aws/route53_test.go
@@ -19,7 +19,7 @@ func (a *AWSTestSuite) TestRoute53CreatePublicCNAME() {
 			ListHostedZones(&route53.ListHostedZonesInput{}).
 			Return(&route53.ListHostedZonesOutput{
 				HostedZones: []*route53.HostedZone{
-					&route53.HostedZone{
+					{
 						Id: aws.String(a.HostedZoneID),
 					},
 				},
@@ -37,7 +37,7 @@ func (a *AWSTestSuite) TestRoute53CreatePublicCNAME() {
 			Return(&route53.ListTagsForResourceOutput{
 				ResourceTagSet: &route53.ResourceTagSet{
 					Tags: []*route53.Tag{
-						&route53.Tag{
+						{
 							Key:   aws.String("random-key"),
 							Value: aws.String("random-value"),
 						},
@@ -50,7 +50,7 @@ func (a *AWSTestSuite) TestRoute53CreatePublicCNAME() {
 			ListHostedZones(gomock.Any()).
 			Return(&route53.ListHostedZonesOutput{
 				HostedZones: []*route53.HostedZone{
-					&route53.HostedZone{
+					{
 						Id: aws.String(a.HostedZoneID),
 					},
 				},
@@ -67,7 +67,7 @@ func (a *AWSTestSuite) TestRoute53CreatePublicCNAME() {
 			Return(&route53.ListTagsForResourceOutput{
 				ResourceTagSet: &route53.ResourceTagSet{
 					Tags: []*route53.Tag{
-						&route53.Tag{
+						{
 							Key:   aws.String("MattermostCloudDNS"),
 							Value: aws.String("public"),
 						},
@@ -119,7 +119,7 @@ func (a *AWSTestSuite) TestRoute53CreatePublicCNAMEListTagsError() {
 			ListHostedZones(&route53.ListHostedZonesInput{}).
 			Return(&route53.ListHostedZonesOutput{
 				HostedZones: []*route53.HostedZone{
-					&route53.HostedZone{
+					{
 						Id: aws.String(a.HostedZoneID),
 					},
 				},
@@ -152,7 +152,7 @@ func (a *AWSTestSuite) TestRoute53CreatePublicCNAMEChangeRecordSetsError() {
 			ListHostedZones(gomock.Any()).
 			Return(&route53.ListHostedZonesOutput{
 				HostedZones: []*route53.HostedZone{
-					&route53.HostedZone{
+					{
 						Id: aws.String(a.HostedZoneID),
 					},
 				},
@@ -169,7 +169,7 @@ func (a *AWSTestSuite) TestRoute53CreatePublicCNAMEChangeRecordSetsError() {
 			Return(&route53.ListTagsForResourceOutput{
 				ResourceTagSet: &route53.ResourceTagSet{
 					Tags: []*route53.Tag{
-						&route53.Tag{
+						{
 							Key:   aws.String("MattermostCloudDNS"),
 							Value: aws.String("public"),
 						},
@@ -202,7 +202,7 @@ func (a *AWSTestSuite) TestRoute53CreatePublicCNAMENoHostedZone() {
 			ListHostedZones(gomock.Any()).
 			Return(&route53.ListHostedZonesOutput{
 				HostedZones: []*route53.HostedZone{
-					&route53.HostedZone{
+					{
 						Id: aws.String(a.HostedZoneID),
 					},
 				},
@@ -219,7 +219,7 @@ func (a *AWSTestSuite) TestRoute53CreatePublicCNAMENoHostedZone() {
 			Return(&route53.ListTagsForResourceOutput{
 				ResourceTagSet: &route53.ResourceTagSet{
 					Tags: []*route53.Tag{
-						&route53.Tag{
+						{
 							Key:   aws.String("random-key"),
 							Value: aws.String("random-value"),
 						},

--- a/model/multitenant_database.go
+++ b/model/multitenant_database.go
@@ -30,7 +30,7 @@ func (c *MultitenantDatabase) SetInstallationIDs(installationIDs MultitenantData
 
 	installations, err := json.Marshal(installationIDs)
 	if err != nil {
-		return errors.Wrap(err, "failed to set installation ids")
+		return errors.Wrap(err, "failed to marshal installation IDs")
 	}
 
 	c.RawInstallationIDs = installations
@@ -47,7 +47,7 @@ func (c *MultitenantDatabase) GetInstallationIDs() (MultitenantDatabaseInstallat
 
 	err := json.Unmarshal(c.RawInstallationIDs, &installationIDs)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get installation ids")
+		return nil, errors.Wrap(err, "failed to unmarshal installation IDs")
 	}
 
 	return installationIDs, nil

--- a/model/multitenant_database_test.go
+++ b/model/multitenant_database_test.go
@@ -40,7 +40,7 @@ func TestGetAndSetInstallationIDs(t *testing.T) {
 		}
 		ids, err := database.GetInstallationIDs()
 		require.Error(t, err)
-		require.Equal(t, "failed to get installation ids: invalid character "+
+		require.Equal(t, "failed to unmarshal installation IDs: invalid character "+
 			"'a' looking for beginning of value", err.Error())
 		require.Nil(t, ids)
 	})


### PR DESCRIPTION
This is a first pass at cleaning up some database logging. Along
with updating some log messages, some of the locking logic was
refactored to store the logger inside the locker. This now matches
how we handle locking elsewhere in the cloud server.

A follow-up to https://github.com/mattermost/mattermost-cloud/pull/226 to get fresh comments.

Fixes https://mattermost.atlassian.net/browse/MM-25633

```release-note
Cleanup multitenant database logging
```
