### PR TITLE
MM-26670 Add ability to look up an Installation by DNS name

### DIFF
--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -23,6 +23,10 @@ func initInstallation(apiRouter *mux.Router, context *Context) {
 	installationsRouter.Handle("", addContext(handleGetInstallations)).Methods("GET")
 	installationsRouter.Handle("", addContext(handleCreateInstallation)).Methods("POST")
 
+	searchRouter := apiRouter.PathPrefix("/search").Subrouter()
+	searchRouter.Handle(`/name/{name:[A-Za-z0-9]{1}[A-Za-z0-9\-\.]+}`,
+		addContext(handleGetInstallationByName)).Methods("GET")
+
 	installationRouter := apiRouter.PathPrefix("/installation/{installation:[A-Za-z0-9]{26}}").Subrouter()
 	installationRouter.Handle("", addContext(handleGetInstallation)).Methods("GET")
 	installationRouter.Handle("", addContext(handleRetryCreateInstallation)).Methods("POST")
@@ -34,6 +38,47 @@ func initInstallation(apiRouter *mux.Router, context *Context) {
 	installationRouter.Handle("", addContext(handleDeleteInstallation)).Methods("DELETE")
 }
 
+func handleGetInstallationByName(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	installationDNS, ok := vars["name"]
+	if !ok {
+		c.Logger.Debug("couldn't get Installation DNS out of query")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	c.Logger = c.Logger.WithField("installation search", installationDNS)
+
+	includeGroupConfig, includeGroupConfigOverrides, err := parseGroupConfig(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse group config parameters")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	installations, err := c.Store.GetInstallations(
+		&model.InstallationFilter{
+			Name:           installationDNS,
+			IncludeDeleted: true,
+			PerPage:        model.AllPerPage,
+		}, includeGroupConfig, includeGroupConfigOverrides)
+
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if len(installations) != 1 {
+		c.Logger.Debugf("getting installation with name %s returned %d results but should only return 1",
+			installationDNS, len(installations))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, installations[0])
+}
+
 // handleGetInstallation responds to GET /api/installation/{installation}, returning the installation in question.
 func handleGetInstallation(c *Context, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
@@ -42,7 +87,7 @@ func handleGetInstallation(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	includeGroupConfig, includeGroupConfigOverrides, err := parseGroupConfig(r.URL)
 	if err != nil {
-		c.Logger.WithError(err).Error("failed to parse paging parameters")
+		c.Logger.WithError(err).Error("failed to parse group config parameters")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -57,7 +57,7 @@ func handleGetInstallationByName(c *Context, w http.ResponseWriter, r *http.Requ
 
 	installations, err := c.Store.GetInstallations(
 		&model.InstallationFilter{
-			Name:           installationDNS,
+			DNS:            installationDNS,
 			IncludeDeleted: true,
 			PerPage:        model.AllPerPage,
 		}, includeGroupConfig, includeGroupConfigOverrides)

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +40,6 @@ func TestGetInstallations(t *testing.T) {
 		installation, err := client.GetInstallation(model.NewID(), nil)
 		require.NoError(t, err)
 		require.Nil(t, installation)
-
 	})
 
 	t.Run("no installations", func(t *testing.T) {
@@ -179,6 +179,19 @@ func TestGetInstallations(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, installation4, installation)
 			})
+
+			t.Run("get installation by name", func(t *testing.T) {
+				installation, err := client.GetInstallationByName(installation4.DNS, nil)
+				assert.NoError(t, err)
+				require.NotNil(t, installation)
+				assert.Equal(t, installation4.ID, installation.ID)
+				assert.Equal(t, installation4.DNS, installation.DNS)
+
+				noInstallation, err := client.GetInstallationByName("notarealname", nil)
+				assert.Nil(t, noInstallation)
+				assert.Error(t, err)
+			})
+
 		})
 
 		t.Run("get installations", func(t *testing.T) {

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -187,7 +187,7 @@ func TestGetInstallations(t *testing.T) {
 				assert.Equal(t, installation4.ID, installation.ID)
 				assert.Equal(t, installation4.DNS, installation.DNS)
 
-				noInstallation, err := client.GetInstallationByName("notarealname", nil)
+				noInstallation, err := client.GetInstallationByName("notreal", nil)
 				assert.Nil(t, noInstallation)
 				assert.Error(t, err)
 			})

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -181,11 +181,11 @@ func TestGetInstallations(t *testing.T) {
 			})
 
 			t.Run("get installation by name", func(t *testing.T) {
-				installation, err := client.GetInstallationByName(installation4.DNS, nil)
+				installation, err := client.GetInstallationByName(installation1.DNS, nil)
 				assert.NoError(t, err)
 				require.NotNil(t, installation)
-				assert.Equal(t, installation4.ID, installation.ID)
-				assert.Equal(t, installation4.DNS, installation.DNS)
+				assert.Equal(t, installation1.ID, installation.ID)
+				assert.Equal(t, installation1.DNS, installation.DNS)
 
 				noInstallation, err := client.GetInstallationByName("notreal", nil)
 				assert.Nil(t, noInstallation)

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -181,13 +181,13 @@ func TestGetInstallations(t *testing.T) {
 			})
 
 			t.Run("get installation by name", func(t *testing.T) {
-				installation, err := client.GetInstallationByName(installation1.DNS, nil)
+				installation, err := client.GetInstallationByDNS(installation1.DNS, nil)
 				assert.NoError(t, err)
 				require.NotNil(t, installation)
 				assert.Equal(t, installation1.ID, installation.ID)
 				assert.Equal(t, installation1.DNS, installation.DNS)
 
-				noInstallation, err := client.GetInstallationByName("notreal", nil)
+				noInstallation, err := client.GetInstallationByDNS("notreal", nil)
 				assert.Nil(t, noInstallation)
 				assert.Error(t, err)
 			})

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -112,6 +112,9 @@ func (sqlStore *SQLStore) GetInstallations(filter *model.InstallationFilter, inc
 	if !filter.IncludeDeleted {
 		builder = builder.Where("DeleteAt = 0")
 	}
+	if filter.Name != "" {
+		builder = builder.Where("DNS = ?", filter.Name)
+	}
 
 	var rawInstallations rawInstallations
 	err := sqlStore.selectBuilder(sqlStore.db, &rawInstallations, builder)

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -112,8 +112,8 @@ func (sqlStore *SQLStore) GetInstallations(filter *model.InstallationFilter, inc
 	if !filter.IncludeDeleted {
 		builder = builder.Where("DeleteAt = 0")
 	}
-	if filter.Name != "" {
-		builder = builder.Where("DNS = ?", filter.Name)
+	if filter.DNS != "" {
+		builder = builder.Where("DNS = ?", filter.DNS)
 	}
 
 	var rawInstallations rawInstallations

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -129,6 +129,20 @@ func TestInstallations(t *testing.T) {
 		require.Equal(t, installation3, installation)
 	})
 
+	t.Run("get installation 3 by name", func(t *testing.T) {
+		installations, err := sqlStore.GetInstallations(
+			&model.InstallationFilter{
+				Name:    installation3.DNS,
+				PerPage: model.AllPerPage,
+			}, false, false)
+
+		require.Equal(t, 1, len(installations))
+		installation := installations[0]
+
+		require.NoError(t, err)
+		require.Equal(t, installation.ID, installation3.ID)
+	})
+
 	t.Run("get and delete installation 4", func(t *testing.T) {
 		installation, err := sqlStore.GetInstallation(installation4.ID, false, false)
 		require.NoError(t, err)

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -132,7 +132,7 @@ func TestInstallations(t *testing.T) {
 	t.Run("get installation 3 by name", func(t *testing.T) {
 		installations, err := sqlStore.GetInstallations(
 			&model.InstallationFilter{
-				Name:    installation3.DNS,
+				DNS:     installation3.DNS,
 				PerPage: model.AllPerPage,
 			}, false, false)
 

--- a/model/client.go
+++ b/model/client.go
@@ -354,8 +354,8 @@ func (c *Client) GetInstallation(installationID string, request *GetInstallation
 	}
 }
 
-// GetInstallationByName finds an installation with the given FQDN.
-func (c *Client) GetInstallationByName(DNS string, request *GetInstallationRequest) (*Installation, error) {
+// GetInstallationByDNS finds an installation with the given FQDN.
+func (c *Client) GetInstallationByDNS(DNS string, request *GetInstallationRequest) (*Installation, error) {
 	if request == nil {
 		request = &GetInstallationRequest{
 			IncludeGroupConfig:          false,

--- a/model/client.go
+++ b/model/client.go
@@ -365,7 +365,7 @@ func (c *Client) GetInstallationByName(DNS string, request *GetInstallationReque
 	installations, err := c.GetInstallations(&GetInstallationsRequest{
 		IncludeGroupConfig:          request.IncludeGroupConfig,
 		IncludeGroupConfigOverrides: request.IncludeGroupConfigOverrides,
-		IncludeDeleted:              true,
+		IncludeDeleted:              false,
 		PerPage:                     AllPerPage,
 		DNS:                         DNS,
 	})

--- a/model/installation.go
+++ b/model/installation.go
@@ -50,6 +50,7 @@ type InstallationFilter struct {
 	Page           int
 	PerPage        int
 	IncludeDeleted bool
+	Name           string
 }
 
 // Clone returns a deep copy the installation.

--- a/model/installation.go
+++ b/model/installation.go
@@ -50,7 +50,7 @@ type InstallationFilter struct {
 	Page           int
 	PerPage        int
 	IncludeDeleted bool
-	Name           string
+	DNS            string
 }
 
 // Clone returns a deep copy the installation.

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -160,6 +160,7 @@ type GetInstallationsRequest struct {
 	Page                        int
 	PerPage                     int
 	IncludeDeleted              bool
+	DNS                         string
 }
 
 // ApplyToURL modifies the given url to include query string parameters for the request.
@@ -177,6 +178,9 @@ func (request *GetInstallationsRequest) ApplyToURL(u *url.URL) {
 	q.Add("per_page", strconv.Itoa(request.PerPage))
 	if request.IncludeDeleted {
 		q.Add("include_deleted", "true")
+	}
+	if request.DNS != "" {
+		q.Add("dns_name", request.DNS)
 	}
 	u.RawQuery = q.Encode()
 }


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Adds API endpoint GET `/api/search/name/{FQDN}`
This new endpoint uses GetInstallations with an InstallationFilter to fetch Installations using their FQDN, in order to satisfy MM-26670

Also I felt conflicted about where to actually put this API endpoint. I added it to a new `search` subrouter with the thought that in the future we may want other search methods, and because there was not a great way to add a `search` subrouter to the Installation routes directly since the existing ones assume you have the Installation ID and I think that's the right pattern.

So please provide feedback on that in particular if you have an opinion!

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
[MM-26670](https://mattermost.atlassian.net/browse/MM-26670)
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Adds new endpoint GET /api/search/name/{query} to allow fetching Installations by name
```
