### PR TITLE
Add cloud webhook listener (cwl)

### DIFF
--- a/cmd/tools/README.md
+++ b/cmd/tools/README.md
@@ -1,0 +1,43 @@
+# Mattermost Cloud Tools
+
+A collection of optional tools that support working with the cloud server.
+
+## CWL - Cloud Webhook Listener
+
+A small listener that pretty prints cloud webhooks. Cloud webhooks are fired off from many state changes to cloud resources along with other important events. Run `cloud webhook -h` to get info on managing these.
+
+Example output from an installation being created:
+
+```
+2020/06/29 09:58:34 Starting cloud webhook listener on port 8065
+2020/06/29 10:06:08 [ INST | zf8a ] n/a -> creation-requested
+2020/06/29 10:06:10 [ CLIN | 86i7 ] n/a -> creation-requested
+2020/06/29 10:06:17 [ INST | zf8a ] creation-requested -> creation-in-progress
+2020/06/29 10:06:20 [ CLIN | 86i7 ] creation-requested -> reconciling
+2020/06/29 10:06:44 [ CLIN | 86i7 ] reconciling -> stable
+2020/06/29 10:06:54 [ INST | zf8a ] creation-in-progress -> stable
+```
+
+### Installation
+
+From the repo root:
+
+```
+go install ./cmd/tools/cwl
+```
+
+### Running CWL
+
+Assuming `GOPATH/bin` is in your `PATH`, then run `cwl`.
+
+### Configuration
+
+The default `cwl` listening port is `8065`. This is the default Mattermost server port as well, which allows you to quickly switch between testing the Mattermost cloud plugin and using `cwl` without having to delete your webhook in the cloud server.
+
+To use another port, set `CWL_PORT`.
+
+Example:
+
+```
+export CWL_PORT=9001
+```

--- a/cmd/tools/cwl/cwl.go
+++ b/cmd/tools/cwl/cwl.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	cloud "github.com/mattermost/mattermost-cloud/model"
+)
+
+const (
+	// DefaultPort is default listening port for incoming webhooks.
+	DefaultPort = "8065"
+	// ListenPortEnv is the env var name for overriding the default listen port.
+	ListenPortEnv = "CWL_PORT"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	webhook, err := cloud.WebhookPayloadFromReader(r.Body)
+	if err != nil {
+		log.Printf("Error: failed to parse webhook: %s", err)
+		return
+	}
+
+	wType := "UNKN"
+	switch webhook.Type {
+	case cloud.TypeCluster:
+		wType = "CLSR"
+	case cloud.TypeInstallation:
+		wType = "INST"
+	case cloud.TypeClusterInstallation:
+		wType = "CLIN"
+	}
+
+	log.Printf("[ %s | %s ] %s -> %s", wType, webhook.ID[0:4], webhook.OldState, webhook.NewState)
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func main() {
+	port := DefaultPort
+	if len(os.Getenv(ListenPortEnv)) != 0 {
+		port = os.Getenv(ListenPortEnv)
+	}
+
+	log.Printf("Starting cloud webhook listener on port %s", port)
+
+	http.HandleFunc("/", handler)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}


### PR DESCRIPTION
This small utility can print webhooks received from a cloud
server. This can be useful for development and troubleshooting.

```release-note
None
```
