### PR TITLE
Shorten database username for Mattermost installations

### DIFF
--- a/internal/tools/aws/database_multitenant.go
+++ b/internal/tools/aws/database_multitenant.go
@@ -757,8 +757,9 @@ func (d *RDSMultitenantDatabase) ensureMultitenantDatabaseSecretIsCreated(rdsClu
 		}
 
 		// PostgreSQL username can't start with integers, so prepend something
-		// valid just in case.
-		username := fmt.Sprintf("dbuser_%s", d.installationID)
+		// valid just in case. Name can't be longer than 32 characters for MySQL
+		// databases though.
+		username := fmt.Sprintf("user_%s", d.installationID)
 		installationSecret, err = d.createInstallationSecret(installationSecretName, username, description, tags)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create a multitenant RDS database secret %s", installationSecretName)


### PR DESCRIPTION
The database username must be shorter than 32 characters to support
our current default version of MySQL.

Fixes https://mattermost.atlassian.net/browse/MM-27664

```release-note
Shorten database username for Mattermost installations
```
