### PR TITLE
Fixing ctx timing to make sure that Nginx load balancer services are in place for Prometheus Route53 registration.

### DIFF
--- a/internal/provisioner/kops_utils.go
+++ b/internal/provisioner/kops_utils.go
@@ -98,7 +98,7 @@ func getPrivateLoadBalancerEndpoint(ctx context.Context, namespace string, logge
 	}
 
 	for {
-		services, err := k8sClient.Clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
+		services, err := k8sClient.Clientset.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return "", err
 		}

--- a/internal/provisioner/prometheus.go
+++ b/internal/provisioner/prometheus.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
@@ -88,7 +89,7 @@ func (p *prometheus) CreateOrUpgrade() error {
 	}
 
 	p.logger.Debugln("CNAME was not provisioned for prometheus")
-	ctx, cancel := context.WithTimeout(context.Background(), 120)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(120)*time.Second)
 	defer cancel()
 
 	endpoint, err := getPrivateLoadBalancerEndpoint(ctx, "nginx", logger.WithField("prometheus-action", "create"), p.kops.GetKubeConfigPath())


### PR DESCRIPTION
#### Summary
Fixing the context for private load balancer service listing. This helps to ensure that Nginx Load Balancer services are in place before attempting to register Prometheus with Route53 private record.

#### Release Note
```release-note
- Fixing context for private load balancer service listing
```
