### PR TITLE
Update kops and golang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   default:
     docker:
-    - image: circleci/golang:1.14.1
+    - image: circleci/golang:1.14.6
 
 aliases:
 - &restore_cache
@@ -57,7 +57,7 @@ jobs:
 
   test-postgres:
     docker:
-    - image: circleci/golang:1.14.1
+    - image: circleci/golang:1.14.6
       environment:
         CLOUD_DATABASE=postgres://cloud_test@localhost:5432/cloud_test?sslmode=disable
     - image: circleci/postgres:11.2-alpine

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,12 @@
 ################################################################################
 
 ## Docker Build Versions
-DOCKER_BUILD_IMAGE = golang:1.14.4
+DOCKER_BUILD_IMAGE = golang:1.14.6
 DOCKER_BASE_IMAGE = alpine:3.12
 
 ## Tool Versions
 TERRAFORM_VERSION=0.11.14
-KOPS_VERSION=v1.17.0
+KOPS_VERSION=v1.17.1
 HELM_VERSION=v2.16.9
 KUBECTL_VERSION=v1.18.3
 


### PR DESCRIPTION
#### Summary
Update kops to 1.17.1 due some security release and golang to 1.14.6

#### Ticket Link
None

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Update kops to 1.17.1
```
