### PR TITLE
kops: validate AMI image before running the upgrade k8s cluster

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -83,7 +83,7 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 		return errors.Wrapf(err, "error checking the AWS AMI Image %s", cluster.ProvisionerMetadataKops.AMI)
 	}
 	if !isAMIValid {
-		return errors.Wrapf(err, "invalid AWS AMI Image %s", cluster.ProvisionerMetadataKops.AMI)
+		return errors.Errorf("invalid AWS AMI Image %s", cluster.ProvisionerMetadataKops.AMI)
 	}
 
 	kopsMetadata := cluster.ProvisionerMetadataKops
@@ -436,8 +436,16 @@ func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster, aws
 }
 
 // UpgradeCluster upgrades a cluster to the latest recommended production ready k8s version.
-func (provisioner *KopsProvisioner) UpgradeCluster(cluster *model.Cluster) error {
+func (provisioner *KopsProvisioner) UpgradeCluster(cluster *model.Cluster, awsClient aws.AWS) error {
 	logger := provisioner.logger.WithField("cluster", cluster.ID)
+
+	isAMIValid, err := awsClient.IsValidAMI(cluster.ProvisionerMetadataKops.AMI, logger)
+	if err != nil {
+		return errors.Wrapf(err, "error checking the AWS AMI Image %s", cluster.ProvisionerMetadataKops.AMI)
+	}
+	if !isAMIValid {
+		return errors.Errorf("invalid AWS AMI Image %s", cluster.ProvisionerMetadataKops.AMI)
+	}
 
 	kopsMetadata := cluster.ProvisionerMetadataKops
 

--- a/internal/supervisor/cluster.go
+++ b/internal/supervisor/cluster.go
@@ -31,7 +31,7 @@ type clusterProvisioner interface {
 	PrepareCluster(cluster *model.Cluster) bool
 	CreateCluster(cluster *model.Cluster, aws aws.AWS) error
 	ProvisionCluster(cluster *model.Cluster, aws aws.AWS) error
-	UpgradeCluster(cluster *model.Cluster) error
+	UpgradeCluster(cluster *model.Cluster, aws aws.AWS) error
 	ResizeCluster(cluster *model.Cluster) error
 	DeleteCluster(cluster *model.Cluster, aws aws.AWS) error
 	RefreshKopsMetadata(cluster *model.Cluster) error
@@ -198,7 +198,7 @@ func (s *ClusterSupervisor) provisionCluster(cluster *model.Cluster, logger log.
 }
 
 func (s *ClusterSupervisor) upgradeCluster(cluster *model.Cluster, logger log.FieldLogger) string {
-	err := s.provisioner.UpgradeCluster(cluster)
+	err := s.provisioner.UpgradeCluster(cluster, s.aws)
 	if err != nil {
 		logger.WithError(err).Error("Failed to upgrade cluster")
 		return model.ClusterStateUpgradeFailed

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -74,7 +74,7 @@ func (p *mockClusterProvisioner) ProvisionCluster(cluster *model.Cluster, aws aw
 	return nil
 }
 
-func (p *mockClusterProvisioner) UpgradeCluster(cluster *model.Cluster) error {
+func (p *mockClusterProvisioner) UpgradeCluster(cluster *model.Cluster, aws aws.AWS) error {
 	return nil
 }
 


### PR DESCRIPTION
#### Summary
validate AMI image before running the upgrade k8s commands, similar we do when creating the cluster

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-29325

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
kops: validate AMI image before running the upgrade k8s cluster
```
