### PR TITLE
k8s/namespace: when deleting the namespace make sure everything gets deleted as well

### DIFF
--- a/k8s/namespaces.go
+++ b/k8s/namespaces.go
@@ -72,8 +72,14 @@ func (kc *KubeClient) GetNamespaces(namespaceNames []string) ([]*corev1.Namespac
 // Any errors will be returned immediately and the remaining namespaces will be
 // skipped.
 func (kc *KubeClient) DeleteNamespaces(namespaceNames []string) error {
+	policy := metav1.DeletePropagationForeground
+	gracePeriod := int64(45)
+	deleteOpts := &metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriod,
+		PropagationPolicy:  &policy,
+	}
 	for _, namespaceName := range namespaceNames {
-		err := kc.Clientset.CoreV1().Namespaces().Delete(namespaceName, &metav1.DeleteOptions{})
+		err := kc.Clientset.CoreV1().Namespaces().Delete(namespaceName, deleteOpts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

#### Summary
Just to make sure we delete everything inside the namespace before removing the namespace, to avoid orphans hanging around in the cluster

#### Ticket Link
n/a

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
k8s/namespace: when deleting the namespace make sure everything gets deleted as well
```
