### PR TITLE
[MM-28321] Increasing the Prometheus persistent volume to 100Gi from 8Gi

### DIFF
--- a/helm-charts/prometheus_values.yaml
+++ b/helm-charts/prometheus_values.yaml
@@ -3,6 +3,8 @@ serviceAccounts:
     create: false
 
 server:
+  persistentVolume:
+    size: 100Gi
   ingress:
     enabled: true
     annotations:


### PR DESCRIPTION
#### Summary
Increasing the Prometheus persistent volume to 100Gi from 8Gi

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28321

#### Release Note
<!--
```release-note
- Increasing the Prometheus persistent volume to 100Gi from 8Gi
```
