### PR TITLE
[MM-28659] Introducing Thanos utility group

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -34,6 +34,7 @@ func init() {
 	clusterCreateCmd.Flags().Bool("allow-installations", true, "Whether the cluster will allow for new installations to be scheduled.")
 	clusterCreateCmd.Flags().String("prometheus-version", model.PrometheusDefaultVersion, "The version of Prometheus to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("prometheus-operator-version", model.PrometheusOperatorDefaultVersion, "The version of Prometheus Operator to provision. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().String("thanos-version", model.ThanosDefaultVersion, "The version of Thanos to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("fluentbit-version", model.FluentbitDefaultVersion, "The version of Fluentbit to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("nginx-version", model.NginxDefaultVersion, "The version of Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("teleport-version", model.TeleportDefaultVersion, "The version of Teleport to provision. Use 'stable' to provision the latest stable version published upstream.")
@@ -41,6 +42,7 @@ func init() {
 	clusterProvisionCmd.Flags().String("cluster", "", "The id of the cluster to be provisioned.")
 	clusterProvisionCmd.Flags().String("prometheus-version", "", "The version of Prometheus to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.Flags().String("prometheus-operator-version", "", "The version of Prometheus Operator to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
+	clusterProvisionCmd.Flags().String("thanos-version", "", "The version of Thanos to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.Flags().String("fluentbit-version", "", "The version of Fluentbit to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.Flags().String("nginx-version", "", "The version of Nginx to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
 	clusterProvisionCmd.Flags().String("teleport-version", "", "The version of Teleport to provision, no change if omitted. Use \"stable\" as an argument to this command to indicate that you wish to remove the pinned version and return the utility to tracking the latest version.")
@@ -510,6 +512,7 @@ var clusterShowStateReport = &cobra.Command{
 func processUtilityFlags(command *cobra.Command) map[string]string {
 	prometheusVersion, _ := command.Flags().GetString("prometheus-version")
 	prometheusOperatorVersion, _ := command.Flags().GetString("prometheus-operator-version")
+	thanosVersion, _ := command.Flags().GetString("thanos-version")
 	fluentbitVersion, _ := command.Flags().GetString("fluentbit-version")
 	nginxVersion, _ := command.Flags().GetString("nginx-version")
 	teleportVersion, _ := command.Flags().GetString("teleport-version")
@@ -522,6 +525,10 @@ func processUtilityFlags(command *cobra.Command) map[string]string {
 
 	if prometheusOperatorVersion != "" {
 		utilityVersions[model.PrometheusOperatorCanonicalName] = prometheusOperatorVersion
+	}
+
+	if thanosVersion != "" {
+		utilityVersions[model.ThanosCanonicalName] = thanosVersion
 	}
 
 	if fluentbitVersion != "" {

--- a/helm-charts/thanos_values.yaml
+++ b/helm-charts/thanos_values.yaml
@@ -1,0 +1,452 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry, and imagePullSecrets
+##
+# global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+#   storageClass: myStorageClass
+
+## Bitnami Thanos image
+## ref: https://hub.docker.com/r/bitnami/thanos/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/thanos
+  tag: 0.15.0
+  ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## String to partially override thanos.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override thanos.fullname template
+##
+# fullnameOverride:
+
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
+## Objstore Configuration
+## Specify content for objstore.yml
+##
+# objstoreConfig: |-
+#   type: s3
+#   config:
+#     bucket: cloud-test-thanos-poc
+#     endpoint: s3.us-east-1.amazonaws.com
+
+## Secret with Objstore Configuration
+## Note: This will override objstoreConfig
+##
+# existingObjstoreSecret:
+##  optional item list for specifying a custom Secret key. If so, path should be objstore.yml
+# existingObjstoreSecretItems: []
+
+## Provide a common service account to be shared with all components
+##
+# existingServiceAccount: my-service-account
+
+## Thanos Querier parameters
+##
+querier:
+  ## Set to true to enable Thanos Querier component
+  ##
+  enabled: true
+
+  ## Log level
+  ##
+  logLevel: info
+
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+    ## Provide an existing service account for querier
+    ##
+    # existingServiceAccount: querier-service-account
+
+  ## Labels to treat as a replica indicator along which data is deduplicated
+  ##
+  replicaLabel: replica
+
+  ## Dinamically configure store APIs using DNS discovery
+  ##
+  dnsDiscovery:
+    enabled: true
+    ## Sidecars service name to discover them using DNS discovery
+    ## Evaluated as a template.
+    sidecarsService: "prometheus-operated"
+    ##
+    ## Sidecars namespace to discover them using DNS discovery
+    ## Evaluated as a template.
+    sidecarsNamespace: "{{ .Release.Namespace }}"
+
+  ## Statically configure store APIs to connect with Thanos Querier
+  ##
+  stores: []
+    # - prometheus-operated.prometheus-operator:10901
+
+  ## Querier Service Discovery Configuration
+  ## Specify content for servicediscovery.yml
+  ##
+  # sdConfig:
+
+  ## ConfigMap with Querier Service Discovery Configuration
+  ## NOTE: This will override querier.sdConfig
+  ##
+  # existingSDConfigmap:
+
+  ## Extra Flags to passed to Thanos Querier
+  ##
+  extraFlags: []
+
+  ## Number of Thanos Querier replicas to deploy
+  ##
+  replicaCount: 1
+
+  ## StrategyType, can be set to RollingUpdate or Recreate by default.
+  ##
+  strategyType: RollingUpdate
+
+  ## Affinity for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: 
+    podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/component
+            operator: In
+            values:
+            - querier
+        topologyKey: kubernetes.io/hostname
+
+
+
+  ## Node labels for pod assignment. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Annotations for querier pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Pod priority
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## K8s Security Context for Thanos Querier pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Thanos Querier containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits:
+      cpu: "1"
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+  ## Thanos Querier pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /-/healthy
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+  readinessProbe:
+    httpGet:
+      path: /-/ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 6
+
+  ## Thanos Querier GRPC TLS parameters
+  ## to configure --grpc-server-tls-cert, --grpc-server-tls-key, --grpc-server-tls-client-ca, --grpc-client-tls-secure, --grpc-client-tls-cert, --grpc-client-tls-key, --grpc-client-tls-ca, --grpc-client-server-name
+  ## ref: https://github.com/thanos-io/thanos/blob/master/docs/components/query.md#flags
+  grpcTLS:
+    # TLS server side 
+    server:
+      # Enable TLS for GRPC server
+      secure: false
+      # TLS Certificate for gRPC server, leave blank to disable TLS
+      cert:
+      # TLS Key for the gRPC server, leave blank to disable TLS
+      key:
+      # TLS CA to verify clients against. If no client CA is specified, there is no client verification on server side. (tls.NoClientCert)
+      ca:
+    # TLS client side
+    client:
+      # Use TLS when talking to the gRPC server
+      secure: false
+      # TLS Certificates to use to identify this client to the server
+      cert:
+      # TLS Key for the client's certificate
+      key:
+      # TLS CA Certificates to use to verify gRPC servers
+      ca:
+      # Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1
+      servername:
+
+  ## Service paramaters
+  ##
+  service:
+    ## Service type
+    ##
+    # type: ClusterIP
+    # type: ClusterIP
+    type: LoadBalancer
+    ## Thanos Querier service clusterIP IP
+    ##
+    # clusterIP: None
+    ## HTTP Port
+    ##
+    http:
+      port: 9090
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## GRPC Port
+    ##
+    grpc:
+      port: 10901
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Provide any additional annotations which may be required
+    ##
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+      service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+      service.beta.kubernetes.io/aws-load-balancer-type: nlb
+
+  ## Autoscaling parameters
+  ##
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 8
+    targetCPU: 50
+    targetMemory: 50
+
+  ## Querier Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+  ## Configure the ingress resource that allows you to access Thanos Querier
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: true
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    # hostname: thanos.local
+    hostname: example.thanos.com
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations:
+      kubernetes.io/ingress.class: nginx-controller
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    ## extraHosts:
+    ## - name: thanos.local
+    ##   path: /
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    ## extraTls:
+    ## - hosts:
+    ##     - thanos.local
+    ##   secretName: thanos.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+    ##
+    secrets: []
+    ## - name: thanos.local-tls
+    ##   key:
+
+    ## Create an ingress object for the GRPC service. This requires an HTTP/2
+    ## capable Ingress controller (eg. traefik using AWS NLB). Example annotations
+    ## - ingress.kubernetes.io/protocol: h2c
+    ## - service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    ## - service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    ## For more information see https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/
+    ## and also the documentation for your ingress controller.
+    ##
+    ## The options that are accepted are identical to the HTTP one listed above
+    grpc:
+      enabled: true
+      certManager: false
+      hostname: example-grpc.thanos.com
+      annotations: {}
+      ## - hosts:
+      ##     - thanos.local
+      ##   secretName: thanos-grpc.local-tls
+
+      ## extraHosts:
+      ## - name: thanos-grpc.local
+      ##   path: /
+
+      ## extraTls:
+      ## - hosts:
+      ##     - thanos-grpc.local
+      ##   secretName: thanos-grpc.local-tls
+
+      secrets: []
+      ## - name: thanos-grpc.local-tls
+      ##   key:
+      ##   certificate:
+
+## Thanos Bucket Web parameters
+##
+bucketweb:
+  ## Set to true to enable Thanos Bucket Web component
+  ##
+  enabled: false
+
+
+## Thanos Compactor parameters
+##
+compactor:
+  ## Set to true to enable Thanos Compactor component
+  ##
+  enabled: false
+
+  
+
+## Thanos Store Gateway parameters
+##
+storegateway:
+  ## Set to true to enable Thanos Store Gateway component
+  ##
+  enabled: false
+
+
+## Thanos Ruler parameters
+##
+ruler:
+  ## Set to true to enable Thanos Ruler component
+  ##
+  enabled: false
+
+
+## Prometheus metrics
+##
+metrics:
+  enabled: true
+
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    enabled: true
+    ## Namespace in which Prometheus is running
+    ##
+    # namespace: monitoring
+    ## Labels to add to the ServiceMonitor object
+    ##
+    # labels:
+    ## Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # interval: 10s
+    ## Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # scrapeTimeout: 10s
+
+## Init Container paramaters
+## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component
+## values from the securityContext section of the component
+##
+volumePermissions:
+  enabled: false
+
+
+## Minio Chart configuration
+##
+minio:
+  ## Set to true to deploy a MinIO chart
+  ## to be used as an objstore for Thanos
+  ##
+  enabled: false

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -1078,6 +1078,7 @@ func TestGetAllUtilityMetadata(t *testing.T) {
 			DesiredUtilityVersions: map[string]string{
 				"prometheus":          "10.3.0",
 				"prometheus-operator": "9.4.4",
+				"thanos":              "2.4.3",
 				"nginx":               "stable",
 			},
 		})
@@ -1087,11 +1088,13 @@ func TestGetAllUtilityMetadata(t *testing.T) {
 
 	assert.Equal(t, "", utilityMetadata.ActualVersions.Prometheus)
 	assert.Equal(t, "", utilityMetadata.ActualVersions.PrometheusOperator)
+	assert.Equal(t, "", utilityMetadata.ActualVersions.Thanos)
 	assert.Equal(t, "", utilityMetadata.ActualVersions.Nginx)
 	assert.Equal(t, "", utilityMetadata.ActualVersions.Fluentbit)
 
 	assert.Equal(t, "", utilityMetadata.DesiredVersions.Nginx)
 	assert.Equal(t, "10.3.0", utilityMetadata.DesiredVersions.Prometheus)
 	assert.Equal(t, "9.4.4", utilityMetadata.DesiredVersions.PrometheusOperator)
+	assert.Equal(t, "2.4.3", utilityMetadata.DesiredVersions.Thanos)
 	assert.Equal(t, model.FluentbitDefaultVersion, utilityMetadata.DesiredVersions.Fluentbit)
 }

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -24,7 +24,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			NodeMinCount:           2,
 			NodeMaxCount:           2,
 			Zones:                  []string{"us-east-1a"},
-			DesiredUtilityVersions: map[string]string{"fluentbit": "2.8.7", "nginx": "2.15.0", "prometheus": "10.4.0", "prometheus-operator": "9.4.4", "teleport": "0.3.0"},
+			DesiredUtilityVersions: map[string]string{"fluentbit": "2.8.7", "nginx": "2.15.0", "prometheus": "10.4.0", "prometheus-operator": "9.4.4", "thanos": "2.4.3", "teleport": "0.3.0"},
 		}
 	}
 
@@ -82,6 +82,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"nginx":               "2.15.0",
 				"prometheus":          "10.4.0",
 				"prometheus-operator": "9.4.4",
+				"thanos":              "2.4.3",
 				"teleport":            "0.3.0"},
 		}, clusterRequest)
 	})

--- a/internal/provisioner/kops_utils.go
+++ b/internal/provisioner/kops_utils.go
@@ -103,7 +103,7 @@ func getPrivateLoadBalancerEndpoint(ctx context.Context, namespace string, logge
 			return "", err
 		}
 		for _, service := range services.Items {
-			if strings.HasSuffix(service.Name, "internal") {
+			if strings.HasSuffix(service.Name, "internal") || strings.HasSuffix(service.Name, "querier") {
 				if service.Status.LoadBalancer.Ingress != nil {
 					endpoint := service.Status.LoadBalancer.Ingress[0].Hostname
 					if endpoint == "" {

--- a/internal/provisioner/prometheus_operator.go
+++ b/internal/provisioner/prometheus_operator.go
@@ -122,7 +122,15 @@ func (p *prometheusOperator) CreateOrUpgrade() error {
 		return errors.Wrapf(err, "failed to create the Thanos object storage secret")
 	}
 
-	h := p.NewHelmDeployment()
+	privateDomainName, err := p.awsClient.GetPrivateZoneDomainName(logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to lookup private zone name")
+	}
+
+	app := "prometheus"
+	dns := fmt.Sprintf("%s.%s.%s", p.cluster.ID, app, privateDomainName)
+
+	h := p.NewHelmDeployment(dns)
 	err = h.Update()
 	if err != nil {
 		return errors.Wrap(err, "failed to create the Prometheus Operator Helm deployment")
@@ -133,13 +141,6 @@ func (p *prometheusOperator) CreateOrUpgrade() error {
 		return err
 	}
 
-	privateDomainName, err := p.awsClient.GetPrivateZoneDomainName(logger)
-	if err != nil {
-		return errors.Wrap(err, "unable to lookup private zone name")
-	}
-
-	app := "prometheus"
-	dns := fmt.Sprintf("%s.%s.%s", p.cluster.ID, app, privateDomainName)
 	if p.awsClient.IsProvisionedPrivateCNAME(dns, p.logger) {
 		p.logger.Debugln("CNAME was already provisioned for prometheus")
 		return nil
@@ -187,13 +188,7 @@ func (p *prometheusOperator) Migrate() error {
 	return nil
 }
 
-func (p *prometheusOperator) NewHelmDeployment() *helmDeployment {
-	privateDomainName, err := p.awsClient.GetPrivateZoneDomainName(p.logger)
-	if err != nil {
-		p.logger.WithError(err).Error("unable to lookup private zone name")
-	}
-	prometheusDNS := fmt.Sprintf("%s.prometheus.%s", p.cluster.ID, privateDomainName)
-
+func (p *prometheusOperator) NewHelmDeployment(prometheusDNS string) *helmDeployment {
 	helmValueArguments := fmt.Sprintf("prometheus.prometheusSpec.externalLabels.clusterID=%s,prometheus.ingress.hosts={%s},prometheus.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", p.cluster.ID, prometheusDNS, strings.Join(p.provisioner.allowCIDRRangeList, "\\,"))
 
 	return &helmDeployment{

--- a/internal/provisioner/thanos.go
+++ b/internal/provisioner/thanos.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type thanos struct {
+	awsClient      aws.AWS
+	cluster        *model.Cluster
+	kops           *kops.Cmd
+	logger         log.FieldLogger
+	provisioner    *KopsProvisioner
+	desiredVersion string
+	actualVersion  string
+}
+
+func newThanosHandle(cluster *model.Cluster, provisioner *KopsProvisioner, awsClient aws.AWS, kops *kops.Cmd, logger log.FieldLogger) (*thanos, error) {
+	if logger == nil {
+		return nil, fmt.Errorf("cannot instantiate Thanos handle with nil logger")
+	}
+
+	if cluster == nil {
+		return nil, errors.New("cannot create a connection to Thanos if the cluster provided is nil")
+	}
+
+	if provisioner == nil {
+		return nil, errors.New("cannot create a connection to Thanos if the provisioner provided is nil")
+	}
+
+	if awsClient == nil {
+		return nil, errors.New("cannot create a connection to Thanos if the awsClient provided is nil")
+	}
+
+	if kops == nil {
+		return nil, errors.New("cannot create a connection to Thanos if the Kops command provided is nil")
+	}
+
+	version, err := cluster.DesiredUtilityVersion(model.ThanosCanonicalName)
+	if err != nil {
+		return nil, errors.Wrap(err, "something went wrong while getting chart version for Thanos")
+	}
+
+	return &thanos{
+		awsClient:      awsClient,
+		cluster:        cluster,
+		kops:           kops,
+		logger:         logger.WithField("cluster-utility", model.ThanosCanonicalName),
+		provisioner:    provisioner,
+		desiredVersion: version,
+	}, nil
+}
+
+func (t *thanos) CreateOrUpgrade() error {
+	logger := t.logger.WithField("thanos-action", "create")
+
+	environment, err := t.awsClient.GetCloudEnvironmentName()
+	if err != nil {
+		return errors.Wrap(err, "failed to get environment name for thanos objstore secret")
+	}
+
+	if environment == "" {
+		return errors.New("cannot create a thanos objstore secret if environment is empty")
+	}
+
+	awsRegion := os.Getenv("AWS_REGION")
+	if awsRegion == "" {
+		awsRegion = aws.DefaultAWSRegion
+	}
+
+	h := t.NewHelmDeployment()
+	err = h.Update()
+	if err != nil {
+		return errors.Wrap(err, "failed to create the Thanos Helm deployment")
+	}
+
+	err = t.updateVersion(h)
+	if err != nil {
+		return err
+	}
+
+	privateDomainName, err := t.awsClient.GetPrivateZoneDomainName(logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to lookup private zone name")
+	}
+
+	app := "thanos"
+	dns := fmt.Sprintf("%s.%s.%s", t.cluster.ID, app, privateDomainName)
+
+	if t.awsClient.IsProvisionedPrivateCNAME(dns, t.logger) {
+		t.logger.Debugln("Main CNAME was already provisioned for thanos")
+	} else {
+		t.logger.Debugln("Main CNAME was not provisioned for thanos")
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(120)*time.Second)
+		defer cancel()
+
+		endpoint, err := getPrivateLoadBalancerEndpoint(ctx, "nginx", logger.WithField("thanos-action", "create"), t.kops.GetKubeConfigPath())
+		if err != nil {
+			return errors.Wrap(err, "couldn't get the load balancer endpoint (nginx) for Thanos")
+		}
+
+		logger.Infof("Registering DNS %s for %s", dns, app)
+		err = t.awsClient.CreatePrivateCNAME(dns, []string{endpoint}, logger.WithField("thanos-dns-create", dns))
+		if err != nil {
+			return errors.Wrap(err, "failed to create a CNAME to point to Thanos")
+		}
+	}
+
+	grpcDNS := fmt.Sprintf("%s-grpc.%s.%s", t.cluster.ID, app, privateDomainName)
+	if t.awsClient.IsProvisionedPrivateCNAME(grpcDNS, t.logger) {
+		t.logger.Debugln("GRPC CNAME was already provisioned for thanos")
+	} else {
+		t.logger.Debugln("GRPC CNAME was not provisioned for thanos")
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(120)*time.Second)
+		defer cancel()
+
+		endpoint, err := getPrivateLoadBalancerEndpoint(ctx, "prometheus", logger.WithField("thanos-action", "create"), t.kops.GetKubeConfigPath())
+		if err != nil {
+			return errors.Wrap(err, "couldn't get the load balancer endpoint for Thanos")
+		}
+
+		logger.Infof("Registering GRPC DNS %s for %s", grpcDNS, app)
+		err = t.awsClient.CreatePrivateCNAME(grpcDNS, []string{endpoint}, logger.WithField("thanos-dns-create", grpcDNS))
+		if err != nil {
+			return errors.Wrap(err, "failed to create a CNAME to point to Thanos GRPC")
+		}
+	}
+	return nil
+}
+
+func (t *thanos) Destroy() error {
+	logger := t.logger.WithField("prometheus-action", "destroy")
+
+	privateDomainName, err := t.awsClient.GetPrivateZoneDomainName(logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to lookup private zone name")
+	}
+	app := "thanos"
+	dns := fmt.Sprintf("%s.%s.%s", t.cluster.ID, app, privateDomainName)
+
+	logger.Infof("Deleting Route53 DNS Record for %s", app)
+	err = t.awsClient.DeletePrivateCNAME(dns, logger.WithField("thanos-dns-delete", dns))
+	if err != nil {
+		return errors.Wrap(err, "failed to delete Route53 DNS record")
+	}
+
+	grpcDNS := fmt.Sprintf("%s-grpc.%s.%s", t.cluster.ID, app, privateDomainName)
+	logger.Infof("Deleting GRPC Route53 DNS Record for %s", app)
+	err = t.awsClient.DeletePrivateCNAME(grpcDNS, logger.WithField("thanos-dns-delete", grpcDNS))
+	if err != nil {
+		return errors.Wrap(err, "failed to delete GRPC Route53 DNS record")
+	}
+
+	t.actualVersion = ""
+	return nil
+}
+
+func (t *thanos) Migrate() error {
+	return nil
+}
+
+func (t *thanos) NewHelmDeployment() *helmDeployment {
+	privateDomainName, err := t.awsClient.GetPrivateZoneDomainName(t.logger)
+	if err != nil {
+		t.logger.WithError(err).Error("unable to lookup private zone name")
+	}
+	thanosDNS := fmt.Sprintf("%s.thanos.%s", t.cluster.ID, privateDomainName)
+	thanosDNSGRPC := fmt.Sprintf("%s-grpc.thanos.%s", t.cluster.ID, privateDomainName)
+
+	helmValueArguments := fmt.Sprintf("querier.ingress.hostname=%s,querier.ingress.grpc.hostname=%s,querier.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", thanosDNS, thanosDNSGRPC, strings.Join(t.provisioner.allowCIDRRangeList, "\\,"))
+
+	return &helmDeployment{
+		chartDeploymentName: "thanos",
+		chartName:           "bitnami/thanos",
+		kops:                t.kops,
+		kopsProvisioner:     t.provisioner,
+		logger:              t.logger,
+		namespace:           "prometheus",
+		setArgument:         helmValueArguments,
+		valuesPath:          "helm-charts/thanos_values.yaml",
+		desiredVersion:      t.desiredVersion,
+	}
+}
+
+func (t *thanos) Name() string {
+	return model.ThanosCanonicalName
+}
+
+func (t *thanos) DesiredVersion() string {
+	return t.desiredVersion
+}
+
+func (t *thanos) ActualVersion() string {
+	return strings.TrimPrefix(t.actualVersion, "thanos-")
+}
+
+func (t *thanos) updateVersion(h *helmDeployment) error {
+	actualVersion, err := h.Version()
+	if err != nil {
+		return err
+	}
+
+	t.actualVersion = actualVersion
+	return nil
+}

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -64,6 +64,9 @@ func (request *CreateClusterRequest) SetDefaults() {
 	if _, ok := request.DesiredUtilityVersions[PrometheusOperatorCanonicalName]; !ok {
 		request.DesiredUtilityVersions[PrometheusOperatorCanonicalName] = PrometheusOperatorDefaultVersion
 	}
+	if _, ok := request.DesiredUtilityVersions[ThanosCanonicalName]; !ok {
+		request.DesiredUtilityVersions[ThanosCanonicalName] = ThanosDefaultVersion
+	}
 	if _, ok := request.DesiredUtilityVersions[NginxCanonicalName]; !ok {
 		request.DesiredUtilityVersions[NginxCanonicalName] = NginxDefaultVersion
 	}

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -14,6 +14,8 @@ const (
 	PrometheusCanonicalName = "prometheus"
 	// PrometheusOperatorCanonicalName is the canonical string representation of prometheus operator
 	PrometheusOperatorCanonicalName = "prometheus-operator"
+	// ThanosCanonicalName is the canonical string representation of prometheus
+	ThanosCanonicalName = "thanos"
 	// NginxCanonicalName is the canonical string representation of nginx
 	NginxCanonicalName = "nginx"
 	// FluentbitCanonicalName is the canonical string representation of fluentbit
@@ -27,6 +29,8 @@ const (
 	PrometheusDefaultVersion = "10.4.0"
 	// PrometheusOperatorDefaultVersion defines the default version for the Helm chart
 	PrometheusOperatorDefaultVersion = "9.4.4"
+	// ThanosDefaultVersion defines the default version for the Helm chart
+	ThanosDefaultVersion = "2.4.3"
 	// NginxDefaultVersion defines the default version for the Helm chart
 	NginxDefaultVersion = "2.15.0"
 	// FluentbitDefaultVersion defines the default version for the Helm chart
@@ -45,6 +49,7 @@ type UtilityMetadata struct {
 type utilityVersions struct {
 	Prometheus         string
 	PrometheusOperator string
+	Thanos             string
 	Nginx              string
 	Fluentbit          string
 	Teleport           string
@@ -152,6 +157,8 @@ func getUtilityVersion(versions *utilityVersions, utility string) string {
 		return versions.Prometheus
 	case PrometheusOperatorCanonicalName:
 		return versions.PrometheusOperator
+	case ThanosCanonicalName:
+		return versions.Thanos
 	case NginxCanonicalName:
 		return versions.Nginx
 	case FluentbitCanonicalName:
@@ -173,6 +180,8 @@ func setUtilityVersion(versions *utilityVersions, utility, desiredVersion string
 		versions.Prometheus = desiredVersion
 	case PrometheusOperatorCanonicalName:
 		versions.PrometheusOperator = desiredVersion
+	case ThanosCanonicalName:
+		versions.Thanos = desiredVersion
 	case NginxCanonicalName:
 		versions.Nginx = desiredVersion
 	case FluentbitCanonicalName:

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -35,12 +35,14 @@ func TestGetUtilityVersion(t *testing.T) {
 	u := &utilityVersions{
 		Prometheus:         "4",
 		PrometheusOperator: "3",
+		Thanos:             "4",
 		Nginx:              "5",
 		Fluentbit:          "6",
 	}
 
 	assert.Equal(t, getUtilityVersion(u, PrometheusCanonicalName), "4")
 	assert.Equal(t, getUtilityVersion(u, PrometheusOperatorCanonicalName), "3")
+	assert.Equal(t, getUtilityVersion(u, ThanosCanonicalName), "4")
 	assert.Equal(t, getUtilityVersion(u, NginxCanonicalName), "5")
 	assert.Equal(t, getUtilityVersion(u, FluentbitCanonicalName), "6")
 	assert.Equal(t, getUtilityVersion(u, "anything else"), "")
@@ -80,6 +82,10 @@ func TestSetDesired(t *testing.T) {
 	version, err = c.DesiredUtilityVersion(PrometheusOperatorCanonicalName)
 	require.NoError(t, err)
 	assert.Equal(t, "", version)
+
+	version, err = c.DesiredUtilityVersion(ThanosCanonicalName)
+	require.NoError(t, err)
+	assert.Equal(t, "", version)
 }
 
 func TestGetActualVersion(t *testing.T) {
@@ -88,6 +94,7 @@ func TestGetActualVersion(t *testing.T) {
 			DesiredVersions: utilityVersions{
 				Prometheus:         "",
 				PrometheusOperator: "",
+				Thanos:             "",
 				Nginx:              "10.3",
 				Fluentbit:          "1337",
 				Teleport:           "12345",
@@ -95,6 +102,7 @@ func TestGetActualVersion(t *testing.T) {
 			ActualVersions: utilityVersions{
 				Prometheus:         "prometheus-10.3",
 				PrometheusOperator: "kube-prometheus-stack-9.4",
+				Thanos:             "thanos-2.4",
 				Nginx:              "nginx-10.2",
 				Fluentbit:          "fluent-bit-0.9",
 				Teleport:           "teleport-0.3.0",
@@ -109,6 +117,10 @@ func TestGetActualVersion(t *testing.T) {
 	version, err = c.ActualUtilityVersion(PrometheusOperatorCanonicalName)
 	assert.NoError(t, err)
 	assert.Equal(t, "kube-prometheus-stack-9.4", version)
+
+	version, err = c.ActualUtilityVersion(ThanosCanonicalName)
+	assert.NoError(t, err)
+	assert.Equal(t, "thanos-2.4", version)
 
 	version, err = c.ActualUtilityVersion(NginxCanonicalName)
 	assert.NoError(t, err)
@@ -133,6 +145,7 @@ func TestGetDesiredVersion(t *testing.T) {
 			DesiredVersions: utilityVersions{
 				Prometheus:         "",
 				PrometheusOperator: "",
+				Thanos:             "",
 				Nginx:              "10.3",
 				Fluentbit:          "1337",
 				Teleport:           "12345",
@@ -140,6 +153,7 @@ func TestGetDesiredVersion(t *testing.T) {
 			ActualVersions: utilityVersions{
 				Prometheus:         "prometheus-10.3",
 				PrometheusOperator: "kube-prometheus-stack-9.4",
+				Thanos:             "thanos-2.4",
 				Nginx:              "nginx-10.2",
 				Fluentbit:          "fluent-bit-0.9",
 				Teleport:           "teleport-0.3.0",
@@ -152,6 +166,10 @@ func TestGetDesiredVersion(t *testing.T) {
 	assert.Equal(t, "", version)
 
 	version, err = c.DesiredUtilityVersion(PrometheusOperatorCanonicalName)
+	assert.NoError(t, err)
+	assert.Equal(t, "", version)
+
+	version, err = c.DesiredUtilityVersion(ThanosCanonicalName)
 	assert.NoError(t, err)
 	assert.Equal(t, "", version)
 


### PR DESCRIPTION
#### Summary
- Introducing Thanos utility group.
- Two R53 records created as part of each Thanos deployment. One targeting then normal ingress and the other one the GRPC ingress that will be used by the central querier. 
- Autoscaling, requests and limits set for Thanos Querier.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28659

#### Release Note
```release-note
- Introducing Thanos utility group.
- Two R53 records created as part of each Thanos deployment. One targeting then normal ingress and the other one the GRPC ingress that will be used by the central querier. 
- Autoscaling, requests and limits set for Thanos Querier.
```
