### PR TITLE
Revert "drop requests to prometheus ingress if is not using the dns name"

### DIFF
--- a/helm-charts/nginx_values.yaml
+++ b/helm-charts/nginx_values.yaml
@@ -10,7 +10,7 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-
+    
     internal:
       enabled: true
       annotations:
@@ -18,7 +18,7 @@ controller:
         service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
         service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
         service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-
+      
     enableHttp: true
     enableHttps: true
     targetPorts:
@@ -62,7 +62,7 @@ controller:
          return 308 https://$host$request_uri;
       }
 
-  resources:
+  resources: 
    limits:
      cpu: 1000m
      memory: 500Mi

--- a/internal/provisioner/prometheus.go
+++ b/internal/provisioner/prometheus.go
@@ -132,8 +132,6 @@ func (p *prometheus) NewHelmDeployment() *helmDeployment {
 	}
 	prometheusDNS := fmt.Sprintf("%s.prometheus.%s", p.cluster.ID, privateDomainName)
 
-	helmValueArguments := fmt.Sprintf("server.ingress.hosts={%[1]s},server.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/configuration-snippet='if ($host != \"%[1]s\") {return 404;}'", prometheusDNS)
-
 	return &helmDeployment{
 		chartDeploymentName: "prometheus",
 		chartName:           "stable/prometheus",
@@ -141,7 +139,7 @@ func (p *prometheus) NewHelmDeployment() *helmDeployment {
 		kopsProvisioner:     p.provisioner,
 		logger:              p.logger,
 		namespace:           "prometheus",
-		setArgument:         helmValueArguments,
+		setArgument:         fmt.Sprintf("server.ingress.hosts={%s}", prometheusDNS),
 		valuesPath:          "helm-charts/prometheus_values.yaml",
 		desiredVersion:      p.desiredVersion,
 	}


### PR DESCRIPTION
Reverts mattermost/mattermost-cloud#294


this is broken and we are working in a better fix