### PR TITLE
rds: fix azs to get at least 2 az

### DIFF
--- a/internal/tools/aws/rds.go
+++ b/internal/tools/aws/rds.go
@@ -6,6 +6,8 @@ package aws
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -114,8 +116,16 @@ func (a *Client) rdsEnsureDBClusterCreated(awsID, vpcID, username, password, kms
 		return err
 	}
 
+	// default to at least 2 AZ
+	rdsAZs := azs[0:2]
+	if len(azs) >= 3 {
+		rand.Seed(time.Now().UnixNano())
+		rand.Shuffle(len(azs), func(i, j int) { azs[i], azs[j] = azs[j], azs[i] })
+		rdsAZs = azs[0:3]
+	}
+
 	input := &rds.CreateDBClusterInput{
-		AvailabilityZones:     azs,
+		AvailabilityZones:     rdsAZs,
 		BackupRetentionPeriod: aws.Int64(7),
 		DBClusterIdentifier:   aws.String(awsID),
 		DatabaseName:          aws.String("mattermost"),


### PR DESCRIPTION
#### Summary
rds: fix azs to get at least 2 az

when creating the RDS we need to have the max of 3 azs

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
