### PR TITLE
Add API to list multitenant databases

### DIFF
--- a/cmd/cloud/databases.go
+++ b/cmd/cloud/databases.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	databaseCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
+
+	databaseListCmd.Flags().String("vpc-id", "", "The VPC ID by which to filter databases.")
+	databaseListCmd.Flags().String("database-type", "", "The database type by which to filter databases.")
+	databaseListCmd.Flags().Int("page", 0, "The page of databases to fetch, starting at 0.")
+	databaseListCmd.Flags().Int("per-page", 100, "The number of databases to fetch per page.")
+
+	databaseCmd.AddCommand(databaseListCmd)
+}
+
+var databaseCmd = &cobra.Command{
+	Use:   "database",
+	Short: "View information on known external multitenant databases",
+}
+
+var databaseListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List multitenant databases that are currently in use.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		vpcID, _ := command.Flags().GetString("vpc-id")
+		databaseType, _ := command.Flags().GetString("database-type")
+		page, _ := command.Flags().GetInt("page")
+		perPage, _ := command.Flags().GetInt("per-page")
+		databases, err := client.GetMultitenantDatabases(&model.GetDatabasesRequest{
+			VpcID:        vpcID,
+			DatabaseType: databaseType,
+			Page:         page,
+			PerPage:      perPage,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to query databases")
+		}
+
+		err = printJSON(databases)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -28,6 +28,7 @@ func init() {
 	rootCmd.AddCommand(clusterCmd)
 	rootCmd.AddCommand(installationCmd)
 	rootCmd.AddCommand(groupCmd)
+	rootCmd.AddCommand(databaseCmd)
 	rootCmd.AddCommand(schemaCmd)
 	rootCmd.AddCommand(webhookCmd)
 	rootCmd.AddCommand(securityCmd)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -15,5 +15,6 @@ func Register(rootRouter *mux.Router, context *Context) {
 	initClusterInstallation(apiRouter, context)
 	initGroup(apiRouter, context)
 	initWebhook(apiRouter, context)
+	initDatabases(apiRouter, context)
 	initSecurity(apiRouter, context)
 }

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -56,6 +56,8 @@ type Store interface {
 	GetWebhook(webhookID string) (*model.Webhook, error)
 	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
 	DeleteWebhook(webhookID string) error
+
+	GetMultitenantDatabases(filter *model.MultitenantDatabaseFilter) ([]*model.MultitenantDatabase, error)
 }
 
 // Provisioner describes the interface required to communicate with the Kubernetes cluster.

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+// initDatabases registers database endpoints on the given router.
+func initDatabases(apiRouter *mux.Router, context *Context) {
+	addContext := func(handler contextHandlerFunc) *contextHandler {
+		return newContextHandler(context, handler)
+	}
+
+	databaseRouter := apiRouter.PathPrefix("/databases").Subrouter()
+	databaseRouter.Handle("", addContext(handleGetDatabases)).Methods("GET")
+}
+
+// handleGetDatabases responds to GET /api/databases, returning a list of
+// multitenant databases.
+func handleGetDatabases(c *Context, w http.ResponseWriter, r *http.Request) {
+	var err error
+
+	page, perPage, _, err := parsePaging(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse paging parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	vpcID, databaseType := parseDatabaseListRequest(r.URL)
+
+	filter := &model.MultitenantDatabaseFilter{
+		VpcID:                 vpcID,
+		DatabaseType:          databaseType,
+		Page:                  page,
+		PerPage:               perPage,
+		MaxInstallationsLimit: model.NoInstallationsLimit,
+	}
+
+	databases, err := c.Store.GetMultitenantDatabases(filter)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query multitenant databases")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if databases == nil {
+		databases = []*model.MultitenantDatabase{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, databases)
+}

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -16,6 +16,15 @@ func logSecurityLockConflict(resourceType string, logger logrus.FieldLogger) {
 	logger.WithField("api-security-lock-conflict", resourceType).Warn("API security lock conflict detected")
 }
 
+func parseString(u *url.URL, name string, defaultValue string) string {
+	valueStr := u.Query().Get(name)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	return valueStr
+}
+
 func parseInt(u *url.URL, name string, defaultValue int) (int, error) {
 	valueStr := u.Query().Get(name)
 	if valueStr == "" {
@@ -75,4 +84,11 @@ func parseGroupConfig(u *url.URL) (bool, bool, error) {
 	}
 
 	return includeGroupConfig, includeGroupConfigOverrides, nil
+}
+
+func parseDatabaseListRequest(u *url.URL) (string, string) {
+	vpcID := parseString(u, "vpc_id", "")
+	databaseType := parseString(u, "database_type", "")
+
+	return vpcID, databaseType
 }

--- a/model/client.go
+++ b/model/client.go
@@ -710,6 +710,30 @@ func (c *Client) LeaveGroup(installationID string, request *LeaveGroupRequest) e
 	}
 }
 
+// GetMultitenantDatabases fetches the list of multitenant databases from the configured provisioning server.
+func (c *Client) GetMultitenantDatabases(request *GetDatabasesRequest) ([]*MultitenantDatabase, error) {
+	u, err := url.Parse(c.buildURL("/api/databases"))
+	if err != nil {
+		return nil, err
+	}
+
+	request.ApplyToURL(u)
+
+	resp, err := c.doGet(u.String())
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return MultitenantDatabasesFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // CreateWebhook requests the creation of a webhook from the configured provisioning server.
 func (c *Client) CreateWebhook(request *CreateWebhookRequest) (*Webhook, error) {
 	resp, err := c.doPost(c.buildURL("/api/webhooks"), request)

--- a/model/multitenant_database.go
+++ b/model/multitenant_database.go
@@ -4,6 +4,11 @@
 
 package model
 
+import (
+	"encoding/json"
+	"io"
+)
+
 // MultitenantDatabase represents database infrastructure that contains multiple
 // installation databases.
 type MultitenantDatabase struct {
@@ -11,9 +16,9 @@ type MultitenantDatabase struct {
 	VpcID          string
 	DatabaseType   string
 	Installations  MultitenantDatabaseInstallations
-	LockAcquiredBy *string
 	CreateAt       int64
 	DeleteAt       int64
+	LockAcquiredBy *string
 	LockAcquiredAt int64
 }
 
@@ -61,4 +66,17 @@ type MultitenantDatabaseFilter struct {
 	MaxInstallationsLimit int
 	Page                  int
 	PerPage               int
+}
+
+// MultitenantDatabasesFromReader decodes a json-encoded list of multitenant databases from the given io.Reader.
+func MultitenantDatabasesFromReader(reader io.Reader) ([]*MultitenantDatabase, error) {
+	databases := []*MultitenantDatabase{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&databases)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return databases, nil
 }

--- a/model/multitenant_database_request.go
+++ b/model/multitenant_database_request.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"net/url"
+	"strconv"
+)
+
+// GetDatabasesRequest describes the parameters to request a list of multitenant databases.
+type GetDatabasesRequest struct {
+	VpcID        string
+	DatabaseType string
+	Page         int
+	PerPage      int
+}
+
+// ApplyToURL modifies the given url to include query string parameters for the request.
+func (request *GetDatabasesRequest) ApplyToURL(u *url.URL) {
+	q := u.Query()
+	q.Add("page", strconv.Itoa(request.Page))
+	q.Add("per_page", strconv.Itoa(request.PerPage))
+	q.Add("vpc_id", request.VpcID)
+	q.Add("database_type", request.DatabaseType)
+
+	u.RawQuery = q.Encode()
+}


### PR DESCRIPTION
This new endpoint allows the client to request information on all
currently-known multitenant databases. Note that other RDS clusters
could exist that the provisioner has not yet found and added to the
store.

Fixes https://mattermost.atlassian.net/browse/MM-27691

```release-note
Add API to list multitenant databases
```
