### PR TITLE
Check ID field in webhook listener

### DIFF
--- a/cmd/tools/cwl/cwl.go
+++ b/cmd/tools/cwl/cwl.go
@@ -25,6 +25,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Error: failed to parse webhook: %s", err)
 		return
 	}
+	if len(webhook.ID) == 0 {
+		return
+	}
 
 	wType := "UNKN"
 	switch webhook.Type {


### PR DESCRIPTION
This prevents issues when non-cloud-webhooks are received by the
CWL.

```release-note
None
```
