### PR TITLE
Add cloud resource API security locking

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -17,7 +17,7 @@ import (
 )
 
 func init() {
-	clusterCmd.PersistentFlags().String("server", "http://localhost:8075", "The provisioning server whose API will be queried.")
+	clusterCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
 
 	clusterCreateCmd.Flags().String("provider", "aws", "Cloud provider hosting the cluster.")
 	clusterCreateCmd.Flags().String("version", "latest", "The Kubernetes version to target. Use 'latest' or versions such as '1.16.10'.")

--- a/cmd/cloud/cluster_installation.go
+++ b/cmd/cloud/cluster_installation.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	clusterInstallationCmd.PersistentFlags().String("server", "http://localhost:8075", "The provisioning server whose API will be queried.")
+	clusterInstallationCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
 
 	clusterInstallationGetCmd.Flags().String("cluster-installation", "", "The id of the cluster installation to be fetched.")
 	clusterInstallationGetCmd.MarkFlagRequired("cluster-installation")

--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	groupCmd.PersistentFlags().String("server", "http://localhost:8075", "The provisioning server whose API will be queried.")
+	groupCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
 
 	groupCreateCmd.Flags().String("name", "", "A unique name describing this group of installations.")
 	groupCreateCmd.Flags().String("description", "", "An optional description for this group of installations.")

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	installationCmd.PersistentFlags().String("server", "http://localhost:8075", "The provisioning server whose API will be queried.")
+	installationCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
 
 	installationCreateCmd.Flags().String("owner", "", "An opaque identifier describing the owner of the installation.")
 	installationCreateCmd.Flags().String("group", "", "The id of the group to join")

--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -30,6 +30,7 @@ func init() {
 	rootCmd.AddCommand(groupCmd)
 	rootCmd.AddCommand(schemaCmd)
 	rootCmd.AddCommand(webhookCmd)
+	rootCmd.AddCommand(securityCmd)
 	rootCmd.AddCommand(workbenchCmd)
 	rootCmd.AddCommand(completionCmd)
 }

--- a/cmd/cloud/security.go
+++ b/cmd/cloud/security.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	securityCmd.PersistentFlags().String("server", "http://localhost:8075", "The provisioning server whose API will be queried.")
+
+	securityClusterCmd.PersistentFlags().String("cluster", "", "The id of the cluster.")
+	securityClusterCmd.MarkPersistentFlagRequired("cluster")
+
+	securityInstallationCmd.PersistentFlags().String("installation", "", "The id of the installation.")
+	securityInstallationCmd.MarkPersistentFlagRequired("installation")
+
+	securityClusterInstallationCmd.PersistentFlags().String("cluster-installation", "", "The id of the cluster installation.")
+	securityClusterInstallationCmd.MarkPersistentFlagRequired("cluster-installation")
+
+	securityGroupCmd.PersistentFlags().String("group", "", "The id of the group.")
+	securityGroupCmd.MarkPersistentFlagRequired("group")
+
+	securityCmd.AddCommand(securityClusterCmd)
+	securityClusterCmd.AddCommand(securityClusterLockAPICmd)
+	securityClusterCmd.AddCommand(securityClusterUnlockAPICmd)
+
+	securityCmd.AddCommand(securityInstallationCmd)
+	securityInstallationCmd.AddCommand(securityInstallationLockAPICmd)
+	securityInstallationCmd.AddCommand(securityInstallationUnlockAPICmd)
+
+	securityCmd.AddCommand(securityClusterInstallationCmd)
+	securityClusterInstallationCmd.AddCommand(securityClusterInstallationLockAPICmd)
+	securityClusterInstallationCmd.AddCommand(securityClusterInstallationUnlockAPICmd)
+
+	securityCmd.AddCommand(securityGroupCmd)
+	securityGroupCmd.AddCommand(securityGroupLockAPICmd)
+	securityGroupCmd.AddCommand(securityGroupUnlockAPICmd)
+}
+
+var securityCmd = &cobra.Command{
+	Use:   "security",
+	Short: "Manage security locks for different cloud resources.",
+}
+
+var securityClusterCmd = &cobra.Command{
+	Use:   "cluster",
+	Short: "Manage security locks for cluster resources.",
+}
+
+var securityClusterLockAPICmd = &cobra.Command{
+	Use:   "api-lock",
+	Short: "Lock API changes on a given cluster",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		clusterID, _ := command.Flags().GetString("cluster")
+		err := client.LockAPIForCluster(clusterID)
+		if err != nil {
+			return errors.Wrap(err, "failed to lock cluster API")
+		}
+
+		return nil
+	},
+}
+
+var securityClusterUnlockAPICmd = &cobra.Command{
+	Use:   "api-unlock",
+	Short: "Unlock API changes on a given cluster",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		clusterID, _ := command.Flags().GetString("cluster")
+		err := client.UnlockAPIForCluster(clusterID)
+		if err != nil {
+			return errors.Wrap(err, "failed to unlock cluster API")
+		}
+
+		return nil
+	},
+}
+
+var securityInstallationCmd = &cobra.Command{
+	Use:   "installation",
+	Short: "Manage security locks for installation resources.",
+}
+
+var securityInstallationLockAPICmd = &cobra.Command{
+	Use:   "api-lock",
+	Short: "Lock API changes on a given installation",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		installationID, _ := command.Flags().GetString("installation")
+		err := client.LockAPIForInstallation(installationID)
+		if err != nil {
+			return errors.Wrap(err, "failed to lock installation API")
+		}
+
+		return nil
+	},
+}
+
+var securityInstallationUnlockAPICmd = &cobra.Command{
+	Use:   "api-unlock",
+	Short: "Unlock API changes on a given installation",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		installationID, _ := command.Flags().GetString("installation")
+		err := client.UnlockAPIForInstallation(installationID)
+		if err != nil {
+			return errors.Wrap(err, "failed to unlock installation API")
+		}
+
+		return nil
+	},
+}
+
+var securityClusterInstallationCmd = &cobra.Command{
+	Use:   "cluster-installation",
+	Short: "Manage security locks for cluster installation resources.",
+}
+
+var securityClusterInstallationLockAPICmd = &cobra.Command{
+	Use:   "api-lock",
+	Short: "Lock API changes on a given cluster installation",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		clusterInstallationID, _ := command.Flags().GetString("cluster-installation")
+		err := client.LockAPIForClusterInstallation(clusterInstallationID)
+		if err != nil {
+			return errors.Wrap(err, "failed to lock cluster installation API")
+		}
+
+		return nil
+	},
+}
+
+var securityClusterInstallationUnlockAPICmd = &cobra.Command{
+	Use:   "api-unlock",
+	Short: "Unlock API changes on a given cluster installation",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		clusterInstallationID, _ := command.Flags().GetString("cluster-installation")
+		err := client.UnlockAPIForClusterInstallation(clusterInstallationID)
+		if err != nil {
+			return errors.Wrap(err, "failed to unlock cluster installation API")
+		}
+
+		return nil
+	},
+}
+
+var securityGroupCmd = &cobra.Command{
+	Use:   "group",
+	Short: "Manage security locks for group resources.",
+}
+
+var securityGroupLockAPICmd = &cobra.Command{
+	Use:   "api-lock",
+	Short: "Lock API changes on a given group",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		groupID, _ := command.Flags().GetString("group")
+		err := client.LockAPIForGroup(groupID)
+		if err != nil {
+			return errors.Wrap(err, "failed to lock group API")
+		}
+
+		return nil
+	},
+}
+
+var securityGroupUnlockAPICmd = &cobra.Command{
+	Use:   "api-unlock",
+	Short: "Unlock API changes on a given group",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		groupID, _ := command.Flags().GetString("group")
+		err := client.UnlockAPIForGroup(groupID)
+		if err != nil {
+			return errors.Wrap(err, "failed to unlock group API")
+		}
+
+		return nil
+	},
+}

