### PR TITLE
add installation dns in the webhook payload for the installations

### DIFF
--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -185,6 +185,7 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		NewState:  model.InstallationStateCreationRequested,
 		OldState:  "n/a",
 		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"DNS": installation.DNS},
 	}
 	err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {
@@ -231,6 +232,7 @@ func handleRetryCreateInstallation(c *Context, w http.ResponseWriter, r *http.Re
 			NewState:  newState,
 			OldState:  installation.State,
 			Timestamp: time.Now().UnixNano(),
+			ExtraData: map[string]string{"DNS": installation.DNS},
 		}
 		installation.State = newState
 
@@ -308,6 +310,7 @@ func handleUpdateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 			NewState:  newState,
 			OldState:  oldState,
 			Timestamp: time.Now().UnixNano(),
+			ExtraData: map[string]string{"DNS": installation.DNS},
 		}
 		err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
 		if err != nil {
@@ -491,6 +494,7 @@ func handleHibernateInstallation(c *Context, w http.ResponseWriter, r *http.Requ
 		NewState:  newState,
 		OldState:  oldState,
 		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"DNS": installation.DNS},
 	}
 	err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {
@@ -549,6 +553,7 @@ func handleWakeupInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		NewState:  newState,
 		OldState:  oldState,
 		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"DNS": installation.DNS},
 	}
 	err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {
@@ -598,6 +603,7 @@ func handleDeleteInstallation(c *Context, w http.ResponseWriter, r *http.Request
 			NewState:  newState,
 			OldState:  installation.State,
 			Timestamp: time.Now().UnixNano(),
+			ExtraData: map[string]string{"DNS": installation.DNS},
 		}
 		installation.State = newState
 

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -182,6 +182,7 @@ func (s *InstallationSupervisor) Supervise(installation *model.Installation) {
 		NewState:  newState,
 		OldState:  oldState,
 		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"DNS": installation.DNS},
 	}
 	err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {


### PR DESCRIPTION

#### Summary
Adding the Installation DNS in the extra data when sending the installation wwebhook messages

#### Ticket Link
<!--
none

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
