### PR TITLE
Add new container exec API endpoint

### DIFF
--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -21,6 +21,14 @@ type mockProvisioner struct {
 	CommandError error
 }
 
+func (s *mockProvisioner) ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error) {
+	if len(s.Output) == 0 {
+		s.Output = []byte(`{"ServiceSettings":{"SiteURL":"http://test.example.com"}}`)
+	}
+
+	return s.Output, s.CommandError
+}
+
 func (s *mockProvisioner) ExecMattermostCLI(*model.Cluster, *model.ClusterInstallation, ...string) ([]byte, error) {
 	if len(s.Output) == 0 {
 		s.Output = []byte(`{"ServiceSettings":{"SiteURL":"http://test.example.com"}}`)

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -63,6 +63,7 @@ type Store interface {
 
 // Provisioner describes the interface required to communicate with the Kubernetes cluster.
 type Provisioner interface {
+	ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
 	ExecMattermostCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
 	GetClusterResources(*model.Cluster, bool) (*k8s.ClusterResources, error)
 }

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -447,10 +447,11 @@ func (provisioner *KopsProvisioner) GetClusterInstallationResource(cluster *mode
 
 // ExecMattermostCLI invokes the Mattermost CLI for the given cluster installation with the given args.
 func (provisioner *KopsProvisioner) ExecMattermostCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error) {
-	return provisioner.execCLI(cluster, clusterInstallation, append([]string{"./bin/mattermost"}, args...)...)
+	return provisioner.ExecClusterInstallationCLI(cluster, clusterInstallation, append([]string{"./bin/mattermost"}, args...)...)
 }
 
-func (provisioner *KopsProvisioner) execCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error) {
+// ExecClusterInstallationCLI execs the provided command on the defined cluster installation.
+func (provisioner *KopsProvisioner) ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error) {
 	logger := provisioner.logger.WithFields(log.Fields{
 		"cluster":      clusterInstallation.ClusterID,
 		"installation": clusterInstallation.InstallationID,
@@ -529,6 +530,7 @@ func getMattermostEnvWithOverrides(installation *model.Installation) model.EnvVa
 	}
 
 	mattermostEnv["MM_CLOUD_INSTALLATION_ID"] = model.EnvVar{Value: installation.ID}
+	mattermostEnv["MM_SERVICESETTINGS_ENABLELOCALMODE"] = model.EnvVar{Value: "true"}
 
 	if !installation.InternalFilestore() {
 		mattermostEnv["MM_FILESETTINGS_AMAZONS3SSE"] = model.EnvVar{Value: "true"}

--- a/model/client.go
+++ b/model/client.go
@@ -600,6 +600,25 @@ func (c *Client) RunMattermostCLICommandOnClusterInstallation(clusterInstallatio
 	}
 }
 
+// ExecClusterInstallationCLI runs a valid exec command against a cluster installation.
+func (c *Client) ExecClusterInstallationCLI(clusterInstallationID, command string, subcommand []string) ([]byte, error) {
+	resp, err := c.doPost(c.buildURL("/api/cluster_installation/%s/exec/%s", clusterInstallationID, command), subcommand)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	bytes, _ := ioutil.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return bytes, nil
+
+	default:
+		return bytes, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // CreateGroup requests the creation of a group from the configured provisioning server.
 func (c *Client) CreateGroup(request *CreateGroupRequest) (*Group, error) {
 	resp, err := c.doPost(c.buildURL("/api/groups"), request)

--- a/model/cluster_installation_request.go
+++ b/model/cluster_installation_request.go
@@ -62,3 +62,17 @@ func NewClusterInstallationMattermostCLISubcommandFromReader(reader io.Reader) (
 
 	return clusterInstallationMattermostCLISubcommand, nil
 }
+
+// ClusterInstallationExecSubcommand describes the payload necessary to run container exec commands on a cluster installation.
+type ClusterInstallationExecSubcommand []string
+
+// NewClusterInstallationExecSubcommandFromReader will create a ClusterInstallationExecSubcommand from an io.Reader.
+func NewClusterInstallationExecSubcommandFromReader(reader io.Reader) (ClusterInstallationExecSubcommand, error) {
+	var clusterInstallationExecSubcommand ClusterInstallationExecSubcommand
+	err := json.NewDecoder(reader).Decode(&clusterInstallationExecSubcommand)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode cluster installation exec request")
+	}
+
+	return clusterInstallationExecSubcommand, nil
+}

--- a/model/exec.go
+++ b/model/exec.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+const execMMCTL = "mmctl"
+
+// IsValidExecCommand returns wheather the provided command is valid or not.
+func IsValidExecCommand(command string) bool {
+	return command == execMMCTL
+}


### PR DESCRIPTION
This new endpoint initially allows for running mmctl commands in
cluster installations. In the future, more commands can be approved
for use and can be managed under this endpoint.

The original mattermost-cli endpoint remains to not introduce a
breaking change and will be refactored later.

Fixes https://mattermost.atlassian.net/browse/MM-28239

```release-note
Add new container exec API endpoint
```