--- a/cmd/cloud/security.go
+++ b/cmd/cloud/security.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	securityCmd.PersistentFlags().String("server", "http://localhost:8075", "The provisioning server whose API will be queried.")
+	securityCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
 
 	securityClusterCmd.PersistentFlags().String("cluster", "", "The id of the cluster.")
 	securityClusterCmd.MarkPersistentFlagRequired("cluster")

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -29,8 +29,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// clusterRootDir is the local directory that contains cluster configuration.
-const clusterRootDir = "clusters"
+const (
+	clusterRootDir        = "clusters"
+	defaultLocalServerAPI = "http://localhost:8075"
+)
 
 var instanceID string
 

--- a/cmd/cloud/webhook.go
+++ b/cmd/cloud/webhook.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	webhookCmd.PersistentFlags().String("server", "http://localhost:8075", "The provisioning server whose API will be queried.")
+	webhookCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
 
 	webhookCreateCmd.Flags().String("owner", "", "An opaque identifier describing the owner of the webhook.")
 	webhookCreateCmd.Flags().String("url", "", "The callback URL of the webhook.")

--- a/cmd/cloud/workbench.go
+++ b/cmd/cloud/workbench.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	workbenchCmd.PersistentFlags().String("server", "http://localhost:8075", "The provisioning server whose API will be queried.")
+	workbenchCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
 	workbenchCmd.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
 
 	workbenchClusterCmd.Flags().String("cluster", "", "The id of the cluster to work on.")

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -15,4 +15,5 @@ func Register(rootRouter *mux.Router, context *Context) {
 	initClusterInstallation(apiRouter, context)
 	initGroup(apiRouter, context)
 	initWebhook(apiRouter, context)
+	initSecurity(apiRouter, context)
 }

--- a/internal/api/cluster_installation.go
+++ b/internal/api/cluster_installation.go
@@ -158,6 +158,12 @@ func handleSetClusterInstallationConfig(c *Context, w http.ResponseWriter, r *ht
 		return
 	}
 
