### PR TITLE
Add table output option for resource lists

### DIFF
--- a/cmd/cloud/cluster_installation.go
+++ b/cmd/cloud/cluster_installation.go
@@ -6,9 +6,11 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +26,7 @@ func init() {
 	clusterInstallationListCmd.Flags().Int("page", 0, "The page of cluster installations to fetch, starting at 0.")
 	clusterInstallationListCmd.Flags().Int("per-page", 100, "The number of cluster installations to fetch per page.")
 	clusterInstallationListCmd.Flags().Bool("include-deleted", false, "Whether to include deleted cluster installations.")
+	clusterInstallationListCmd.Flags().Bool("table", false, "Whether to display the returned cluster installation list in a table or not")
 
 	clusterInstallationConfigCmd.PersistentFlags().String("cluster-installation", "", "The id of the cluster installation.")
 	clusterInstallationConfigCmd.MarkFlagRequired("cluster-installation")
@@ -109,6 +112,20 @@ var clusterInstallationListCmd = &cobra.Command{
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to query cluster installations")
+		}
+
+		outputToTable, _ := command.Flags().GetBool("table")
+		if outputToTable {
+			table := tablewriter.NewWriter(os.Stdout)
+			table.SetAlignment(tablewriter.ALIGN_LEFT)
+			table.SetHeader([]string{"ID", "STATE", "INSTALLATION ID", "CLUSTER ID"})
+
+			for _, ci := range clusterInstallations {
+				table.Append([]string{ci.ID, ci.State, ci.InstallationID, ci.InstallationID})
+			}
+			table.Render()
+
+			return nil
 		}
 
 		err = printJSON(clusterInstallations)

--- a/cmd/cloud/cluster_installation.go
+++ b/cmd/cloud/cluster_installation.go
@@ -121,7 +121,7 @@ var clusterInstallationListCmd = &cobra.Command{
 			table.SetHeader([]string{"ID", "STATE", "INSTALLATION ID", "CLUSTER ID"})
 
 			for _, ci := range clusterInstallations {
-				table.Append([]string{ci.ID, ci.State, ci.InstallationID, ci.InstallationID})
+				table.Append([]string{ci.ID, ci.State, ci.InstallationID, ci.ClusterID})
 			}
 			table.Render()
 

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -5,7 +5,10 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -49,6 +52,7 @@ func init() {
 	installationListCmd.Flags().Int("page", 0, "The page of installations to fetch, starting at 0.")
 	installationListCmd.Flags().Int("per-page", 100, "The number of installations to fetch per page.")
 	installationListCmd.Flags().Bool("include-deleted", false, "Whether to include deleted installations.")
+	installationListCmd.Flags().Bool("table", false, "Whether to display the returned installation list in a table or not")
 
 	installationHibernateCmd.Flags().String("installation", "", "The id of the installation to put into hibernation.")
 	installationHibernateCmd.MarkFlagRequired("installation")
@@ -308,6 +312,20 @@ var installationListCmd = &cobra.Command{
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to query installations")
+		}
+
+		outputToTable, _ := command.Flags().GetBool("table")
+		if outputToTable {
+			table := tablewriter.NewWriter(os.Stdout)
+			table.SetAlignment(tablewriter.ALIGN_LEFT)
+			table.SetHeader([]string{"ID", "STATE", "VERSION", "DATABASE", "FILESTORE", "DNS"})
+
+			for _, installation := range installations {
+				table.Append([]string{installation.ID, installation.State, installation.Version, installation.Database, installation.Filestore, installation.DNS})
+			}
+			table.Render()
+
+			return nil
 		}
 
 		err = printJSON(installations)

--- a/cmd/cloud/webhook.go
+++ b/cmd/cloud/webhook.go
@@ -5,7 +5,10 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +28,7 @@ func init() {
 	webhookListCmd.Flags().Int("page", 0, "The page of webhooks to fetch, starting at 0.")
 	webhookListCmd.Flags().Int("per-page", 100, "The number of webhooks to fetch per page.")
 	webhookListCmd.Flags().Bool("include-deleted", false, "Whether to include deleted webhooks.")
+	webhookListCmd.Flags().Bool("table", false, "Whether to display the returned webhook list in a table or not")
 
 	webhookDeleteCmd.Flags().String("webhook", "", "The id of the webhook to be deleted.")
 	webhookDeleteCmd.MarkFlagRequired("webhook")
@@ -117,6 +121,20 @@ var webhookListCmd = &cobra.Command{
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to query webhooks")
+		}
+
+		outputToTable, _ := command.Flags().GetBool("table")
+		if outputToTable {
+			table := tablewriter.NewWriter(os.Stdout)
+			table.SetAlignment(tablewriter.ALIGN_LEFT)
+			table.SetHeader([]string{"ID", "OWNER", "URL"})
+
+			for _, webhook := range webhooks {
+				table.Append([]string{webhook.ID, webhook.OwnerID, webhook.URL})
+			}
+			table.Render()
+
+			return nil
 		}
 
 		err = printJSON(webhooks)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/lib/pq v1.8.0
 	github.com/mattermost/mattermost-operator v1.6.1-0.20200818143941-8810bed9630a
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pborman/uuid v1.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -603,6 +603,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
@@ -663,6 +665,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2/go.mod h1:rSAaSIOAGT9odnlyGlUfAJaoc5w2fSBUmeGDbRWPxyQ=
+github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
+github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
The new table option allows for listing resources in a more compact
and readable way. Not all resource fields are shown so the standard
JSON output should be used when viewing all details is required.

Fixes https://mattermost.atlassian.net/browse/MM-28986

```release-note
Add table output option for resource lists
```
