### PR TITLE
Add read replica configuration to installations

### DIFF
--- a/internal/tools/aws/database_multitenant.go
+++ b/internal/tools/aws/database_multitenant.go
@@ -209,24 +209,27 @@ func (d *RDSMultitenantDatabase) GenerateDatabaseSpecAndSecret(store model.Insta
 		return nil, nil, errors.Wrap(err, "failed to unmarshal secret payload")
 	}
 
-	var databaseConnectionString string
+	var databaseConnectionString, databaseReadReplicasString string
 	if d.databaseType == model.DatabaseEngineTypeMySQL {
-		databaseConnectionString = MattermostMySQLConnString(
-			installationDatabaseName,
-			*rdsCluster.Endpoint,
-			installationSecret.MasterUsername,
-			installationSecret.MasterPassword,
-		)
+		databaseConnectionString, databaseReadReplicasString =
+			MattermostMySQLConnStrings(
+				installationDatabaseName,
+				*rdsCluster.Endpoint,
+				installationSecret.MasterUsername,
+				installationSecret.MasterPassword,
+			)
 	} else {
-		databaseConnectionString = MattermostPostgresConnString(
-			installationDatabaseName,
-			*rdsCluster.Endpoint,
-			installationSecret.MasterUsername,
-			installationSecret.MasterPassword,
-		)
+		databaseConnectionString, databaseReadReplicasString =
+			MattermostPostgresConnStrings(
+				installationDatabaseName,
+				*rdsCluster.Endpoint,
+				installationSecret.MasterUsername,
+				installationSecret.MasterPassword,
+			)
 	}
 	secretStringData := map[string]string{
-		"DB_CONNECTION_STRING": databaseConnectionString,
+		"DB_CONNECTION_STRING":              databaseConnectionString,
+		"MM_SQLSETTINGS_DATASOURCEREPLICAS": databaseReadReplicasString,
 	}
 
 	databaseSecret := &corev1.Secret{

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -108,26 +108,37 @@ func MattermostRDSDatabaseName(installationID string) string {
 	return fmt.Sprintf("%s%s", rdsDatabaseNamePrefix, installationID)
 }
 
-// MattermostMySQLConnString formats the connection string used for accessing a Mattermost database.
-func MattermostMySQLConnString(schema, endpoint, username, password string) string {
-	return fmt.Sprintf("mysql://%s:%s@tcp(%s:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
+// MattermostMySQLConnStrings formats the connection string used for accessing a
+// Mattermost database.
+func MattermostMySQLConnStrings(schema, endpoint, username, password string) (string, string) {
+	dbConnection := fmt.Sprintf("mysql://%s:%s@tcp(%s:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
 		username, password, endpoint, schema)
+	readReplicas := fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
+		username, password, endpoint, schema)
+
+	return dbConnection, readReplicas
 }
 
-// RDSMySQLConnString formats the connection string used for accessing a MySQL RDS cluster.
+// RDSMySQLConnString formats the connection string used by the provisioner for
+// accessing a MySQL RDS cluster.
 func RDSMySQLConnString(schema, endpoint, username, password string) string {
 	return fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?interpolateParams=true&charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
 		username, password, endpoint, schema)
 }
 
-// MattermostPostgresConnString formats the connection string used by Mattermost
+// MattermostPostgresConnStrings formats the connection strings used by Mattermost
 // servers to access a PostgreSQL database.
-func MattermostPostgresConnString(schema, endpoint, username, password string) string {
-	return fmt.Sprintf("postgres://%s:%s@%s:5432/%s?connect_timeout=10",
+func MattermostPostgresConnStrings(schema, endpoint, username, password string) (string, string) {
+	dbConnection := fmt.Sprintf("postgres://%s:%s@%s:5432/%s?connect_timeout=10",
 		username, password, endpoint, schema)
+	readReplicas := fmt.Sprintf("postgres://%s:%s@%s:5432/%s?connect_timeout=10",
+		username, password, endpoint, schema)
+
+	return dbConnection, readReplicas
 }
 
-// RDSPostgresConnString formats the connection string used for accessing a Postgres RDS cluster.
+// RDSPostgresConnString formats the connection string used by the provisioner
+// for accessing a Postgres RDS cluster.
 func RDSPostgresConnString(schema, endpoint, username, password string) string {
 	return fmt.Sprintf("postgres://%s:%s@%s:5432/%s?connect_timeout=10",
 		username, password, endpoint, schema)


### PR DESCRIPTION
New installations created with external databases now have the
correct read replica settings applied. This includes both MySQL
and PostgreSQL database engines for multitenant and single tenant
database types.

Fixes https://mattermost.atlassian.net/browse/MM-28840

```release-note
Add read replica configuration to installations
```