+	if clusterInstallation.APISecurityLock {
+		logSecurityLockConflict("cluster-installation", c.Logger)
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
 	cluster, err := c.Store.GetCluster(clusterInstallation.ClusterID)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to query cluster")
@@ -251,6 +257,12 @@ func handleRunClusterInstallationMattermostCLI(c *Context, w http.ResponseWriter
 	if clusterInstallation.IsDeleted() {
 		c.Logger.Error("cluster installation is deleted")
 		w.WriteHeader(http.StatusGone)
+		return
+	}
+
+	if clusterInstallation.APISecurityLock {
+		logSecurityLockConflict("cluster-installation", c.Logger)
+		w.WriteHeader(http.StatusForbidden)
 		return
 	}
 

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -23,6 +23,8 @@ type Store interface {
 	UpdateCluster(cluster *model.Cluster) error
 	LockCluster(clusterID, lockerID string) (bool, error)
 	UnlockCluster(clusterID, lockerID string, force bool) (bool, error)
+	LockClusterAPI(clusterID string) error
+	UnlockClusterAPI(clusterID string) error
 	DeleteCluster(clusterID string) error
 
 	CreateInstallation(installation *model.Installation) error
@@ -31,10 +33,14 @@ type Store interface {
 	UpdateInstallation(installation *model.Installation) error
 	LockInstallation(installationID, lockerID string) (bool, error)
 	UnlockInstallation(installationID, lockerID string, force bool) (bool, error)
+	LockInstallationAPI(installationID string) error
+	UnlockInstallationAPI(installationID string) error
 	DeleteInstallation(installationID string) error
 
 	GetClusterInstallation(clusterInstallationID string) (*model.ClusterInstallation, error)
 	GetClusterInstallations(filter *model.ClusterInstallationFilter) ([]*model.ClusterInstallation, error)
+	LockClusterInstallationAPI(clusterInstallationID string) error
+	UnlockClusterInstallationAPI(clusterInstallationID string) error
 
 	CreateGroup(group *model.Group) error
 	GetGroup(groupID string) (*model.Group, error)
@@ -42,6 +48,8 @@ type Store interface {
 	UpdateGroup(group *model.Group) error
 	LockGroup(groupID, lockerID string) (bool, error)
 	UnlockGroup(groupID, lockerID string, force bool) (bool, error)
+	LockGroupAPI(groupID string) error
+	UnlockGroupAPI(groupID string) error
 	DeleteGroup(groupID string) error
 
 	CreateWebhook(webhook *model.Webhook) error

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -9,7 +9,12 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
+
+func logSecurityLockConflict(resourceType string, logger logrus.FieldLogger) {
+	logger.WithField("api-security-lock-conflict", resourceType).Warn("API security lock conflict detected")
+}
 
 func parseInt(u *url.URL, name string, defaultValue int) (int, error) {
 	valueStr := u.Query().Get(name)

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -591,6 +591,22 @@ func TestUpdateInstallation(t *testing.T) {
 		require.Nil(t, installationReponse)
 	})
 
+	t.Run("while api-security-locked", func(t *testing.T) {
+		err = sqlStore.LockInstallationAPI(installation1.ID)
+		require.NoError(t, err)
+
+		upgradeRequest := &model.PatchInstallationRequest{
+			Version: sToP(model.NewID()),
+			License: sToP(model.NewID()),
+		}
+		installationResponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
+		require.EqualError(t, err, "failed with status code 403")
+		require.Nil(t, installationResponse)
+
+		err = sqlStore.UnlockInstallationAPI(installation1.ID)
+		require.NoError(t, err)
+	})
+
 	t.Run("while upgrading", func(t *testing.T) {
 		installation1.State = model.InstallationStateUpdateRequested
 		err = sqlStore.UpdateInstallation(installation1)
@@ -600,7 +616,7 @@ func TestUpdateInstallation(t *testing.T) {
 			Version: sToP(model.NewID()),
 			License: sToP(model.NewID()),
 		}
-		installationReponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
+		installationResponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
 		require.NoError(t, err)
 
 		installation1, err = client.GetInstallation(installation1.ID, nil)
@@ -608,7 +624,7 @@ func TestUpdateInstallation(t *testing.T) {
 		require.Equal(t, model.InstallationStateUpdateRequested, installation1.State)
 		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
 		require.Equal(t, "mattermost/mattermost-enterprise-edition", installation1.Image)
-		require.Equal(t, installationReponse, installation1)
+		require.Equal(t, installationResponse, installation1)
 	})
 
 	t.Run("after upgrade failed", func(t *testing.T) {
@@ -620,14 +636,14 @@ func TestUpdateInstallation(t *testing.T) {
 			Version: sToP(model.NewID()),
 			License: sToP(model.NewID()),
 		}
-		installationReponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
+		installationResponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
 		require.NoError(t, err)
 
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpdateRequested, installation1.State)
 		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
-		require.Equal(t, installationReponse, installation1)
+		require.Equal(t, installationResponse, installation1)
 	})
 
 	t.Run("while stable", func(t *testing.T) {
@@ -639,14 +655,14 @@ func TestUpdateInstallation(t *testing.T) {
 			Version: sToP(model.NewID()),
 			License: sToP(model.NewID()),
 		}
-		installationReponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
+		installationResponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
 		require.NoError(t, err)
 
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpdateRequested, installation1.State)
 		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
-		require.Equal(t, installationReponse, installation1)
+		require.Equal(t, installationResponse, installation1)
 	})
 
 	t.Run("after deletion failed", func(t *testing.T) {
@@ -658,9 +674,9 @@ func TestUpdateInstallation(t *testing.T) {
 			Version: sToP(model.NewID()),
 			License: sToP(model.NewID()),
 		}
-		installationReponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
+		installationResponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
 		require.EqualError(t, err, "failed with status code 400")
-		require.Nil(t, installationReponse)
+		require.Nil(t, installationResponse)
 	})
 
 	t.Run("while deleting", func(t *testing.T) {
@@ -672,9 +688,9 @@ func TestUpdateInstallation(t *testing.T) {
 			Version: sToP(model.NewID()),
 			License: sToP(model.NewID()),
 		}
-		installationReponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
+		installationResponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
 		require.EqualError(t, err, "failed with status code 400")
-		require.Nil(t, installationReponse)
+		require.Nil(t, installationResponse)
 	})
 
 	t.Run("to version with embedded slash", func(t *testing.T) {
@@ -686,14 +702,14 @@ func TestUpdateInstallation(t *testing.T) {
 			Version: sToP("mattermost/mattermost-enterprise:v5.12"),
 			License: sToP(model.NewID()),
 		}
-		installationReponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
+		installationResponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
 		require.NoError(t, err)
 
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpdateRequested, installation1.State)
 		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
-		require.Equal(t, installationReponse, installation1)
+		require.Equal(t, installationResponse, installation1)
 	})
 
 	t.Run("to invalid size", func(t *testing.T) {
@@ -704,9 +720,9 @@ func TestUpdateInstallation(t *testing.T) {
 		upgradeRequest := &model.PatchInstallationRequest{
 			Size: sToP(model.NewID()),
 		}
-		installationReponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
+		installationResponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
 		require.EqualError(t, err, "failed with status code 400")
-		require.Nil(t, installationReponse)
+		require.Nil(t, installationResponse)
 	})
 
 	t.Run("installation record updated", func(t *testing.T) {
@@ -719,14 +735,14 @@ func TestUpdateInstallation(t *testing.T) {
 			License: sToP(model.NewID()),
 			Size:    sToP("miniSingleton"),
 		}
-		installationReponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
+		installationResponse, err := client.UpdateInstallation(installation1.ID, upgradeRequest)
 		require.NoError(t, err)
 
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpdateRequested, installation1.State)
 		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
-		require.Equal(t, installationReponse, installation1)
+		require.Equal(t, installationResponse, installation1)
 	})
 
 	t.Run("empty update request", func(t *testing.T) {
@@ -735,14 +751,14 @@ func TestUpdateInstallation(t *testing.T) {
 		require.NoError(t, err)
 
 		updateRequest := &model.PatchInstallationRequest{}
-		installationReponse, err := client.UpdateInstallation(installation1.ID, updateRequest)
+		installationResponse, err := client.UpdateInstallation(installation1.ID, updateRequest)
 		require.NoError(t, err)
 
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateStable, installation1.State)
 		ensureInstallationMatchesRequest(t, installation1, updateRequest)
-		require.Equal(t, installationReponse, installation1)
+		require.Equal(t, installationResponse, installation1)
 	})
 }
 
@@ -807,6 +823,17 @@ func TestJoinGroup(t *testing.T) {
 
 		err = client.JoinGroup(group1.ID, installation1.ID)
 		require.EqualError(t, err, "failed with status code 409")
+	})
+
+	t.Run("while api-security-locked", func(t *testing.T) {
+		err = sqlStore.LockInstallationAPI(installation1.ID)
+		require.NoError(t, err)
+
+		err = client.JoinGroup(group1.ID, installation1.ID)
+		require.EqualError(t, err, "failed with status code 403")
+
+		err = sqlStore.UnlockInstallationAPI(installation1.ID)
+		require.NoError(t, err)
 	})
 
 	t.Run("to group 1", func(t *testing.T) {
@@ -913,6 +940,17 @@ func TestLeaveGroup(t *testing.T) {
 		require.EqualError(t, err, "failed with status code 409")
 	})
 
+	t.Run("while api-security-locked", func(t *testing.T) {
+		err = sqlStore.LockInstallationAPI(installation1.ID)
+		require.NoError(t, err)
+
+		err = client.LeaveGroup(installation1.ID, &model.LeaveGroupRequest{RetainConfig: true})
+		require.EqualError(t, err, "failed with status code 403")
+
+		err = sqlStore.UnlockInstallationAPI(installation1.ID)
+		require.NoError(t, err)
+	})
+
 	t.Run("while in group 1", func(t *testing.T) {
 		t.Run("don't retain group config", func(t *testing.T) {
 			oldVersion := installation1.Version
@@ -1010,6 +1048,17 @@ func TestDeleteInstallation(t *testing.T) {
 
 		err = client.DeleteInstallation(installation1.ID)
 		require.EqualError(t, err, "failed with status code 409")
+	})
+
+	t.Run("while api-security-locked", func(t *testing.T) {
+		err = sqlStore.LockInstallationAPI(installation1.ID)
+		require.NoError(t, err)
+
+		err = client.DeleteInstallation(installation1.ID)
+		require.EqualError(t, err, "failed with status code 403")
+
+		err = sqlStore.UnlockInstallationAPI(installation1.ID)
+		require.NoError(t, err)
 	})
 
 	t.Run("while", func(t *testing.T) {

--- a/internal/api/security.go
+++ b/internal/api/security.go
@@ -20,19 +20,19 @@ func initSecurity(apiRouter *mux.Router, context *Context) {
 
 	securityClusterRouter := securityRouter.PathPrefix("/cluster/{cluster:[A-Za-z0-9]{26}}").Subrouter()
 	securityClusterRouter.Handle("/api/lock", addContext(handleClusterLockAPI)).Methods("POST")
-	securityClusterRouter.Handle("/api/unlock", addContext(handleClusterUnockAPI)).Methods("POST")
+	securityClusterRouter.Handle("/api/unlock", addContext(handleClusterUnlockAPI)).Methods("POST")
 
 	securityInstallationRouter := securityRouter.PathPrefix("/installation/{installation:[A-Za-z0-9]{26}}").Subrouter()
 	securityInstallationRouter.Handle("/api/lock", addContext(handleInstallationLockAPI)).Methods("POST")
-	securityInstallationRouter.Handle("/api/unlock", addContext(handleInstallationUnockAPI)).Methods("POST")
+	securityInstallationRouter.Handle("/api/unlock", addContext(handleInstallationUnlockAPI)).Methods("POST")
 
 	securityClusterInstallationRouter := securityRouter.PathPrefix("/cluster_installation/{cluster_installation:[A-Za-z0-9]{26}}").Subrouter()
 	securityClusterInstallationRouter.Handle("/api/lock", addContext(handleClusterInstallationLockAPI)).Methods("POST")
-	securityClusterInstallationRouter.Handle("/api/unlock", addContext(handleClusterInstallationUnockAPI)).Methods("POST")
+	securityClusterInstallationRouter.Handle("/api/unlock", addContext(handleClusterInstallationUnlockAPI)).Methods("POST")
 
 	securityGroupRouter := securityRouter.PathPrefix("/group/{group:[A-Za-z0-9]{26}}").Subrouter()
 	securityGroupRouter.Handle("/api/lock", addContext(handleGroupLockAPI)).Methods("POST")
-	securityGroupRouter.Handle("/api/unlock", addContext(handleGroupUnockAPI)).Methods("POST")
+	securityGroupRouter.Handle("/api/unlock", addContext(handleGroupUnlockAPI)).Methods("POST")
 }
 
 // handleClusterLockAPI responds to POST /api/cluster/{cluster}/api/lock,
@@ -65,9 +65,9 @@ func handleClusterLockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleClusterUnockAPI responds to POST /api/cluster/{cluster}/api/unlock,
+// handleClusterUnlockAPI responds to POST /api/cluster/{cluster}/api/unlock,
 // unlocking API changes for this cluster.
-func handleClusterUnockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+func handleClusterUnlockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	clusterID := vars["cluster"]
 	c.Logger = c.Logger.WithField("cluster", clusterID)
@@ -125,9 +125,9 @@ func handleInstallationLockAPI(c *Context, w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleInstallationUnockAPI responds to POST /api/installation/{installation}/api/unlock,
+// handleInstallationUnlockAPI responds to POST /api/installation/{installation}/api/unlock,
 // unlocking API changes for this installation.
-func handleInstallationUnockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+func handleInstallationUnlockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	installationID := vars["installation"]
 	c.Logger = c.Logger.WithField("installation", installationID)
@@ -185,9 +185,9 @@ func handleClusterInstallationLockAPI(c *Context, w http.ResponseWriter, r *http
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleClusterInstallationUnockAPI responds to POST /api/cluster_installation/{cluster_installation}/api/unlock,
+// handleClusterInstallationUnlockAPI responds to POST /api/cluster_installation/{cluster_installation}/api/unlock,
 // unlocking API changes for this cluster installation.
-func handleClusterInstallationUnockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+func handleClusterInstallationUnlockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	clusterInstallationID := vars["cluster_installation"]
 	c.Logger = c.Logger.WithField("cluster_installation", clusterInstallationID)
@@ -245,9 +245,9 @@ func handleGroupLockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleGroupUnockAPI responds to POST /api/group/{group}/api/unlock,
+// handleGroupUnlockAPI responds to POST /api/group/{group}/api/unlock,
 // unlocking API changes for this group.
-func handleGroupUnockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+func handleGroupUnlockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	groupID := vars["group"]
 	c.Logger = c.Logger.WithField("group", groupID)

--- a/internal/api/security.go
+++ b/internal/api/security.go
@@ -1,0 +1,276 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// initSecurity registers security endpoints on the given router.
+func initSecurity(apiRouter *mux.Router, context *Context) {
+	addContext := func(handler contextHandlerFunc) *contextHandler {
+		return newContextHandler(context, handler)
+	}
+
+	securityRouter := apiRouter.PathPrefix("/security").Subrouter()
+
+	securityClusterRouter := securityRouter.PathPrefix("/cluster/{cluster:[A-Za-z0-9]{26}}").Subrouter()
+	securityClusterRouter.Handle("/api/lock", addContext(handleClusterLockAPI)).Methods("POST")
+	securityClusterRouter.Handle("/api/unlock", addContext(handleClusterUnockAPI)).Methods("POST")
+
+	securityInstallationRouter := securityRouter.PathPrefix("/installation/{installation:[A-Za-z0-9]{26}}").Subrouter()
+	securityInstallationRouter.Handle("/api/lock", addContext(handleInstallationLockAPI)).Methods("POST")
+	securityInstallationRouter.Handle("/api/unlock", addContext(handleInstallationUnockAPI)).Methods("POST")
+
+	securityClusterInstallationRouter := securityRouter.PathPrefix("/cluster_installation/{cluster_installation:[A-Za-z0-9]{26}}").Subrouter()
+	securityClusterInstallationRouter.Handle("/api/lock", addContext(handleClusterInstallationLockAPI)).Methods("POST")
+	securityClusterInstallationRouter.Handle("/api/unlock", addContext(handleClusterInstallationUnockAPI)).Methods("POST")
+
+	securityGroupRouter := securityRouter.PathPrefix("/group/{group:[A-Za-z0-9]{26}}").Subrouter()
+	securityGroupRouter.Handle("/api/lock", addContext(handleGroupLockAPI)).Methods("POST")
+	securityGroupRouter.Handle("/api/unlock", addContext(handleGroupUnockAPI)).Methods("POST")
+}
+
+// handleClusterLockAPI responds to POST /api/cluster/{cluster}/api/lock,
+// locking API changes for this cluster.
+func handleClusterLockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	clusterID := vars["cluster"]
+	c.Logger = c.Logger.WithField("cluster", clusterID)
+
+	cluster, err := c.Store.GetCluster(clusterID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query cluster")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if cluster == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if !cluster.APISecurityLock {
+		err = c.Store.LockClusterAPI(cluster.ID)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to lock cluster API")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleClusterUnockAPI responds to POST /api/cluster/{cluster}/api/unlock,
+// unlocking API changes for this cluster.
+func handleClusterUnockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	clusterID := vars["cluster"]
+	c.Logger = c.Logger.WithField("cluster", clusterID)
+
+	cluster, err := c.Store.GetCluster(clusterID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query cluster")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if cluster == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if cluster.APISecurityLock {
+		err = c.Store.UnlockClusterAPI(cluster.ID)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to unlock cluster API")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleInstallationLockAPI responds to POST /api/installation/{installation}/api/lock,
+// locking API changes for this installation.
+func handleInstallationLockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	installationID := vars["installation"]
+	c.Logger = c.Logger.WithField("installation", installationID)
+
+	installation, err := c.Store.GetInstallation(installationID, false, false)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query installation")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if installation == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if !installation.APISecurityLock {
+		err = c.Store.LockInstallationAPI(installation.ID)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to lock installation API")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleInstallationUnockAPI responds to POST /api/installation/{installation}/api/unlock,
+// unlocking API changes for this installation.
+func handleInstallationUnockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	installationID := vars["installation"]
+	c.Logger = c.Logger.WithField("installation", installationID)
+
+	installation, err := c.Store.GetInstallation(installationID, false, false)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query installation")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if installation == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if installation.APISecurityLock {
+		err = c.Store.UnlockInstallationAPI(installation.ID)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to unlock installation API")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleClusterInstallationLockAPI responds to POST /api/cluster_installation/{cluster_installation}/api/lock,
+// locking API changes for this cluster installation.
+func handleClusterInstallationLockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	clusterInstallationID := vars["cluster_installation"]
+	c.Logger = c.Logger.WithField("cluster_installation", clusterInstallationID)
+
+	clusterInstallation, err := c.Store.GetClusterInstallation(clusterInstallationID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query cluster installation")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if clusterInstallation == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if !clusterInstallation.APISecurityLock {
+		err = c.Store.LockClusterInstallationAPI(clusterInstallation.ID)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to lock cluster installation API")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleClusterInstallationUnockAPI responds to POST /api/cluster_installation/{cluster_installation}/api/unlock,
+// unlocking API changes for this cluster installation.
+func handleClusterInstallationUnockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	clusterInstallationID := vars["cluster_installation"]
+	c.Logger = c.Logger.WithField("cluster_installation", clusterInstallationID)
+
+	clusterInstallation, err := c.Store.GetClusterInstallation(clusterInstallationID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query cluster installation")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if clusterInstallation == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if clusterInstallation.APISecurityLock {
+		err = c.Store.UnlockClusterInstallationAPI(clusterInstallation.ID)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to unlock cluster installation API")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleGroupLockAPI responds to POST /api/group/{group}/api/lock,
+// locking API changes for this group.
+func handleGroupLockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	groupID := vars["group"]
+	c.Logger = c.Logger.WithField("group", groupID)
+
+	group, err := c.Store.GetGroup(groupID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query group")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if group == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if !group.APISecurityLock {
+		err = c.Store.LockGroupAPI(group.ID)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to lock group API")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleGroupUnockAPI responds to POST /api/group/{group}/api/unlock,
+// unlocking API changes for this group.
+func handleGroupUnockAPI(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	groupID := vars["group"]
+	c.Logger = c.Logger.WithField("group", groupID)
+
+	group, err := c.Store.GetGroup(groupID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query group")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if group == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if group.APISecurityLock {
+		err = c.Store.UnlockGroupAPI(group.ID)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to unlock group API")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1046,170 +1046,17 @@ var migrations = []migration{
 			return err
 		}
 
-		_, err = e.Exec(`ALTER TABLE Installation RENAME TO InstallationTemp;`)
+		_, err = e.Exec(`ALTER TABLE Installation ADD COLUMN APISecurityLock BOOLEAN NOT NULL DEFAULT 'false';`)
 		if err != nil {
 			return err
 		}
 
-		_, err = e.Exec(`
-				CREATE TABLE Installation (
-					ID TEXT PRIMARY KEY,
-					OwnerID TEXT NOT NULL,
-					Version TEXT NOT NULL,
-					Image TEXT NOT NULL,
-					DNS TEXT NOT NULL,
-					Database TEXT NOT NULL,
-					Filestore TEXT NOT NULL,
-					License TEXT NULL,
-					Size TEXT NOT NULL,
-					MattermostEnvRaw BYTEA NULL,
-					Affinity TEXT NOT NULL,
-					GroupSequence BIGINT NULL,
-					GroupID TEXT NULL,
-					State TEXT NOT NULL,
-					CreateAt BIGINT NOT NULL,
-					DeleteAt BIGINT NOT NULL,
-					APISecurityLock BOOLEAN NOT NULL,
-					LockAcquiredBy TEXT NULL,
-					LockAcquiredAt BIGINT NOT NULL
-				);
-			`)
+		_, err = e.Exec(`ALTER TABLE ClusterInstallation ADD COLUMN APISecurityLock BOOLEAN NOT NULL DEFAULT 'false';`)
 		if err != nil {
 			return err
 		}
 
-		_, err = e.Exec(`
-				INSERT INTO Installation
-				SELECT
-					ID,
-					OwnerID,
-					Version,
-					Image,
-					DNS,
-					Database,
-					Filestore,
-					License,
-					Size,
-					MattermostEnvRaw,
-					Affinity,
-					GroupSequence,
-					GroupID,
-					State,
-					CreateAt,
-					DeleteAt,
-					'false',
-					LockAcquiredBy,
-					LockAcquiredAt
-				FROM
-				InstallationTemp;
-			`)
-		if err != nil {
-			return err
-		}
-
-		_, err = e.Exec(`DROP TABLE InstallationTemp;`)
-		if err != nil {
-			return err
-		}
-
-		_, err = e.Exec(`ALTER TABLE ClusterInstallation RENAME TO ClusterInstallationTemp;`)
-		if err != nil {
-			return err
-		}
-
-		_, err = e.Exec(`
-				CREATE TABLE ClusterInstallation (
-					ID TEXT PRIMARY KEY,
-					ClusterID TEXT NOT NULL,
-					InstallationID TEXT NOT NULL,
-					Namespace TEXT NOT NULL,
-					State TEXT NOT NULL,
-					CreateAt BIGINT NOT NULL,
-					DeleteAt BIGINT NOT NULL,
-					APISecurityLock BOOLEAN NOT NULL,
-					LockAcquiredBy TEXT NULL,
-					LockAcquiredAt BIGINT NOT NULL
-				);
-			`)
-		if err != nil {
-			return err
-		}
-
-		_, err = e.Exec(`
-				INSERT INTO ClusterInstallation
-				SELECT
-					ID,
-					ClusterID,
-					InstallationID,
-					Namespace,
-					State,
-					CreateAt,
-					DeleteAt,
-					'false',
-					LockAcquiredBy,
-					LockAcquiredAt
-				FROM
-				ClusterInstallationTemp;
-			`)
-		if err != nil {
-			return err
-		}
-
-		_, err = e.Exec(`DROP TABLE ClusterInstallationTemp;`)
-		if err != nil {
-			return err
-		}
-
-		_, err = e.Exec(`ALTER TABLE "Group" RENAME TO "GroupTemp";`)
-		if err != nil {
-			return err
-		}
-
-		_, err = e.Exec(`
-			CREATE TABLE "Group" (
-				ID TEXT PRIMARY KEY,
-				Name TEXT,
-				Description TEXT,
-				Version TEXT,
-				Image TEXT,
-				MattermostEnvRaw BYTEA NULL,
-				MaxRolling BIGINT NOT NULL,
-				Sequence BIGINT NOT NULL,
-				CreateAt BIGINT NOT NULL,
-				DeleteAt BIGINT NOT NULL,
-				APISecurityLock BOOLEAN NOT NULL,
-				LockAcquiredBy TEXT NULL,
-				LockAcquiredAt BIGINT NOT NULL
-			);
-		`)
-		if err != nil {
-			return err
-		}
-
-		_, err = e.Exec(`
-			INSERT INTO "Group"
-				SELECT
-					ID,
-					Name,
-					Description,
-					Version,
-					Image,
-					MattermostEnvRaw,
-					MaxRolling,
-					Sequence,
-					CreateAt,
-					DeleteAt,
-					'false',
-					LockAcquiredBy,
-					LockAcquiredAt
-				FROM
-					"GroupTemp";
-				`)
-		if err != nil {
-			return err
-		}
-
-		_, err = e.Exec(`DROP TABLE "GroupTemp";`)
+		_, err = e.Exec(`ALTER TABLE "Group" ADD COLUMN APISecurityLock BOOLEAN NOT NULL DEFAULT 'false';`)
 		if err != nil {
 			return err
 		}

--- a/model/client.go
+++ b/model/client.go
@@ -787,3 +787,60 @@ func (c *Client) DeleteWebhook(webhookID string) error {
 		return errors.Errorf("failed with status code %d", resp.StatusCode)
 	}
 }
+
+// LockAPIForCluster locks API changes for a given cluster.
+func (c *Client) LockAPIForCluster(clusterID string) error {
+	return c.makeSecurityCall("cluster", clusterID, "api", "lock")
+}
+
+// UnlockAPIForCluster unlocks API changes for a given cluster.
+func (c *Client) UnlockAPIForCluster(clusterID string) error {
+	return c.makeSecurityCall("cluster", clusterID, "api", "unlock")
+}
+
+// LockAPIForInstallation locks API changes for a given installation.
+func (c *Client) LockAPIForInstallation(installationID string) error {
+	return c.makeSecurityCall("installation", installationID, "api", "lock")
+}
+
+// UnlockAPIForInstallation unlocks API changes for a given installation.
+func (c *Client) UnlockAPIForInstallation(installationID string) error {
+	return c.makeSecurityCall("installation", installationID, "api", "unlock")
+}
+
+// LockAPIForClusterInstallation locks API changes for a given cluster installation.
+func (c *Client) LockAPIForClusterInstallation(clusterID string) error {
+	return c.makeSecurityCall("cluster_installation", clusterID, "api", "lock")
+}
+
+// UnlockAPIForClusterInstallation unlocks API changes for a given cluster installation.
+func (c *Client) UnlockAPIForClusterInstallation(clusterID string) error {
+	return c.makeSecurityCall("cluster_installation", clusterID, "api", "unlock")
+}
+
+// LockAPIForGroup locks API changes for a given group.
+func (c *Client) LockAPIForGroup(groupID string) error {
+	return c.makeSecurityCall("group", groupID, "api", "lock")
+}
+
+// UnlockAPIForGroup unlocks API changes for a given group.
+func (c *Client) UnlockAPIForGroup(groupID string) error {
+	return c.makeSecurityCall("group", groupID, "api", "unlock")
+}
+
+func (c *Client) makeSecurityCall(resourceType, id, securityType, action string) error {
+	resp, err := c.doPost(c.buildURL("/api/security/%s/%s/%s/%s", resourceType, id, securityType, action), nil)
+	if err != nil {
+		return err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+
+	default:
+		return errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+
+}

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -22,6 +22,7 @@ type Cluster struct {
 	AllowInstallations      bool
 	CreateAt                int64
 	DeleteAt                int64
+	APISecurityLock         bool
 	LockAcquiredBy          *string
 	LockAcquiredAt          int64
 }

--- a/model/cluster_installation.go
+++ b/model/cluster_installation.go
@@ -11,15 +11,16 @@ import (
 
 // ClusterInstallation is a single namespace within a cluster composing a potentially larger installation.
 type ClusterInstallation struct {
-	ID             string
-	ClusterID      string
-	InstallationID string
-	Namespace      string
-	State          string
-	CreateAt       int64
-	DeleteAt       int64
-	LockAcquiredBy *string
-	LockAcquiredAt int64
+	ID              string
+	ClusterID       string
+	InstallationID  string
+	Namespace       string
+	State           string
+	CreateAt        int64
+	DeleteAt        int64
+	APISecurityLock bool
+	LockAcquiredBy  *string
+	LockAcquiredAt  int64
 }
 
 // ClusterInstallationFilter describes the parameters used to constrain a set of cluster installations.

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -25,6 +25,7 @@ type CreateClusterRequest struct {
 	NodeMinCount           int64             `json:"node-min-count,omitempty"`
 	NodeMaxCount           int64             `json:"node-max-count,omitempty"`
 	AllowInstallations     bool              `json:"allow-installations,omitempty"`
+	APISecurityLock        bool              `json:"api-security-lock,omitempty"`
 	DesiredUtilityVersions map[string]string `json:"utility-versions,omitempty"`
 }
 

--- a/model/group.go
+++ b/model/group.go
@@ -11,18 +11,19 @@ import (
 
 // Group represents a group of Mattermost installations.
 type Group struct {
-	ID             string
-	Sequence       int64
-	Name           string
-	Description    string
-	Version        string
-	Image          string
-	MaxRolling     int64
-	MattermostEnv  EnvVarMap
-	CreateAt       int64
-	DeleteAt       int64
-	LockAcquiredBy *string
-	LockAcquiredAt int64
+	ID              string
+	Sequence        int64
+	Name            string
+	Description     string
+	Version         string
+	Image           string
+	MaxRolling      int64
+	MattermostEnv   EnvVarMap
+	CreateAt        int64
+	DeleteAt        int64
+	APISecurityLock bool
+	LockAcquiredBy  *string
+	LockAcquiredAt  int64
 }
 
 // GroupFilter describes the parameters used to constrain a set of groups.

--- a/model/group_request.go
+++ b/model/group_request.go
@@ -15,12 +15,13 @@ import (
 
 // CreateGroupRequest specifies the parameters for a new group.
 type CreateGroupRequest struct {
-	Name          string
-	Description   string
-	Version       string
-	Image         string
-	MaxRolling    int64
-	MattermostEnv EnvVarMap
+	Name            string
+	Description     string
+	Version         string
+	Image           string
+	MaxRolling      int64
+	APISecurityLock bool
+	MattermostEnv   EnvVarMap
 }
 
 // SetDefaults sets the default values for a group create request.

--- a/model/installation.go
+++ b/model/installation.go
@@ -12,25 +12,26 @@ import (
 
 // Installation represents a Mattermost installation.
 type Installation struct {
-	ID             string
-	OwnerID        string
-	GroupID        *string
-	GroupSequence  *int64 `json:"GroupSequence,omitempty"`
-	Version        string
-	Image          string
-	DNS            string
-	Database       string
-	Filestore      string
-	License        string
-	MattermostEnv  EnvVarMap
-	Size           string
-	Affinity       string
-	State          string
-	CreateAt       int64
-	DeleteAt       int64
-	LockAcquiredBy *string
-	LockAcquiredAt int64
-	GroupOverrides map[string]string `json:"GroupOverrides,omitempty"`
+	ID              string
+	OwnerID         string
+	GroupID         *string
+	GroupSequence   *int64 `json:"GroupSequence,omitempty"`
+	Version         string
+	Image           string
+	DNS             string
+	Database        string
+	Filestore       string
+	License         string
+	MattermostEnv   EnvVarMap
+	Size            string
+	Affinity        string
+	State           string
+	CreateAt        int64
+	DeleteAt        int64
+	APISecurityLock bool
+	LockAcquiredBy  *string
+	LockAcquiredAt  int64
+	GroupOverrides  map[string]string `json:"GroupOverrides,omitempty"`
 
 	// configconfigMergedWithGroup is set when the installation configuration
 	// has been overridden with group configuration. This value can then be

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -18,17 +18,18 @@ import (
 
 // CreateInstallationRequest specifies the parameters for a new installation.
 type CreateInstallationRequest struct {
-	OwnerID       string
-	GroupID       string
-	Version       string
-	Image         string
-	DNS           string
-	License       string
-	Size          string
-	Affinity      string
-	Database      string
-	Filestore     string
-	MattermostEnv EnvVarMap
+	OwnerID         string
+	GroupID         string
+	Version         string
+	Image           string
+	DNS             string
+	License         string
+	Size            string
+	Affinity        string
+	Database        string
+	Filestore       string
+	APISecurityLock bool
+	MattermostEnv   EnvVarMap
 }
 
 // SetDefaults sets the default values for an installation create request.


### PR DESCRIPTION
This introduces the concept of cloud resource API security locking
for clusters, installations, cluster installations and groups. When
a resource is locked, no changes can be made to the resource until
it is unlocked again.

Locking and unlocking occurs via a new set of cloud server API
endpoints under /security. By separating the ability to control
resource locks out from the normal endpoints, the security endpoints
can be blocked off from other consumers of the cloud server API.
In the future, these endponts could also be exposed on a separate
port from the normal API if desired.

When creating new cloud resources, it is now possible to create them
in a state where they are immediately locked from API changes. This
opens up the possibility for clients of the cloud server API to
create resources, but not modify or delete which offers greater
control over their basic permissions. This functionality should
be especially helpful when dealing with long-lived resources that
are not changed often.

Fixes https://mattermost.atlassian.net/browse/MM-25542

```release-note
Add cloud resource API security locking
```