### PR TITLE
GetInstallationsByDNS is returning error if length is 0

### DIFF
--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -189,7 +189,7 @@ func TestGetInstallations(t *testing.T) {
 
 				noInstallation, err := client.GetInstallationByDNS("notreal", nil)
 				assert.Nil(t, noInstallation)
-				assert.Error(t, err)
+				assert.NoError(t, err)
 			})
 
 		})

--- a/model/client.go
+++ b/model/client.go
@@ -376,6 +376,8 @@ func (c *Client) GetInstallationByDNS(DNS string, request *GetInstallationReques
 	if len(installations) > 1 {
 		return nil, errors.Errorf("received ambiguous response (%d Installations) when expecting only one",
 			len(installations))
+	} else if len(installations) == 0 {
+		return nil, nil
 	}
 	return installations[0], nil
 }

--- a/model/client.go
+++ b/model/client.go
@@ -373,7 +373,7 @@ func (c *Client) GetInstallationByDNS(DNS string, request *GetInstallationReques
 		return nil, errors.Wrap(err, "problem getting installation")
 	}
 
-	if len(installations) != 1 {
+	if len(installations) > 1 {
 		return nil, errors.Errorf("received ambiguous response (%d Installations) when expecting only one",
 			len(installations))
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR just check for ambiguous response if the number of returned installations is greater than 0 otherwise we're always receiving the error `error="received ambiguous response (0 Installations) when expecting only one"`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
none
```
