### PR TITLE
Enable default AWS S3 SSE

### DIFF
--- a/internal/tools/aws/s3.go
+++ b/internal/tools/aws/s3.go
@@ -35,6 +35,22 @@ func (a *Client) s3EnsureBucketCreated(bucketName string, logger log.FieldLogger
 		return errors.Wrap(err, "unable to block public bucket access")
 	}
 
+	_, err = a.Service().s3.PutBucketEncryption(&s3.PutBucketEncryptionInput{
+		Bucket: aws.String(bucketName),
+		ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
+			Rules: []*s3.ServerSideEncryptionRule{
+				{
+					ApplyServerSideEncryptionByDefault: &s3.ServerSideEncryptionByDefault{
+						SSEAlgorithm: aws.String(s3.ServerSideEncryptionAes256),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to set bucket encryption default")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This sets the default encryption scheme for new installation S3
buckets to use AES-256 encryption. The Mattermost filestore SSE
configuration option is also set to true to force the behavior
when a license is present.

This also corrects an issue where the cloud installation ID env
var was lost when updating installations.

Fixes https://mattermost.atlassian.net/browse/MM-24783

```release-note
Enable default AWS S3 SSE
```
