### PR TITLE
k8s: if pod is not found continue the check and assume that was part of the old replicaset

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -357,11 +357,11 @@ func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster, aws
 			logger.Infof("Waiting up to %d seconds for %q pod %q to start...", wait, deployment, pod.GetName())
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(wait)*time.Second)
 			defer cancel()
-			pod, err := k8sClient.WaitForPodRunning(ctx, namespace, pod.GetName())
+			_, err := k8sClient.WaitForPodRunning(ctx, namespace, pod.GetName())
 			if err != nil {
 				return err
 			}
-			logger.Infof("Successfully deployed operator pod %q", pod.Name)
+			logger.Infof("Successfully deployed service pod %q", pod.GetName())
 		}
 	}
 
@@ -384,7 +384,7 @@ func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster, aws
 			if err != nil {
 				return err
 			}
-			logger.Infof("Successfully deployed operator pod %q", pod.Name)
+			logger.Infof("Successfully deployed service pod %q", pod.GetName())
 		}
 	}
 
@@ -407,7 +407,7 @@ func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster, aws
 			if err != nil {
 				return err
 			}
-			logger.Infof("Successfully deployed support apps pod %q", pod.Name)
+			logger.Infof("Successfully deployed support apps pod %q", pod.GetName())
 		}
 	}
 


### PR DESCRIPTION
#### Summary
During the reprovision on the k8s cluster we notice sometimes some deployments get stuck in the `WaitForPodRunning` because we apply all the manifests and right away start checking if the deployment was successful, but to check that we get a list of the pods running for a specific deployment.

In some cases, after we apply the manifest, the deployment can have the pods running for the old version and for the new version. And then, the provisioned get all of those, and we have the provision failed because some pods will get in a delete state and not running (since they are from an old version) and the function does not check that.

test in a cluster and reprovisioned several times and not errors any more


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
k8s: if pod is not found continue the check and assume that was part of the old replicaset
```
