### PR TITLE
add white-list cidrs to internal ingress for prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ For more information on this change and reasoning for it, check out the [kops re
 This is related to the changes introduced in [PR-263](https://github.com/mattermost/mattermost-cloud/pull/263)
 
 Please follow the steps below for the reprovisioning of existing clusters:
-- Reprovision the cluster by running ```cloud cluster provision --cluster <cluster_id> --nginx-version 2.11.0```.
+- Reprovision the cluster by running ```cloud cluster provision --cluster <cluster_id> --nginx-version 2.15.0```.
 - Check that new nginx deployed both internal and public Load Balancers (nginx-ingress-nginx-controller-internal and nginx-ingress-nginx-controller).
 - Manually update Prometheus Route53 record to use the new private Load Balancer (nginx-ingress-nginx-controller-internal).
 - Manually update cluster installations Route53 records one by one to use the new public Load balancer (nginx-ingress-nginx-controller).

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -80,7 +80,7 @@ var serverCmd = &cobra.Command{
 
 		allowListCIDRRange, _ := command.Flags().GetStringSlice("allow-list-cidr-range")
 		if len(allowListCIDRRange) == 0 {
-			return errors.Error("allow-list-cidr-range must have at least one value")
+			return errors.New("allow-list-cidr-range must have at least one value")
 		}
 
 		logger := logger.WithField("instance", instanceID)

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -80,7 +80,7 @@ var serverCmd = &cobra.Command{
 
 		allowListCIDRRange, _ := command.Flags().GetStringSlice("allow-list-cidr-range")
 		if len(allowListCIDRRange) == 0 {
-			return errors.Errorf("allow-list-cidr-range must have at least one value")
+			return errors.Error("allow-list-cidr-range must have at least one value")
 		}
 
 		logger := logger.WithField("instance", instanceID)

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -46,6 +46,8 @@ func init() {
 	serverCmd.PersistentFlags().Bool("installation-supervisor", true, "Whether this server will run an installation supervisor or not.")
 	serverCmd.PersistentFlags().Bool("cluster-installation-supervisor", true, "Whether this server will run a cluster installation supervisor or not.")
 	serverCmd.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
+	serverCmd.PersistentFlags().StringSlice("allow-list-cidr-range", []string{"0.0.0.0/0"}, "The list of CIDRs to allow communication with the private ingress.")
+
 	serverCmd.PersistentFlags().Int("poll", 30, "The interval in seconds to poll for background work.")
 	serverCmd.PersistentFlags().Int("cluster-resource-threshold", 80, "The percent threshold where new installations won't be scheduled on a multi-tenant cluster.")
 	serverCmd.PersistentFlags().Int("cluster-resource-threshold-scale-value", 0, "The number of worker nodes to scale up by when the threshold is passed. Set to 0 for no scaling. Scaling will never exceed the cluster max worker configuration value.")
@@ -74,6 +76,11 @@ var serverCmd = &cobra.Command{
 		machineLogs, _ := command.Flags().GetBool("machine-readable-logs")
 		if machineLogs {
 			logger.SetFormatter(&logrus.JSONFormatter{})
+		}
+
+		allowListCIDRRange, _ := command.Flags().GetStringSlice("allow-list-cidr-range")
+		if len(allowListCIDRRange) == 0 {
+			return errors.Errorf("allow-list-cidr-range must have at least one value")
 		}
 
 		logger := logger.WithField("instance", instanceID)
@@ -182,6 +189,7 @@ var serverCmd = &cobra.Command{
 			s3StateStore,
 			owner,
 			useExistingResources,
+			allowListCIDRRange,
 			resourceUtil,
 			logger,
 			sqlStore,

--- a/helm-charts/nginx_values.yaml
+++ b/helm-charts/nginx_values.yaml
@@ -10,7 +10,7 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    
+
     internal:
       enabled: true
       annotations:
@@ -18,7 +18,8 @@ controller:
         service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
         service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
         service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-      
+      externalTrafficPolicy: Local
+
     enableHttp: true
     enableHttps: true
     targetPorts:
@@ -62,7 +63,7 @@ controller:
          return 308 https://$host$request_uri;
       }
 
-  resources: 
+  resources:
    limits:
      cpu: 1000m
      memory: 500Mi

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -24,7 +24,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			NodeMinCount:           2,
 			NodeMaxCount:           2,
 			Zones:                  []string{"us-east-1a"},
-			DesiredUtilityVersions: map[string]string{"fluentbit": "2.8.7", "nginx": "2.11.0", "prometheus": "10.4.0", "teleport": "0.3.0"},
+			DesiredUtilityVersions: map[string]string{"fluentbit": "2.8.7", "nginx": "2.15.0", "prometheus": "10.4.0", "teleport": "0.3.0"},
 		}
 	}
 
@@ -79,7 +79,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			Zones:              []string{"zone1", "zone2"},
 			DesiredUtilityVersions: map[string]string{
 				"fluentbit":  "2.8.7",
-				"nginx":      "2.11.0",
+				"nginx":      "2.15.0",
 				"prometheus": "10.4.0",
 				"teleport":   "0.3.0"},
 		}, clusterRequest)

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -35,6 +35,7 @@ type KopsProvisioner struct {
 	s3StateStore            string
 	privateSubnetIds        string
 	publicSubnetIds         string
+	allowCIDRRangeList      []string
 	owner                   string
 	useExistingAWSResources bool
 	resourceUtil            *utils.ResourceUtil
@@ -44,7 +45,7 @@ type KopsProvisioner struct {
 
 // NewKopsProvisioner creates a new KopsProvisioner.
 // TODO(gsagula): Consider replacing all these paramaters with a struct for readability.
-func NewKopsProvisioner(s3StateStore, owner string, useExistingAWSResources bool,
+func NewKopsProvisioner(s3StateStore, owner string, useExistingAWSResources bool, allowCIDRRangeList []string,
 	resourceUtil *utils.ResourceUtil, logger log.FieldLogger, store model.InstallationDatabaseStoreInterface) *KopsProvisioner {
 
 	logger = logger.WithField("provisioner", "kops")
@@ -52,6 +53,7 @@ func NewKopsProvisioner(s3StateStore, owner string, useExistingAWSResources bool
 	return &KopsProvisioner{
 		s3StateStore:            s3StateStore,
 		useExistingAWSResources: useExistingAWSResources,
+		allowCIDRRangeList:      allowCIDRRangeList,
 		logger:                  logger,
 		resourceUtil:            resourceUtil,
 		owner:                   owner,

--- a/internal/provisioner/prometheus.go
+++ b/internal/provisioner/prometheus.go
@@ -133,6 +133,8 @@ func (p *prometheus) NewHelmDeployment() *helmDeployment {
 	}
 	prometheusDNS := fmt.Sprintf("%s.prometheus.%s", p.cluster.ID, privateDomainName)
 
+	helmValueArguments := fmt.Sprintf("server.ingress.hosts={%s},nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", prometheusDNS, strings.Join(p.provisioner.allowCIDRRangeList, ","))
+
 	return &helmDeployment{
 		chartDeploymentName: "prometheus",
 		chartName:           "stable/prometheus",
@@ -140,7 +142,7 @@ func (p *prometheus) NewHelmDeployment() *helmDeployment {
 		kopsProvisioner:     p.provisioner,
 		logger:              p.logger,
 		namespace:           "prometheus",
-		setArgument:         fmt.Sprintf("server.ingress.hosts={%s}", prometheusDNS),
+		setArgument:         helmValueArguments,
 		valuesPath:          "helm-charts/prometheus_values.yaml",
 		desiredVersion:      p.desiredVersion,
 	}

--- a/internal/provisioner/prometheus.go
+++ b/internal/provisioner/prometheus.go
@@ -133,7 +133,7 @@ func (p *prometheus) NewHelmDeployment() *helmDeployment {
 	}
 	prometheusDNS := fmt.Sprintf("%s.prometheus.%s", p.cluster.ID, privateDomainName)
 
-	helmValueArguments := fmt.Sprintf("server.ingress.hosts={%s},nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", prometheusDNS, strings.Join(p.provisioner.allowCIDRRangeList, ","))
+	helmValueArguments := fmt.Sprintf("server.ingress.hosts={%s},server.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", prometheusDNS, strings.Join(p.provisioner.allowCIDRRangeList, "\\,"))
 
 	return &helmDeployment{
 		chartDeploymentName: "prometheus",

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -24,11 +24,9 @@ const (
 	// PrometheusDefaultVersion defines the default version for the Helm chart
 	PrometheusDefaultVersion = "10.4.0"
 	// NginxDefaultVersion defines the default version for the Helm chart
-	NginxDefaultVersion = "2.11.0"
+	NginxDefaultVersion = "2.15.0"
 	// FluentbitDefaultVersion defines the default version for the Helm chart
 	FluentbitDefaultVersion = "2.8.7"
-	// PublicNginxDefaultVersion defines the default version for the Helm chart
-	PublicNginxDefaultVersion = "2.11.0"
 	// TeleportDefaultVersion defines the default version for the Helm chart
 	TeleportDefaultVersion = "0.3.0"
 )


### PR DESCRIPTION
#### Summary
Block access from public lb to an internal endpoint.


For dev we are allowing all. For other envs we need to set the flag `allow-list-cidr-range` to block the public access

follow up PR to add the flags in test/stg and prod envs:
- TEST: https://gitlab.internal.core.cloud.mattermost.com/cloud/cloud-private/-/merge_requests/140
- STG: https://gitlab.internal.core.cloud.mattermost.com/cloud/cloud-private/-/merge_requests/141
- PROD: https://gitlab.internal.core.cloud.mattermost.com/cloud/cloud-private/-/merge_requests/142

for STG / PROD we need to have the tag and deploy in those envs before merging the gitlab prs.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
add white-list cidrs to internal ingress for prometheus
```
