### PR TITLE
Use PostgreSQL version 11.7 for new databases

### DIFF
--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -39,6 +39,14 @@ const (
 	// there is no cluster running in the VPC.
 	VpcClusterIDTagValueNone = "none"
 
+	// DefaultDatabaseMySQLVersion is the default version of MySQL used when
+	// creating databases.
+	DefaultDatabaseMySQLVersion = "5.7"
+
+	// DefaultDatabasePostgresVersion is the default version of PostgreSQL used
+	// when creating databases.
+	DefaultDatabasePostgresVersion = "11.7"
+
 	// DefaultDBSubnetGroupName is the default DB subnet group name used when
 	// creating DB clusters. This group name is defined by the owner of the AWS
 	// accounts and can be the same across all accounts.

--- a/internal/tools/aws/rds.go
+++ b/internal/tools/aws/rds.go
@@ -99,11 +99,11 @@ func (a *Client) rdsEnsureDBClusterCreated(awsID, vpcID, username, password, kms
 	switch databaseType {
 	case model.DatabaseEngineTypeMySQL:
 		engine = "aurora-mysql"
-		engineVersion = "5.7"
+		engineVersion = DefaultDatabaseMySQLVersion
 		port = 3306
 	case model.DatabaseEngineTypePostgres:
 		engine = "aurora-postgresql"
-		engineVersion = "9.6.17"
+		engineVersion = DefaultDatabasePostgresVersion
 		port = 5432
 	default:
 		return errors.Errorf("%s is an invalid database engine type", databaseType)


### PR DESCRIPTION
This bumps the version of Postgres used for new single-tenant
databases.

Fixes https://mattermost.atlassian.net/browse/MM-27342

```release-note
Use PostgreSQL version 11.7 for new databases
```
