### PR TITLE
drop requests to prometheus ingress if is not using the dns name

### DIFF
--- a/helm-charts/nginx_values.yaml
+++ b/helm-charts/nginx_values.yaml
@@ -10,7 +10,7 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    
+
     internal:
       enabled: true
       annotations:
@@ -18,7 +18,7 @@ controller:
         service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
         service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
         service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-      
+
     enableHttp: true
     enableHttps: true
     targetPorts:
@@ -62,7 +62,7 @@ controller:
          return 308 https://$host$request_uri;
       }
 
-  resources: 
+  resources:
    limits:
      cpu: 1000m
      memory: 500Mi

--- a/internal/provisioner/prometheus.go
+++ b/internal/provisioner/prometheus.go
@@ -132,6 +132,8 @@ func (p *prometheus) NewHelmDeployment() *helmDeployment {
 	}
 	prometheusDNS := fmt.Sprintf("%s.prometheus.%s", p.cluster.ID, privateDomainName)
 
+	helmValueArguments := fmt.Sprintf("server.ingress.hosts={%[1]s},server.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/configuration-snippet='if ($host != \"%[1]s\") {return 404;}'", prometheusDNS)
+
 	return &helmDeployment{
 		chartDeploymentName: "prometheus",
 		chartName:           "stable/prometheus",
@@ -139,7 +141,7 @@ func (p *prometheus) NewHelmDeployment() *helmDeployment {
 		kopsProvisioner:     p.provisioner,
 		logger:              p.logger,
 		namespace:           "prometheus",
-		setArgument:         fmt.Sprintf("server.ingress.hosts={%s}", prometheusDNS),
+		setArgument:         helmValueArguments,
 		valuesPath:          "helm-charts/prometheus_values.yaml",
 		desiredVersion:      p.desiredVersion,
 	}


### PR DESCRIPTION
### Summary
If anyone tries to access the ingresses using the IP of the LB we can drop the request and only accept if is coming from the dns name.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
drop requests to prometheus ingress if is not using the dns name
```
