### PR TITLE
Add S3 Multitenant Filestore

### DIFF
--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -54,6 +54,36 @@ func (mr *MockAWSMockRecorder) GetCertificateSummaryByTag(key, value, logger int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCertificateSummaryByTag", reflect.TypeOf((*MockAWS)(nil).GetCertificateSummaryByTag), key, value, logger)
 }
 
+// GetAccountAliases mocks base method
+func (m *MockAWS) GetAccountAliases() (*iam.ListAccountAliasesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAccountAliases")
+	ret0, _ := ret[0].(*iam.ListAccountAliasesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAccountAliases indicates an expected call of GetAccountAliases
+func (mr *MockAWSMockRecorder) GetAccountAliases() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountAliases", reflect.TypeOf((*MockAWS)(nil).GetAccountAliases))
+}
+
+// GetCloudEnvironmentName mocks base method
+func (m *MockAWS) GetCloudEnvironmentName() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCloudEnvironmentName")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCloudEnvironmentName indicates an expected call of GetCloudEnvironmentName
+func (mr *MockAWSMockRecorder) GetCloudEnvironmentName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudEnvironmentName", reflect.TypeOf((*MockAWS)(nil).GetCloudEnvironmentName))
+}
+
 // GetAndClaimVpcResources mocks base method
 func (m *MockAWS) GetAndClaimVpcResources(clusterID, owner string, logger logrus.FieldLogger) (aws.ClusterResources, error) {
 	m.ctrl.T.Helper()
@@ -267,21 +297,6 @@ func (m *MockAWS) IsValidAMI(AMIImage string, logger logrus.FieldLogger) (bool, 
 func (mr *MockAWSMockRecorder) IsValidAMI(AMIImage, logger interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidAMI", reflect.TypeOf((*MockAWS)(nil).IsValidAMI), AMIImage, logger)
-}
-
-// GetAccountAliases mocks base method
-func (m *MockAWS) GetAccountAliases() (*iam.ListAccountAliasesOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAccountAliases")
-	ret0, _ := ret[0].(*iam.ListAccountAliasesOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAccountAliases indicates an expected call of GetAccountAliases
-func (mr *MockAWSMockRecorder) GetAccountAliases() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountAliases", reflect.TypeOf((*MockAWS)(nil).GetAccountAliases))
 }
 
 // DynamoDBEnsureTableDeleted mocks base method

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -139,7 +139,7 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 		mattermostInstallation.Spec.Database = *databaseSpec
 	}
 
-	filestoreSpec, filestoreSecret, err := provisioner.resourceUtil.GetFilestore(installation).GenerateFilestoreSpecAndSecret(logger)
+	filestoreSpec, filestoreSecret, err := provisioner.resourceUtil.GetFilestore(installation).GenerateFilestoreSpecAndSecret(provisioner.store, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate filestore configuration")
 	}
@@ -534,6 +534,10 @@ func getMattermostEnvWithOverrides(installation *model.Installation) model.EnvVa
 
 	if !installation.InternalFilestore() {
 		mattermostEnv["MM_FILESETTINGS_AMAZONS3SSE"] = model.EnvVar{Value: "true"}
+	}
+
+	if installation.Filestore == model.InstallationFilestoreMultiTenantAwsS3 {
+		mattermostEnv["MM_FILESETTINGS_AMAZONS3PATHPREFIX"] = model.EnvVar{Value: installation.ID}
 	}
 
 	return mattermostEnv

--- a/internal/provisioner/teleport.go
+++ b/internal/provisioner/teleport.go
@@ -40,7 +40,7 @@ func newTeleportHandle(cluster *model.Cluster, desiredVersion string, provisione
 		return nil, errors.New("cannot create a connection to Teleport if the Kops command provided is nil")
 	}
 
-	environment, err := getEnvironment(awsClient)
+	environment, err := awsClient.GetCloudEnvironmentName()
 	if err != nil {
 		return nil, err
 	}
@@ -130,20 +130,4 @@ func (n *teleport) NewHelmDeployment() *helmDeployment {
 
 func (n *teleport) Name() string {
 	return model.TeleportCanonicalName
-}
-
-func getEnvironment(awsClient aws.AWS) (string, error) {
-	accountAliases, err := awsClient.GetAccountAliases()
-	if err != nil {
-		return "", err
-	}
-	if len(accountAliases.AccountAliases) < 1 {
-		return "", errors.New("Account Alias not defined")
-	}
-	for _, alias := range accountAliases.AccountAliases {
-		if strings.HasPrefix(*alias, "mattermost-cloud") && len(strings.Split(*alias, "-")) == 3 {
-			return strings.Split(*alias, "-")[2], nil
-		}
-	}
-	return "", errors.New("Account environment was not obtained")
 }

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -441,7 +441,7 @@ func (s *InstallationSupervisor) preProvisionInstallation(installation *model.In
 		return model.InstallationStateCreationPreProvisioning
 	}
 
-	err = s.resourceUtil.GetFilestore(installation).Provision(logger)
+	err = s.resourceUtil.GetFilestore(installation).Provision(s.store, logger)
 	if err != nil {
 		logger.WithError(err).Error("Failed to provision installation filestore")
 		return model.InstallationStateCreationPreProvisioning
@@ -798,7 +798,7 @@ func (s *InstallationSupervisor) finalDeletionCleanup(installation *model.Instal
 		return model.InstallationStateDeletionFinalCleanup
 	}
 
-	err = s.resourceUtil.GetFilestore(installation).Teardown(s.keepFilestoreData, logger)
+	err = s.resourceUtil.GetFilestore(installation).Teardown(s.keepFilestoreData, s.store, logger)
 	if err != nil {
 		logger.WithError(err).Error("Failed to delete filestore")
 		return model.InstallationStateDeletionFinalCleanup

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -205,6 +205,10 @@ func (a *mockAWS) GetAccountAliases() (*iam.ListAccountAliasesOutput, error) {
 	return nil, nil
 }
 
+func (a *mockAWS) GetCloudEnvironmentName() (string, error) {
+	return "test", nil
+}
+
 func (a *mockAWS) DynamoDBEnsureTableDeleted(tableName string, logger log.FieldLogger) error {
 	return nil
 }

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -227,12 +227,23 @@ const (
 	// changing this value will break the connection to AWS resources for existing installations.
 	DefaultRDSEncryptionTagKey = "rds-encryption-key"
 
-	// DefaultRDSMultitenantVPCIDTagKey is the key used to identify the VPC ID
-	// used for multitenant RDS
-	// database clusters.
+	// VpcIDTagKey is the key used to identify resources belonging to a given
+	// VPC.
 	// Warning:
 	// changing this value will break the connection to AWS resources for existing installations.
-	DefaultRDSMultitenantVPCIDTagKey = "tag:VpcID"
+	VpcIDTagKey = "tag:VpcID"
+
+	// FilestoreMultitenantS3TagKey is the key used to identify S3 buckets that
+	// provide multitenant filestores.
+	// Warning:
+	// changing this value will break the connection to AWS resources for existing installations.
+	FilestoreMultitenantS3TagKey = "tag:Filestore"
+
+	// FilestoreMultitenantS3TagValue is FilestoreMultitenantS3TagKey value for
+	// S3 multitenant databases.
+	// Warning:
+	// changing this value will break the connection to AWS resources for existing installations.
+	FilestoreMultitenantS3TagValue = "Multitenant"
 
 	// DefaultRDSMultitenantDatabaseIDTagKey is the key used to identify a
 	// multitenant RDS database clusters.

--- a/internal/tools/aws/filestore_multitenant.go
+++ b/internal/tools/aws/filestore_multitenant.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/mattermost/mattermost-cloud/model"
+	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// S3MultitenantFilestore is a filestore backed by a shared AWS S3 bucket.
+type S3MultitenantFilestore struct {
+	installationID string
+	awsClient      *Client
+}
+
+// NewS3MultitenantFilestore returns a new NewS3MultitenantFilestore interface.
+func NewS3MultitenantFilestore(installationID string, awsClient *Client) *S3MultitenantFilestore {
+	return &S3MultitenantFilestore{
+		installationID: installationID,
+		awsClient:      awsClient,
+	}
+}
+
+// Provision completes all the steps necessary to provision an S3 multitenant
+// filestore.
+func (f *S3MultitenantFilestore) Provision(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	err := f.s3FilestoreProvision(store, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to provision AWS multitenant S3 filestore")
+	}
+
+	return nil
+}
+
+// Teardown removes all AWS resources related to a shared S3 filestore.
+func (f *S3MultitenantFilestore) Teardown(keepData bool, store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	awsID := CloudID(f.installationID)
+
+	logger = logger.WithFields(log.Fields{
+		"awsID":          awsID,
+		"filestore-type": "s3-multitenant",
+	})
+	logger.Info("Tearing down AWS S3 filestore")
+
+	bucketName, err := f.getMultitenantBucketName(store)
+	if err != nil {
+		return errors.Wrap(err, "failed to find multitenant bucket")
+	}
+
+	logger = logger.WithField("s3-bucket-name", bucketName)
+
+	err = f.awsClient.iamEnsureUserDeleted(awsID, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete AWS IAM user")
+	}
+
+	err = f.awsClient.secretsManagerEnsureIAMAccessKeySecretDeleted(awsID, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete IAM access key secret")
+	}
+
+	if keepData {
+		logger.Info("AWS S3 bucket was left intact due to the keep-data setting of this server")
+		return nil
+	}
+
+	err = f.awsClient.S3EnsureBucketDirectoryDeleted(bucketName, f.installationID, logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to ensure that AWS S3 filestore was deleted")
+	}
+
+	logger.Debug("AWS multitenant S3 filestore was deleted")
+	return nil
+}
+
+// GenerateFilestoreSpecAndSecret creates the k8s filestore spec and secret for
+// accessing the shared S3 bucket.
+func (f *S3MultitenantFilestore) GenerateFilestoreSpecAndSecret(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) (*mmv1alpha1.Minio, *corev1.Secret, error) {
+	awsID := CloudID(f.installationID)
+
+	logger = logger.WithFields(log.Fields{
+		"awsID":          awsID,
+		"filestore-type": "s3-multitenant",
+	})
+	logger.Debug("Generating S3 multitenant filestore information")
+
+	bucketName, err := f.getMultitenantBucketName(store)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to find multitenant bucket")
+	}
+
+	logger = logger.WithField("s3-bucket-name", bucketName)
+
+	iamAccessKey, err := f.awsClient.secretsManagerGetIAMAccessKey(awsID, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	filestoreSecretName := fmt.Sprintf("%s-iam-access-key", f.installationID)
+	filestoreSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: filestoreSecretName,
+		},
+		StringData: map[string]string{
+			"accesskey": iamAccessKey.ID,
+			"secretkey": iamAccessKey.Secret,
+		},
+	}
+
+	S3RegionURL := S3URL
+	awsRegion := *f.awsClient.config.Region
+	if awsRegion != "" && awsRegion != "us-east-1" {
+		S3RegionURL = "s3." + awsRegion + ".amazonaws.com"
+	}
+
+	filestoreSpec := &mmv1alpha1.Minio{
+		ExternalURL:    S3RegionURL,
+		ExternalBucket: bucketName,
+		Secret:         filestoreSecretName,
+	}
+
+	logger.Debug("AWS multitenant S3 filestore configuration generated for cluster installation")
+
+	return filestoreSpec, filestoreSecret, nil
+}
+
+// s3FilestoreProvision provisions a shared S3 filestore for an installation.
+func (f *S3MultitenantFilestore) s3FilestoreProvision(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	awsID := CloudID(f.installationID)
+
+	logger = logger.WithFields(log.Fields{
+		"awsID":          awsID,
+		"filestore-type": "s3-multitenant",
+	})
+	logger.Info("Provisioning AWS multitenant S3 filestore")
+
+	bucketName, err := f.getMultitenantBucketName(store)
+	if err != nil {
+		return errors.Wrap(err, "failed to find multitenant bucket")
+	}
+
+	logger = logger.WithField("s3-bucket-name", bucketName)
+
+	user, err := f.awsClient.iamEnsureUserCreated(awsID, logger)
+	if err != nil {
+		return err
+	}
+
+	// The IAM policy lookup requires the AWS account ID for the ARN. The user
+	// object contains this ID so we will user that.
+	arn, err := arn.Parse(*user.Arn)
+	if err != nil {
+		return err
+	}
+	policyARN := fmt.Sprintf("arn:aws:iam::%s:policy/%s", arn.AccountID, awsID)
+	policy, err := f.awsClient.iamEnsureS3PolicyCreated(awsID, policyARN, bucketName, f.installationID, logger)
+	if err != nil {
+		return err
+	}
+	err = f.awsClient.iamEnsurePolicyAttached(awsID, policyARN, logger)
+	if err != nil {
+		return err
+	}
+	logger.WithFields(log.Fields{
+		"iam-policy-name": *policy.PolicyName,
+		"iam-user-name":   *user.UserName,
+	}).Debug("AWS IAM policy attached to user")
+
+	ak, err := f.awsClient.iamEnsureAccessKeyCreated(awsID, logger)
+	if err != nil {
+		return err
+	}
+	logger.WithField("iam-user-name", *user.UserName).Debug("AWS IAM user access key created")
+
+	err = f.awsClient.secretsManagerEnsureIAMAccessKeySecretCreated(awsID, ak, logger)
+	if err != nil {
+		return err
+	}
+	logger.WithField("iam-user-name", *user.UserName).Debug("AWS secrets manager secret created")
+
+	return nil
+}
+
+func (f *S3MultitenantFilestore) getMultitenantBucketName(store model.InstallationDatabaseStoreInterface) (string, error) {
+	envName, err := f.awsClient.GetCloudEnvironmentName()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get cloud environment name")
+	}
+	vpc, err := getVPCForInstallation(f.installationID, store, f.awsClient)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to find cluster installation VPC")
+	}
+
+	bucketName := MattermostMultitenantS3Name(envName, *vpc.VpcId)
+
+	// Ensure the bucket exists and that the tags are correct.
+	tags, err := f.awsClient.Service().s3.GetBucketTagging(&s3.GetBucketTaggingInput{
+		Bucket: aws.String(bucketName),
+	})
+	if aerr, ok := err.(awserr.Error); ok {
+		if aerr.Code() == s3.ErrCodeNoSuchBucket {
+			return "", errors.Wrapf(err, "failed to find bucket %s", bucketName)
+		}
+	} else if err != nil {
+		return "", errors.Wrap(err, "failed to get bucket tags")
+	}
+
+	if !ensureTagInTagset(trimTagPrefix(VpcIDTagKey), *vpc.VpcId, tags.TagSet) {
+		return "", errors.Errorf("failed to find %s tag on S3 bucket %s", VpcIDTagKey, bucketName)
+	}
+	if !ensureTagInTagset(trimTagPrefix(FilestoreMultitenantS3TagKey), FilestoreMultitenantS3TagValue, tags.TagSet) {
+		return "", errors.Errorf("failed to find %s tag on S3 bucket %s", FilestoreMultitenantS3TagKey, bucketName)
+	}
+
+	return bucketName, nil
+}
+
+func ensureTagInTagset(key, value string, tags []*s3.Tag) bool {
+	for _, tag := range tags {
+		if *tag.Key == key && *tag.Value == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/tools/aws/filestore_test.go
+++ b/internal/tools/aws/filestore_test.go
@@ -31,7 +31,7 @@ func TestFilestoreProvision(t *testing.T) {
 
 	logger.Warnf("Provisioning down AWS filestore %s", id)
 
-	err := filestore.Provision(logger)
+	err := filestore.Provision(nil, logger)
 	require.NoError(t, err)
 }
 
@@ -48,6 +48,6 @@ func TestFilestoreTeardown(t *testing.T) {
 
 	logger.Warnf("Tearing down AWS filestore %s", id)
 
-	err := filestore.Teardown(false, logger)
+	err := filestore.Teardown(false, nil, logger)
 	require.NoError(t, err)
 }

--- a/internal/tools/aws/s3.go
+++ b/internal/tools/aws/s3.go
@@ -87,3 +87,19 @@ func (a *Client) S3EnsureBucketDeleted(bucketName string, logger log.FieldLogger
 
 	return nil
 }
+
+// S3EnsureBucketDirectoryDeleted is used to ensure that a bucket directory is
+// deleted.
+func (a *Client) S3EnsureBucketDirectoryDeleted(bucketName, directory string, logger log.FieldLogger) error {
+	iter := s3manager.NewDeleteListIterator(a.Service().s3, &s3.ListObjectsInput{
+		Bucket: aws.String(bucketName),
+		Prefix: aws.String(directory),
+	})
+
+	err := s3manager.NewBatchDeleteWithClient(a.Service().s3).Delete(aws.BackgroundContext(), iter)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete bucket directory")
+	}
+
+	return nil
+}

--- a/internal/tools/aws/session.go
+++ b/internal/tools/aws/session.go
@@ -27,13 +27,13 @@ func NewAWSSessionWithLogger(config *aws.Config, logger log.FieldLogger) (*sessi
 		if r.HTTPResponse != nil && r.HTTPRequest != nil {
 			var buffer bytes.Buffer
 
-			buffer.WriteString(fmt.Sprintf("[aws] %s %s %s ", r.HTTPRequest.Method, r.HTTPResponse.Status, r.HTTPResponse.Request.URL.String()))
+			buffer.WriteString(fmt.Sprintf("[aws] %s %s (%s)", r.HTTPRequest.Method, r.HTTPRequest.URL.String(), r.HTTPResponse.Status))
 
 			paramBytes, err := json.Marshal(r.Params)
 			if err != nil {
 				buffer.WriteString(err.Error())
 			} else {
-				buffer.Write(paramBytes)
+				logger = logger.WithField("params", string(paramBytes))
 			}
 
 			logger = logger.WithFields(logrus.Fields{

--- a/internal/tools/utils/utils.go
+++ b/internal/tools/utils/utils.go
@@ -102,6 +102,8 @@ func (r *ResourceUtil) GetFilestore(installation *model.Installation) model.File
 		return model.NewMinioOperatorFilestore()
 	case model.InstallationFilestoreAwsS3:
 		return aws.NewS3Filestore(installation.ID, r.awsClient)
+	case model.InstallationFilestoreMultiTenantAwsS3:
+		return aws.NewS3MultitenantFilestore(installation.ID, r.awsClient)
 	}
 
 	// Warning: we should never get here as it would mean that we didn't match


### PR DESCRIPTION
This new filestore option allows multiple installations to share
a single S3 bucket. When used, IAM bucket policies are created to
limit installation access to a single subdirectory of the bucket
and the Mattermost server configuration is set to use this
subdirectory.

Other changes:
 - Move AWS environment lookup logic to the AWS package.
 - Changed AWS debug logging to use more log fields.

Fixes https://mattermost.atlassian.net/browse/MM-28449

```release-note
Add S3 Multitenant Filestore
```
