### PR TITLE
Add database endpoint init check to single tenant databases

### DIFF
--- a/internal/tools/aws/database.go
+++ b/internal/tools/aws/database.go
@@ -143,12 +143,14 @@ func (d *RDSDatabase) GenerateDatabaseSpecAndSecret(store model.InstallationData
 		"database-type":   d.databaseType,
 	})
 
-	var connTemplate string
+	var connTemplate, databaseCheckPort string
 	switch d.databaseType {
 	case model.DatabaseEngineTypeMySQL:
 		connTemplate = mysqlConnStringTemplate
+		databaseCheckPort = "3306"
 	case model.DatabaseEngineTypePostgres:
 		connTemplate = postgresConnStringTemplate
+		databaseCheckPort = "5432"
 	default:
 		return nil, nil, errors.Errorf("%s is an invalid database engine type", d.databaseType)
 	}
@@ -177,7 +179,8 @@ func (d *RDSDatabase) GenerateDatabaseSpecAndSecret(store model.InstallationData
 			Name: databaseSecretName,
 		},
 		StringData: map[string]string{
-			"DB_CONNECTION_STRING": databaseConnectionString,
+			"DB_CONNECTION_STRING":    databaseConnectionString,
+			"DB_CONNECTION_CHECK_URL": fmt.Sprintf("http://%s:%s", *result.DBClusters[0].Endpoint, databaseCheckPort),
 		},
 	}
 

