### PR TITLE
NewFromConfig KubeClient creation option, rename and refactor 'New' to 'NewFromFile'

### DIFF
--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -263,7 +263,7 @@ func (d *helmDeployment) Version() (string, error) {
 
 // helmSetup is used for the initial setup of Helm in cluster.
 func helmSetup(logger log.FieldLogger, kops *kops.Cmd) error {
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to set up the k8s client")
 	}

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -178,7 +178,7 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 	logger.WithField("name", kopsMetadata.Name).Info("Successfully deployed kubernetes")
 
 	logger.WithField("name", kopsMetadata.Name).Info("Updating VolumeBindingMode in default storage class")
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster, aws
 	logger.Info("Provisioning cluster")
 
 	// Begin deploying the mattermost operator.
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return err
 	}
@@ -716,7 +716,7 @@ func (provisioner *KopsProvisioner) GetClusterResources(cluster *model.Cluster, 
 		return nil, errors.Wrap(err, "failed to export kubecfg")
 	}
 
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to construct k8s client")
 	}
@@ -786,7 +786,7 @@ func (provisioner *KopsProvisioner) RefreshKopsMetadata(cluster *model.Cluster) 
 		return errors.Wrap(err, "failed to export kubecfg")
 	}
 
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to construct k8s client")
 	}

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -41,7 +41,7 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 		return errors.Wrap(err, "failed to export kubecfg")
 	}
 
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func (provisioner *KopsProvisioner) HibernateClusterInstallation(cluster *model.
 		return errors.Wrap(err, "failed to export kubecfg")
 	}
 
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to create kubernetes client")
 	}
@@ -230,7 +230,7 @@ func (provisioner *KopsProvisioner) UpdateClusterInstallation(cluster *model.Clu
 		return errors.Wrap(err, "failed to export kubecfg")
 	}
 
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return err
 	}
@@ -359,7 +359,7 @@ func (provisioner *KopsProvisioner) DeleteClusterInstallation(cluster *model.Clu
 		return errors.Wrap(err, "failed to export kubecfg")
 	}
 
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return err
 	}
@@ -419,7 +419,7 @@ func (provisioner *KopsProvisioner) GetClusterInstallationResource(cluster *mode
 		return nil, errors.Wrap(err, "failed to export kubecfg")
 	}
 
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +458,7 @@ func (provisioner *KopsProvisioner) execCLI(cluster *model.Cluster, clusterInsta
 		return nil, errors.Wrap(err, "failed to export kubecfg")
 	}
 
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to construct k8s client")
 	}

--- a/internal/provisioner/kops_utils.go
+++ b/internal/provisioner/kops_utils.go
@@ -92,7 +92,7 @@ func waitForNamespacesDeleted(ctx context.Context, namespaces []string, k8sClien
 
 // getPrivateLoadBalancerEndpoint returns the private load balancer endpoint of the NGINX service.
 func getPrivateLoadBalancerEndpoint(ctx context.Context, namespace string, logger log.FieldLogger, configPath string) (string, error) {
-	k8sClient, err := k8s.New(configPath, logger)
+	k8sClient, err := k8s.NewFromFile(configPath, logger)
 	if err != nil {
 		return "", err
 	}
@@ -138,7 +138,7 @@ func (provisioner *KopsProvisioner) GetPublicLoadBalancerEndpoint(cluster *model
 		return "", errors.Wrap(err, "failed to export kubecfg")
 	}
 
-	k8sClient, err := k8s.New(kops.GetKubeConfigPath(), logger)
+	k8sClient, err := k8s.NewFromFile(kops.GetKubeConfigPath(), logger)
 	if err != nil {
 		return "", err
 	}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -30,7 +30,7 @@ func NewFromConfig(config *rest.Config, logger log.FieldLogger) (*KubeClient, er
 	return createKubeClient(config, logger)
 }
 
-// New returns a new KubeClient for accessing the kubernetes API.
+// NewFromFile returns a new KubeClient for accessing the kubernetes API. (previously named 'New')
 func NewFromFile(configLocation string, logger log.FieldLogger) (*KubeClient, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", configLocation)
 	if err != nil {

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -25,13 +25,22 @@ type KubeClient struct {
 	logger              log.FieldLogger
 }
 
+// NewFromConfig takes in an already created Kubernetes config object, and returns a KubeClient for accessing the kubernetes API
+func NewFromConfig(config *rest.Config, logger log.FieldLogger) (*KubeClient, error) {
+	return createKubeClient(config, logger)
+}
+
 // New returns a new KubeClient for accessing the kubernetes API.
-func New(configLocation string, logger log.FieldLogger) (*KubeClient, error) {
+func NewFromFile(configLocation string, logger log.FieldLogger) (*KubeClient, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", configLocation)
 	if err != nil {
 		return nil, err
 	}
 
+	return createKubeClient(config, logger)
+}
+
+func createKubeClient(config *rest.Config, logger log.FieldLogger) (*KubeClient, error) {
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### Summary
In order to support creation of the KubeClient programmatically (ie, without a .kube/config.json file) needed to add a new creation method that accepts Kubernetes rest.Config structs. In order to not confuse people, I've renamed `New` method to `NewFromFile`, alongside the `NewFromConfig` method. References have been updated. 

#### Ticket Link
n/a

#### Release Note
```release-note
The k8s client `New` method has been renamed to `NewFromFile`. All references will need to be updated.
The k8s client now supports creation of KubeClient objects with a Kubernetes rest.Config
```
