### PR TITLE
MM-27216 - added MM_CLOUD_INSTALLATION_ID

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -62,6 +62,12 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 		return errors.Wrapf(err, "failed to create network policy %s", clusterInstallation.Namespace)
 	}
 
+	// add installation ID to mattermost-server env variables
+	if installation.MattermostEnv == nil {
+		installation.MattermostEnv = map[string]model.EnvVar{}
+	}
+	installation.MattermostEnv["MM_CLOUD_INSTALLATION_ID"] = model.EnvVar{Value: installation.ID}
+
 	mattermostInstallation := &mmv1alpha1.ClusterInstallation{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterInstallation",

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -194,6 +194,8 @@ func (sqlStore *SQLStore) CreateInstallation(installation *model.Installation) e
 	installation.ID = model.NewID()
 	installation.CreateAt = GetMillis()
 
+	// add installation ID to mattermost-server env variables
+	installation.MattermostEnv["MM_CLOUD_INSTALLATION_ID"] = model.EnvVar{Value: installation.ID}
 	envJSON, err := json.Marshal(installation.MattermostEnv)
 	if err != nil {
 		return errors.Wrap(err, "unable to marshal MattermostEnv")

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -194,11 +194,6 @@ func (sqlStore *SQLStore) CreateInstallation(installation *model.Installation) e
 	installation.ID = model.NewID()
 	installation.CreateAt = GetMillis()
 
-	// add installation ID to mattermost-server env variables
-	if installation.MattermostEnv == nil {
-		installation.MattermostEnv = map[string]model.EnvVar{}
-	}
-	installation.MattermostEnv["MM_CLOUD_INSTALLATION_ID"] = model.EnvVar{Value: installation.ID}
 	envJSON, err := json.Marshal(installation.MattermostEnv)
 	if err != nil {
 		return errors.Wrap(err, "unable to marshal MattermostEnv")

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -195,6 +195,9 @@ func (sqlStore *SQLStore) CreateInstallation(installation *model.Installation) e
 	installation.CreateAt = GetMillis()
 
 	// add installation ID to mattermost-server env variables
+	if installation.MattermostEnv == nil {
+		installation.MattermostEnv = map[string]model.EnvVar{}
+	}
 	installation.MattermostEnv["MM_CLOUD_INSTALLATION_ID"] = model.EnvVar{Value: installation.ID}
 	envJSON, err := json.Marshal(installation.MattermostEnv)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Added env variable to mattermost-server envmap to identify the installation

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-27216
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added MM_CLOUD_INSTALLATION_ID env variable to identify mattermost-server installations
```