--- a/k8s/custom_resources_test.go
+++ b/k8s/custom_resources_test.go
@@ -9,23 +9,42 @@ import (
 
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	"github.com/stretchr/testify/require"
+	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apixv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestCustomResourceDefinition(t *testing.T) {
+func TestCustomResourceDefinitionBetaV1(t *testing.T) {
 	testClient := newTestKubeClient()
 	customResourceDefinition := &apixv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-crd"},
 	}
 
 	t.Run("create custom resource definition", func(t *testing.T) {
-		result, err := testClient.createOrUpdateCustomResourceDefinition(customResourceDefinition)
+		result, err := testClient.createOrUpdateCustomResourceDefinitionBetaV1(customResourceDefinition)
 		require.NoError(t, err)
 		require.Equal(t, customResourceDefinition.GetName(), result.GetName())
 	})
 	t.Run("create duplicate custom resource definition", func(t *testing.T) {
-		result, err := testClient.createOrUpdateCustomResourceDefinition(customResourceDefinition)
+		result, err := testClient.createOrUpdateCustomResourceDefinitionBetaV1(customResourceDefinition)
+		require.NoError(t, err)
+		require.Equal(t, customResourceDefinition.GetName(), result.GetName())
+	})
+}
+
+func TestCustomResourceDefinitionV1(t *testing.T) {
+	testClient := newTestKubeClient()
+	customResourceDefinition := &apixv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-crd"},
+	}
+
+	t.Run("create custom resource definition", func(t *testing.T) {
+		result, err := testClient.createOrUpdateCustomResourceDefinitionV1(customResourceDefinition)
+		require.NoError(t, err)
+		require.Equal(t, customResourceDefinition.GetName(), result.GetName())
+	})
+	t.Run("create duplicate custom resource definition", func(t *testing.T) {
+		result, err := testClient.createOrUpdateCustomResourceDefinitionV1(customResourceDefinition)
 		require.NoError(t, err)
 		require.Equal(t, customResourceDefinition.GetName(), result.GetName())
 	})

--- a/k8s/manifest.go
+++ b/k8s/manifest.go
@@ -22,6 +22,7 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	rbacbetav1 "k8s.io/api/rbac/v1beta1"
+	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apixv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apixv1beta1scheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,7 +137,9 @@ func (kc *KubeClient) createFileResource(deployNamespace string, obj interface{}
 	case *rbacbetav1.ClusterRoleBinding:
 		return kc.createOrUpdateClusterRoleBindingBetaV1(obj.(*rbacbetav1.ClusterRoleBinding))
 	case *apixv1beta1.CustomResourceDefinition:
-		return kc.createOrUpdateCustomResourceDefinition(obj.(*apixv1beta1.CustomResourceDefinition))
+		return kc.createOrUpdateCustomResourceDefinitionBetaV1(obj.(*apixv1beta1.CustomResourceDefinition))
+	case *apixv1.CustomResourceDefinition:
+		return kc.createOrUpdateCustomResourceDefinitionV1(obj.(*apixv1.CustomResourceDefinition))
 	case *mmv1alpha1.ClusterInstallation:
 		return kc.createOrUpdateClusterInstallation(deployNamespace, obj.(*mmv1alpha1.ClusterInstallation))
 	case *apiv1.Secret:

--- a/manifests/operator-manifests/mattermost/crds/mm_clusterinstallation_crd.yaml
+++ b/manifests/operator-manifests/mattermost/crds/mm_clusterinstallation_crd.yaml
@@ -1,25 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinstallations.mattermost.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.state
-    description: State of Mattermost
-    name: State
-    type: string
-  - JSONPath: .status.image
-    description: Image of Mattermost
-    name: Image
-    type: string
-  - JSONPath: .status.version
-    description: Version of Mattermost
-    name: Version
-    type: string
-  - JSONPath: .status.endpoint
-    description: Endpoint
-    name: Endpoint
-    type: string
   group: mattermost.com
   names:
     kind: ClusterInstallation
@@ -27,1262 +10,1449 @@ spec:
     plural: clusterinstallations
     singular: clusterinstallation
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ClusterInstallation is the Schema for the clusterinstallations
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: 'Specification of the desired behavior of the Mattermost cluster.
-            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
-          properties:
-            affinity:
-              description: If specified, affinity will define the pod's scheduling
-                constraints
-              properties:
-                nodeAffinity:
-                  description: Describes node affinity scheduling rules for the pod.
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node matches the corresponding matchExpressions; the
-                        node(s) with the highest sum are the most preferred.
-                      items:
-                        description: An empty preferred scheduling term matches all
-                          objects with implicit weight 0 (i.e. it's a no-op). A null
-                          preferred scheduling term matches no objects (i.e. is also
-                          a no-op).
-                        properties:
-                          preference:
-                            description: A node selector term, associated with the
-                              corresponding weight.
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          weight:
-                            description: Weight associated with matching the corresponding
-                              nodeSelectorTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - preference
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to an update), the system may or may not try to
-                        eventually evict the pod from its node.
-                      properties:
-                        nodeSelectorTerms:
-                          description: Required. A list of node selector terms. The
-                            terms are ORed.
-                          items:
-                            description: A null or empty node selector term matches
-                              no objects. The requirements of them are ANDed. The
-                              TopologySelectorTerm type implements a subset of the
-                              NodeSelectorTerm.
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          type: array
-                      required:
-                      - nodeSelectorTerms
-                      type: object
-                  type: object
-                podAffinity:
-                  description: Describes pod affinity scheduling rules (e.g. co-locate
-                    this pod in the same node, zone, etc. as some other pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node has pods which matches the corresponding podAffinityTerm;
-                        the node(s) with the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to a pod label update), the system may or may not
-                        try to eventually evict the pod from its node. When there
-                        are multiple elements, the lists of nodes corresponding to
-                        each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-                podAntiAffinity:
-                  description: Describes pod anti-affinity scheduling rules (e.g.
-                    avoid putting this pod in the same node, zone, etc. as some other
-                    pod(s)).
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the anti-affinity expressions specified by this
-                        field, but it may choose a node that violates one or more
-                        of the expressions. The node that is most preferred is the
-                        one with the greatest sum of weights, i.e. for each node that
-                        meets all of the scheduling requirements (resource request,
-                        requiredDuringScheduling anti-affinity expressions, etc.),
-                        compute a sum by iterating through the elements of this field
-                        and adding "weight" to the sum if the node has pods which
-                        matches the corresponding podAffinityTerm; the node(s) with
-                        the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the anti-affinity requirements specified by
-                        this field are not met at scheduling time, the pod will not
-                        be scheduled onto the node. If the anti-affinity requirements
-                        specified by this field cease to be met at some point during
-                        pod execution (e.g. due to a pod label update), the system
-                        may or may not try to eventually evict the pod from its node.
-                        When there are multiple elements, the lists of nodes corresponding
-                        to each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            blueGreen:
-              description: BlueGreen defines the configuration of BlueGreen deployment
-                for a ClusterInstallation
-              properties:
-                blue:
-                  description: Blue defines the blue deployment.
-                  properties:
-                    image:
-                      description: Image defines the base Docker image that will be
-                        used for the deployment. Required when BlueGreen or Canary
-                        is enabled.
-                      type: string
-                    ingressName:
-                      description: IngressName defines the ingress name that will
-                        be used by the deployment. This option is not used for Canary
-                        builds.
-                      type: string
-                    name:
-                      description: Name defines the name of the deployment
-                      type: string
-                    resourceLabels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    version:
-                      description: Version defines the Docker image version that will
-                        be used for the deployment. Required when BlueGreen or Canary
-                        is enabled.
-                      type: string
-                  type: object
-                enable:
-                  description: Enable defines if BlueGreen deployment will be applied.
-                  type: boolean
-                green:
-                  description: Green defines the green deployment.
-                  properties:
-                    image:
-                      description: Image defines the base Docker image that will be
-                        used for the deployment. Required when BlueGreen or Canary
-                        is enabled.
-                      type: string
-                    ingressName:
-                      description: IngressName defines the ingress name that will
-                        be used by the deployment. This option is not used for Canary
-                        builds.
-                      type: string
-                    name:
-                      description: Name defines the name of the deployment
-                      type: string
-                    resourceLabels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    version:
-                      description: Version defines the Docker image version that will
-                        be used for the deployment. Required when BlueGreen or Canary
-                        is enabled.
-                      type: string
-                  type: object
-                productionDeployment:
-                  description: ProductionDeployment defines if the current production
-                    is blue or green.
-                  type: string
-              type: object
-            canary:
-              description: Canary defines the configuration of Canary deployment for
-                a ClusterInstallation
-              properties:
-                deployment:
-                  description: Deployment defines the canary deployment.
-                  properties:
-                    image:
-                      description: Image defines the base Docker image that will be
-                        used for the deployment. Required when BlueGreen or Canary
-                        is enabled.
-                      type: string
-                    ingressName:
-                      description: IngressName defines the ingress name that will
-                        be used by the deployment. This option is not used for Canary
-                        builds.
-                      type: string
-                    name:
-                      description: Name defines the name of the deployment
-                      type: string
-                    resourceLabels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    version:
-                      description: Version defines the Docker image version that will
-                        be used for the deployment. Required when BlueGreen or Canary
-                        is enabled.
-                      type: string
-                  type: object
-                enable:
-                  description: Enable defines if a canary build will be deployed.
-                  type: boolean
-              type: object
-            database:
-              description: Database defines the database configuration for a ClusterInstallation.
-              properties:
-                backupRemoteDeletePolicy:
-                  description: Defines the backup retention policy.
-                  type: string
-                backupRestoreSecretName:
-                  description: Defines the secret to be used when performing a database
-                    restore.
-                  type: string
-                backupSchedule:
-                  description: Defines the interval for backups in cron expression
-                    format.
-                  type: string
-                backupSecretName:
-                  description: Defines the secret to be used for uploading/restoring
-                    backup.
-                  type: string
-                backupURL:
-                  description: Defines the object storage url for uploading backups.
-                  type: string
-                initBucketURL:
-                  description: Defines the AWS S3 bucket where the Database Backup
-                    is stored. The operator will download the file to restore the
-                    data.
-                  type: string
-                replicas:
-                  description: Defines the number of database replicas. For redundancy
-                    use at least 2 replicas. Setting this will override the number
-                    of replicas set by 'Size'.
-                  format: int32
-                  type: integer
-                resources:
-                  description: Defines the resource requests and limits for the database
-                    pods.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        type: string
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        type: string
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                secret:
-                  description: "Optionally enter the name of an already-existing Secret
-                    for connecting to the database. This secret should be configured
-                    as follows: \n User-Managed Database   - Key: DB_CONNECTION_STRING
-                    | Value: <FULL_DATABASE_CONNECTION_STRING> Operator-Managed Database
-                    \  - Key: ROOT_PASSWORD | Value: <ROOT_DATABASE_PASSWORD>   -
-                    Key: USER | Value: <USER_NAME>   - Key: PASSWORD | Value: <USER_PASSWORD>
-                    \  - Key: DATABASE Value: <DATABASE_NAME> \n Notes:   If you define
-                    all secret values for both User-Managed and   Operator-Managed
-                    database types, the User-Managed connection string will   take
-                    precedence and the Operator-Managed values will be ignored. If
-                    the   secret is left blank, the default behavior is to use an
-                    Operator-Managed   database with strong randomly-generated database
-                    credentials."
-                  type: string
-                storageSize:
-                  description: Defines the storage size for the database. ie 50Gi
-                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                  type: string
-                type:
-                  type: string
-              type: object
-            elasticSearch:
-              description: ElasticSearch defines the ElasticSearch configuration for
-                a ClusterInstallation.
-              properties:
-                host:
-                  type: string
-                password:
-                  type: string
-                username:
-                  type: string
-              type: object
-            image:
-              description: Image defines the ClusterInstallation Docker image.
-              type: string
-            ingressAnnotations:
-              additionalProperties:
-                type: string
-              type: object
-            ingressName:
-              description: IngressName defines the name to be used when creating the
-                ingress rules
-              type: string
-            livenessProbe:
-              description: Defines the probe to check if the application is up and
-                running.
-              properties:
-                exec:
-                  description: One and only one of the following should be specified.
-                    Exec specifies the action to take.
-                  properties:
-                    command:
-                      description: Command is the command line to execute inside the
-                        container, the working directory for the command  is root
-                        ('/') in the container's filesystem. The command is simply
-                        exec'd, it is not run inside a shell, so traditional shell
-                        instructions ('|', etc) won't work. To use a shell, you need
-                        to explicitly call out to that shell. Exit status of 0 is
-                        treated as live/healthy and non-zero is unhealthy.
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                failureThreshold:
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
-                  format: int32
-                  type: integer
-                httpGet:
-                  description: HTTPGet specifies the http request to perform.
-                  properties:
-                    host:
-                      description: Host name to connect to, defaults to the pod IP.
-                        You probably want to set "Host" in httpHeaders instead.
-                      type: string
-                    httpHeaders:
-                      description: Custom headers to set in the request. HTTP allows
-                        repeated headers.
-                      items:
-                        description: HTTPHeader describes a custom header to be used
-                          in HTTP probes
-                        properties:
-                          name:
-                            description: The header field name
-                            type: string
-                          value:
-                            description: The header field value
-                            type: string
-                        required:
-                        - name
-                        - value
-                        type: object
-                      type: array
-                    path:
-                      description: Path to access on the HTTP server.
-                      type: string
-                    port:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: Name or number of the port to access on the container.
-                        Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                      x-kubernetes-int-or-string: true
-                    scheme:
-                      description: Scheme to use for connecting to the host. Defaults
-                        to HTTP.
-                      type: string
-                  required:
-                  - port
-                  type: object
-                initialDelaySeconds:
-                  description: 'Number of seconds after the container has started
-                    before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                  format: int32
-                  type: integer
-                periodSeconds:
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
-                  format: int32
-                  type: integer
-                successThreshold:
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness
-                    and startup. Minimum value is 1.
-                  format: int32
-                  type: integer
-                tcpSocket:
-                  description: 'TCPSocket specifies an action involving a TCP port.
-                    TCP hooks not yet supported TODO: implement a realistic TCP lifecycle
-                    hook'
-                  properties:
-                    host:
-                      description: 'Optional: Host name to connect to, defaults to
-                        the pod IP.'
-                      type: string
-                    port:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: Number or name of the port to access on the container.
-                        Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                      x-kubernetes-int-or-string: true
-                  required:
-                  - port
-                  type: object
-                timeoutSeconds:
-                  description: 'Number of seconds after which the probe times out.
-                    Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                  format: int32
-                  type: integer
-              type: object
-            mattermostEnv:
-              description: Optional environment variables to set in the Mattermost
-                application pods.
-              items:
-                description: EnvVar represents an environment variable present in
-                  a Container.
+  versions:
+  - additionalPrinterColumns:
+    - description: State of Mattermost
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: Image of Mattermost
+      jsonPath: .status.image
+      name: Image
+      type: string
+    - description: Version of Mattermost
+      jsonPath: .status.version
+      name: Version
+      type: string
+    - description: Endpoint
+      jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterInstallation is the Schema for the clusterinstallations
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the desired behavior of the Mattermost
+              cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+            properties:
+              affinity:
+                description: If specified, affinity will define the pod's scheduling
+                  constraints
                 properties:
-                  name:
-                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                    type: string
-                  value:
-                    description: 'Variable references $(VAR_NAME) are expanded using
-                      the previous defined environment variables in the container
-                      and any service environment variables. If a variable cannot
-                      be resolved, the reference in the input string will be unchanged.
-                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                      $$(VAR_NAME). Escaped references will never be expanded, regardless
-                      of whether the variable exists or not. Defaults to "".'
-                    type: string
-                  valueFrom:
-                    description: Source for the environment variable's value. Cannot
-                      be used if value is not empty.
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
                     properties:
-                      configMapKeyRef:
-                        description: Selects a key of a ConfigMap.
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
                         properties:
-                          key:
-                            description: The key to select.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its key
-                              must be defined
-                            type: boolean
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
                         required:
-                        - key
-                        type: object
-                      fieldRef:
-                        description: 'Selects a field of the pod: supports metadata.name,
-                          metadata.namespace, metadata.labels, metadata.annotations,
-                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP,
-                          status.podIPs.'
-                        properties:
-                          apiVersion:
-                            description: Version of the schema the FieldPath is written
-                              in terms of, defaults to "v1".
-                            type: string
-                          fieldPath:
-                            description: Path of the field to select in the specified
-                              API version.
-                            type: string
-                        required:
-                        - fieldPath
-                        type: object
-                      resourceFieldRef:
-                        description: 'Selects a resource of the container: only resources
-                          limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage,
-                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                          are currently supported.'
-                        properties:
-                          containerName:
-                            description: 'Container name: required for volumes, optional
-                              for env vars'
-                            type: string
-                          divisor:
-                            description: Specifies the output format of the exposed
-                              resources, defaults to "1"
-                            type: string
-                          resource:
-                            description: 'Required: resource to select'
-                            type: string
-                        required:
-                        - resource
-                        type: object
-                      secretKeyRef:
-                        description: Selects a key of a secret in the pod's namespace
-                        properties:
-                          key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
-                            type: boolean
-                        required:
-                        - key
+                        - nodeSelectorTerms
                         type: object
                     type: object
-                required:
-                - name
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
                 type: object
-              type: array
-            mattermostLicenseSecret:
-              description: Secret that contains the mattermost license
-              type: string
-            minio:
-              description: Minio defines the configuration of Minio for a ClusterInstallation.
-              properties:
-                externalBucket:
-                  description: Set to the bucket name of your external MinIO or S3.
-                  type: string
-                externalURL:
-                  description: Set to use an external MinIO deployment or S3. Must
-                    also set 'Secret' and 'ExternalBucket'.
-                  type: string
-                replicas:
-                  description: 'Defines the number of Minio replicas. Supply 1 to
-                    run Minio in standalone mode with no redundancy. Supply 4 or more
-                    to run Minio in distributed mode. Note that it is not possible
-                    to upgrade Minio from standalone to distributed mode. Setting
-                    this will override the number of replicas set by ''Size''. More
-                    info: https://docs.min.io/docs/distributed-minio-quickstart-guide.html'
-                  format: int32
-                  type: integer
-                resources:
-                  description: Defines the resource requests and limits for the Minio
-                    pods.
-                  properties:
-                    limits:
-                      additionalProperties:
+              blueGreen:
+                description: BlueGreen defines the configuration of BlueGreen deployment
+                  for a ClusterInstallation
+                properties:
+                  blue:
+                    description: Blue defines the blue deployment.
+                    properties:
+                      image:
+                        description: Image defines the base Docker image that will
+                          be used for the deployment. Required when BlueGreen or Canary
+                          is enabled.
                         type: string
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
+                      ingressName:
+                        description: IngressName defines the ingress name that will
+                          be used by the deployment. This option is not used for Canary
+                          builds.
                         type: string
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                secret:
-                  description: 'Optionally enter the name of already existing secret.
-                    Secret should have two values: "accesskey" and "secretkey". Required
-                    when "ExternalURL" is set.'
-                  type: string
-                storageSize:
-                  description: Defines the storage size for Minio. ie 50Gi
-                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                  type: string
-              type: object
-            nodeSelector:
-              additionalProperties:
-                type: string
-              description: 'NodeSelector is a selector which must be true for the
-                pod to fit on a node. Selector which must match a node''s labels for
-                the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
-              type: object
-            readinessProbe:
-              description: Defines the probe to check if the application is ready
-                to accept traffic.
-              properties:
-                exec:
-                  description: One and only one of the following should be specified.
-                    Exec specifies the action to take.
-                  properties:
-                    command:
-                      description: Command is the command line to execute inside the
-                        container, the working directory for the command  is root
-                        ('/') in the container's filesystem. The command is simply
-                        exec'd, it is not run inside a shell, so traditional shell
-                        instructions ('|', etc) won't work. To use a shell, you need
-                        to explicitly call out to that shell. Exit status of 0 is
-                        treated as live/healthy and non-zero is unhealthy.
-                      items:
+                      name:
+                        description: Name defines the name of the deployment
                         type: string
-                      type: array
-                  type: object
-                failureThreshold:
-                  description: Minimum consecutive failures for the probe to be considered
-                    failed after having succeeded. Defaults to 3. Minimum value is
-                    1.
-                  format: int32
-                  type: integer
-                httpGet:
-                  description: HTTPGet specifies the http request to perform.
-                  properties:
-                    host:
-                      description: Host name to connect to, defaults to the pod IP.
-                        You probably want to set "Host" in httpHeaders instead.
-                      type: string
-                    httpHeaders:
-                      description: Custom headers to set in the request. HTTP allows
-                        repeated headers.
-                      items:
-                        description: HTTPHeader describes a custom header to be used
-                          in HTTP probes
-                        properties:
-                          name:
-                            description: The header field name
-                            type: string
-                          value:
-                            description: The header field value
-                            type: string
-                        required:
-                        - name
-                        - value
+                      resourceLabels:
+                        additionalProperties:
+                          type: string
                         type: object
-                      type: array
-                    path:
-                      description: Path to access on the HTTP server.
-                      type: string
-                    port:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: Name or number of the port to access on the container.
-                        Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                      x-kubernetes-int-or-string: true
-                    scheme:
-                      description: Scheme to use for connecting to the host. Defaults
-                        to HTTP.
-                      type: string
-                  required:
-                  - port
-                  type: object
-                initialDelaySeconds:
-                  description: 'Number of seconds after the container has started
-                    before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                  format: int32
-                  type: integer
-                periodSeconds:
-                  description: How often (in seconds) to perform the probe. Default
-                    to 10 seconds. Minimum value is 1.
-                  format: int32
-                  type: integer
-                successThreshold:
-                  description: Minimum consecutive successes for the probe to be considered
-                    successful after having failed. Defaults to 1. Must be 1 for liveness
-                    and startup. Minimum value is 1.
-                  format: int32
-                  type: integer
-                tcpSocket:
-                  description: 'TCPSocket specifies an action involving a TCP port.
-                    TCP hooks not yet supported TODO: implement a realistic TCP lifecycle
-                    hook'
+                      version:
+                        description: Version defines the Docker image version that
+                          will be used for the deployment. Required when BlueGreen
+                          or Canary is enabled.
+                        type: string
+                    type: object
+                  enable:
+                    description: Enable defines if BlueGreen deployment will be applied.
+                    type: boolean
+                  green:
+                    description: Green defines the green deployment.
+                    properties:
+                      image:
+                        description: Image defines the base Docker image that will
+                          be used for the deployment. Required when BlueGreen or Canary
+                          is enabled.
+                        type: string
+                      ingressName:
+                        description: IngressName defines the ingress name that will
+                          be used by the deployment. This option is not used for Canary
+                          builds.
+                        type: string
+                      name:
+                        description: Name defines the name of the deployment
+                        type: string
+                      resourceLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      version:
+                        description: Version defines the Docker image version that
+                          will be used for the deployment. Required when BlueGreen
+                          or Canary is enabled.
+                        type: string
+                    type: object
+                  productionDeployment:
+                    description: ProductionDeployment defines if the current production
+                      is blue or green.
+                    type: string
+                type: object
+              canary:
+                description: Canary defines the configuration of Canary deployment
+                  for a ClusterInstallation
+                properties:
+                  deployment:
+                    description: Deployment defines the canary deployment.
+                    properties:
+                      image:
+                        description: Image defines the base Docker image that will
+                          be used for the deployment. Required when BlueGreen or Canary
+                          is enabled.
+                        type: string
+                      ingressName:
+                        description: IngressName defines the ingress name that will
+                          be used by the deployment. This option is not used for Canary
+                          builds.
+                        type: string
+                      name:
+                        description: Name defines the name of the deployment
+                        type: string
+                      resourceLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      version:
+                        description: Version defines the Docker image version that
+                          will be used for the deployment. Required when BlueGreen
+                          or Canary is enabled.
+                        type: string
+                    type: object
+                  enable:
+                    description: Enable defines if a canary build will be deployed.
+                    type: boolean
+                type: object
+              database:
+                description: Database defines the database configuration for a ClusterInstallation.
+                properties:
+                  backupRemoteDeletePolicy:
+                    description: Defines the backup retention policy.
+                    type: string
+                  backupRestoreSecretName:
+                    description: Defines the secret to be used when performing a database
+                      restore.
+                    type: string
+                  backupSchedule:
+                    description: Defines the interval for backups in cron expression
+                      format.
+                    type: string
+                  backupSecretName:
+                    description: Defines the secret to be used for uploading/restoring
+                      backup.
+                    type: string
+                  backupURL:
+                    description: Defines the object storage url for uploading backups.
+                    type: string
+                  initBucketURL:
+                    description: Defines the AWS S3 bucket where the Database Backup
+                      is stored. The operator will download the file to restore the
+                      data.
+                    type: string
+                  replicas:
+                    description: Defines the number of database replicas. For redundancy
+                      use at least 2 replicas. Setting this will override the number
+                      of replicas set by 'Size'.
+                    format: int32
+                    type: integer
+                  resources:
+                    description: Defines the resource requests and limits for the
+                      database pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  secret:
+                    description: "Optionally enter the name of an already-existing
+                      Secret for connecting to the database. This secret should be
+                      configured as follows: \n User-Managed Database   - Key: DB_CONNECTION_STRING
+                      | Value: <FULL_DATABASE_CONNECTION_STRING> Operator-Managed
+                      Database   - Key: ROOT_PASSWORD | Value: <ROOT_DATABASE_PASSWORD>
+                      \  - Key: USER | Value: <USER_NAME>   - Key: PASSWORD | Value:
+                      <USER_PASSWORD>   - Key: DATABASE Value: <DATABASE_NAME> \n
+                      Notes:   If you define all secret values for both User-Managed
+                      and   Operator-Managed database types, the User-Managed connection
+                      string will   take precedence and the Operator-Managed values
+                      will be ignored. If the   secret is left blank, the default
+                      behavior is to use an Operator-Managed   database with strong
+                      randomly-generated database credentials."
+                    type: string
+                  storageSize:
+                    description: Defines the storage size for the database. ie 50Gi
+                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                    type: string
+                  type:
+                    description: Defines the type of database to use for an Operator-Managed
+                      database. This value is ignored when using a User-Managed database.
+                    type: string
+                type: object
+              elasticSearch:
+                description: ElasticSearch defines the ElasticSearch configuration
+                  for a ClusterInstallation.
+                properties:
+                  host:
+                    type: string
+                  password:
+                    type: string
+                  username:
+                    type: string
+                type: object
+              image:
+                description: Image defines the ClusterInstallation Docker image.
+                type: string
+              ingressAnnotations:
+                additionalProperties:
+                  type: string
+                type: object
+              ingressName:
+                description: IngressName defines the name to be used when creating
+                  the ingress rules
+                type: string
+              livenessProbe:
+                description: Defines the probe to check if the application is up and
+                  running.
+                properties:
+                  exec:
+                    description: One and only one of the following should be specified.
+                      Exec specifies the action to take.
+                    properties:
+                      command:
+                        description: Command is the command line to execute inside
+                          the container, the working directory for the command  is
+                          root ('/') in the container's filesystem. The command is
+                          simply exec'd, it is not run inside a shell, so traditional
+                          shell instructions ('|', etc) won't work. To use a shell,
+                          you need to explicitly call out to that shell. Exit status
+                          of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded. Defaults to 3. Minimum
+                      value is 1.
+                    format: int32
+                    type: integer
+                  httpGet:
+                    description: HTTPGet specifies the http request to perform.
+                    properties:
+                      host:
+                        description: Host name to connect to, defaults to the pod
+                          IP. You probably want to set "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: The header field name
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: Scheme to use for connecting to the host. Defaults
+                          to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe. Default
+                      to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed. Defaults to 1. Must
+                      be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: 'TCPSocket specifies an action involving a TCP port.
+                      TCP hooks not yet supported TODO: implement a realistic TCP
+                      lifecycle hook'
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  timeoutSeconds:
+                    description: 'Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                type: object
+              mattermostEnv:
+                description: Optional environment variables to set in the Mattermost
+                  application pods.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
                   properties:
-                    host:
-                      description: 'Optional: Host name to connect to, defaults to
-                        the pod IP.'
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
-                    port:
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previous defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                        $$(VAR_NAME). Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, metadata.labels, metadata.annotations,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              mattermostLicenseSecret:
+                description: Secret that contains the mattermost license
+                type: string
+              minio:
+                description: Minio defines the configuration of Minio for a ClusterInstallation.
+                properties:
+                  externalBucket:
+                    description: Set to the bucket name of your external MinIO or
+                      S3.
+                    type: string
+                  externalURL:
+                    description: Set to use an external MinIO deployment or S3. Must
+                      also set 'Secret' and 'ExternalBucket'.
+                    type: string
+                  replicas:
+                    description: 'Defines the number of Minio replicas. Supply 1 to
+                      run Minio in standalone mode with no redundancy. Supply 4 or
+                      more to run Minio in distributed mode. Note that it is not possible
+                      to upgrade Minio from standalone to distributed mode. Setting
+                      this will override the number of replicas set by ''Size''. More
+                      info: https://docs.min.io/docs/distributed-minio-quickstart-guide.html'
+                    format: int32
+                    type: integer
+                  resources:
+                    description: Defines the resource requests and limits for the
+                      Minio pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  secret:
+                    description: 'Optionally enter the name of already existing secret.
+                      Secret should have two values: "accesskey" and "secretkey".
+                      Required when "ExternalURL" is set.'
+                    type: string
+                  storageSize:
+                    description: Defines the storage size for Minio. ie 50Gi
+                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                    type: string
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: 'NodeSelector is a selector which must be true for the
+                  pod to fit on a node. Selector which must match a node''s labels
+                  for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                type: object
+              readinessProbe:
+                description: Defines the probe to check if the application is ready
+                  to accept traffic.
+                properties:
+                  exec:
+                    description: One and only one of the following should be specified.
+                      Exec specifies the action to take.
+                    properties:
+                      command:
+                        description: Command is the command line to execute inside
+                          the container, the working directory for the command  is
+                          root ('/') in the container's filesystem. The command is
+                          simply exec'd, it is not run inside a shell, so traditional
+                          shell instructions ('|', etc) won't work. To use a shell,
+                          you need to explicitly call out to that shell. Exit status
+                          of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded. Defaults to 3. Minimum
+                      value is 1.
+                    format: int32
+                    type: integer
+                  httpGet:
+                    description: HTTPGet specifies the http request to perform.
+                    properties:
+                      host:
+                        description: Host name to connect to, defaults to the pod
+                          IP. You probably want to set "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: The header field name
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: Scheme to use for connecting to the host. Defaults
+                          to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe. Default
+                      to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed. Defaults to 1. Must
+                      be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: 'TCPSocket specifies an action involving a TCP port.
+                      TCP hooks not yet supported TODO: implement a realistic TCP
+                      lifecycle hook'
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  timeoutSeconds:
+                    description: 'Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                type: object
+              replicas:
+                description: Replicas defines the number of replicas to use for the
+                  Mattermost app servers. Setting this will override the number of
+                  replicas set by 'Size'.
+                format: int32
+                type: integer
+              resourceLabels:
+                additionalProperties:
+                  type: string
+                type: object
+              resources:
+                description: Defines the resource requests and limits for the Mattermost
+                  app server pods.
+                properties:
+                  limits:
+                    additionalProperties:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Number or name of the port to access on the container.
-                        Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                  required:
-                  - port
-                  type: object
-                timeoutSeconds:
-                  description: 'Number of seconds after which the probe times out.
-                    Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                  format: int32
-                  type: integer
-              type: object
-            replicas:
-              description: Replicas defines the number of replicas to use for the
-                Mattermost app servers. Setting this will override the number of replicas
-                set by 'Size'.
-              format: int32
-              type: integer
-            resourceLabels:
-              additionalProperties:
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              serviceAnnotations:
+                additionalProperties:
+                  type: string
+                type: object
+              size:
+                description: 'Size defines the size of the ClusterInstallation. This
+                  is typically specified in number of users. This will override replica
+                  and resource requests/limits appropriately for the provided number
+                  of users. This is a write-only field - its value is erased after
+                  setting appropriate values of resources. Accepted values are: 100users,
+                  1000users, 5000users, 10000users, 250000users. If replicas and resource
+                  requests/limits are not specified, and Size is not provided the
+                  configuration for 5000users will be applied. Setting ''Replicas'',
+                  ''Resources'', ''Minio.Replicas'', ''Minio.Resource'', ''Database.Replicas'',
+                  or ''Database.Resources'' will override the values set by Size.
+                  Setting new Size will override previous values regardless if set
+                  by Size or manually.'
                 type: string
-              type: object
-            resources:
-              description: Defines the resource requests and limits for the Mattermost
-                app server pods.
-              properties:
-                limits:
-                  additionalProperties:
-                    type: string
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    type: string
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            serviceAnnotations:
-              additionalProperties:
+              startupProbe:
+                description: Defines the probe to check if the application is up and
+                  running during the start up process.
+                properties:
+                  exec:
+                    description: One and only one of the following should be specified.
+                      Exec specifies the action to take.
+                    properties:
+                      command:
+                        description: Command is the command line to execute inside
+                          the container, the working directory for the command  is
+                          root ('/') in the container's filesystem. The command is
+                          simply exec'd, it is not run inside a shell, so traditional
+                          shell instructions ('|', etc) won't work. To use a shell,
+                          you need to explicitly call out to that shell. Exit status
+                          of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded. Defaults to 3. Minimum
+                      value is 1.
+                    format: int32
+                    type: integer
+                  httpGet:
+                    description: HTTPGet specifies the http request to perform.
+                    properties:
+                      host:
+                        description: Host name to connect to, defaults to the pod
+                          IP. You probably want to set "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: The header field name
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: Scheme to use for connecting to the host. Defaults
+                          to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe. Default
+                      to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed. Defaults to 1. Must
+                      be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: 'TCPSocket specifies an action involving a TCP port.
+                      TCP hooks not yet supported TODO: implement a realistic TCP
+                      lifecycle hook'
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  timeoutSeconds:
+                    description: 'Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                type: object
+              useIngressTLS:
+                type: boolean
+              useServiceLoadBalancer:
+                type: boolean
+              version:
+                description: Version defines the ClusterInstallation Docker image
+                  version.
                 type: string
-              type: object
-            size:
-              description: 'Size defines the size of the ClusterInstallation. This
-                is typically specified in number of users. This will set replica and
-                resource requests/limits appropriately for the provided number of
-                users. Accepted values are: 100users, 1000users, 5000users, 10000users,
-                250000users. Defaults to 5000users. Setting ''Replicas'', ''Resources'',
-                ''Minio.Replicas'', ''Minio.Resource'', ''Database.Replicas'', or
-                ''Database.Resources'' will override the values set by Size.'
-              type: string
-            useIngressTLS:
-              type: boolean
-            useServiceLoadBalancer:
-              type: boolean
-            version:
-              description: Version defines the ClusterInstallation Docker image version.
-              type: string
-          required:
-          - ingressName
-          type: object
-        status:
-          description: 'Most recent observed status of the Mattermost cluster. Read-only.
-            Not included when requesting from the apiserver, only from the Mattermost
-            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
-          properties:
-            blueName:
-              description: The name of the blue deployment in BlueGreen
-              type: string
-            endpoint:
-              description: The endpoint to access the Mattermost instance
-              type: string
-            greenName:
-              description: The name of the green deployment in BlueGreen
-              type: string
-            image:
-              description: The image running on the pods in the Mattermost instance
-              type: string
-            replicas:
-              description: Total number of non-terminated pods targeted by this Mattermost
-                deployment
-              format: int32
-              type: integer
-            state:
-              description: Represents the running state of the Mattermost instance
-              type: string
-            updatedReplicas:
-              description: Total number of non-terminated pods targeted by this Mattermost
-                deployment that are running with the desired image.
-              format: int32
-              type: integer
-            version:
-              description: The version currently running in the Mattermost instance
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+            required:
+            - ingressName
+            type: object
+          status:
+            description: 'Most recent observed status of the Mattermost cluster. Read-only.
+              Not included when requesting from the apiserver, only from the Mattermost
+              Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+            properties:
+              blueName:
+                description: The name of the blue deployment in BlueGreen
+                type: string
+              endpoint:
+                description: The endpoint to access the Mattermost instance
+                type: string
+              greenName:
+                description: The name of the green deployment in BlueGreen
+                type: string
+              image:
+                description: The image running on the pods in the Mattermost instance
+                type: string
+              replicas:
+                description: Total number of non-terminated pods targeted by this
+                  Mattermost deployment
+                format: int32
+                type: integer
+              state:
+                description: Represents the running state of the Mattermost instance
+                type: string
+              updatedReplicas:
+                description: Total number of non-terminated pods targeted by this
+                  Mattermost deployment that are running with the desired image.
+                format: int32
+                type: integer
+              version:
+                description: The version currently running in the Mattermost instance
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/manifests/operator-manifests/mattermost/operator.yaml
+++ b/manifests/operator-manifests/mattermost/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: mattermost-operator
       containers:
         - name: mattermost-operator
-          image: mattermost/mattermost-operator:v1.5.0
+          image: mattermost/mattermost-operator:v1.6.0
           imagePullPolicy: IfNotPresent
           command:
           - mattermost-operator


### PR DESCRIPTION
This new database init check is used to prevent the main Mattermost
app container from starting until a basic database endpoint check
is successful.

To accomplish this, the Mattermost Operator has been updates to
version `1.6.0`.

Fixes https://mattermost.atlassian.net/browse/MM-26765

```release-note
Add database endpoint init check to single tenant databases
```
