### PR TITLE
MM-16248 Add a health check to Provisioner start-up

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -182,7 +182,7 @@ var serverCmd = &cobra.Command{
 		}
 		awsClient := toolsAWS.NewAWSClientWithConfig(awsConfig, logger)
 
-		err = healthCheck(awsConfig, s3StateStore)
+		err = checkRequirements(awsConfig, s3StateStore)
 		if err != nil {
 			return errors.Wrap(err, "failed health check")
 		}
@@ -277,7 +277,7 @@ var serverCmd = &cobra.Command{
 	},
 }
 
-func healthCheck(awsConfig *sdkAWS.Config, s3StateStore string) error {
+func checkRequirements(awsConfig *sdkAWS.Config, s3StateStore string) error {
 	for _, requiredUtility := range []string{
 		"terraform",
 		"helm",

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -6,11 +6,13 @@ package main
 
 import (
 	"context"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path"
 	"strings"
 	"syscall"
 	"time"
@@ -172,15 +174,18 @@ var serverCmd = &cobra.Command{
 		if awsRegion == "" {
 			awsRegion = toolsAWS.DefaultAWSRegion
 		}
-		awsClient := toolsAWS.NewAWSClientWithConfig(
-			&sdkAWS.Config{
-				Region: sdkAWS.String(awsRegion),
-				// TODO: we should use Retryer for a more robust retry strategy.
-				// https://github.com/aws/aws-sdk-go/blob/99cd35c8c7d369ba8c32c46ed306f6c88d24cfd7/aws/request/retryer.go#L20
-				MaxRetries: sdkAWS.Int(toolsAWS.DefaultAWSClientRetries),
-			},
-			logger,
-		)
+		awsConfig := &sdkAWS.Config{
+			Region: sdkAWS.String(awsRegion),
+			// TODO: we should use Retryer for a more robust retry strategy.
+			// https://github.com/aws/aws-sdk-go/blob/99cd35c8c7d369ba8c32c46ed306f6c88d24cfd7/aws/request/retryer.go#L20
+			MaxRetries: sdkAWS.Int(toolsAWS.DefaultAWSClientRetries),
+		}
+		awsClient := toolsAWS.NewAWSClientWithConfig(awsConfig, logger)
+
+		err = healthCheck(awsConfig, s3StateStore)
+		if err != nil {
+			return errors.Wrap(err, "failed health check")
+		}
 
 		resourceUtil := utils.NewResourceUtil(instanceID, awsClient)
 
@@ -270,6 +275,63 @@ var serverCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func healthCheck(awsConfig *sdkAWS.Config, s3StateStore string) error {
+	for _, requiredUtility := range []string{
+		"terraform",
+		"helm",
+		"kops",
+		"kubectl",
+	} {
+		_, err := exec.LookPath(requiredUtility)
+		if err != nil {
+			return errors.Errorf("failed to find %s on the PATH", requiredUtility)
+		}
+	}
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return errors.Wrap(err, "failed to determine the current user's home directory")
+	}
+	sshDir := path.Join(homedir, ".ssh")
+	possibleKeys, err := ioutil.ReadDir(sshDir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to find a SSH key in %s", sshDir)
+
+	}
+	hasKeys := func() bool {
+		for _, k := range possibleKeys {
+			if k.IsDir() {
+				continue
+			}
+			keyFile, err := os.Open(path.Join(sshDir, k.Name()))
+			if err != nil {
+				continue
+			}
+			prefix := make([]byte, 3)
+			read, err := keyFile.Read(prefix)
+			if read == 0 || err != nil {
+				continue
+			}
+			if string(prefix) == "ssh" {
+				return true
+			}
+		}
+		return false
+	}()
+	if !hasKeys {
+		return errors.Errorf("failed to find an SSH key in %s", homedir)
+	}
+	if !strings.HasPrefix(s3StateStore, "cloud") {
+		return errors.Errorf("the state bucket in S3 provided (%s) does not start with 'cloud-' which is a required prefix", s3StateStore)
+	}
+	client := toolsAWS.NewAWSClientWithConfig(awsConfig, logger)
+	_, err = client.GetCloudEnvironmentName()
+	if err != nil {
+		return errors.Wrap(err, "failed to establish a connection with AWS")
+	}
+
+	return nil
 }
 
 // deprecationWarnings performs all checks for deprecated settings and warns if


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This change adds a few health checks to Provisioner startup to end early if basic necessary components are not in place.

1) Checks for the following binaries installed on the system:
    - terraform
    - kubectl
    - kops
    - helm
2) Checks that there is at least one SSH key installed in `~/.ssh`.

    One limitation of this is that AWS doesn't support all SSH key types, so e.g. if you have an ed25519 key, this check will pass but then later operations may fail. I didn't want to bake AWS's limitation surrounding this into our codebase, however, as hopefully they will support ed25519 keys and I am not sure (and couldn't find documentation describing) which other key types they _do_ support, other than RSA.

3) Establishes a connection with AWS and does `GetCloudEnvironmentName()` in order to confirm that the connection to AWS works -- thereby confirming that the user has set up AWS credentials or environment variables.

Am I missing anything else?

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-16248

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added a health check to Provisioner startup to ensure the basic requirements are met.
```
