### PR TITLE
MM-29236 - Introduce Cluster and Installation Annotations

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -36,7 +36,7 @@ func init() {
 	clusterCreateCmd.Flags().String("fluentbit-version", model.FluentbitDefaultVersion, "The version of Fluentbit to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("nginx-version", model.NginxDefaultVersion, "The version of Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("teleport-version", model.TeleportDefaultVersion, "The version of Teleport to provision. Use 'stable' to provision the latest stable version published upstream.")
-	clusterCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the cluster. Accepts multiple values.")
+	clusterCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the cluster. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 
 	clusterProvisionCmd.Flags().String("cluster", "", "The id of the cluster to be provisioned.")
 	clusterProvisionCmd.Flags().String("prometheus-version", "", "The version of Prometheus to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -36,6 +36,7 @@ func init() {
 	clusterCreateCmd.Flags().String("fluentbit-version", model.FluentbitDefaultVersion, "The version of Fluentbit to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("nginx-version", model.NginxDefaultVersion, "The version of Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("teleport-version", model.TeleportDefaultVersion, "The version of Teleport to provision. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the cluster. Accepts multiple values.")
 
 	clusterProvisionCmd.Flags().String("cluster", "", "The id of the cluster to be provisioned.")
 	clusterProvisionCmd.Flags().String("prometheus-version", "", "The version of Prometheus to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
@@ -113,6 +114,7 @@ var clusterCreateCmd = &cobra.Command{
 		kopsAMI, _ := command.Flags().GetString("kops-ami")
 		zones, _ := command.Flags().GetString("zones")
 		allowInstallations, _ := command.Flags().GetBool("allow-installations")
+		annotations, _ := command.Flags().GetStringArray("annotation")
 
 		request := &model.CreateClusterRequest{
 			Provider:               provider,
@@ -121,6 +123,7 @@ var clusterCreateCmd = &cobra.Command{
 			Zones:                  strings.Split(zones, ","),
 			AllowInstallations:     allowInstallations,
 			DesiredUtilityVersions: processUtilityFlags(command),
+			ExtraAnnotations:       annotations,
 		}
 
 		size, _ := command.Flags().GetString("size")

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -123,7 +123,7 @@ var clusterCreateCmd = &cobra.Command{
 			Zones:                  strings.Split(zones, ","),
 			AllowInstallations:     allowInstallations,
 			DesiredUtilityVersions: processUtilityFlags(command),
-			ExtraAnnotations:       annotations,
+			Annotations:       annotations,
 		}
 
 		size, _ := command.Flags().GetString("size")

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -28,6 +28,7 @@ func init() {
 	installationCreateCmd.Flags().String("database", model.InstallationDatabaseMysqlOperator, "The Mattermost server database type. Accepts mysql-operator, aws-rds, aws-rds-postgres, or aws-multitenant-rds")
 	installationCreateCmd.Flags().String("filestore", model.InstallationFilestoreMinioOperator, "The Mattermost server filestore type. Accepts minio-operator or aws-s3")
 	installationCreateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
+	installationCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the installation. Accepts multiple values.")
 	installationCreateCmd.MarkFlagRequired("owner")
 	installationCreateCmd.MarkFlagRequired("dns")
 
@@ -98,6 +99,7 @@ var installationCreateCmd = &cobra.Command{
 		database, _ := command.Flags().GetString("database")
 		filestore, _ := command.Flags().GetString("filestore")
 		mattermostEnv, _ := command.Flags().GetStringArray("mattermost-env")
+		annotations, _ := command.Flags().GetStringArray("annotation")
 
 		envVarMap, err := parseEnvVarInput(mattermostEnv, false)
 		if err != nil {
@@ -105,17 +107,18 @@ var installationCreateCmd = &cobra.Command{
 		}
 
 		request := &model.CreateInstallationRequest{
-			OwnerID:       ownerID,
-			GroupID:       groupID,
-			Version:       version,
-			Image:         image,
-			Size:          size,
-			DNS:           dns,
-			License:       license,
-			Affinity:      affinity,
-			Database:      database,
-			Filestore:     filestore,
-			MattermostEnv: envVarMap,
+			OwnerID:          ownerID,
+			GroupID:          groupID,
+			Version:          version,
+			Image:            image,
+			Size:             size,
+			DNS:              dns,
+			License:          license,
+			Affinity:         affinity,
+			Database:         database,
+			Filestore:        filestore,
+			MattermostEnv:    envVarMap,
+			ExtraAnnotations: annotations,
 		}
 
 		dryRun, _ := command.Flags().GetBool("dry-run")

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -118,7 +118,7 @@ var installationCreateCmd = &cobra.Command{
 			Database:         database,
 			Filestore:        filestore,
 			MattermostEnv:    envVarMap,
-			ExtraAnnotations: annotations,
+			Annotations: annotations,
 		}
 
 		dryRun, _ := command.Flags().GetBool("dry-run")

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -28,7 +28,7 @@ func init() {
 	installationCreateCmd.Flags().String("database", model.InstallationDatabaseMysqlOperator, "The Mattermost server database type. Accepts mysql-operator, aws-rds, aws-rds-postgres, or aws-multitenant-rds")
 	installationCreateCmd.Flags().String("filestore", model.InstallationFilestoreMinioOperator, "The Mattermost server filestore type. Accepts minio-operator or aws-s3")
 	installationCreateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
-	installationCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the installation. Accepts multiple values.")
+	installationCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the installation. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 	installationCreateCmd.MarkFlagRequired("owner")
 	installationCreateCmd.MarkFlagRequired("dns")
 

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -134,7 +134,7 @@ func handleCreateCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	annotations, err := model.AnnotationsFromStringSlice(createClusterRequest.ExtraAnnotations)
+	annotations, err := model.AnnotationsFromStringSlice(createClusterRequest.Annotations)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to validate extra annotations")
 		w.WriteHeader(http.StatusBadRequest)

--- a/internal/api/cluster_installation_test.go
+++ b/internal/api/cluster_installation_test.go
@@ -271,7 +271,7 @@ func TestGetClusterInstallationConfig(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	cluster := &model.Cluster{}
-	err := sqlStore.CreateCluster(cluster)
+	err := sqlStore.CreateCluster(cluster, nil)
 	require.NoError(t, err)
 
 	clusterInstallation1 := &model.ClusterInstallation{
@@ -320,7 +320,7 @@ func TestSetClusterInstallationConfig(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	cluster := &model.Cluster{}
-	err := sqlStore.CreateCluster(cluster)
+	err := sqlStore.CreateCluster(cluster, nil)
 	require.NoError(t, err)
 
 	clusterInstallation1 := &model.ClusterInstallation{
@@ -399,7 +399,7 @@ func TestRunClusterInstallationExecCommand(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	cluster := &model.Cluster{}
-	err := sqlStore.CreateCluster(cluster)
+	err := sqlStore.CreateCluster(cluster, nil)
 	require.NoError(t, err)
 
 	clusterInstallation1 := &model.ClusterInstallation{
@@ -491,7 +491,7 @@ func TestRunClusterInstallationMattermostCLI(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	cluster := &model.Cluster{}
-	err := sqlStore.CreateCluster(cluster)
+	err := sqlStore.CreateCluster(cluster, nil)
 	require.NoError(t, err)
 
 	clusterInstallation1 := &model.ClusterInstallation{

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -89,14 +89,13 @@ func TestClusters(t *testing.T) {
 		cluster1, err := client.CreateCluster(&model.CreateClusterRequest{
 			Provider:         model.ProviderAWS,
 			Zones:            []string{"zone"},
-			ExtraAnnotations: []string{"multitenant", "super-awesome"},
+			ExtraAnnotations: []string{"my-annotation"},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, cluster1)
 		require.Equal(t, model.ProviderAWS, cluster1.Provider)
-		require.Equal(t, 2, len(cluster1.Annotations))
-		assert.True(t, containsAnnotation("multitenant", cluster1.Annotations))
-		assert.True(t, containsAnnotation("super-awesome", cluster1.Annotations))
+		require.Equal(t, 1, len(cluster1.Annotations))
+		assert.True(t, containsAnnotation("my-annotation", cluster1.Annotations))
 		// require.Equal(t, []string{"zone"}, cluster1.Zones)
 
 		actualCluster1, err := client.GetCluster(cluster1.ID)
@@ -105,7 +104,7 @@ func TestClusters(t *testing.T) {
 		require.Equal(t, model.ProviderAWS, actualCluster1.Provider)
 		// require.Equal(t, []string{"zone"}, actualCluster1.Zones)
 		require.Equal(t, model.ClusterStateCreationRequested, actualCluster1.State)
-		require.Equal(t, cluster1.Annotations, actualCluster1.Annotations)
+		require.Equal(t, cluster1.Annotations, model.SortAnnotations(actualCluster1.Annotations))
 
 		time.Sleep(1 * time.Millisecond)
 
@@ -357,7 +356,7 @@ func TestCreateCluster(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				assert.Equal(t, testCase.expected, cluster.Annotations)
+				assert.Equal(t, testCase.expected, model.SortAnnotations(cluster.Annotations))
 			})
 		}
 	})

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -89,7 +89,7 @@ func TestClusters(t *testing.T) {
 		cluster1, err := client.CreateCluster(&model.CreateClusterRequest{
 			Provider:         model.ProviderAWS,
 			Zones:            []string{"zone"},
-			ExtraAnnotations: []string{"my-annotation"},
+			Annotations: []string{"my-annotation"},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, cluster1)
@@ -310,7 +310,7 @@ func TestCreateCluster(t *testing.T) {
 		_, err := client.CreateCluster(&model.CreateClusterRequest{
 			Provider:         model.ProviderAWS,
 			Zones:            []string{"zone"},
-			ExtraAnnotations: []string{"my invalid annotation"},
+			Annotations: []string{"my invalid annotation"},
 		})
 		require.EqualError(t, err, "failed with status code 400")
 	})
@@ -319,7 +319,7 @@ func TestCreateCluster(t *testing.T) {
 		cluster, err := client.CreateCluster(&model.CreateClusterRequest{
 			Provider:         model.ProviderAWS,
 			Zones:            []string{"zone"},
-			ExtraAnnotations: []string{"my-annotation"},
+			Annotations: []string{"my-annotation"},
 		})
 		require.NoError(t, err)
 		require.Equal(t, model.ProviderAWS, cluster.Provider)
@@ -352,7 +352,7 @@ func TestCreateCluster(t *testing.T) {
 				cluster, err := client.CreateCluster(&model.CreateClusterRequest{
 					Provider:         model.ProviderAWS,
 					Zones:            []string{"zone"},
-					ExtraAnnotations: testCase.annotations,
+					Annotations: testCase.annotations,
 				})
 				require.NoError(t, err)
 
@@ -381,7 +381,7 @@ func TestRetryCreateCluster(t *testing.T) {
 	cluster1, err := client.CreateCluster(&model.CreateClusterRequest{
 		Provider:         model.ProviderAWS,
 		Zones:            []string{"zone"},
-		ExtraAnnotations: []string{"my-annotation"},
+		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
 
@@ -466,7 +466,7 @@ func TestProvisionCluster(t *testing.T) {
 	cluster1, err := client.CreateCluster(&model.CreateClusterRequest{
 		Provider:         model.ProviderAWS,
 		Zones:            []string{"zone"},
-		ExtraAnnotations: []string{"my-annotation"},
+		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
 
@@ -610,7 +610,7 @@ func TestUpgradeCluster(t *testing.T) {
 	cluster1, err := client.CreateCluster(&model.CreateClusterRequest{
 		Provider:         model.ProviderAWS,
 		Zones:            []string{"zone"},
-		ExtraAnnotations: []string{"my-annotation"},
+		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
 
@@ -785,7 +785,7 @@ func TestUpdateClusterConfiguration(t *testing.T) {
 		Provider:           model.ProviderAWS,
 		Zones:              []string{"zone"},
 		AllowInstallations: true,
-		ExtraAnnotations:   []string{"my-annotation"},
+		Annotations:   []string{"my-annotation"},
 	})
 	require.NoError(t, err)
 
@@ -868,7 +868,7 @@ func TestResizeCluster(t *testing.T) {
 	cluster1, err := client.CreateCluster(&model.CreateClusterRequest{
 		Provider:         model.ProviderAWS,
 		Zones:            []string{"zone"},
-		ExtraAnnotations: []string{"my-annotation"},
+		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
 

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -17,9 +17,11 @@ type Supervisor interface {
 
 // Store describes the interface required to persist changes made via API requests.
 type Store interface {
-	CreateCluster(cluster *model.Cluster) error
+	CreateCluster(cluster *model.Cluster, annotations []*model.Annotation) error
 	GetCluster(clusterID string) (*model.Cluster, error)
+	GetClusterDTO(clusterID string) (*model.ClusterDTO, error)
 	GetClusters(filter *model.ClusterFilter) ([]*model.Cluster, error)
+	GetClusterDTOs(filter *model.ClusterFilter) ([]*model.ClusterDTO, error)
 	UpdateCluster(cluster *model.Cluster) error
 	LockCluster(clusterID, lockerID string) (bool, error)
 	UnlockCluster(clusterID, lockerID string, force bool) (bool, error)
@@ -27,9 +29,11 @@ type Store interface {
 	UnlockClusterAPI(clusterID string) error
 	DeleteCluster(clusterID string) error
 
-	CreateInstallation(installation *model.Installation) error
+	CreateInstallation(installation *model.Installation, annotations []*model.Annotation) error
 	GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error)
+	GetInstallationDTO(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.InstallationDTO, error)
 	GetInstallations(filter *model.InstallationFilter, includeGroupConfig, includeGroupConfigOverrides bool) ([]*model.Installation, error)
+	GetInstallationDTOs(filter *model.InstallationFilter, includeGroupConfig, includeGroupConfigOverrides bool) ([]*model.InstallationDTO, error)
 	GetInstallationsCount(includeDeleted bool) (int, error)
 	UpdateInstallation(installation *model.Installation) error
 	LockInstallation(installationID, lockerID string) (bool, error)

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -389,7 +389,7 @@ func TestDeleteGroup(t *testing.T) {
 	require.NoError(t, err)
 
 	installation1.State = model.InstallationStateStable
-	err = sqlStore.UpdateInstallation(installation1)
+	err = sqlStore.UpdateInstallation(installation1.Installation)
 	require.NoError(t, err)
 
 	t.Run("join group", func(t *testing.T) {
@@ -481,10 +481,10 @@ func TestGroupStatus(t *testing.T) {
 
 		installation.State = state
 		installation.GroupSequence = sequence
-		err = sqlStore.UpdateInstallation(installation)
+		err = sqlStore.UpdateInstallation(installation.Installation)
 		require.NoError(t, err)
 
-		return installation
+		return installation.Installation
 	}
 
 	group, err := client.CreateGroup(&model.CreateGroupRequest{

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -172,7 +172,7 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		State:           model.InstallationStateCreationRequested,
 	}
 
-	annotations, err := model.AnnotationsFromStringSlice(createInstallationRequest.ExtraAnnotations)
+	annotations, err := model.AnnotationsFromStringSlice(createInstallationRequest.Annotations)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to validate extra annotations")
 		w.WriteHeader(http.StatusBadRequest)

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -24,6 +24,7 @@ import (
 func TestGetInstallations(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
@@ -119,6 +120,15 @@ func TestGetInstallations(t *testing.T) {
 	t.Run("results", func(t *testing.T) {
 		ownerID1 := model.NewID()
 		ownerID2 := model.NewID()
+		annotations := []*model.Annotation{
+			{ID: "", Name: "multi-tenant"},
+			{ID: "", Name: "super-awesome"},
+		}
+
+		for _, ann := range annotations {
+			err := sqlStore.CreateAnnotation(ann)
+			require.NoError(t, err)
+		}
 
 		installation1 := &model.Installation{
 			OwnerID:  ownerID1,
@@ -127,7 +137,7 @@ func TestGetInstallations(t *testing.T) {
 			Size:     "1000users",
 			Affinity: model.InstallationAffinityIsolated,
 		}
-		err := sqlStore.CreateInstallation(installation1)
+		err := sqlStore.CreateInstallation(installation1, annotations)
 		require.NoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
@@ -138,7 +148,7 @@ func TestGetInstallations(t *testing.T) {
 			DNS:      "dns2.example.com",
 			Affinity: model.InstallationAffinityIsolated,
 		}
-		err = sqlStore.CreateInstallation(installation2)
+		err = sqlStore.CreateInstallation(installation2, nil)
 		require.NoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
@@ -149,7 +159,7 @@ func TestGetInstallations(t *testing.T) {
 			DNS:      "dns3.example.com",
 			Affinity: model.InstallationAffinityIsolated,
 		}
-		err = sqlStore.CreateInstallation(installation3)
+		err = sqlStore.CreateInstallation(installation3, nil)
 		require.NoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
@@ -160,24 +170,27 @@ func TestGetInstallations(t *testing.T) {
 			DNS:      "dns4.example.com",
 			Affinity: model.InstallationAffinityIsolated,
 		}
-		err = sqlStore.CreateInstallation(installation4)
+		err = sqlStore.CreateInstallation(installation4, nil)
 		require.NoError(t, err)
 		err = sqlStore.DeleteInstallation(installation4.ID)
 		require.NoError(t, err)
-		installation4, err = client.GetInstallation(installation4.ID, nil)
+		installation4DTO, err := client.GetInstallation(installation4.ID, nil)
 		require.NoError(t, err)
+		installation4 = installation4DTO.Installation
 
 		t.Run("get installation", func(t *testing.T) {
 			t.Run("installation 1", func(t *testing.T) {
-				installation, err := client.GetInstallation(installation1.ID, nil)
+				installationDTO, err := client.GetInstallation(installation1.ID, nil)
 				require.NoError(t, err)
-				require.Equal(t, installation1, installation)
+				require.Equal(t, installation1, installationDTO.Installation)
+				require.Equal(t, 2, len(installationDTO.Annotations))
+				require.Equal(t, annotations, installationDTO.Annotations)
 			})
 
 			t.Run("get deleted installation", func(t *testing.T) {
-				installation, err := client.GetInstallation(installation4.ID, nil)
+				installationDTO, err := client.GetInstallation(installation4.ID, nil)
 				require.NoError(t, err)
-				require.Equal(t, installation4, installation)
+				require.Equal(t, installation4, installationDTO.Installation)
 			})
 
 			t.Run("get installation by name", func(t *testing.T) {
@@ -253,9 +266,9 @@ func TestGetInstallations(t *testing.T) {
 
 			for _, testCase := range testCases {
 				t.Run(testCase.Description, func(t *testing.T) {
-					installations, err := client.GetInstallations(testCase.GetInstallationsRequest)
+					installationDTOs, err := client.GetInstallations(testCase.GetInstallationsRequest)
 					require.NoError(t, err)
-					require.Equal(t, testCase.Expected, installations)
+					require.Equal(t, testCase.Expected, dtosToInstallations(installationDTOs))
 				})
 			}
 		})
@@ -291,6 +304,7 @@ func TestGetInstallations(t *testing.T) {
 func TestCreateInstallation(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
@@ -374,12 +388,24 @@ func TestCreateInstallation(t *testing.T) {
 		require.EqualError(t, err, "failed with status code 400")
 	})
 
+	t.Run("invalid annotations", func(t *testing.T) {
+		_, err := client.CreateInstallation(&model.CreateInstallationRequest{
+			OwnerID:          "owner",
+			Version:          "version",
+			DNS:              "dns.example.com",
+			Affinity:         model.InstallationAffinityIsolated,
+			ExtraAnnotations: []string{"my invalid annotation"},
+		})
+		require.EqualError(t, err, "failed with status code 400")
+	})
+
 	t.Run("valid", func(t *testing.T) {
 		installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
-			OwnerID:  "owner",
-			Version:  "version",
-			DNS:      "dns.example.com",
-			Affinity: model.InstallationAffinityIsolated,
+			OwnerID:          "owner",
+			Version:          "version",
+			DNS:              "dns.example.com",
+			Affinity:         model.InstallationAffinityIsolated,
+			ExtraAnnotations: []string{"my-annotation"},
 		})
 		require.NoError(t, err)
 		require.Equal(t, "owner", installation.OwnerID)
@@ -392,6 +418,7 @@ func TestCreateInstallation(t *testing.T) {
 		require.EqualValues(t, 0, installation.LockAcquiredAt)
 		require.NotEqual(t, 0, installation.CreateAt)
 		require.EqualValues(t, 0, installation.DeleteAt)
+		assert.True(t, containsAnnotation("my-annotation", installation.Annotations))
 	})
 
 	t.Run("valid with custom image", func(t *testing.T) {
@@ -458,11 +485,46 @@ func TestCreateInstallation(t *testing.T) {
 			require.EqualError(t, err, "failed with status code 400")
 		})
 	})
+
+	t.Run("handle annotations", func(t *testing.T) {
+		annotations := []*model.Annotation{
+			{ID: "", Name: "multi-tenant"},
+			{ID: "", Name: "super-awesome"},
+		}
+
+		for _, ann := range annotations {
+			err := sqlStore.CreateAnnotation(ann)
+			require.NoError(t, err)
+		}
+
+		for i, testCase := range []struct {
+			description string
+			annotations []string
+			expected    []*model.Annotation
+		}{
+			{"nil annotations", nil, nil},
+			{"empty annotations", []string{}, nil},
+			{"with annotations", []string{"multi-tenant", "super-awesome"}, annotations},
+		} {
+			t.Run(testCase.description, func(t *testing.T) {
+				installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
+					OwnerID:          "owner1",
+					Version:          "version",
+					DNS:              fmt.Sprintf("dns-annotation%d.example.com", i),
+					ExtraAnnotations: testCase.annotations,
+				})
+				require.NoError(t, err)
+
+				assert.Equal(t, testCase.expected, installation.Annotations)
+			})
+		}
+	})
 }
 
 func TestRetryCreateInstallation(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
@@ -476,10 +538,11 @@ func TestRetryCreateInstallation(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	installation1, err := client.CreateInstallation(&model.CreateInstallationRequest{
-		OwnerID:  "owner",
-		Version:  "version",
-		DNS:      "dns.example.com",
-		Affinity: model.InstallationAffinityIsolated,
+		OwnerID:          "owner",
+		Version:          "version",
+		DNS:              "dns.example.com",
+		Affinity:         model.InstallationAffinityIsolated,
+		ExtraAnnotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
 
@@ -490,7 +553,7 @@ func TestRetryCreateInstallation(t *testing.T) {
 
 	t.Run("while locked", func(t *testing.T) {
 		installation1.State = model.InstallationStateStable
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		lockerID := model.NewID()
@@ -510,7 +573,7 @@ func TestRetryCreateInstallation(t *testing.T) {
 
 	t.Run("while creating", func(t *testing.T) {
 		installation1.State = model.InstallationStateCreationRequested
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		err = client.RetryCreateInstallation(installation1.ID)
@@ -519,11 +582,12 @@ func TestRetryCreateInstallation(t *testing.T) {
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateCreationRequested, installation1.State)
+		assert.True(t, containsAnnotation("my-annotation", installation1.Annotations))
 	})
 
 	t.Run("while stable", func(t *testing.T) {
 		installation1.State = model.InstallationStateStable
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		err = client.RetryCreateInstallation(installation1.ID)
@@ -532,7 +596,7 @@ func TestRetryCreateInstallation(t *testing.T) {
 
 	t.Run("while creation failed", func(t *testing.T) {
 		installation1.State = model.InstallationStateCreationFailed
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		err = client.RetryCreateInstallation(installation1.ID)
@@ -547,6 +611,7 @@ func TestRetryCreateInstallation(t *testing.T) {
 func TestUpdateInstallation(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
@@ -560,10 +625,11 @@ func TestUpdateInstallation(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	installation1, err := client.CreateInstallation(&model.CreateInstallationRequest{
-		OwnerID:  "owner",
-		Version:  "version",
-		DNS:      "dns.example.com",
-		Affinity: model.InstallationAffinityIsolated,
+		OwnerID:          "owner",
+		Version:          "version",
+		DNS:              "dns.example.com",
+		Affinity:         model.InstallationAffinityIsolated,
+		ExtraAnnotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
 
@@ -594,7 +660,7 @@ func TestUpdateInstallation(t *testing.T) {
 
 	t.Run("while locked", func(t *testing.T) {
 		installation1.State = model.InstallationStateStable
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		lockerID := model.NewID()
@@ -635,7 +701,7 @@ func TestUpdateInstallation(t *testing.T) {
 
 	t.Run("while upgrading", func(t *testing.T) {
 		installation1.State = model.InstallationStateUpdateRequested
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		upgradeRequest := &model.PatchInstallationRequest{
@@ -648,14 +714,15 @@ func TestUpdateInstallation(t *testing.T) {
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpdateRequested, installation1.State)
-		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
+		ensureInstallationMatchesRequest(t, installation1.Installation, upgradeRequest)
 		require.Equal(t, "mattermost/mattermost-enterprise-edition", installation1.Image)
 		require.Equal(t, installationResponse, installation1)
+		assert.True(t, containsAnnotation("my-annotation", installation1.Annotations))
 	})
 
 	t.Run("after upgrade failed", func(t *testing.T) {
 		installation1.State = model.InstallationStateUpdateFailed
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		upgradeRequest := &model.PatchInstallationRequest{
@@ -668,13 +735,13 @@ func TestUpdateInstallation(t *testing.T) {
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpdateRequested, installation1.State)
-		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
+		ensureInstallationMatchesRequest(t, installation1.Installation, upgradeRequest)
 		require.Equal(t, installationResponse, installation1)
 	})
 
 	t.Run("while stable", func(t *testing.T) {
 		installation1.State = model.InstallationStateStable
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		upgradeRequest := &model.PatchInstallationRequest{
@@ -687,13 +754,13 @@ func TestUpdateInstallation(t *testing.T) {
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpdateRequested, installation1.State)
-		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
+		ensureInstallationMatchesRequest(t, installation1.Installation, upgradeRequest)
 		require.Equal(t, installationResponse, installation1)
 	})
 
 	t.Run("after deletion failed", func(t *testing.T) {
 		installation1.State = model.InstallationStateDeletionFailed
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		upgradeRequest := &model.PatchInstallationRequest{
@@ -707,7 +774,7 @@ func TestUpdateInstallation(t *testing.T) {
 
 	t.Run("while deleting", func(t *testing.T) {
 		installation1.State = model.InstallationStateDeletionRequested
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		upgradeRequest := &model.PatchInstallationRequest{
@@ -721,7 +788,7 @@ func TestUpdateInstallation(t *testing.T) {
 
 	t.Run("to version with embedded slash", func(t *testing.T) {
 		installation1.State = model.InstallationStateStable
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		upgradeRequest := &model.PatchInstallationRequest{
@@ -734,13 +801,13 @@ func TestUpdateInstallation(t *testing.T) {
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpdateRequested, installation1.State)
-		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
+		ensureInstallationMatchesRequest(t, installation1.Installation, upgradeRequest)
 		require.Equal(t, installationResponse, installation1)
 	})
 
 	t.Run("to invalid size", func(t *testing.T) {
 		installation1.State = model.InstallationStateStable
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		upgradeRequest := &model.PatchInstallationRequest{
@@ -753,7 +820,7 @@ func TestUpdateInstallation(t *testing.T) {
 
 	t.Run("installation record updated", func(t *testing.T) {
 		installation1.State = model.InstallationStateStable
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		upgradeRequest := &model.PatchInstallationRequest{
@@ -767,13 +834,13 @@ func TestUpdateInstallation(t *testing.T) {
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateUpdateRequested, installation1.State)
-		ensureInstallationMatchesRequest(t, installation1, upgradeRequest)
+		ensureInstallationMatchesRequest(t, installation1.Installation, upgradeRequest)
 		require.Equal(t, installationResponse, installation1)
 	})
 
 	t.Run("empty update request", func(t *testing.T) {
 		installation1.State = model.InstallationStateStable
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		updateRequest := &model.PatchInstallationRequest{}
@@ -783,7 +850,7 @@ func TestUpdateInstallation(t *testing.T) {
 		installation1, err = client.GetInstallation(installation1.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, model.InstallationStateStable, installation1.State)
-		ensureInstallationMatchesRequest(t, installation1, updateRequest)
+		ensureInstallationMatchesRequest(t, installation1.Installation, updateRequest)
 		require.Equal(t, installationResponse, installation1)
 	})
 }
@@ -791,6 +858,7 @@ func TestUpdateInstallation(t *testing.T) {
 func TestJoinGroup(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
@@ -911,6 +979,7 @@ func TestJoinGroup(t *testing.T) {
 func TestLeaveGroup(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
@@ -939,7 +1008,7 @@ func TestLeaveGroup(t *testing.T) {
 	require.NoError(t, err)
 
 	installation1.State = model.InstallationStateStable
-	err = sqlStore.UpdateInstallation(installation1)
+	err = sqlStore.UpdateInstallation(installation1.Installation)
 	require.NoError(t, err)
 
 	err = client.JoinGroup(group1.ID, installation1.ID)
@@ -1027,6 +1096,7 @@ func TestLeaveGroup(t *testing.T) {
 func TestDeleteInstallation(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
@@ -1054,7 +1124,7 @@ func TestDeleteInstallation(t *testing.T) {
 
 	t.Run("while locked", func(t *testing.T) {
 		installation1.State = model.InstallationStateStable
-		err = sqlStore.UpdateInstallation(installation1)
+		err = sqlStore.UpdateInstallation(installation1.Installation)
 		require.NoError(t, err)
 
 		lockerID := model.NewID()
@@ -1108,7 +1178,7 @@ func TestDeleteInstallation(t *testing.T) {
 		for _, validDeletingState := range validDeletingStates {
 			t.Run(validDeletingState, func(t *testing.T) {
 				installation1.State = validDeletingState
-				err = sqlStore.UpdateInstallation(installation1)
+				err = sqlStore.UpdateInstallation(installation1.Installation)
 				require.NoError(t, err)
 
 				err := client.DeleteInstallation(installation1.ID)
@@ -1120,4 +1190,12 @@ func TestDeleteInstallation(t *testing.T) {
 			})
 		}
 	})
+}
+
+func dtosToInstallations(dtos []*model.InstallationDTO) []*model.Installation {
+	installations := make([]*model.Installation, 0, len(dtos))
+	for _, dto := range dtos {
+		installations = append(installations, dto.Installation)
+	}
+	return installations
 }

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -394,7 +394,7 @@ func TestCreateInstallation(t *testing.T) {
 			Version:          "version",
 			DNS:              "dns.example.com",
 			Affinity:         model.InstallationAffinityIsolated,
-			ExtraAnnotations: []string{"my invalid annotation"},
+			Annotations: []string{"my invalid annotation"},
 		})
 		require.EqualError(t, err, "failed with status code 400")
 	})
@@ -405,7 +405,7 @@ func TestCreateInstallation(t *testing.T) {
 			Version:          "version",
 			DNS:              "dns.example.com",
 			Affinity:         model.InstallationAffinityIsolated,
-			ExtraAnnotations: []string{"my-annotation"},
+			Annotations: []string{"my-annotation"},
 		})
 		require.NoError(t, err)
 		require.Equal(t, "owner", installation.OwnerID)
@@ -511,7 +511,7 @@ func TestCreateInstallation(t *testing.T) {
 					OwnerID:          "owner1",
 					Version:          "version",
 					DNS:              fmt.Sprintf("dns-annotation%d.example.com", i),
-					ExtraAnnotations: testCase.annotations,
+					Annotations: testCase.annotations,
 				})
 				require.NoError(t, err)
 
@@ -542,7 +542,7 @@ func TestRetryCreateInstallation(t *testing.T) {
 		Version:          "version",
 		DNS:              "dns.example.com",
 		Affinity:         model.InstallationAffinityIsolated,
-		ExtraAnnotations: []string{"my-annotation"},
+		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
 
@@ -629,7 +629,7 @@ func TestUpdateInstallation(t *testing.T) {
 		Version:          "version",
 		DNS:              "dns.example.com",
 		Affinity:         model.InstallationAffinityIsolated,
-		ExtraAnnotations: []string{"my-annotation"},
+		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
 

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -184,7 +184,7 @@ func TestGetInstallations(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, installation1, installationDTO.Installation)
 				require.Equal(t, 2, len(installationDTO.Annotations))
-				require.Equal(t, annotations, installationDTO.Annotations)
+				require.Equal(t, annotations, model.SortAnnotations(installationDTO.Annotations))
 			})
 
 			t.Run("get deleted installation", func(t *testing.T) {

--- a/internal/api/lock.go
+++ b/internal/api/lock.go
@@ -13,8 +13,8 @@ import (
 
 // lockCluster synchronizes access to the given cluster across potentially
 // multiple provisioning servers.
-func lockCluster(c *Context, clusterID string) (*model.Cluster, int, func()) {
-	cluster, err := c.Store.GetCluster(clusterID)
+func lockCluster(c *Context, clusterID string) (*model.ClusterDTO, int, func()) {
+	cluster, err := c.Store.GetClusterDTO(clusterID)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to query cluster")
 		return nil, http.StatusInternalServerError, nil
@@ -83,8 +83,8 @@ func lockGroup(c *Context, groupID string) (*model.Group, int, func()) {
 
 // lockInstallation synchronizes access to the given installation across
 // potentially multiple provisioning servers.
-func lockInstallation(c *Context, installationID string) (*model.Installation, int, func()) {
-	installation, err := c.Store.GetInstallation(installationID, false, false)
+func lockInstallation(c *Context, installationID string) (*model.InstallationDTO, int, func()) {
+	installation, err := c.Store.GetInstallationDTO(installationID, false, false)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to query installation")
 		return nil, http.StatusInternalServerError, nil

--- a/internal/api/lock.go
+++ b/internal/api/lock.go
@@ -14,12 +14,12 @@ import (
 // lockCluster synchronizes access to the given cluster across potentially
 // multiple provisioning servers.
 func lockCluster(c *Context, clusterID string) (*model.ClusterDTO, int, func()) {
-	cluster, err := c.Store.GetClusterDTO(clusterID)
+	clusterDTO, err := c.Store.GetClusterDTO(clusterID)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to query cluster")
 		return nil, http.StatusInternalServerError, nil
 	}
-	if cluster == nil {
+	if clusterDTO == nil {
 		return nil, http.StatusNotFound, nil
 	}
 
@@ -34,9 +34,9 @@ func lockCluster(c *Context, clusterID string) (*model.ClusterDTO, int, func()) 
 
 	unlockOnce := sync.Once{}
 
-	return cluster, 0, func() {
+	return clusterDTO, 0, func() {
 		unlockOnce.Do(func() {
-			unlocked, err := c.Store.UnlockCluster(cluster.ID, c.RequestID, false)
+			unlocked, err := c.Store.UnlockCluster(clusterDTO.ID, c.RequestID, false)
 			if err != nil {
 				c.Logger.WithError(err).Errorf("failed to unlock cluster")
 			} else if unlocked != true {
@@ -84,12 +84,12 @@ func lockGroup(c *Context, groupID string) (*model.Group, int, func()) {
 // lockInstallation synchronizes access to the given installation across
 // potentially multiple provisioning servers.
 func lockInstallation(c *Context, installationID string) (*model.InstallationDTO, int, func()) {
-	installation, err := c.Store.GetInstallationDTO(installationID, false, false)
+	installationDTO, err := c.Store.GetInstallationDTO(installationID, false, false)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to query installation")
 		return nil, http.StatusInternalServerError, nil
 	}
-	if installation == nil {
+	if installationDTO == nil {
 		return nil, http.StatusNotFound, nil
 	}
 
@@ -104,9 +104,9 @@ func lockInstallation(c *Context, installationID string) (*model.InstallationDTO
 
 	unlockOnce := sync.Once{}
 
-	return installation, 0, func() {
+	return installationDTO, 0, func() {
 		unlockOnce.Do(func() {
-			unlocked, err := c.Store.UnlockInstallation(installation.ID, c.RequestID, false)
+			unlocked, err := c.Store.UnlockInstallation(installationDTO.ID, c.RequestID, false)
 			if err != nil {
 				c.Logger.WithError(err).Errorf("failed to unlock installation")
 			} else if unlocked != true {

--- a/internal/store/annotation.go
+++ b/internal/store/annotation.go
@@ -68,7 +68,7 @@ func (sqlStore *SQLStore) getOrCreateAnnotations(db dbInterface, annotations []*
 	for i, ann := range annotations {
 		annotation, err := sqlStore.getOrCreateAnnotation(db, ann)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "failed to get or create annotation '%s'", ann.Name)
 		}
 		annotations[i] = annotation
 	}

--- a/internal/store/annotation.go
+++ b/internal/store/annotation.go
@@ -73,7 +73,6 @@ func (sqlStore *SQLStore) getOrCreateAnnotations(db dbInterface, annotations []*
 		annotations[i] = annotation
 	}
 
-	model.SortAnnotations(annotations)
 	return annotations, nil
 }
 
@@ -127,7 +126,6 @@ func (sqlStore *SQLStore) GetAnnotationsForCluster(clusterID string) ([]*model.A
 		return nil, errors.Wrap(err, "failed to get annotations for Cluster")
 	}
 
-	model.SortAnnotations(annotations)
 	return annotations, nil
 }
 
@@ -163,10 +161,6 @@ func (sqlStore *SQLStore) GetAnnotationsForClusters(filter *model.ClusterFilter)
 		)
 	}
 
-	for _, ann := range annotations {
-		model.SortAnnotations(ann)
-	}
-
 	return annotations, nil
 }
 
@@ -183,7 +177,6 @@ func (sqlStore *SQLStore) GetAnnotationsForInstallation(installationID string) (
 		return nil, errors.Wrap(err, "failed to get annotations for Installation")
 	}
 
-	model.SortAnnotations(annotations)
 	return annotations, nil
 }
 
@@ -217,10 +210,6 @@ func (sqlStore *SQLStore) GetAnnotationsForInstallations(filter *model.Installat
 			annotations[ca.InstallationID],
 			&model.Annotation{ID: ca.AnnotationID, Name: ca.AnnotationName},
 		)
-	}
-
-	for _, ann := range annotations {
-		model.SortAnnotations(ann)
 	}
 
 	return annotations, nil

--- a/internal/store/annotation.go
+++ b/internal/store/annotation.go
@@ -6,6 +6,7 @@ package store
 
 import (
 	"database/sql"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"

--- a/internal/store/annotation.go
+++ b/internal/store/annotation.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"database/sql"
+	sq "github.com/Masterminds/squirrel"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+var annotationSelect sq.SelectBuilder
+var annotationColumns = []string{
+	"Annotation.ID", "Annotation.Name",
+}
+
+func init() {
+	annotationSelect = sq.Select(annotationColumns...).
+		From("Annotation")
+}
+
+// GetAnnotationByName fetches the given annotation by name.
+func (sqlStore *SQLStore) GetAnnotationByName(name string) (*model.Annotation, error) {
+	return sqlStore.getAnnotationByName(sqlStore.db, name)
+}
+
+func (sqlStore *SQLStore) getAnnotationByName(db queryer, name string) (*model.Annotation, error) {
+	var annotation model.Annotation
+
+	builder := annotationSelect.
+		Where("Name = ?", name).
+		Limit(1)
+	err := sqlStore.getBuilder(db, &annotation, builder)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "failed to get annotation by name")
+	}
+
+	return &annotation, nil
+}
+
+// CreateAnnotation records the given annotation to the database, assigning it a unique ID.
+func (sqlStore *SQLStore) CreateAnnotation(annotation *model.Annotation) error {
+	return sqlStore.createAnnotation(sqlStore.db, annotation)
+}
+
+func (sqlStore *SQLStore) createAnnotation(db execer, annotation *model.Annotation) error {
+	annotation.ID = model.NewID()
+
+	_, err := sqlStore.execBuilder(db, sq.Insert("Annotation").
+		SetMap(map[string]interface{}{
+			"ID":   annotation.ID,
+			"Name": annotation.Name,
+		}))
+	if err != nil {
+		return errors.Wrap(err, "failed to create annotation")
+	}
+
+	return nil
+}
+
+// getOrCreateAnnotations fetches annotations by name or creates them if they do not exist.
+func (sqlStore *SQLStore) getOrCreateAnnotations(db dbInterface, annotations []*model.Annotation) ([]*model.Annotation, error) {
+	for i, ann := range annotations {
+		annotation, err := sqlStore.getOrCreateAnnotation(db, ann)
+		if err != nil {
+			return nil, err
+		}
+		annotations[i] = annotation
+	}
+
+	model.SortAnnotations(annotations)
+	return annotations, nil
+}
+
+func (sqlStore *SQLStore) getOrCreateAnnotation(db dbInterface, annotation *model.Annotation) (*model.Annotation, error) {
+	fetched, err := sqlStore.getAnnotationByName(db, annotation.Name)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get annotation by name")
+	}
+	if fetched != nil {
+		return fetched, nil
+	}
+
+	err = sqlStore.createAnnotation(db, annotation)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create annotation")
+	}
+
+	return annotation, nil
+}
+
+// CreateClusterAnnotations maps selected annotations to cluster and stores it in the database.
+func (sqlStore *SQLStore) CreateClusterAnnotations(clusterID string, annotations []*model.Annotation) ([]*model.Annotation, error) {
+	return sqlStore.createClusterAnnotations(sqlStore.db, clusterID, annotations)
+}
+
+func (sqlStore *SQLStore) createClusterAnnotations(db execer, clusterID string, annotations []*model.Annotation) ([]*model.Annotation, error) {
+	builder := sq.Insert("ClusterAnnotation").
+		Columns("ID", "ClusterID", "AnnotationID")
+
+	for _, a := range annotations {
+		builder = builder.Values(model.NewID(), clusterID, a.ID)
+	}
+	_, err := sqlStore.execBuilder(db, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create cluster annotations")
+	}
+
+	return annotations, nil
+}
+
+// GetAnnotationsForCluster fetches all annotations assigned to the cluster.
+func (sqlStore *SQLStore) GetAnnotationsForCluster(clusterID string) ([]*model.Annotation, error) {
+	var annotations []*model.Annotation
+
+	builder := sq.Select(annotationColumns...).
+		From("ClusterAnnotation").
+		Where("ClusterID = ?", clusterID).
+		LeftJoin("Annotation ON Annotation.ID=AnnotationID")
+	err := sqlStore.selectBuilder(sqlStore.db, &annotations, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get annotations for Cluster")
+	}
+
+	model.SortAnnotations(annotations)
+	return annotations, nil
+}
+
+type clusterAnnotation struct {
+	ClusterID      string
+	AnnotationID   string
+	AnnotationName string
+}
+
+// GetAnnotationsForClusters fetches all annotations assigned to the clusters.
+func (sqlStore *SQLStore) GetAnnotationsForClusters(filter *model.ClusterFilter) (map[string][]*model.Annotation, error) {
+	var clusterAnnotations []*clusterAnnotation
+
+	builder := sq.Select(
+		"Cluster.ID as ClusterID",
+		"Annotation.ID as AnnotationID",
+		"Annotation.Name as AnnotationName").
+		From("Cluster").
+		LeftJoin("ClusterAnnotation ON ClusterAnnotation.ClusterID = Cluster.ID").
+		Join("Annotation ON Annotation.ID=AnnotationID")
+	builder = sqlStore.applyClustersFilter(builder, filter)
+
+	err := sqlStore.selectBuilder(sqlStore.db, &clusterAnnotations, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get annotations for Cluster")
+	}
+
+	annotations := map[string][]*model.Annotation{}
+	for _, ca := range clusterAnnotations {
+		annotations[ca.ClusterID] = append(
+			annotations[ca.ClusterID],
+			&model.Annotation{ID: ca.AnnotationID, Name: ca.AnnotationName},
+		)
+	}
+
+	for _, ann := range annotations {
+		model.SortAnnotations(ann)
+	}
+
+	return annotations, nil
+}
+
+// GetAnnotationsForInstallation fetches all annotations assigned to the installation.
+func (sqlStore *SQLStore) GetAnnotationsForInstallation(installationID string) ([]*model.Annotation, error) {
+	var annotations []*model.Annotation
+
+	builder := sq.Select(annotationColumns...).
+		From("InstallationAnnotation").
+		Where("InstallationID = ?", installationID).
+		LeftJoin("Annotation ON Annotation.ID=AnnotationID")
+	err := sqlStore.selectBuilder(sqlStore.db, &annotations, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get annotations for Installation")
+	}
+
+	model.SortAnnotations(annotations)
+	return annotations, nil
+}
+
+type installationAnnotation struct {
+	InstallationID string
+	AnnotationID   string
+	AnnotationName string
+}
+
+// GetAnnotationsForInstallations fetches all annotations assigned to installations.
+func (sqlStore *SQLStore) GetAnnotationsForInstallations(filter *model.InstallationFilter) (map[string][]*model.Annotation, error) {
+	var installationAnnotations []*installationAnnotation
+
+	builder := sq.Select(
+		"Installation.ID as InstallationID",
+		"Annotation.ID as AnnotationID",
+		"Annotation.Name as AnnotationName").
+		From("Installation").
+		LeftJoin("InstallationAnnotation ON InstallationAnnotation.InstallationID = Installation.ID").
+		Join("Annotation ON Annotation.ID=AnnotationID")
+	builder = sqlStore.applyInstallationFilter(builder, filter)
+
+	err := sqlStore.selectBuilder(sqlStore.db, &installationAnnotations, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get annotations for Installation")
+	}
+
+	annotations := map[string][]*model.Annotation{}
+	for _, ca := range installationAnnotations {
+		annotations[ca.InstallationID] = append(
+			annotations[ca.InstallationID],
+			&model.Annotation{ID: ca.AnnotationID, Name: ca.AnnotationName},
+		)
+	}
+
+	for _, ann := range annotations {
+		model.SortAnnotations(ann)
+	}
+
+	return annotations, nil
+}
+
+// CreateInstallationAnnotations maps selected annotations to installation and stores it in the database.
+func (sqlStore *SQLStore) CreateInstallationAnnotations(installationID string, annotations []*model.Annotation) ([]*model.Annotation, error) {
+	return sqlStore.createInstallationAnnotations(sqlStore.db, installationID, annotations)
+}
+
+func (sqlStore *SQLStore) createInstallationAnnotations(db execer, installationID string, annotations []*model.Annotation) ([]*model.Annotation, error) {
+	builder := sq.Insert("InstallationAnnotation").
+		Columns("ID", "InstallationID", "AnnotationID")
+
+	for _, a := range annotations {
+		builder = builder.Values(model.NewID(), installationID, a.ID)
+	}
+	_, err := sqlStore.execBuilder(db, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create installation annotations")
+	}
+
+	return annotations, nil
+}

--- a/internal/store/annotation_test.go
+++ b/internal/store/annotation_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestAnnotations_Cluster(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	annotation1 := model.Annotation{Name: "annotation1"}
+	annotation2 := model.Annotation{Name: "annotation2"}
+
+	err := sqlStore.CreateAnnotation(&annotation1)
+	require.NoError(t, err)
+
+	err = sqlStore.CreateAnnotation(&annotation2)
+	require.NoError(t, err)
+
+	t.Run("fail to create annotations with same name", func(t *testing.T) {
+		err := sqlStore.CreateAnnotation(&model.Annotation{Name: annotation1.Name})
+		require.Error(t, err)
+		assert.Contains(t, strings.ToLower(err.Error()), "unique constraint") // Make sure error comes from DB
+	})
+
+	t.Run("get annotation by name", func(t *testing.T) {
+		annotation, err := sqlStore.GetAnnotationByName(annotation1.Name)
+		require.NoError(t, err)
+		assert.Equal(t, &annotation1, annotation)
+	})
+
+	t.Run("get unknown annotation", func(t *testing.T) {
+		annotation, err := sqlStore.GetAnnotationByName("unknown")
+		require.NoError(t, err)
+		assert.Nil(t, annotation)
+	})
+
+	annotations := []*model.Annotation{&annotation1, &annotation2}
+
+	cluster1 := model.Cluster{}
+	err = sqlStore.createCluster(sqlStore.db, &cluster1)
+	require.NoError(t, err)
+
+	_, err = sqlStore.CreateClusterAnnotations(cluster1.ID, annotations)
+	require.NoError(t, err)
+
+	t.Run("get annotations for cluster", func(t *testing.T) {
+		annotationsForCluster, err := sqlStore.GetAnnotationsForCluster(cluster1.ID)
+		require.NoError(t, err)
+		assert.Equal(t, len(annotations), len(annotationsForCluster))
+		assert.True(t, containsAnnotation(annotation1, annotationsForCluster))
+		assert.True(t, containsAnnotation(annotation2, annotationsForCluster))
+	})
+
+	t.Run("fail to assign the same annotation to the cluster twice", func(t *testing.T) {
+		_, err = sqlStore.CreateClusterAnnotations(cluster1.ID, annotations)
+		require.Error(t, err)
+		assert.Contains(t, strings.ToLower(err.Error()), "unique constraint") // Make sure error comes from DB
+	})
+
+	cluster2 := model.Cluster{}
+	err = sqlStore.CreateCluster(&cluster2, annotations)
+	require.NoError(t, err)
+
+	t.Run("get annotations for cluster2", func(t *testing.T) {
+		annotationsForCluster, err := sqlStore.GetAnnotationsForCluster(cluster2.ID)
+		require.NoError(t, err)
+		assert.Equal(t, len(annotations), len(annotationsForCluster))
+		assert.True(t, containsAnnotation(annotation1, annotationsForCluster))
+		assert.True(t, containsAnnotation(annotation2, annotationsForCluster))
+	})
+
+	t.Run("get annotations for clusters", func(t *testing.T) {
+		annotationsForClusters, err := sqlStore.GetAnnotationsForClusters(&model.ClusterFilter{PerPage: model.AllPerPage})
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(annotationsForClusters))
+		assert.True(t, containsAnnotation(annotation1, annotationsForClusters[cluster1.ID]))
+		assert.True(t, containsAnnotation(annotation2, annotationsForClusters[cluster1.ID]))
+		assert.True(t, containsAnnotation(annotation1, annotationsForClusters[cluster2.ID]))
+		assert.True(t, containsAnnotation(annotation2, annotationsForClusters[cluster2.ID]))
+	})
+}
+
+func TestAnnotations_Installation(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	annotation1 := model.Annotation{Name: "annotation1"}
+	annotation2 := model.Annotation{Name: "annotation2"}
+
+	err := sqlStore.CreateAnnotation(&annotation1)
+	require.NoError(t, err)
+	err = sqlStore.CreateAnnotation(&annotation2)
+	require.NoError(t, err)
+
+	annotations := []*model.Annotation{&annotation1, &annotation2}
+
+	installation1 := model.Installation{}
+	err = sqlStore.createInstallation(sqlStore.db, &installation1)
+	require.NoError(t, err)
+
+	_, err = sqlStore.CreateInstallationAnnotations(installation1.ID, annotations)
+	require.NoError(t, err)
+
+	t.Run("get annotations for installation", func(t *testing.T) {
+		annotationsForInstallation, err := sqlStore.GetAnnotationsForInstallation(installation1.ID)
+		require.NoError(t, err)
+		assert.Equal(t, len(annotations), len(annotationsForInstallation))
+		assert.True(t, containsAnnotation(annotation1, annotationsForInstallation))
+		assert.True(t, containsAnnotation(annotation2, annotationsForInstallation))
+	})
+
+	t.Run("fail to assign the same annotation to the installation twice", func(t *testing.T) {
+		_, err = sqlStore.CreateInstallationAnnotations(installation1.ID, annotations)
+		require.Error(t, err)
+		assert.Contains(t, strings.ToLower(err.Error()), "unique constraint") // Make sure error comes from DB
+	})
+
+	installation2 := model.Installation{DNS: "dns2.com"}
+	err = sqlStore.CreateInstallation(&installation2, annotations)
+	require.NoError(t, err)
+
+	t.Run("get annotations for installation2", func(t *testing.T) {
+		annotationsForInstallation, err := sqlStore.GetAnnotationsForInstallation(installation2.ID)
+		require.NoError(t, err)
+		assert.Equal(t, len(annotations), len(annotationsForInstallation))
+		assert.True(t, containsAnnotation(annotation1, annotationsForInstallation))
+		assert.True(t, containsAnnotation(annotation2, annotationsForInstallation))
+	})
+
+	t.Run("get annotations for installations", func(t *testing.T) {
+		annotationsForInstallations, err := sqlStore.GetAnnotationsForInstallations(&model.InstallationFilter{PerPage: model.AllPerPage})
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(annotationsForInstallations))
+		assert.True(t, containsAnnotation(annotation1, annotationsForInstallations[installation1.ID]))
+		assert.True(t, containsAnnotation(annotation2, annotationsForInstallations[installation1.ID]))
+		assert.True(t, containsAnnotation(annotation1, annotationsForInstallations[installation2.ID]))
+		assert.True(t, containsAnnotation(annotation2, annotationsForInstallations[installation2.ID]))
+	})
+}
+
+func containsAnnotation(annotation model.Annotation, annotations []*model.Annotation) bool {
+	for _, a := range annotations {
+		if *a == annotation {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/annotation_test.go
+++ b/internal/store/annotation_test.go
@@ -5,12 +5,13 @@
 package store
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"testing"
 )
 
 func TestAnnotations_Cluster(t *testing.T) {

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -17,7 +17,7 @@ var clusterSelect sq.SelectBuilder
 
 func init() {
 	clusterSelect = sq.
-		Select("Cluster.ID", "Provider", "Provisioner", "ProviderMetadataRaw", "ProvisionerMetadataRaw",
+		Select("ID", "Provider", "Provisioner", "ProviderMetadataRaw", "ProvisionerMetadataRaw",
 			"UtilityMetadataRaw", "State", "AllowInstallations", "CreateAt", "DeleteAt",
 			"APISecurityLock", "LockAcquiredBy", "LockAcquiredAt").
 		From("Cluster")

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -17,11 +17,9 @@ var clusterSelect sq.SelectBuilder
 
 func init() {
 	clusterSelect = sq.
-		Select(
-			"ID", "Provider", "Provisioner", "ProviderMetadataRaw", "ProvisionerMetadataRaw",
+		Select("Cluster.ID", "Provider", "Provisioner", "ProviderMetadataRaw", "ProvisionerMetadataRaw",
 			"UtilityMetadataRaw", "State", "AllowInstallations", "CreateAt", "DeleteAt",
-			"APISecurityLock", "LockAcquiredBy", "LockAcquiredAt",
-		).
+			"APISecurityLock", "LockAcquiredBy", "LockAcquiredAt").
 		From("Cluster")
 }
 
@@ -108,7 +106,18 @@ func (sqlStore *SQLStore) GetCluster(id string) (*model.Cluster, error) {
 func (sqlStore *SQLStore) GetClusters(filter *model.ClusterFilter) ([]*model.Cluster, error) {
 	builder := clusterSelect.
 		OrderBy("CreateAt ASC")
+	builder = sqlStore.applyClustersFilter(builder, filter)
 
+	var rawClusters rawClusters
+	err := sqlStore.selectBuilder(sqlStore.db, &rawClusters, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query for clusters")
+	}
+
+	return rawClusters.toClusters()
+}
+
+func (sqlStore *SQLStore) applyClustersFilter(builder sq.SelectBuilder, filter *model.ClusterFilter) sq.SelectBuilder {
 	if filter.PerPage != model.AllPerPage {
 		builder = builder.
 			Limit(uint64(filter.PerPage)).
@@ -119,13 +128,7 @@ func (sqlStore *SQLStore) GetClusters(filter *model.ClusterFilter) ([]*model.Clu
 		builder = builder.Where("DeleteAt = 0")
 	}
 
-	var rawClusters rawClusters
-	err := sqlStore.selectBuilder(sqlStore.db, &rawClusters, builder)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to query for clusters")
-	}
-
-	return rawClusters.toClusters()
+	return builder
 }
 
 // GetUnlockedClustersPendingWork returns an unlocked cluster in a pending state.
@@ -147,7 +150,40 @@ func (sqlStore *SQLStore) GetUnlockedClustersPendingWork() ([]*model.Cluster, er
 }
 
 // CreateCluster records the given cluster to the database, assigning it a unique ID.
-func (sqlStore *SQLStore) CreateCluster(cluster *model.Cluster) error {
+func (sqlStore *SQLStore) CreateCluster(cluster *model.Cluster, annotations []*model.Annotation) error {
+	tx, err := sqlStore.beginTransaction(sqlStore.db)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	err = sqlStore.createCluster(tx, cluster)
+	if err != nil {
+		return errors.Wrap(err, "failed to create cluster")
+	}
+
+	if len(annotations) > 0 {
+		annotations, err := sqlStore.getOrCreateAnnotations(tx, annotations)
+		if err != nil {
+			return errors.Wrap(err, "failed to get or create annotations")
+		}
+
+		_, err = sqlStore.createClusterAnnotations(tx, cluster.ID, annotations)
+		if err != nil {
+			return errors.Wrap(err, "failed to create annotations for cluster")
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return errors.Wrap(err, "failed to commit the transaction")
+	}
+
+	return nil
+}
+
+// createCluster records the given cluster to the database, assigning it a unique ID.
+func (sqlStore *SQLStore) createCluster(execer execer, cluster *model.Cluster) error {
 	cluster.ID = model.NewID()
 	cluster.CreateAt = GetMillis()
 
@@ -156,7 +192,7 @@ func (sqlStore *SQLStore) CreateCluster(cluster *model.Cluster) error {
 		return errors.Wrap(err, "unable to build raw cluster metadata")
 	}
 
-	_, err = sqlStore.execBuilder(sqlStore.db, sq.
+	_, err = sqlStore.execBuilder(execer, sq.
 		Insert("Cluster").
 		SetMap(map[string]interface{}{
 			"ID":                     cluster.ID,

--- a/internal/store/cluster_dto.go
+++ b/internal/store/cluster_dto.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+// GetClusterDTO fetches the given cluster by id with data from connected tables.
+func (sqlStore *SQLStore) GetClusterDTO(id string) (*model.ClusterDTO, error) {
+	cluster, err := sqlStore.GetCluster(id)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get cluster")
+	}
+	if cluster == nil {
+		return nil, nil
+	}
+
+	annotation, err := sqlStore.GetAnnotationsForCluster(id)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get annotations for cluster")
+	}
+
+	return &model.ClusterDTO{
+		Cluster:     cluster,
+		Annotations: annotation,
+	}, nil
+}
+
+// GetClusterDTOs fetches the given page of clusters with data from connected tables. The first page is 0.
+func (sqlStore *SQLStore) GetClusterDTOs(filter *model.ClusterFilter) ([]*model.ClusterDTO, error) {
+	clusters, err := sqlStore.GetClusters(filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get clusters")
+	}
+
+	annotations, err := sqlStore.GetAnnotationsForClusters(filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get annotations for clusters")
+	}
+
+	dtos := make([]*model.ClusterDTO, 0, len(clusters))
+	for _, c := range clusters {
+		dtos = append(dtos, &model.ClusterDTO{Cluster: c, Annotations: annotations[c.ID]})
+	}
+
+	return dtos, nil
+}

--- a/internal/store/cluster_dto_test.go
+++ b/internal/store/cluster_dto_test.go
@@ -5,11 +5,12 @@
 package store
 
 import (
+	"testing"
+
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestClusterDTOs(t *testing.T) {

--- a/internal/store/cluster_dto_test.go
+++ b/internal/store/cluster_dto_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestClusterDTOs(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	t.Run("get unknown cluster DTO", func(t *testing.T) {
+		cluster, err := sqlStore.GetClusterDTO("unknown")
+		require.NoError(t, err)
+		require.Nil(t, cluster)
+	})
+
+	annotation1 := model.Annotation{Name: "annotation1"}
+	annotation2 := model.Annotation{Name: "annotation2"}
+
+	// Create only one annotation beforehand to test both get by name and create.
+	err := sqlStore.CreateAnnotation(&annotation1)
+	require.NoError(t, err)
+
+	annotations := []*model.Annotation{&annotation1, &annotation2}
+
+	cluster1 := &model.Cluster{
+		Provider:                "aws",
+		Provisioner:             "kops",
+		ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
+		ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
+		UtilityMetadata:         &model.UtilityMetadata{},
+		State:                   model.ClusterStateCreationRequested,
+		AllowInstallations:      false,
+	}
+
+	cluster2 := &model.Cluster{
+		Provider:                "azure",
+		Provisioner:             "cluster-api",
+		ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
+		ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
+		UtilityMetadata:         &model.UtilityMetadata{},
+		State:                   model.ClusterStateStable,
+		AllowInstallations:      true,
+	}
+
+	err = sqlStore.CreateCluster(cluster1, annotations)
+	require.NoError(t, err)
+
+	err = sqlStore.CreateCluster(cluster2, nil)
+	require.NoError(t, err)
+
+	t.Run("get cluster DTO", func(t *testing.T) {
+		clusterDTO, err := sqlStore.GetClusterDTO(cluster1.ID)
+		require.NoError(t, err)
+		assert.Equal(t, cluster1, clusterDTO.Cluster)
+		assert.Equal(t, len(annotations), len(clusterDTO.Annotations))
+		assert.Equal(t, annotations, clusterDTO.Annotations)
+	})
+
+	t.Run("get cluster DTOs", func(t *testing.T) {
+		clusterDTOs, err := sqlStore.GetClusterDTOs(&model.ClusterFilter{PerPage: model.AllPerPage, IncludeDeleted: true})
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(clusterDTOs))
+		assert.Equal(t, []*model.ClusterDTO{cluster1.ToDTO(annotations), cluster2.ToDTO(nil)}, clusterDTOs)
+	})
+}

--- a/internal/store/cluster_dto_test.go
+++ b/internal/store/cluster_dto_test.go
@@ -63,13 +63,17 @@ func TestClusterDTOs(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, cluster1, clusterDTO.Cluster)
 		assert.Equal(t, len(annotations), len(clusterDTO.Annotations))
-		assert.Equal(t, annotations, clusterDTO.Annotations)
+		assert.Equal(t, annotations, model.SortAnnotations(clusterDTO.Annotations))
 	})
 
 	t.Run("get cluster DTOs", func(t *testing.T) {
 		clusterDTOs, err := sqlStore.GetClusterDTOs(&model.ClusterFilter{PerPage: model.AllPerPage, IncludeDeleted: true})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(clusterDTOs))
+
+		for _, c := range clusterDTOs {
+			model.SortAnnotations(c.Annotations)
+		}
 		assert.Equal(t, []*model.ClusterDTO{cluster1.ToDTO(annotations), cluster2.ToDTO(nil)}, clusterDTOs)
 	})
 }

--- a/internal/store/group_test.go
+++ b/internal/store/group_test.go
@@ -346,7 +346,7 @@ func TestGetUnlockedGroupsPendingWork(t *testing.T) {
 		State:     model.InstallationStateCreationRequested,
 	}
 
-	err = sqlStore.CreateInstallation(installation1)
+	err = sqlStore.CreateInstallation(installation1, nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Millisecond)
@@ -421,7 +421,7 @@ func TestGetGroupRollingMetadata(t *testing.T) {
 		State:     model.InstallationStateCreationRequested,
 	}
 
-	err = sqlStore.CreateInstallation(installation1)
+	err = sqlStore.CreateInstallation(installation1, nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Millisecond)
@@ -606,7 +606,7 @@ func TestGetGroupStatus(t *testing.T) {
 		State:     model.InstallationStateCreationRequested,
 	}
 
-	err = sqlStore.CreateInstallation(installation1)
+	err = sqlStore.CreateInstallation(installation1, nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Millisecond)

--- a/internal/store/installation_dto.go
+++ b/internal/store/installation_dto.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+// GetInstallationDTO fetches the given installation by id with data from connected tables.
+func (sqlStore *SQLStore) GetInstallationDTO(id string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.InstallationDTO, error) {
+	installation, err := sqlStore.GetInstallation(id, includeGroupConfig, includeGroupConfigOverrides)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get installation")
+	}
+	if installation == nil {
+		return nil, nil
+	}
+
+	annotations, err := sqlStore.GetAnnotationsForInstallation(id)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get annotations for installation")
+	}
+
+	return &model.InstallationDTO{
+		Installation: installation,
+		Annotations:  annotations,
+	}, nil
+}
+
+// GetInstallationDTOs fetches the given page of installation with data from connected tables. The first page is 0.
+func (sqlStore *SQLStore) GetInstallationDTOs(filter *model.InstallationFilter, includeGroupConfig, includeGroupConfigOverrides bool) ([]*model.InstallationDTO, error) {
+	installations, err := sqlStore.GetInstallations(filter, includeGroupConfig, includeGroupConfigOverrides)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get installations")
+	}
+
+	annotations, err := sqlStore.GetAnnotationsForInstallations(filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get annotations for installations")
+	}
+
+	dtos := make([]*model.InstallationDTO, 0, len(installations))
+	for _, inst := range installations {
+		dtos = append(dtos, &model.InstallationDTO{Installation: inst, Annotations: annotations[inst.ID]})
+	}
+
+	return dtos, nil
+}

--- a/internal/store/installation_dto_test.go
+++ b/internal/store/installation_dto_test.go
@@ -70,7 +70,7 @@ func TestInstallationDTOs(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, installation1, installationDTO.Installation)
 		assert.Equal(t, len(annotations), len(installationDTO.Annotations))
-		assert.Equal(t, annotations, installationDTO.Annotations)
+		assert.Equal(t, annotations, model.SortAnnotations(installationDTO.Annotations))
 	})
 
 	t.Run("get installation DTOs", func(t *testing.T) {
@@ -81,6 +81,9 @@ func TestInstallationDTOs(t *testing.T) {
 		)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(installationDTOs))
+		for _, i := range installationDTOs {
+			model.SortAnnotations(i.Annotations)
+		}
 		assert.Equal(t, []*model.InstallationDTO{installation1.ToDTO(annotations), installation2.ToDTO(nil)}, installationDTOs)
 	})
 }

--- a/internal/store/installation_dto_test.go
+++ b/internal/store/installation_dto_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestInstallationDTOs(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	t.Run("get unknown cluster DTO", func(t *testing.T) {
+		cluster, err := sqlStore.GetInstallationDTO("unknown", false, false)
+		require.NoError(t, err)
+		require.Nil(t, cluster)
+	})
+
+	annotation1 := model.Annotation{Name: "annotation1"}
+	annotation2 := model.Annotation{Name: "annotation2"}
+
+	// Create only one annotation beforehand to test both get by name and create.
+	err := sqlStore.CreateAnnotation(&annotation1)
+	require.NoError(t, err)
+	annotations := []*model.Annotation{&annotation1, &annotation2}
+
+	groupID1 := model.NewID()
+
+	installation1 := &model.Installation{
+		OwnerID:   "owner1",
+		Version:   "version",
+		DNS:       "dns.example.com",
+		Database:  model.InstallationDatabaseMysqlOperator,
+		Filestore: model.InstallationFilestoreMinioOperator,
+		Size:      mmv1alpha1.Size100String,
+		Affinity:  model.InstallationAffinityIsolated,
+		GroupID:   &groupID1,
+		State:     model.InstallationStateCreationRequested,
+	}
+
+	installation2 := &model.Installation{
+		OwnerID:   "owner1",
+		Version:   "version2",
+		Image:     "custom-image",
+		DNS:       "dns2.example.com",
+		Database:  model.InstallationDatabaseMysqlOperator,
+		Filestore: model.InstallationFilestoreMinioOperator,
+		Size:      mmv1alpha1.Size100String,
+		Affinity:  model.InstallationAffinityIsolated,
+		GroupID:   &groupID1,
+		State:     model.InstallationStateStable,
+	}
+
+	err = sqlStore.CreateInstallation(installation1, annotations)
+	require.NoError(t, err)
+
+	err = sqlStore.CreateInstallation(installation2, nil)
+	require.NoError(t, err)
+
+	t.Run("get installation DTO", func(t *testing.T) {
+		installationDTO, err := sqlStore.GetInstallationDTO(installation1.ID, false, false)
+		require.NoError(t, err)
+		assert.Equal(t, installation1, installationDTO.Installation)
+		assert.Equal(t, len(annotations), len(installationDTO.Annotations))
+		assert.Equal(t, annotations, installationDTO.Annotations)
+	})
+
+	t.Run("get installation DTOs", func(t *testing.T) {
+		installationDTOs, err := sqlStore.GetInstallationDTOs(
+			&model.InstallationFilter{PerPage: model.AllPerPage, IncludeDeleted: true},
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(installationDTOs))
+		assert.Equal(t, []*model.InstallationDTO{installation1.ToDTO(annotations), installation2.ToDTO(nil)}, installationDTOs)
+	})
+}

--- a/internal/store/installation_dto_test.go
+++ b/internal/store/installation_dto_test.go
@@ -5,12 +5,13 @@
 package store
 
 import (
+	"testing"
+
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/mattermost/mattermost-cloud/model"
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestInstallationDTOs(t *testing.T) {

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1115,4 +1115,59 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.21.0"), semver.MustParse("0.22.0"), func(e execer) error {
+		// Changes:
+		// 1. Add Annotation table.
+		// 2. Add ClusterAnnotation table.
+		// 3. Add InstallationAnnotation table.
+		// 4. Add constraints to ensure Annotation to Cluster mappings and Annotation to Installation mappings are unique.
+
+		_, err := e.Exec(`
+			CREATE TABLE Annotation (
+				ID TEXT PRIMARY KEY,
+				Name TEXT NOT NULL UNIQUE
+			);
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+			CREATE TABLE ClusterAnnotation (
+				ID TEXT PRIMARY KEY,
+				ClusterID TEXT NOT NULL,
+				AnnotationID TEXT NOT NULL
+			);
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+			CREATE UNIQUE INDEX ClusterAnnotation_ClusterID_AnnotationID ON ClusterAnnotation (ClusterID, AnnotationID);
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+			CREATE TABLE InstallationAnnotation (
+				ID TEXT PRIMARY KEY,
+				InstallationID TEXT NOT NULL,
+				AnnotationID TEXT NOT NULL
+			);
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+			CREATE UNIQUE INDEX InstallationAnnotation_InstallationID_AnnotationID ON InstallationAnnotation (InstallationID, AnnotationID);
+		`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/internal/store/testing.go
+++ b/internal/store/testing.go
@@ -6,13 +6,14 @@ package store
 
 import (
 	"fmt"
+	"net/url"
+	"os"
+	"testing"
+
 	"github.com/mattermost/mattermost-cloud/model"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net/url"
-	"os"
-	"testing"
 )
 
 func makeUnmigratedTestSQLStore(tb testing.TB, logger log.FieldLogger) *SQLStore {

--- a/internal/store/testing.go
+++ b/internal/store/testing.go
@@ -6,13 +6,13 @@ package store
 
 import (
 	"fmt"
+	"github.com/mattermost/mattermost-cloud/model"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"net/url"
 	"os"
 	"testing"
-
-	"github.com/mattermost/mattermost-cloud/model"
-	log "github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 )
 
 func makeUnmigratedTestSQLStore(tb testing.TB, logger log.FieldLogger) *SQLStore {
@@ -53,4 +53,10 @@ func MakeTestSQLStore(tb testing.TB, logger log.FieldLogger) *SQLStore {
 	require.NoError(tb, err)
 
 	return sqlStore
+}
+
+// CloseConnection closes underlying database connection.
+func CloseConnection(tb testing.TB, sqlStore *SQLStore) {
+	err := sqlStore.db.Close()
+	assert.NoError(tb, err)
 }

--- a/internal/supervisor/cluster_installation_test.go
+++ b/internal/supervisor/cluster_installation_test.go
@@ -151,7 +151,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 				supervisor := supervisor.NewClusterInstallationSupervisor(sqlStore, &mockClusterInstallationProvisioner{}, &mockAWS{}, "instanceID", logger)
 
 				installation := &model.Installation{}
-				err := sqlStore.CreateInstallation(installation)
+				err := sqlStore.CreateInstallation(installation, nil)
 				require.NoError(t, err)
 
 				clusterInstallation := &model.ClusterInstallation{
@@ -186,7 +186,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 				supervisor := supervisor.NewClusterInstallationSupervisor(sqlStore, &mockClusterInstallationProvisioner{}, &mockAWS{}, "instanceID", logger)
 
 				cluster := &model.Cluster{}
-				err := sqlStore.CreateCluster(cluster)
+				err := sqlStore.CreateCluster(cluster, nil)
 				require.NoError(t, err)
 
 				clusterInstallation := &model.ClusterInstallation{
@@ -223,11 +223,11 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 				supervisor := supervisor.NewClusterInstallationSupervisor(sqlStore, &mockClusterInstallationProvisioner{}, &mockAWS{}, "instanceID", logger)
 
 				cluster := &model.Cluster{}
-				err := sqlStore.CreateCluster(cluster)
+				err := sqlStore.CreateCluster(cluster, nil)
 				require.NoError(t, err)
 
 				installation := &model.Installation{}
-				err = sqlStore.CreateInstallation(installation)
+				err = sqlStore.CreateInstallation(installation, nil)
 				require.NoError(t, err)
 
 				clusterInstallation := &model.ClusterInstallation{
@@ -251,11 +251,11 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 		supervisor := supervisor.NewClusterInstallationSupervisor(sqlStore, &mockClusterInstallationProvisioner{}, &mockAWS{}, "instanceID", logger)
 
 		cluster := &model.Cluster{}
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		installation := &model.Installation{}
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -148,7 +148,7 @@ func TestClusterSupervisorSupervise(t *testing.T) {
 				ProvisionerMetadataKops: &model.KopsMetadata{},
 				State:                   tc.InitialState,
 			}
-			err := sqlStore.CreateCluster(cluster)
+			err := sqlStore.CreateCluster(cluster, nil)
 			require.NoError(t, err)
 
 			supervisor.Supervise(cluster)
@@ -168,7 +168,7 @@ func TestClusterSupervisorSupervise(t *testing.T) {
 			Provider: model.ProviderAWS,
 			State:    model.ClusterStateDeletionRequested,
 		}
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		// The stored cluster is ClusterStateDeletionRequested, so we will pass

--- a/internal/supervisor/group_test.go
+++ b/internal/supervisor/group_test.go
@@ -187,7 +187,7 @@ func TestGroupSupervisor(t *testing.T) {
 			State:    model.InstallationStateStable,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		supervisor.Supervise(group)
@@ -214,7 +214,7 @@ func TestGroupSupervisor(t *testing.T) {
 			Affinity: model.InstallationAffinityIsolated,
 			GroupID:  &group.ID,
 			State:    model.InstallationStateStable,
-		})
+		}, nil)
 		require.NoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
@@ -227,7 +227,7 @@ func TestGroupSupervisor(t *testing.T) {
 			Affinity: model.InstallationAffinityIsolated,
 			GroupID:  &group.ID,
 			State:    model.InstallationStateStable,
-		})
+		}, nil)
 		require.NoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
@@ -240,7 +240,7 @@ func TestGroupSupervisor(t *testing.T) {
 			Affinity: model.InstallationAffinityIsolated,
 			GroupID:  &group.ID,
 			State:    model.InstallationStateStable,
-		})
+		}, nil)
 		require.NoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
@@ -270,7 +270,7 @@ func TestGroupSupervisor(t *testing.T) {
 			State:    model.InstallationStateDeletionRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		supervisor.Supervise(group)
@@ -297,7 +297,7 @@ func TestGroupSupervisor(t *testing.T) {
 				Affinity: model.InstallationAffinityIsolated,
 				GroupID:  &group.ID,
 				State:    model.InstallationStateStable,
-			})
+			}, nil)
 			require.NoError(t, err)
 
 			time.Sleep(1 * time.Millisecond)
@@ -310,7 +310,7 @@ func TestGroupSupervisor(t *testing.T) {
 				Affinity: model.InstallationAffinityIsolated,
 				GroupID:  &group.ID,
 				State:    model.InstallationStateStable,
-			})
+			}, nil)
 			require.NoError(t, err)
 
 			supervisor.Supervise(group)
@@ -340,7 +340,7 @@ func TestGroupSupervisor(t *testing.T) {
 				Affinity: model.InstallationAffinityIsolated,
 				GroupID:  &group.ID,
 				State:    model.InstallationStateStable,
-			})
+			}, nil)
 			require.NoError(t, err)
 
 			time.Sleep(1 * time.Millisecond)
@@ -353,7 +353,7 @@ func TestGroupSupervisor(t *testing.T) {
 				Affinity: model.InstallationAffinityIsolated,
 				GroupID:  &group.ID,
 				State:    model.InstallationStateDeletionInProgress,
-			})
+			}, nil)
 			require.NoError(t, err)
 
 			supervisor.Supervise(group)

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -373,7 +373,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -388,7 +388,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateStable,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -411,7 +411,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -426,7 +426,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationInProgress,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		// The stored installation is InstallationStateCreationInProgress, so we
@@ -455,7 +455,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationRequested,
 		}
 
-		err := sqlStore.CreateInstallation(installation)
+		err := sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
@@ -470,7 +470,7 @@ func TestInstallationSupervisor(t *testing.T) {
 
 		cluster := standardStableTestCluster()
 		cluster.AllowInstallations = false
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -485,7 +485,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
@@ -499,7 +499,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -523,7 +523,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
@@ -537,7 +537,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -552,7 +552,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -575,7 +575,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -590,7 +590,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -613,7 +613,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -628,7 +628,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationDNS,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -651,7 +651,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -666,7 +666,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -689,7 +689,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -704,7 +704,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationPreProvisioning,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -727,7 +727,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -742,7 +742,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationPreProvisioning,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -765,7 +765,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -780,7 +780,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationInProgress,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -803,7 +803,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -818,7 +818,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationInProgress,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -841,7 +841,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -856,7 +856,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationInProgress,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -879,7 +879,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -894,7 +894,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationFinalTasks,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -928,7 +928,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationNoCompatibleClusters,
 		}
 
-		err := sqlStore.CreateInstallation(installation)
+		err := sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
@@ -942,7 +942,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -966,7 +966,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationNoCompatibleClusters,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
@@ -980,7 +980,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -995,7 +995,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationNoCompatibleClusters,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)
@@ -1009,7 +1009,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1024,7 +1024,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateUpdateRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -1047,7 +1047,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1062,7 +1062,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateUpdateInProgress,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -1085,7 +1085,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1100,7 +1100,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateUpdateInProgress,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -1123,7 +1123,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1138,7 +1138,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateHibernationRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -1161,7 +1161,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1176,7 +1176,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateHibernationInProgress,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -1199,7 +1199,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1214,7 +1214,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateHibernationInProgress,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -1237,7 +1237,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1252,7 +1252,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateDeletionRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -1275,7 +1275,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1290,7 +1290,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateDeletionRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -1313,7 +1313,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1328,7 +1328,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateDeletionInProgress,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -1351,7 +1351,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1366,7 +1366,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateDeletionRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -1389,7 +1389,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1404,7 +1404,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateDeletionRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		clusterInstallation := &model.ClusterInstallation{
@@ -1428,7 +1428,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 			cluster := standardStableTestCluster()
-			err := sqlStore.CreateCluster(cluster)
+			err := sqlStore.CreateCluster(cluster, nil)
 			require.NoError(t, err)
 
 			owner := model.NewID()
@@ -1443,7 +1443,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				State:    model.InstallationStateCreationRequested,
 			}
 
-			err = sqlStore.CreateInstallation(installation)
+			err = sqlStore.CreateInstallation(installation, nil)
 			require.NoError(t, err)
 
 			supervisor.Supervise(installation)
@@ -1458,7 +1458,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 			cluster := standardStableTestCluster()
-			err := sqlStore.CreateCluster(cluster)
+			err := sqlStore.CreateCluster(cluster, nil)
 			require.NoError(t, err)
 
 			for i := 1; i < 3; i++ {
@@ -1475,7 +1475,7 @@ func TestInstallationSupervisor(t *testing.T) {
 						State:    model.InstallationStateCreationRequested,
 					}
 
-					err = sqlStore.CreateInstallation(installation)
+					err = sqlStore.CreateInstallation(installation, nil)
 					require.NoError(t, err)
 
 					supervisor.Supervise(installation)
@@ -1492,7 +1492,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 			cluster := standardStableTestCluster()
-			err := sqlStore.CreateCluster(cluster)
+			err := sqlStore.CreateCluster(cluster, nil)
 			require.NoError(t, err)
 
 			owner := model.NewID()
@@ -1507,7 +1507,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				State:    model.InstallationStateCreationRequested,
 			}
 
-			err = sqlStore.CreateInstallation(isolatedInstallation)
+			err = sqlStore.CreateInstallation(isolatedInstallation, nil)
 			require.NoError(t, err)
 
 			supervisor.Supervise(isolatedInstallation)
@@ -1527,7 +1527,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				State:    model.InstallationStateCreationRequested,
 			}
 
-			err = sqlStore.CreateInstallation(multitenantInstallation)
+			err = sqlStore.CreateInstallation(multitenantInstallation, nil)
 			require.NoError(t, err)
 
 			supervisor.Supervise(multitenantInstallation)
@@ -1551,7 +1551,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			supervisor := supervisor.NewInstallationSupervisor(sqlStore, mockInstallationProvisioner, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
 
 			cluster := standardStableTestCluster()
-			err := sqlStore.CreateCluster(cluster)
+			err := sqlStore.CreateCluster(cluster, nil)
 			require.NoError(t, err)
 
 			owner := model.NewID()
@@ -1566,7 +1566,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				State:    model.InstallationStateCreationRequested,
 			}
 
-			err = sqlStore.CreateInstallation(installation)
+			err = sqlStore.CreateInstallation(installation, nil)
 			require.NoError(t, err)
 
 			supervisor.Supervise(installation)
@@ -1591,7 +1591,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		supervisor := supervisor.NewInstallationSupervisor(sqlStore, mockInstallationProvisioner, &mockAWS{}, "instanceID", 80, 2, false, false, &utils.ResourceUtil{}, logger)
 
 		cluster := standardStableTestCluster()
-		err := sqlStore.CreateCluster(cluster)
+		err := sqlStore.CreateCluster(cluster, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1606,7 +1606,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			State:    model.InstallationStateCreationRequested,
 		}
 
-		err = sqlStore.CreateInstallation(installation)
+		err = sqlStore.CreateInstallation(installation, nil)
 		require.NoError(t, err)
 
 		supervisor.Supervise(installation)

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -13,7 +13,7 @@ import (
 const (
 	annotationMinLen        = 3
 	annotationMaxLen        = 64
-	annotationAllowedFormat = "annotations must start with letter and can contain only lowercase letters, numbers or '_', '-' characters"
+	annotationAllowedFormat = "annotations must start with a letter and can contain only lowercase letters, numbers or '_', '-' characters"
 )
 
 var annotationRegex = regexp.MustCompile("^[a-z].[a-z0-9_-]*$")

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -33,10 +33,10 @@ func AnnotationsFromStringSlice(names []string) ([]*Annotation, error) {
 	annotations := make([]*Annotation, 0, len(names))
 	for _, n := range names {
 		if len(n) < annotationMinLen || len(n) > annotationMaxLen {
-			return nil, fmt.Errorf("error: annotation '%s' is invalid: annotations must be between %d and %d characters long", n, annotationMinLen, annotationMaxLen)
+			return nil, fmt.Errorf("annotation '%s' is invalid: annotations must be between %d and %d characters long", n, annotationMinLen, annotationMaxLen)
 		}
 		if !annotationRegex.MatchString(n) {
-			return nil, fmt.Errorf("error: annotation '%s' is invalid: %s", n, annotationAllowedFormat)
+			return nil, fmt.Errorf("annotation '%s' is invalid: %s", n, annotationAllowedFormat)
 		}
 		annotations = append(annotations, &Annotation{Name: n})
 	}

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+const (
+	annotationMinLen        = 3
+	annotationMaxLen        = 64
+	annotationAllowedFormat = "annotations must start with letter and can contain only lowercase letters, numbers or '_', '-' characters"
+)
+
+var annotationRegex = regexp.MustCompile("^[a-z].[a-z0-9_-]*$")
+
+// Annotation represents an annotation.
+type Annotation struct {
+	ID   string
+	Name string
+}
+
+// AnnotationsFromStringSlice converts list of strings to list of annotations
+func AnnotationsFromStringSlice(names []string) ([]*Annotation, error) {
+	if names == nil {
+		return nil, nil
+	}
+
+	annotations := make([]*Annotation, 0, len(names))
+	for _, n := range names {
+		if len(n) < annotationMinLen || len(n) > annotationMaxLen {
+			return nil, fmt.Errorf("error: annotation '%s' is invalid: annotations must be between %d and %d characters long", n, annotationMinLen, annotationMaxLen)
+		}
+		if !annotationRegex.MatchString(n) {
+			return nil, fmt.Errorf("error: annotation '%s' is invalid: %s", n, annotationAllowedFormat)
+		}
+		annotations = append(annotations, &Annotation{Name: n})
+	}
+
+	SortAnnotations(annotations)
+	return annotations, nil
+}
+
+// SortAnnotations sorts annotations by name alphabetically.
+func SortAnnotations(annotations []*Annotation) {
+	sort.Slice(annotations, func(i, j int) bool {
+		return annotations[i].Name < annotations[j].Name
+	})
+}

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -41,13 +41,13 @@ func AnnotationsFromStringSlice(names []string) ([]*Annotation, error) {
 		annotations = append(annotations, &Annotation{Name: n})
 	}
 
-	SortAnnotations(annotations)
 	return annotations, nil
 }
 
 // SortAnnotations sorts annotations by name alphabetically.
-func SortAnnotations(annotations []*Annotation) {
+func SortAnnotations(annotations []*Annotation) []*Annotation {
 	sort.Slice(annotations, func(i, j int) bool {
 		return annotations[i].Name < annotations[j].Name
 	})
+	return annotations
 }

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -16,7 +16,7 @@ const (
 	annotationAllowedFormat = "annotations must start with a letter and can contain only lowercase letters, numbers or '_', '-' characters"
 )
 
-var annotationRegex = regexp.MustCompile("^[a-z].[a-z0-9_-]*$")
+var annotationRegex = regexp.MustCompile("^[a-z]+[a-z0-9_-]*$")
 
 // Annotation represents an annotation.
 type Annotation struct {

--- a/model/annotation_test.go
+++ b/model/annotation_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestAnnotationsFromStringSlice(t *testing.T) {
+
+	t.Run("valid annotations", func(t *testing.T) {
+		for _, testCase := range []struct {
+			description string
+			names       []string
+			annotations []*Annotation
+		}{
+			{"nil array", nil, nil},
+			{"empty array", []string{}, []*Annotation{}},
+			{
+				"valid names",
+				[]string{"abcd", "multi-tenant", "awesome_annotation"},
+				[]*Annotation{{Name: "abcd"}, {Name: "awesome_annotation"}, {Name: "multi-tenant"}},
+			},
+			{
+				"long names",
+				[]string{"multi-tenant-1234-abcd-very-long-name", "super-awesome-long_name"},
+				[]*Annotation{{Name: "multi-tenant-1234-abcd-very-long-name"}, {Name: "super-awesome-long_name"}},
+			},
+		} {
+			t.Run(testCase.description, func(t *testing.T) {
+				annotations, err := AnnotationsFromStringSlice(testCase.names)
+				require.NoError(t, err)
+				assert.Equal(t, testCase.annotations, annotations)
+			})
+		}
+	})
+
+	t.Run("invalid annotations", func(t *testing.T) {
+		for _, testCase := range []struct {
+			description string
+			names       []string
+		}{
+			{
+				"to long name",
+				[]string{"abcd", "my-annotation-1-with-super-long-name-that-is-not-allowed-but-cool"},
+			},
+			{
+				"upper case letter",
+				[]string{"abcd", "xyz", "Abcd"},
+			},
+			{"to short name", []string{"abcd", "ab"}},
+			{"not allowed character ' '", []string{"ab cd"}},
+			{"not allowed character '!'", []string{"ab!cd"}},
+			{"not allowed character ':'", []string{"ab:cd"}},
+			{"not allowed character '{'", []string{"ab{cd}"}},
+			{"not allowed character '+'", []string{"ab+cd"}},
+			{"starts with '_'", []string{"_abcd"}},
+			{"starts with '-'", []string{"-abcd"}},
+			{"starts with number", []string{"6abcd"}},
+		} {
+			t.Run(testCase.description, func(t *testing.T) {
+				annotations, err := AnnotationsFromStringSlice(testCase.names)
+				require.Error(t, err)
+				assert.Nil(t, annotations)
+			})
+		}
+	})
+
+}
+
+func TestSortAnnotations(t *testing.T) {
+
+	for _, testCase := range []struct {
+		description string
+		annotations []*Annotation
+		expected    []*Annotation
+	}{
+		{
+			description: "sort annotations",
+			annotations: []*Annotation{
+				{Name: "xyz"}, {Name: "other-annotation"}, {Name: "other_annotation"}, {Name: "abcdefgh"}, {Name: "abcd"},
+			},
+			expected: []*Annotation{
+				{Name: "abcd"}, {Name: "abcdefgh"}, {Name: "other-annotation"}, {Name: "other_annotation"}, {Name: "xyz"},
+			},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			SortAnnotations(testCase.annotations)
+			assert.Equal(t, testCase.expected, testCase.annotations)
+		})
+	}
+
+}

--- a/model/annotation_test.go
+++ b/model/annotation_test.go
@@ -23,7 +23,7 @@ func TestAnnotationsFromStringSlice(t *testing.T) {
 			{
 				"valid names",
 				[]string{"abcd", "multi-tenant", "awesome_annotation"},
-				[]*Annotation{{Name: "abcd"}, {Name: "awesome_annotation"}, {Name: "multi-tenant"}},
+				[]*Annotation{{Name: "abcd"}, {Name: "multi-tenant"}, {Name: "awesome_annotation"}},
 			},
 			{
 				"long names",

--- a/model/annotation_test.go
+++ b/model/annotation_test.go
@@ -5,9 +5,10 @@
 package model
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestAnnotationsFromStringSlice(t *testing.T) {
@@ -53,6 +54,7 @@ func TestAnnotationsFromStringSlice(t *testing.T) {
 				[]string{"abcd", "xyz", "Abcd"},
 			},
 			{"to short name", []string{"abcd", "ab"}},
+			{"invalid characters", []string{"a?bcd"}},
 			{"not allowed character ' '", []string{"ab cd"}},
 			{"not allowed character '!'", []string{"ab!cd"}},
 			{"not allowed character ':'", []string{"ab:cd"}},

--- a/model/client.go
+++ b/model/client.go
@@ -113,7 +113,7 @@ func (c *Client) doDelete(u string) (*http.Response, error) {
 }
 
 // CreateCluster requests the creation of a cluster from the configured provisioning server.
-func (c *Client) CreateCluster(request *CreateClusterRequest) (*Cluster, error) {
+func (c *Client) CreateCluster(request *CreateClusterRequest) (*ClusterDTO, error) {
 	resp, err := c.doPost(c.buildURL("/api/clusters"), request)
 	if err != nil {
 		return nil, err
@@ -122,7 +122,7 @@ func (c *Client) CreateCluster(request *CreateClusterRequest) (*Cluster, error) 
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return ClusterFromReader(resp.Body)
+		return ClusterDTOFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -148,7 +148,7 @@ func (c *Client) RetryCreateCluster(clusterID string) error {
 
 // ProvisionCluster provisions k8s operators and Helm charts on a
 // cluster from the configured provisioning server.
-func (c *Client) ProvisionCluster(clusterID string, request *ProvisionClusterRequest) (*Cluster, error) {
+func (c *Client) ProvisionCluster(clusterID string, request *ProvisionClusterRequest) (*ClusterDTO, error) {
 	resp, err := c.doPost(c.buildURL("/api/cluster/%s/provision", clusterID), request)
 	if err != nil {
 		return nil, err
@@ -157,7 +157,7 @@ func (c *Client) ProvisionCluster(clusterID string, request *ProvisionClusterReq
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return ClusterFromReader(resp.Body)
+		return ClusterDTOFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -165,7 +165,7 @@ func (c *Client) ProvisionCluster(clusterID string, request *ProvisionClusterReq
 }
 
 // GetCluster fetches the specified cluster from the configured provisioning server.
-func (c *Client) GetCluster(clusterID string) (*Cluster, error) {
+func (c *Client) GetCluster(clusterID string) (*ClusterDTO, error) {
 	resp, err := c.doGet(c.buildURL("/api/cluster/%s", clusterID))
 	if err != nil {
 		return nil, err
@@ -174,7 +174,7 @@ func (c *Client) GetCluster(clusterID string) (*Cluster, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return ClusterFromReader(resp.Body)
+		return ClusterDTOFromReader(resp.Body)
 
 	case http.StatusNotFound:
 		return nil, nil
@@ -185,7 +185,7 @@ func (c *Client) GetCluster(clusterID string) (*Cluster, error) {
 }
 
 // GetClusters fetches the list of clusters from the configured provisioning server.
-func (c *Client) GetClusters(request *GetClustersRequest) ([]*Cluster, error) {
+func (c *Client) GetClusters(request *GetClustersRequest) ([]*ClusterDTO, error) {
 	u, err := url.Parse(c.buildURL("/api/clusters"))
 	if err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ func (c *Client) GetClusters(request *GetClustersRequest) ([]*Cluster, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return ClustersFromReader(resp.Body)
+		return ClusterDTOsFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -226,7 +226,7 @@ func (c *Client) GetClusterUtilities(clusterID string) (*UtilityMetadata, error)
 }
 
 // UpdateCluster updates a cluster's configuration.
-func (c *Client) UpdateCluster(clusterID string, request *UpdateClusterRequest) (*Cluster, error) {
+func (c *Client) UpdateCluster(clusterID string, request *UpdateClusterRequest) (*ClusterDTO, error) {
 	resp, err := c.doPut(c.buildURL("/api/cluster/%s", clusterID), request)
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func (c *Client) UpdateCluster(clusterID string, request *UpdateClusterRequest) 
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return ClusterFromReader(resp.Body)
+		return ClusterDTOFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -243,7 +243,7 @@ func (c *Client) UpdateCluster(clusterID string, request *UpdateClusterRequest) 
 }
 
 // UpgradeCluster upgrades a cluster to the latest recommended production ready k8s version.
-func (c *Client) UpgradeCluster(clusterID string, request *PatchUpgradeClusterRequest) (*Cluster, error) {
+func (c *Client) UpgradeCluster(clusterID string, request *PatchUpgradeClusterRequest) (*ClusterDTO, error) {
 	resp, err := c.doPut(c.buildURL("/api/cluster/%s/kubernetes", clusterID), request)
 	if err != nil {
 		return nil, err
@@ -252,7 +252,7 @@ func (c *Client) UpgradeCluster(clusterID string, request *PatchUpgradeClusterRe
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return ClusterFromReader(resp.Body)
+		return ClusterDTOFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -260,7 +260,7 @@ func (c *Client) UpgradeCluster(clusterID string, request *PatchUpgradeClusterRe
 }
 
 // ResizeCluster resizes a cluster with a new size value.
-func (c *Client) ResizeCluster(clusterID string, request *PatchClusterSizeRequest) (*Cluster, error) {
+func (c *Client) ResizeCluster(clusterID string, request *PatchClusterSizeRequest) (*ClusterDTO, error) {
 	resp, err := c.doPut(c.buildURL("/api/cluster/%s/size", clusterID), request)
 	if err != nil {
 		return nil, err
@@ -269,7 +269,7 @@ func (c *Client) ResizeCluster(clusterID string, request *PatchClusterSizeReques
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return ClusterFromReader(resp.Body)
+		return ClusterDTOFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -294,7 +294,7 @@ func (c *Client) DeleteCluster(clusterID string) error {
 }
 
 // CreateInstallation requests the creation of a installation from the configured provisioning server.
-func (c *Client) CreateInstallation(request *CreateInstallationRequest) (*Installation, error) {
+func (c *Client) CreateInstallation(request *CreateInstallationRequest) (*InstallationDTO, error) {
 	resp, err := c.doPost(c.buildURL("/api/installations"), request)
 	if err != nil {
 		return nil, err
@@ -303,7 +303,7 @@ func (c *Client) CreateInstallation(request *CreateInstallationRequest) (*Instal
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return InstallationFromReader(resp.Body)
+		return InstallationDTOFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -328,7 +328,7 @@ func (c *Client) RetryCreateInstallation(installationID string) error {
 }
 
 // GetInstallation fetches the specified installation from the configured provisioning server.
-func (c *Client) GetInstallation(installationID string, request *GetInstallationRequest) (*Installation, error) {
+func (c *Client) GetInstallation(installationID string, request *GetInstallationRequest) (*InstallationDTO, error) {
 	u, err := url.Parse(c.buildURL("/api/installation/%s", installationID))
 	if err != nil {
 		return nil, err
@@ -344,7 +344,7 @@ func (c *Client) GetInstallation(installationID string, request *GetInstallation
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return InstallationFromReader(resp.Body)
+		return InstallationDTOFromReader(resp.Body)
 
 	case http.StatusNotFound:
 		return nil, nil
@@ -355,7 +355,7 @@ func (c *Client) GetInstallation(installationID string, request *GetInstallation
 }
 
 // GetInstallationByDNS finds an installation with the given FQDN.
-func (c *Client) GetInstallationByDNS(DNS string, request *GetInstallationRequest) (*Installation, error) {
+func (c *Client) GetInstallationByDNS(DNS string, request *GetInstallationRequest) (*InstallationDTO, error) {
 	if request == nil {
 		request = &GetInstallationRequest{
 			IncludeGroupConfig:          false,
@@ -383,7 +383,7 @@ func (c *Client) GetInstallationByDNS(DNS string, request *GetInstallationReques
 }
 
 // GetInstallations fetches the list of installations from the configured provisioning server.
-func (c *Client) GetInstallations(request *GetInstallationsRequest) ([]*Installation, error) {
+func (c *Client) GetInstallations(request *GetInstallationsRequest) ([]*InstallationDTO, error) {
 	u, err := url.Parse(c.buildURL("/api/installations"))
 	if err != nil {
 		return nil, err
@@ -399,7 +399,7 @@ func (c *Client) GetInstallations(request *GetInstallationsRequest) ([]*Installa
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return InstallationsFromReader(resp.Body)
+		return InstallationDTOsFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -431,7 +431,7 @@ func (c *Client) GetInstallationsCount(includeDeleted bool) (int, error) {
 }
 
 // UpdateInstallation updates an installation.
-func (c *Client) UpdateInstallation(installationID string, request *PatchInstallationRequest) (*Installation, error) {
+func (c *Client) UpdateInstallation(installationID string, request *PatchInstallationRequest) (*InstallationDTO, error) {
 	resp, err := c.doPut(c.buildURL("/api/installation/%s/mattermost", installationID), request)
 	if err != nil {
 		return nil, err
@@ -440,7 +440,7 @@ func (c *Client) UpdateInstallation(installationID string, request *PatchInstall
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return InstallationFromReader(resp.Body)
+		return InstallationDTOFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -448,7 +448,7 @@ func (c *Client) UpdateInstallation(installationID string, request *PatchInstall
 }
 
 // HibernateInstallation puts an installation into hibernation.
-func (c *Client) HibernateInstallation(installationID string) (*Installation, error) {
+func (c *Client) HibernateInstallation(installationID string) (*InstallationDTO, error) {
 	resp, err := c.doPost(c.buildURL("/api/installation/%s/hibernate", installationID), nil)
 	if err != nil {
 		return nil, err
@@ -457,7 +457,7 @@ func (c *Client) HibernateInstallation(installationID string) (*Installation, er
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return InstallationFromReader(resp.Body)
+		return InstallationDTOFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -465,7 +465,7 @@ func (c *Client) HibernateInstallation(installationID string) (*Installation, er
 }
 
 // WakeupInstallation wakes an installation from hibernation.
-func (c *Client) WakeupInstallation(installationID string) (*Installation, error) {
+func (c *Client) WakeupInstallation(installationID string) (*InstallationDTO, error) {
 	resp, err := c.doPost(c.buildURL("/api/installation/%s/wakeup", installationID), nil)
 	if err != nil {
 		return nil, err
@@ -474,7 +474,7 @@ func (c *Client) WakeupInstallation(installationID string) (*Installation, error
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return InstallationFromReader(resp.Body)
+		return InstallationDTOFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -36,6 +36,14 @@ func (c *Cluster) Clone() *Cluster {
 	return &clone
 }
 
+// ToDTO expands cluster to ClusterDTO.
+func (c *Cluster) ToDTO(annotations []*Annotation) *ClusterDTO {
+	return &ClusterDTO{
+		Cluster:     c,
+		Annotations: annotations,
+	}
+}
+
 // ClusterFromReader decodes a json-encoded cluster from the given io.Reader.
 func ClusterFromReader(reader io.Reader) (*Cluster, error) {
 	cluster := Cluster{}

--- a/model/cluster_dto.go
+++ b/model/cluster_dto.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// ClusterDTO represents cluster entity with connected data.
+type ClusterDTO struct {
+	*Cluster
+	Annotations []*Annotation `json:"Annotations,omitempty"`
+}
+
+// ClusterDTOFromReader decodes a json-encoded cluster DTO from the given io.Reader.
+func ClusterDTOFromReader(reader io.Reader) (*ClusterDTO, error) {
+	clusterDTO := ClusterDTO{}
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&clusterDTO)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &clusterDTO, nil
+}
+
+// ClusterDTOsFromReader decodes a json-encoded list of cluster DTOs from the given io.Reader.
+func ClusterDTOsFromReader(reader io.Reader) ([]*ClusterDTO, error) {
+	clusterDTOs := []*ClusterDTO{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&clusterDTOs)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return clusterDTOs, nil
+}

--- a/model/cluster_dto.go
+++ b/model/cluster_dto.go
@@ -9,7 +9,7 @@ import (
 	"io"
 )
 
-// ClusterDTO represents cluster entity with connected data.
+// ClusterDTO represents cluster entity with connected data. DTO stands for Data Transfer Object.
 type ClusterDTO struct {
 	*Cluster
 	Annotations []*Annotation `json:"Annotations,omitempty"`

--- a/model/cluster_dto_test.go
+++ b/model/cluster_dto_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestClusterDTOFromReader(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		clusterDTO, err := ClusterDTOFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &ClusterDTO{}, clusterDTO)
+	})
+
+	t.Run("invalid request", func(t *testing.T) {
+		clusterDTO, err := ClusterDTOFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, clusterDTO)
+	})
+
+	t.Run("request", func(t *testing.T) {
+		clusterDTO, err := ClusterDTOFromReader(bytes.NewReader([]byte(
+			`{"ID":"id","Provider":"aws","Annotations":[{"ID":"abc","Name":"efg"}]}`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &ClusterDTO{Cluster: &Cluster{ID: "id", Provider: "aws"}, Annotations: []*Annotation{
+			{ID: "abc", Name: "efg"},
+		}}, clusterDTO)
+	})
+}
+
+func TestClustersDTOFromReader(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		clusterDTOs, err := ClusterDTOsFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*ClusterDTO{}, clusterDTOs)
+	})
+
+	t.Run("invalid request", func(t *testing.T) {
+		clusterDTOs, err := ClusterDTOsFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, clusterDTOs)
+	})
+
+	t.Run("request", func(t *testing.T) {
+		clusterDTOs, err := ClusterDTOsFromReader(bytes.NewReader([]byte(
+			`[{"ID":"id1","Provider":"aws","Annotations":[{"ID":"abc","Name":"efg"}]},{"ID":"id2","Provider":"aws"}]`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*ClusterDTO{
+			{
+				Cluster:     &Cluster{ID: "id1", Provider: "aws"},
+				Annotations: []*Annotation{{ID: "abc", Name: "efg"}},
+			},
+			{
+				Cluster: &Cluster{ID: "id2", Provider: "aws"},
+			},
+		}, clusterDTOs)
+	})
+}

--- a/model/cluster_dto_test.go
+++ b/model/cluster_dto_test.go
@@ -6,8 +6,9 @@ package model
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestClusterDTOFromReader(t *testing.T) {

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -27,6 +27,7 @@ type CreateClusterRequest struct {
 	AllowInstallations     bool              `json:"allow-installations,omitempty"`
 	APISecurityLock        bool              `json:"api-security-lock,omitempty"`
 	DesiredUtilityVersions map[string]string `json:"utility-versions,omitempty"`
+	ExtraAnnotations       []string          `json:"extra-annotations,omitempty"`
 }
 
 // SetDefaults sets the default values for a cluster create request.

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -27,7 +27,7 @@ type CreateClusterRequest struct {
 	AllowInstallations     bool              `json:"allow-installations,omitempty"`
 	APISecurityLock        bool              `json:"api-security-lock,omitempty"`
 	DesiredUtilityVersions map[string]string `json:"utility-versions,omitempty"`
-	ExtraAnnotations       []string          `json:"extra-annotations,omitempty"`
+	Annotations       []string          `json:"annotations,omitempty"`
 }
 
 // SetDefaults sets the default values for a cluster create request.

--- a/model/group_status_test.go
+++ b/model/group_status_test.go
@@ -6,8 +6,9 @@ package model
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGroupStatusFromReader(t *testing.T) {

--- a/model/installation.go
+++ b/model/installation.go
@@ -68,6 +68,14 @@ func (i *Installation) Clone() *Installation {
 	return &clone
 }
 
+// ToDTO expands installation to InstallationDTO.
+func (i *Installation) ToDTO(annotations []*Annotation) *InstallationDTO {
+	return &InstallationDTO{
+		Installation: i,
+		Annotations:  annotations,
+	}
+}
+
 // IsInGroup returns if the installation is in a group or not.
 func (i *Installation) IsInGroup() bool {
 	return i.GroupID != nil

--- a/model/installation_dto.go
+++ b/model/installation_dto.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// InstallationDTO represents a Mattermost installation.
+type InstallationDTO struct {
+	*Installation
+	Annotations []*Annotation `json:"Annotations,omitempty"`
+}
+
+// InstallationDTOFromReader decodes a json-encoded installation DTO from the given io.Reader.
+func InstallationDTOFromReader(reader io.Reader) (*InstallationDTO, error) {
+	installationDTO := InstallationDTO{}
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&installationDTO)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &installationDTO, nil
+}
+
+// InstallationDTOsFromReader decodes a json-encoded list of installation DTOs from the given io.Reader.
+func InstallationDTOsFromReader(reader io.Reader) ([]*InstallationDTO, error) {
+	installationDTOs := []*InstallationDTO{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&installationDTOs)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return installationDTOs, nil
+}

--- a/model/installation_dto.go
+++ b/model/installation_dto.go
@@ -9,7 +9,7 @@ import (
 	"io"
 )
 
-// InstallationDTO represents a Mattermost installation.
+// InstallationDTO represents a Mattermost installation. DTO stands for Data Transfer Object.
 type InstallationDTO struct {
 	*Installation
 	Annotations []*Annotation `json:"Annotations,omitempty"`

--- a/model/installation_dto_test.go
+++ b/model/installation_dto_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestInstallationDTOFromReader(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		installationDTO, err := InstallationDTOFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &InstallationDTO{}, installationDTO)
+	})
+
+	t.Run("invalid request", func(t *testing.T) {
+		installationDTO, err := InstallationDTOFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, installationDTO)
+	})
+
+	t.Run("request", func(t *testing.T) {
+		installationDTO, err := InstallationDTOFromReader(bytes.NewReader([]byte(`{
+			"ID":"id",
+			"OwnerID":"owner",
+			"GroupID":"group_id",
+			"Version":"version",
+			"DNS":"dns",
+			"License": "this_is_my_license",
+			"MattermostEnv": {"key1": {"Value": "value1"}},
+			"Affinity":"affinity",
+			"State":"state",
+			"CreateAt":10,
+			"DeleteAt":20,
+			"LockAcquiredAt":0,
+			"Annotations": [
+				{"ID": "abc", "Name": "efg"}
+			]
+		}`)))
+		require.NoError(t, err)
+		require.Equal(t, &InstallationDTO{
+			Installation: &Installation{
+				ID:             "id",
+				OwnerID:        "owner",
+				GroupID:        sToP("group_id"),
+				Version:        "version",
+				DNS:            "dns",
+				License:        "this_is_my_license",
+				MattermostEnv:  EnvVarMap{"key1": {Value: "value1"}},
+				Affinity:       "affinity",
+				State:          "state",
+				CreateAt:       10,
+				DeleteAt:       20,
+				LockAcquiredBy: nil,
+				LockAcquiredAt: int64(0),
+			},
+			Annotations: []*Annotation{{ID: "abc", Name: "efg"}},
+		}, installationDTO)
+	})
+}
+
+func TestInstallationDTOsFromReader(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		installationDTOs, err := InstallationDTOsFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*InstallationDTO{}, installationDTOs)
+	})
+
+	t.Run("invalid request", func(t *testing.T) {
+		installationDTOs, err := InstallationDTOsFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, installationDTOs)
+	})
+
+	t.Run("request", func(t *testing.T) {
+		installationDTOs, err := InstallationDTOsFromReader(bytes.NewReader([]byte(`[
+			{
+				"ID":"id1",
+				"OwnerID":"owner1",
+				"GroupID":"group_id1",
+				"Version":"version1",
+				"DNS":"dns1",
+				"MattermostEnv": {"key1": {"Value": "value1"}},
+				"Affinity":"affinity1",
+				"State":"state1",
+				"CreateAt":10,
+				"DeleteAt":20,
+				"LockAcquiredAt":0,
+				"Annotations": [
+					{"ID": "abc", "Name": "efg"}
+				]
+			},
+			{
+				"ID":"id2",
+				"OwnerID":"owner2",
+				"GroupID":"group_id2",
+				"Version":"version2",
+				"DNS":"dns2",
+				"License": "this_is_my_license",
+				"MattermostEnv": {"key2": {"Value": "value2"}},
+				"Affinity":"affinity2",
+				"State":"state2",
+				"CreateAt":30,
+				"DeleteAt":40,
+				"LockAcquiredBy": "tester",
+				"LockAcquiredAt":50
+			}
+		]`)))
+		require.NoError(t, err)
+		require.Equal(t, []*InstallationDTO{
+			{
+				Installation: &Installation{
+					ID:             "id1",
+					OwnerID:        "owner1",
+					GroupID:        sToP("group_id1"),
+					Version:        "version1",
+					DNS:            "dns1",
+					MattermostEnv:  EnvVarMap{"key1": {Value: "value1"}},
+					Affinity:       "affinity1",
+					State:          "state1",
+					CreateAt:       10,
+					DeleteAt:       20,
+					LockAcquiredBy: nil,
+					LockAcquiredAt: 0,
+				},
+				Annotations: []*Annotation{{ID: "abc", Name: "efg"}},
+			},
+			{
+				Installation: &Installation{
+					ID:             "id2",
+					OwnerID:        "owner2",
+					GroupID:        sToP("group_id2"),
+					Version:        "version2",
+					DNS:            "dns2",
+					License:        "this_is_my_license",
+					MattermostEnv:  EnvVarMap{"key2": {Value: "value2"}},
+					Affinity:       "affinity2",
+					State:          "state2",
+					CreateAt:       30,
+					DeleteAt:       40,
+					LockAcquiredBy: sToP("tester"),
+					LockAcquiredAt: 50,
+				},
+			},
+		}, installationDTOs)
+	})
+}

--- a/model/installation_dto_test.go
+++ b/model/installation_dto_test.go
@@ -6,8 +6,9 @@ package model
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestInstallationDTOFromReader(t *testing.T) {

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -22,18 +22,19 @@ import (
 
 // CreateInstallationRequest specifies the parameters for a new installation.
 type CreateInstallationRequest struct {
-	OwnerID         string
-	GroupID         string
-	Version         string
-	Image           string
-	DNS             string
-	License         string
-	Size            string
-	Affinity        string
-	Database        string
-	Filestore       string
-	APISecurityLock bool
-	MattermostEnv   EnvVarMap
+	OwnerID          string
+	GroupID          string
+	Version          string
+	Image            string
+	DNS              string
+	License          string
+	Size             string
+	Affinity         string
+	Database         string
+	Filestore        string
+	APISecurityLock  bool
+	MattermostEnv    EnvVarMap
+	ExtraAnnotations []string
 }
 
 // https://man7.org/linux/man-pages/man7/hostname.7.html

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -34,7 +34,7 @@ type CreateInstallationRequest struct {
 	Filestore        string
 	APISecurityLock  bool
 	MattermostEnv    EnvVarMap
-	ExtraAnnotations []string
+	Annotations []string
 }
 
 // https://man7.org/linux/man-pages/man7/hostname.7.html


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This PR introduces the initial version of Cluster and Installation Annotations to the API and Database model:
-  New tables added:
    - `Annotation`
    - `ClusterAnnotation`
    - `InstallationAnnotation`
- Annotations can be added when creating Clusters or Installations with API calls:
  ```
  ...
      "annotations": [
        "abcd", "test", "super-awsome"
    ]
  ...
  ```
- Added `--annotation` flag to `create cluster` and `create installation` commands.
- Introduced `InstllationDTO` and `ClusterDTO` structs as a way to represent Installations and Clusters with data joined from different tables (ex. Annotations)
- Introduced the `CloseConnection` function for some unit tests to close the database connection as we started to hit the Postgress limit when running all unit tests.

API for updating Annotations on existing Clusters and Installation as well as using those for scheduling will be done in different PRs.

P.S.
Sorry for the huge PR, I have underestimated the number of required changes 😞

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-29236

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Introduce Cluster and Installation Annotations
```
