### PR TITLE
Check more than state on reconciling cluster installations

### DIFF
--- a/internal/supervisor/cluster_installation.go
+++ b/internal/supervisor/cluster_installation.go
@@ -230,19 +230,19 @@ func (s *ClusterInstallationSupervisor) deleteClusterInstallation(clusterInstall
 }
 
 func (s *ClusterInstallationSupervisor) checkReconcilingClusterInstallation(clusterInstallation *model.ClusterInstallation, logger log.FieldLogger, installation *model.Installation, cluster *model.Cluster) string {
-
 	cr, err := s.provisioner.GetClusterInstallationResource(cluster, installation, clusterInstallation)
 	if err != nil {
 		logger.WithError(err).Error("Failed to get cluster installation resource")
 		return model.ClusterInstallationStateReconciling
 	}
 
-	if cr.Status.State != mmv1alpha1.Stable {
+	if cr.Status.State != mmv1alpha1.Stable ||
+		cr.Spec.Replicas != cr.Status.Replicas ||
+		cr.Spec.Version != cr.Status.Version {
 		logger.Info("Cluster installation is still reconciling")
 		return model.ClusterInstallationStateReconciling
 	}
 
 	logger.Info("Cluster installation finished reconciling")
 	return model.ClusterInstallationStateStable
-
 }


### PR DESCRIPTION
The new check also verifies the replica count and version values
before proceeding. This shouldn't be necessary, but is being added
to avoid a temporary problem with cluster installation states being
reported as stable briefly before being corrected by the operator.

Fixes https://mattermost.atlassian.net/browse/MM-28558

```release-note
Check more than state on reconciling cluster installations
```
