### PR TITLE
MM-29370 Provide for a configurable directory for the Utility Group

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -127,7 +127,11 @@ var serverCmd = &cobra.Command{
 		keepFilestoreData, _ := command.Flags().GetBool("keep-filestore-data")
 		useExistingResources, _ := command.Flags().GetBool("use-existing-aws-resources")
 
-		model.UtilityValuesDirectory, _ = command.Flags().GetString("utility-values-directory")
+		utilityValuesDirectory, _ := command.Flags().GetString("utility-values-directory")
+		if _, err := os.Stat(utilityValuesDirectory); err != nil {
+			return errors.Wrapf(err, "failed to load Utility Group values from directory %s", utilityValuesDirectory)
+		}
+		model.SetUtilityValuesDirectory(utilityValuesDirectory)
 
 		wd, err := os.Getwd()
 		if err != nil {

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -49,7 +49,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("cluster-installation-supervisor", true, "Whether this server will run a cluster installation supervisor or not.")
 	serverCmd.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
 	serverCmd.PersistentFlags().StringSlice("allow-list-cidr-range", []string{"0.0.0.0/0"}, "The list of CIDRs to allow communication with the private ingress.")
-
+	serverCmd.PersistentFlags().String("utility-values-directory", "./helm-charts", "The location of the Helm charts and other metadata for Cluster Utilities.")
 	serverCmd.PersistentFlags().Int("poll", 30, "The interval in seconds to poll for background work.")
 	serverCmd.PersistentFlags().Int("cluster-resource-threshold", 80, "The percent threshold where new installations won't be scheduled on a multi-tenant cluster.")
 	serverCmd.PersistentFlags().Int("cluster-resource-threshold-scale-value", 0, "The number of worker nodes to scale up by when the threshold is passed. Set to 0 for no scaling. Scaling will never exceed the cluster max worker configuration value.")
@@ -127,6 +127,8 @@ var serverCmd = &cobra.Command{
 		keepFilestoreData, _ := command.Flags().GetBool("keep-filestore-data")
 		useExistingResources, _ := command.Flags().GetBool("use-existing-aws-resources")
 
+		model.UtilityValuesDirectory, _ = command.Flags().GetString("utility-values-directory")
+
 		wd, err := os.Getwd()
 		if err != nil {
 			wd = "error getting working directory"
@@ -151,6 +153,7 @@ var serverCmd = &cobra.Command{
 			"store-version":                          currentVersion,
 			"state-store":                            s3StateStore,
 			"working-directory":                      wd,
+			"utility-values-directory":               model.UtilityValuesDirectory,
 			"cluster-resource-threshold":             clusterResourceThreshold,
 			"cluster-resource-threshold-scale-value": clusterResourceThresholdScaleValue,
 			"use-existing-aws-resources":             useExistingResources,

--- a/internal/provisioner/fluentbit.go
+++ b/internal/provisioner/fluentbit.go
@@ -125,12 +125,16 @@ func (f *fluentbit) NewHelmDeployment(logger log.FieldLogger) *helmDeployment {
 @INCLUDE fluent-bit-output.conf
 %s
 `, elasticSearchDNS, auditLogsConf),
-		valuesPath:      model.UtilityValuesDirectory + "/fluent-bit_values.yaml",
+		valuesPath:      f.ValuesPath(),
 		kopsProvisioner: f.provisioner,
 		kops:            f.kops,
 		logger:          f.logger,
 		desiredVersion:  f.desiredVersion,
 	}
+}
+
+func (f *fluentbit) ValuesPath() string {
+	return model.UtilityValuesDirectory() + "/fluent-bit_values.yaml"
 }
 
 func (f *fluentbit) updateVersion(h *helmDeployment) error {

--- a/internal/provisioner/fluentbit.go
+++ b/internal/provisioner/fluentbit.go
@@ -125,7 +125,7 @@ func (f *fluentbit) NewHelmDeployment(logger log.FieldLogger) *helmDeployment {
 @INCLUDE fluent-bit-output.conf
 %s
 `, elasticSearchDNS, auditLogsConf),
-		valuesPath:      "helm-charts/fluent-bit_values.yaml",
+		valuesPath:      model.UtilityValuesDirectory + "/fluent-bit_values.yaml",
 		kopsProvisioner: f.provisioner,
 		kops:            f.kops,
 		logger:          f.logger,

--- a/internal/provisioner/nginx.go
+++ b/internal/provisioner/nginx.go
@@ -87,6 +87,9 @@ func (n *nginx) Destroy() error {
 	return nil
 }
 
+func (n *nginx) ValuesPath() string {
+	return model.UtilityValuesDirectory() + "/nginx_values.yaml"
+}
 func (n *nginx) NewHelmDeployment() (*helmDeployment, error) {
 	awsACMCert, err := n.awsClient.GetCertificateSummaryByTag(aws.DefaultInstallCertificatesTagKey, aws.DefaultInstallCertificatesTagValue, n.logger)
 	if err != nil {
@@ -103,7 +106,7 @@ func (n *nginx) NewHelmDeployment() (*helmDeployment, error) {
 		chartName:           "ingress-nginx/ingress-nginx",
 		namespace:           "nginx",
 		setArgument:         fmt.Sprintf("controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-ssl-cert=%s,controller.service.internal.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-ssl-cert=%s", *awsACMCert.CertificateArn, *awsACMPrivateCert.CertificateArn),
-		valuesPath:          model.UtilityValuesDirectory + "/nginx_values.yaml",
+		valuesPath:          n.ValuesPath(),
 		kopsProvisioner:     n.provisioner,
 		kops:                n.kops,
 		logger:              n.logger,

--- a/internal/provisioner/nginx.go
+++ b/internal/provisioner/nginx.go
@@ -103,7 +103,7 @@ func (n *nginx) NewHelmDeployment() (*helmDeployment, error) {
 		chartName:           "ingress-nginx/ingress-nginx",
 		namespace:           "nginx",
 		setArgument:         fmt.Sprintf("controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-ssl-cert=%s,controller.service.internal.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-ssl-cert=%s", *awsACMCert.CertificateArn, *awsACMPrivateCert.CertificateArn),
-		valuesPath:          "helm-charts/nginx_values.yaml",
+		valuesPath:          model.UtilityValuesDirectory + "/nginx_values.yaml",
 		kopsProvisioner:     n.provisioner,
 		kops:                n.kops,
 		logger:              n.logger,

--- a/internal/provisioner/prometheus.go
+++ b/internal/provisioner/prometheus.go
@@ -143,9 +143,13 @@ func (p *prometheus) NewHelmDeployment() *helmDeployment {
 		logger:              p.logger,
 		namespace:           "prometheus",
 		setArgument:         helmValueArguments,
-		valuesPath:          model.UtilityValuesDirectory + "/prometheus_values.yaml",
+		valuesPath:          p.ValuesPath(),
 		desiredVersion:      p.desiredVersion,
 	}
+}
+
+func (p *prometheus) ValuesPath() string {
+	return model.UtilityValuesDirectory() + "/prometheus_values.yaml"
 }
 
 func (p *prometheus) Name() string {

--- a/internal/provisioner/prometheus.go
+++ b/internal/provisioner/prometheus.go
@@ -143,7 +143,7 @@ func (p *prometheus) NewHelmDeployment() *helmDeployment {
 		logger:              p.logger,
 		namespace:           "prometheus",
 		setArgument:         helmValueArguments,
-		valuesPath:          "helm-charts/prometheus_values.yaml",
+		valuesPath:          model.UtilityValuesDirectory + "/prometheus_values.yaml",
 		desiredVersion:      p.desiredVersion,
 	}
 }

--- a/internal/provisioner/prometheus_operator.go
+++ b/internal/provisioner/prometheus_operator.go
@@ -204,9 +204,13 @@ func (p *prometheusOperator) NewHelmDeployment() *helmDeployment {
 		logger:              p.logger,
 		namespace:           "prometheus",
 		setArgument:         helmValueArguments,
-		valuesPath:          "helm-charts/prometheus_operator_values.yaml",
+		valuesPath:          p.ValuesPath(),
 		desiredVersion:      p.desiredVersion,
 	}
+}
+
+func (*prometheusOperator) ValuesPath() string {
+	return model.UtilityValuesDirectory() + "/prometheus_operator_values.yaml"
 }
 
 func (p *prometheusOperator) Name() string {

--- a/internal/provisioner/teleport.go
+++ b/internal/provisioner/teleport.go
@@ -120,12 +120,16 @@ func (n *teleport) NewHelmDeployment() *helmDeployment {
 		chartName:           "chartmuseum/teleport",
 		namespace:           "teleport",
 		setArgument:         fmt.Sprintf("config.auth_service.cluster_name=%[1]s,config.teleport.storage.region=%[2]s,config.teleport.storage.table_name=%[1]s,config.teleport.storage.audit_events_uri=dynamodb://%[1]s-events,config.teleport.storage.audit_sessions_uri=s3://%[1]s/records?region=%[2]s", teleportClusterName, awsRegion),
-		valuesPath:          model.UtilityValuesDirectory + "/teleport_values.yaml",
+		valuesPath:          n.ValuesPath(),
 		kopsProvisioner:     n.provisioner,
 		kops:                n.kops,
 		logger:              n.logger,
 		desiredVersion:      n.desiredVersion,
 	}
+}
+
+func (t *teleport) ValuesPath() string {
+	return model.UtilityValuesDirectory() + "/teleport_values.yaml"
 }
 
 func (n *teleport) Name() string {

--- a/internal/provisioner/teleport.go
+++ b/internal/provisioner/teleport.go
@@ -120,7 +120,7 @@ func (n *teleport) NewHelmDeployment() *helmDeployment {
 		chartName:           "chartmuseum/teleport",
 		namespace:           "teleport",
 		setArgument:         fmt.Sprintf("config.auth_service.cluster_name=%[1]s,config.teleport.storage.region=%[2]s,config.teleport.storage.table_name=%[1]s,config.teleport.storage.audit_events_uri=dynamodb://%[1]s-events,config.teleport.storage.audit_sessions_uri=s3://%[1]s/records?region=%[2]s", teleportClusterName, awsRegion),
-		valuesPath:          "helm-charts/teleport_values.yaml",
+		valuesPath:          model.UtilityValuesDirectory + "/teleport_values.yaml",
 		kopsProvisioner:     n.provisioner,
 		kops:                n.kops,
 		logger:              n.logger,

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -37,6 +37,10 @@ type Utility interface {
 	// Name returns the canonical string-version name for the utility,
 	// used throughout the application
 	Name() string
+
+	// ValuesPath returns the path (if any) of the associated values
+	// file or Helm chart that is associated with this Utility
+	ValuesPath() string
 }
 
 // utilityGroup  holds  the  metadata  needed  to  manage  a  specific

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -31,6 +31,10 @@ const (
 	TeleportDefaultVersion = "0.3.0"
 )
 
+// UtilityValuesDirectory is the directory in which Helm charts and
+// other Utility values are stored
+var UtilityValuesDirectory string
+
 // UtilityMetadata is a container struct for any metadata related to
 // cluster utilities that needs to be persisted in the database
 type UtilityMetadata struct {

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -31,9 +31,9 @@ const (
 	TeleportDefaultVersion = "0.3.0"
 )
 
-// UtilityValuesDirectory is the directory in which Helm charts and
+// utilityValuesDirectory is the directory in which Helm charts and
 // other Utility values are stored
-var UtilityValuesDirectory string
+var utilityValuesDirectory string
 
 // UtilityMetadata is a container struct for any metadata related to
 // cluster utilities that needs to be persisted in the database
@@ -67,6 +67,19 @@ func NewUtilityMetadata(metadataBytes []byte) (*UtilityMetadata, error) {
 	}
 
 	return &utilityMetadata, nil
+}
+
+// SetUtilityValuesDirectory sets the global location of values &
+// charts for the UtilityGroup. Note: changing this values affects the
+// whole Provisioner, not just a single cluster
+func SetUtilityValuesDirectory(dir string) {
+	utilityValuesDirectory = dir
+}
+
+// UtilityValuesDirectory returns the global location of the values &
+// charts directory
+func UtilityValuesDirectory() string {
+	return utilityValuesDirectory
 }
 
 // SetUtilityActualVersion stores the provided version for the


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
In order to consume values for the Utility Group from a separate repository, synced into the container via [git-sync](https://github.com/kubernetes/git-sync), as configured in [this merge request](https://gitlab.internal.core.cloud.mattermost.com/cloud/cloud-private/-/merge_requests/199), the Provisioner needs a minimally-intrusive way to specify the source directory for these values. This PR provides a command line argument to allow the user to specify, at `cloud server` time, where these values exist. This should provide the necessary flexibility for development, while allowing the new syncing functionality to operate in production.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-29370

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added a command line option to allow specification of a non-default location for UtilityGroup charts and values 
```
