### PR TITLE
[MM-27482] Increasing the max number of installations that can be deployed in a multitenant database to 100

### DIFF
--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -165,7 +165,7 @@ const (
 
 	// DefaultRDSMultitenantDatabaseCountLimit is the maximum number of
 	// schemas allowed in a multitenant RDS database cluster.
-	DefaultRDSMultitenantDatabaseCountLimit = 10
+	DefaultRDSMultitenantDatabaseCountLimit = 100
 
 	// RDSMultitenantDBClusterResourceNamePrefix identifies the prefix
 	// used for naming multitenant RDS DB cluster resources.


### PR DESCRIPTION
#### Summary
Increasing the max number of installations that can be deployed in a multitenant database to 100.

### Depends on 
Depending on Provisioner work to start using PostgreSQL multitenant databases.
https://mattermost.atlassian.net/browse/MM-27341

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27482

#### Release Note
```release-note
- Increasing the max number of installations that can be deployed in a multitenant database to 100.
```
