### PR TITLE
Add cluster scale up logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Masterminds/squirrel v1.4.0
 	github.com/aws/aws-sdk-go v1.32.5
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/emicklei/go-restful v2.11.2+incompatible // indirect
 	github.com/go-openapi/spec v0.19.6 // indirect
 	github.com/go-openapi/swag v0.19.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,7 +97,6 @@ github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngE
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/brancz/gojsontoyaml v0.0.0-20190425155809-e8bd32d46b3d/go.mod h1:IyUJYN1gvWjtLF5ZuygmxbnsAyP3aJS6cHzIuZY50B0=

--- a/internal/provisioner/fluentbit_test.go
+++ b/internal/provisioner/fluentbit_test.go
@@ -8,17 +8,14 @@ import (
 	"errors"
 	"testing"
 
+	mocks "github.com/mattermost/mattermost-cloud/internal/mocks/aws-tools"
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
-
-	"github.com/bmizerany/assert"
-
-	"github.com/stretchr/testify/require"
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
 
 	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
-
-	mocks "github.com/mattermost/mattermost-cloud/internal/mocks/aws-tools"
-	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewHelmDeploymentWithAuditLogsConfiguration(t *testing.T) {

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -697,7 +698,7 @@ func (provisioner *KopsProvisioner) GetClusterResources(cluster *model.Cluster, 
 			// lead to false positives. In the future, we should use a scheduling
 			// library to perform the check instead.
 			for _, taint := range node.Spec.Taints {
-				if taint.Effect == "NoSchedule" {
+				if taint.Effect == v1.TaintEffectNoSchedule || taint.Effect == v1.TaintEffectPreferNoSchedule {
 					logger.Debugf("Ignoring node %s with taint '%s'", node.GetName(), taint.ToString())
 					skipNode = true
 					break

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -22,6 +22,7 @@ import (
 type installationStore interface {
 	GetClusters(clusterFilter *model.ClusterFilter) ([]*model.Cluster, error)
 	GetCluster(id string) (*model.Cluster, error)
+	UpdateCluster(cluster *model.Cluster) error
 	LockCluster(clusterID, lockerID string) (bool, error)
 	UnlockCluster(clusterID string, lockerID string, force bool) (bool, error)
 
@@ -70,29 +71,31 @@ type installationProvisioner interface {
 // The degree of parallelism is controlled by a weighted semaphore, intended to be shared with
 // other clients needing to coordinate background jobs.
 type InstallationSupervisor struct {
-	store                    installationStore
-	provisioner              installationProvisioner
-	aws                      aws.AWS
-	instanceID               string
-	clusterResourceThreshold int
-	keepDatabaseData         bool
-	keepFilestoreData        bool
-	resourceUtil             *utils.ResourceUtil
-	logger                   log.FieldLogger
+	store                              installationStore
+	provisioner                        installationProvisioner
+	aws                                aws.AWS
+	instanceID                         string
+	clusterResourceThreshold           int
+	clusterResourceThresholdScaleValue int
+	keepDatabaseData                   bool
+	keepFilestoreData                  bool
+	resourceUtil                       *utils.ResourceUtil
+	logger                             log.FieldLogger
 }
 
 // NewInstallationSupervisor creates a new InstallationSupervisor.
-func NewInstallationSupervisor(store installationStore, installationProvisioner installationProvisioner, aws aws.AWS, instanceID string, threshold int, keepDatabaseData, keepFilestoreData bool, resourceUtil *utils.ResourceUtil, logger log.FieldLogger) *InstallationSupervisor {
+func NewInstallationSupervisor(store installationStore, installationProvisioner installationProvisioner, aws aws.AWS, instanceID string, threshold, thresholdScaleValue int, keepDatabaseData, keepFilestoreData bool, resourceUtil *utils.ResourceUtil, logger log.FieldLogger) *InstallationSupervisor {
 	return &InstallationSupervisor{
-		store:                    store,
-		provisioner:              installationProvisioner,
-		aws:                      aws,
-		instanceID:               instanceID,
-		clusterResourceThreshold: threshold,
-		keepDatabaseData:         keepDatabaseData,
-		keepFilestoreData:        keepFilestoreData,
-		resourceUtil:             resourceUtil,
-		logger:                   logger,
+		store:                              store,
+		provisioner:                        installationProvisioner,
+		aws:                                aws,
+		instanceID:                         instanceID,
+		clusterResourceThreshold:           threshold,
+		clusterResourceThresholdScaleValue: thresholdScaleValue,
+		keepDatabaseData:                   keepDatabaseData,
+		keepFilestoreData:                  keepFilestoreData,
+		resourceUtil:                       resourceUtil,
+		logger:                             logger,
 	}
 }
 
@@ -328,12 +331,12 @@ func (s *InstallationSupervisor) createClusterInstallation(cluster *model.Cluste
 
 	size, err := mmv1alpha1.GetClusterSize(installation.Size)
 	if err != nil {
-		logger.WithError(err).Error("invalid cluster installation size")
+		logger.WithError(err).Error("Invalid cluster installation size")
 		return nil
 	}
 	clusterResources, err := s.provisioner.GetClusterResources(cluster, true)
 	if err != nil {
-		logger.WithError(err).Error("failed to get cluster resources")
+		logger.WithError(err).Error("Failed to get cluster resources")
 		return nil
 	}
 
@@ -350,8 +353,51 @@ func (s *InstallationSupervisor) createClusterInstallation(cluster *model.Cluste
 		),
 	)
 	if cpuPercent > s.clusterResourceThreshold || memoryPercent > s.clusterResourceThreshold {
-		logger.Debugf("Cluster %s would exceed the cluster load threshold (%d%%): CPU=%d%%, Memory=%d%%", cluster.ID, s.clusterResourceThreshold, cpuPercent, memoryPercent)
-		return nil
+		if s.clusterResourceThresholdScaleValue != 0 &&
+			cluster.ProvisionerMetadataKops.NodeMinCount < cluster.ProvisionerMetadataKops.NodeMaxCount &&
+			cluster.State == model.ClusterStateStable {
+			// This cluster is ready to scale to meet increased resource demand.
+			// TODO: if this ends up working well, build a safer interface for
+			// updating the cluster. We should try to reuse some of the API flow
+			// that already does this.
+
+			newWorkerCount := cluster.ProvisionerMetadataKops.NodeMinCount + int64(s.clusterResourceThresholdScaleValue)
+			if newWorkerCount > cluster.ProvisionerMetadataKops.NodeMaxCount {
+				newWorkerCount = cluster.ProvisionerMetadataKops.NodeMaxCount
+			}
+
+			cluster.State = model.ClusterStateResizeRequested
+			cluster.ProvisionerMetadataKops.ChangeRequest = &model.KopsMetadataRequestedState{
+				NodeMinCount: newWorkerCount,
+			}
+
+			logger.WithField("cluster", cluster.ID).Infof("Scaling cluster worker nodes from %d to %d (max=%d)",
+				cluster.ProvisionerMetadataKops.NodeMinCount,
+				cluster.ProvisionerMetadataKops.ChangeRequest.NodeMinCount,
+				cluster.ProvisionerMetadataKops.NodeMaxCount,
+			)
+			err = s.store.UpdateCluster(cluster)
+			if err != nil {
+				logger.WithError(err).Error("Failed to update cluster")
+				return nil
+			}
+
+			webhookPayload := &model.WebhookPayload{
+				Type:      model.TypeCluster,
+				ID:        cluster.ID,
+				NewState:  model.ClusterStateResizeRequested,
+				OldState:  model.ClusterStateStable,
+				Timestamp: time.Now().UnixNano(),
+			}
+
+			err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
+			if err != nil {
+				logger.WithError(err).Error("Unable to process and send webhooks")
+			}
+		} else {
+			logger.Debugf("Cluster %s would exceed the cluster load threshold (%d%%): CPU=%d%%, Memory=%d%%", cluster.ID, s.clusterResourceThreshold, cpuPercent, memoryPercent)
+			return nil
+		}
 	}
 
 	// The cluster can support the cluster installation.

--- a/internal/tools/k8s/manifest_test.go
+++ b/internal/tools/k8s/manifest_test.go
@@ -147,7 +147,7 @@ func TestCreate(t *testing.T) {
 
 	t.Run("create from files", func(t *testing.T) {
 		files := []ManifestFile{
-			ManifestFile{
+			{
 				Path:            serviceYAML,
 				DeployNamespace: namespace,
 			},
@@ -157,7 +157,7 @@ func TestCreate(t *testing.T) {
 	})
 	t.Run("create from multi-resource file", func(t *testing.T) {
 		files := []ManifestFile{
-			ManifestFile{
+			{
 				Path:            multiYAML,
 				DeployNamespace: namespace,
 			},
@@ -167,7 +167,7 @@ func TestCreate(t *testing.T) {
 	})
 	t.Run("create with bad yaml format", func(t *testing.T) {
 		files := []ManifestFile{
-			ManifestFile{
+			{
 				Path:            badYAML,
 				DeployNamespace: namespace,
 			},


### PR DESCRIPTION
This adds logic for scaling up cluster worker nodes when scheduling
new installations. If the cloud server is configured to do so, worker
nodes will be increased up to the cluster worker node maximum if the
new installation would exceed the cluster resource threshold. The
cluster scaling and installation reconciliation will happen in
parallel.

Notes on using cluster autoscaling:
To leverage this new functionality, two things need to be done. The
server flag `cluster-resource-threshold-scale-value` needs to be set.
A value of `2` or `3` seems like a good starting spot. The clusters that
you would like to enable autoscaling on need to have their max node
count updated to whatever you are comfortable with.

Note that this does not implement scaling down cluster nodes. Scaling
down can be done manually for now.

Fixes https://mattermost.atlassian.net/browse/MM-25093

```release-note
Add cluster scale up logic
```
