### PR TITLE
Adding support for PersistentVolume and PersistentVolumeClaim in k8s …

### DIFF
--- a/k8s/manifest.go
+++ b/k8s/manifest.go
@@ -155,6 +155,10 @@ func (kc *KubeClient) createFileResource(deployNamespace string, obj interface{}
 		return kc.createOrUpdateNetworkPolicyV1(deployNamespace, obj.(*networkingv1.NetworkPolicy))
 	case *apiregistrationv1beta1.APIService:
 		return kc.createOrUpdateAPIServer(obj.(*apiregistrationv1beta1.APIService))
+	case *apiv1.PersistentVolume:
+		return kc.createOrUpdatePersistentVolume(deployNamespace, obj.(*apiv1.PersistentVolume))
+	case *apiv1.PersistentVolumeClaim:
+		return kc.createOrUpdatePersistenVolumeClaim(deployNamespace, obj.(*apiv1.PersistentVolumeClaim))
 	default:
 		return nil, fmt.Errorf("Error: unsupported k8s manifest type %T", o)
 	}

--- a/k8s/manifest.go
+++ b/k8s/manifest.go
@@ -158,7 +158,7 @@ func (kc *KubeClient) createFileResource(deployNamespace string, obj interface{}
 	case *apiv1.PersistentVolume:
 		return kc.createOrUpdatePersistentVolume(deployNamespace, obj.(*apiv1.PersistentVolume))
 	case *apiv1.PersistentVolumeClaim:
-		return kc.createOrUpdatePersistenVolumeClaim(deployNamespace, obj.(*apiv1.PersistentVolumeClaim))
+		return kc.createOrUpdatePersistentVolumeClaim(deployNamespace, obj.(*apiv1.PersistentVolumeClaim))
 	default:
 		return nil, fmt.Errorf("Error: unsupported k8s manifest type %T", o)
 	}

--- a/k8s/manifest.go
+++ b/k8s/manifest.go
@@ -156,7 +156,7 @@ func (kc *KubeClient) createFileResource(deployNamespace string, obj interface{}
 	case *apiregistrationv1beta1.APIService:
 		return kc.createOrUpdateAPIServer(obj.(*apiregistrationv1beta1.APIService))
 	case *apiv1.PersistentVolume:
-		return kc.createOrUpdatePersistentVolume(deployNamespace, obj.(*apiv1.PersistentVolume))
+		return kc.createOrUpdatePersistentVolume(obj.(*apiv1.PersistentVolume))
 	case *apiv1.PersistentVolumeClaim:
 		return kc.createOrUpdatePersistentVolumeClaim(deployNamespace, obj.(*apiv1.PersistentVolumeClaim))
 	default:

--- a/k8s/persistentvolume.go
+++ b/k8s/persistentvolume.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (kc *KubeClient) createOrUpdatePersistentVolume(namespace string, volume *corev1.PersistentVolume) (metav1.Object, error) {
+	_, err := kc.Clientset.CoreV1().PersistentVolumes().Get(volume.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.Clientset.CoreV1().PersistentVolumes().Create(volume)
+	}
+
+	return kc.Clientset.CoreV1().PersistentVolumes().Update(volume)
+}
+
+func (kc *KubeClient) createOrUpdatePersistenVolumeClaim(namespace string, volumeClaim *corev1.PersistentVolumeClaim) (metav1.Object, error) {
+	_, err := kc.Clientset.CoreV1().PersistentVolumeClaims(namespace).Get(volumeClaim.GetName(), metav1.GetOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return kc.Clientset.CoreV1().PersistentVolumeClaims(namespace).Create(volumeClaim)
+	}
+
+	return kc.Clientset.CoreV1().PersistentVolumeClaims(namespace).Update(volumeClaim)
+}

--- a/k8s/persistentvolume.go
+++ b/k8s/persistentvolume.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (kc *KubeClient) createOrUpdatePersistentVolume(namespace string, volume *corev1.PersistentVolume) (metav1.Object, error) {
+func (kc *KubeClient) createOrUpdatePersistentVolume(volume *corev1.PersistentVolume) (metav1.Object, error) {
 	_, err := kc.Clientset.CoreV1().PersistentVolumes().Get(volume.GetName(), metav1.GetOptions{})
 	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err

--- a/k8s/persistentvolume.go
+++ b/k8s/persistentvolume.go
@@ -23,7 +23,7 @@ func (kc *KubeClient) createOrUpdatePersistentVolume(namespace string, volume *c
 	return kc.Clientset.CoreV1().PersistentVolumes().Update(volume)
 }
 
-func (kc *KubeClient) createOrUpdatePersistenVolumeClaim(namespace string, volumeClaim *corev1.PersistentVolumeClaim) (metav1.Object, error) {
+func (kc *KubeClient) createOrUpdatePersistentVolumeClaim(namespace string, volumeClaim *corev1.PersistentVolumeClaim) (metav1.Object, error) {
 	_, err := kc.Clientset.CoreV1().PersistentVolumeClaims(namespace).Get(volumeClaim.GetName(), metav1.GetOptions{})
 	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err

--- a/k8s/persistentvolume_test.go
+++ b/k8s/persistentvolume_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPersistentVolume(t *testing.T) {
+	testClient := newTestKubeClient()
+	persistentVolume := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
+	}
+
+	t.Run("create service account", func(t *testing.T) {
+		result, err := testClient.createOrUpdatePersistentVolume(persistentVolume)
+		require.NoError(t, err)
+		require.Equal(t, persistentVolume.GetName(), result.GetName())
+	})
+	t.Run("create duplicate service account", func(t *testing.T) {
+		result, err := testClient.createOrUpdatePersistentVolume(persistentVolume)
+		require.NoError(t, err)
+		require.Equal(t, persistentVolume.GetName(), result.GetName())
+	})
+}
+
+func TestPersistentVolumeClaim(t *testing.T) {
+	testClient := newTestKubeClient()
+	persistentVolume := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
+	}
+	namespace := "testing"
+
+	t.Run("create service account", func(t *testing.T) {
+		result, err := testClient.createOrUpdatePersistentVolumeClaim(namespace, persistentVolume)
+		require.NoError(t, err)
+		require.Equal(t, persistentVolume.GetName(), result.GetName())
+	})
+	t.Run("create duplicate service account", func(t *testing.T) {
+		result, err := testClient.createOrUpdatePersistentVolumeClaim(namespace, persistentVolume)
+		require.NoError(t, err)
+		require.Equal(t, persistentVolume.GetName(), result.GetName())
+	})
+}


### PR DESCRIPTION
#### Summary
Adding support for creating and updating persistent volumes and persistent volume claims. Matterwick will be creating and updating these ad-hoc for postgres databases in test environments.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27201

#### Release Note
```release-note
The mattermost-cloud Kubernetes client now supports Persistent Volumes, and Persistent Volume Claims!
```
