### PR TITLE
MM-27129 - Add group status endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ clusters
 cloud*.db
 coverage.out
 .vscode
+/.idea
 build/_output/
 bin/*

--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -267,7 +267,7 @@ var groupListCmd = &cobra.Command{
 
 var groupGetStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Get a particular groups status.",
+	Short: "Get a particular group's status.",
 	RunE: func(command *cobra.Command, args []string) error {
 		command.SilenceUsage = true
 

--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -47,6 +47,9 @@ func init() {
 	groupListCmd.Flags().Bool("include-deleted", false, "Whether to include deleted groups.")
 	groupListCmd.Flags().Bool("table", false, "Whether to display the returned group list in a table or not")
 
+	groupGetStatusCmd.Flags().String("group", "", "The id of the group of which the status should be fetched.")
+	groupGetStatusCmd.MarkFlagRequired("group")
+
 	groupJoinCmd.Flags().String("group", "", "The id of the group to which the installation will be added.")
 	groupJoinCmd.Flags().String("installation", "", "The id of the installation to add to the group.")
 	groupJoinCmd.MarkFlagRequired("group")
@@ -61,6 +64,7 @@ func init() {
 	groupCmd.AddCommand(groupDeleteCmd)
 	groupCmd.AddCommand(groupGetCmd)
 	groupCmd.AddCommand(groupListCmd)
+	groupCmd.AddCommand(groupGetStatusCmd)
 	groupCmd.AddCommand(groupJoinCmd)
 	groupCmd.AddCommand(groupLeaveCmd)
 }
@@ -253,6 +257,33 @@ var groupListCmd = &cobra.Command{
 		}
 
 		err = printJSON(groups)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var groupGetStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Get a particular groups status.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		groupID, _ := command.Flags().GetString("group")
+		groupStatus, err := client.GetGroupStatus(groupID)
+		if err != nil {
+			return errors.Wrap(err, "failed to query group status")
+		}
+		if groupStatus == nil {
+			return nil
+		}
+
+		err = printJSON(groupStatus)
 		if err != nil {
 			return err
 		}

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -52,6 +52,7 @@ type Store interface {
 	LockGroupAPI(groupID string) error
 	UnlockGroupAPI(groupID string) error
 	DeleteGroup(groupID string) error
+	GetGroupStatus(groupID string) (*model.GroupStatus, error)
 
 	CreateWebhook(webhook *model.Webhook) error
 	GetWebhook(webhookID string) (*model.Webhook, error)

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -26,7 +26,6 @@ func initGroup(apiRouter *mux.Router, context *Context) {
 	groupRouter.Handle("", addContext(handleUpdateGroup)).Methods("PUT")
 	groupRouter.Handle("", addContext(handleDeleteGroup)).Methods("DELETE")
 	groupRouter.Handle("/status", addContext(handleGetGroupStatus)).Methods("GET")
-
 }
 
 // handleGetGroup responds to GET /api/group/{group}, returning the group in question.

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -497,9 +497,9 @@ func TestGroupStatus(t *testing.T) {
 
 	t.Run("empty group", func(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
-			InstallationsCount:           0,
-			InstallationsRolledOut:       0,
-			InstallationsAwaitingRollOut: 0,
+			InstallationsTotal:          0,
+			InstallationsUpdated:        0,
+			InstallationsAwaitingUpdate: 0,
 		}
 		groupStatus, err := client.GetGroupStatus(group.ID)
 		require.NoError(t, err)
@@ -508,9 +508,9 @@ func TestGroupStatus(t *testing.T) {
 
 	t.Run("ignore different groups", func(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
-			InstallationsCount:           0,
-			InstallationsRolledOut:       0,
-			InstallationsAwaitingRollOut: 0,
+			InstallationsTotal:          0,
+			InstallationsUpdated:        0,
+			InstallationsAwaitingUpdate: 0,
 		}
 		ignoredGroup, err := client.CreateGroup(&model.CreateGroupRequest{
 			Name:        "group2",
@@ -530,9 +530,9 @@ func TestGroupStatus(t *testing.T) {
 
 	t.Run("count installations", func(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
-			InstallationsCount:           6,
-			InstallationsRolledOut:       2,
-			InstallationsAwaitingRollOut: 1,
+			InstallationsTotal:          6,
+			InstallationsUpdated:        2,
+			InstallationsAwaitingUpdate: 1,
 		}
 		var differentSequence int64 = -1
 

--- a/internal/store/group.go
+++ b/internal/store/group.go
@@ -170,10 +170,10 @@ func (sqlStore *SQLStore) GetGroupRollingMetadata(groupID string) (*GroupRolling
 }
 
 // GetGroupStatus returns total number of installations in the group as well as number or
-// Installations already rolled out and awaiting rollout
+// Installations already rolled out and awaiting rollout.
 //
 // Note: This function uses the same conditions as GetGroupRollingMetadata to be more accurate
-// with the internal state seen by the Group Supervisor
+// with the internal state seen by the Group Supervisor.
 func (sqlStore *SQLStore) GetGroupStatus(groupID string) (*model.GroupStatus, error) {
 	group, err := sqlStore.GetGroup(groupID)
 	if err != nil {

--- a/internal/store/group_test.go
+++ b/internal/store/group_test.go
@@ -585,9 +585,9 @@ func TestGetGroupStatus(t *testing.T) {
 
 	t.Run("empty group", func(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
-			InstallationsCount:           0,
-			InstallationsRolledOut:       0,
-			InstallationsAwaitingRollOut: 0,
+			InstallationsTotal:          0,
+			InstallationsUpdated:        0,
+			InstallationsAwaitingUpdate: 0,
 		}
 		groupStatus, err := sqlStore.GetGroupStatus(group1.ID)
 		require.NoError(t, err)
@@ -614,9 +614,9 @@ func TestGetGroupStatus(t *testing.T) {
 	t.Run("group with installation", func(t *testing.T) {
 		// unstable
 		expectedStatus := &model.GroupStatus{
-			InstallationsCount:           1,
-			InstallationsRolledOut:       0,
-			InstallationsAwaitingRollOut: 0,
+			InstallationsTotal:          1,
+			InstallationsUpdated:        0,
+			InstallationsAwaitingUpdate: 0,
 		}
 		groupStatus, err := sqlStore.GetGroupStatus(group1.ID)
 		require.NoError(t, err)
@@ -630,9 +630,9 @@ func TestGetGroupStatus(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 
 		expectedStatus = &model.GroupStatus{
-			InstallationsCount:           1,
-			InstallationsRolledOut:       0,
-			InstallationsAwaitingRollOut: 1,
+			InstallationsTotal:          1,
+			InstallationsUpdated:        0,
+			InstallationsAwaitingUpdate: 1,
 		}
 		groupStatus, err = sqlStore.GetGroupStatus(group1.ID)
 		require.NoError(t, err)
@@ -644,9 +644,9 @@ func TestGetGroupStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedStatus = &model.GroupStatus{
-			InstallationsCount:           1,
-			InstallationsRolledOut:       1,
-			InstallationsAwaitingRollOut: 0,
+			InstallationsTotal:          1,
+			InstallationsUpdated:        1,
+			InstallationsAwaitingUpdate: 0,
 		}
 		groupStatus, err = sqlStore.GetGroupStatus(group1.ID)
 		require.NoError(t, err)

--- a/model/client.go
+++ b/model/client.go
@@ -714,6 +714,26 @@ func (c *Client) GetGroups(request *GetGroupsRequest) ([]*Group, error) {
 	}
 }
 
+// GetGroupStatus fetches the status for specified group from the configured provisioning server.
+func (c *Client) GetGroupStatus(groupID string) (*GroupStatus, error) {
+	resp, err := c.doGet(c.buildURL("/api/group/%s/status", groupID))
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return GroupStatusFromReader(resp.Body)
+
+	case http.StatusNotFound:
+		return nil, nil
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // JoinGroup joins an installation to the given group, leaving any existing group.
 func (c *Client) JoinGroup(groupID, installationID string) error {
 	resp, err := c.doPut(c.buildURL("/api/installation/%s/group/%s", installationID, groupID), nil)

--- a/model/group_status.go
+++ b/model/group_status.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// GroupStatus represents the status of group rollout
+type GroupStatus struct {
+	InstallationsCount           int64
+	InstallationsRolledOut       int64
+	InstallationsAwaitingRollOut int64
+}
+
+// GroupStatusFromReader decodes a json-encoded group status from the given io.Reader.
+func GroupStatusFromReader(reader io.Reader) (*GroupStatus, error) {
+	groupStatus := GroupStatus{}
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&groupStatus)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &groupStatus, nil
+}

--- a/model/group_status.go
+++ b/model/group_status.go
@@ -11,9 +11,9 @@ import (
 
 // GroupStatus represents the status of a group.
 type GroupStatus struct {
-	InstallationsCount           int64
-	InstallationsRolledOut       int64
-	InstallationsAwaitingRollOut int64
+	InstallationsTotal          int64
+	InstallationsUpdated        int64
+	InstallationsAwaitingUpdate int64
 }
 
 // GroupStatusFromReader decodes a json-encoded group status from the given io.Reader.

--- a/model/group_status.go
+++ b/model/group_status.go
@@ -9,7 +9,7 @@ import (
 	"io"
 )
 
-// GroupStatus represents the status of group rollout
+// GroupStatus represents the status of a group.
 type GroupStatus struct {
 	InstallationsCount           int64
 	InstallationsRolledOut       int64

--- a/model/group_status_test.go
+++ b/model/group_status_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGroupStatusFromReader(t *testing.T) {
+	t.Run("empty json", func(t *testing.T) {
+		groupStatus, err := GroupStatusFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &GroupStatus{}, groupStatus)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		groupStatus, err := GroupStatusFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, groupStatus)
+	})
+
+	t.Run("valid group status", func(t *testing.T) {
+		groupStatus, err := GroupStatusFromReader(bytes.NewReader([]byte(`{
+			"InstallationsCount": 3,
+			"InstallationsRolledOut": 2,
+			"InstallationsAwaitingRollOut": 1
+		}`)))
+		require.NoError(t, err)
+		require.Equal(t, &GroupStatus{
+			InstallationsCount:           3,
+			InstallationsRolledOut:       2,
+			InstallationsAwaitingRollOut: 1,
+		}, groupStatus)
+	})
+}

--- a/model/group_status_test.go
+++ b/model/group_status_test.go
@@ -29,15 +29,15 @@ func TestGroupStatusFromReader(t *testing.T) {
 
 	t.Run("valid group status", func(t *testing.T) {
 		groupStatus, err := GroupStatusFromReader(bytes.NewReader([]byte(`{
-			"InstallationsCount": 3,
-			"InstallationsRolledOut": 2,
-			"InstallationsAwaitingRollOut": 1
+			"InstallationsTotal": 3,
+			"InstallationsUpdated": 2,
+			"InstallationsAwaitingUpdate": 1
 		}`)))
 		require.NoError(t, err)
 		require.Equal(t, &GroupStatus{
-			InstallationsCount:           3,
-			InstallationsRolledOut:       2,
-			InstallationsAwaitingRollOut: 1,
+			InstallationsTotal:          3,
+			InstallationsUpdated:        2,
+			InstallationsAwaitingUpdate: 1,
 		}, groupStatus)
 	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Changes in the PR:
- Add initial version of group status endpoint to API
  - Endpoint path: `api/group/[GROUP_ID]/status`
  - Response data:
    - `InstallationsTotal`
    - `InstallationsUpdated`
    - `InstallationsAwaitingUpdate`
- Add new command to CLI, which targets the new endpoint
  ```
  cloud group status --group=[GROUP_ID]
  ```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-27129

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add endpoint returning the Group status
```
