### PR TITLE
Update cluster installation secrets on installation update

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -130,7 +130,6 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 	if err != nil {
 		return errors.Wrap(err, "failed to generate database configuration")
 	}
-
 	if databaseSpec != nil {
 		_, err = k8sClient.CreateOrUpdateSecret(clusterInstallation.Namespace, databaseSecret)
 		if err != nil {
@@ -143,7 +142,6 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 	if err != nil {
 		return errors.Wrap(err, "failed to generate filestore configuration")
 	}
-
 	if filestoreSecret != nil {
 		_, err = k8sClient.CreateOrUpdateSecret(clusterInstallation.Namespace, filestoreSecret)
 		if err != nil {
@@ -328,6 +326,30 @@ func (provisioner *KopsProvisioner) UpdateClusterInstallation(cluster *model.Clu
 		if k8sErrors.IsNotFound(err) {
 			logger.Infof("Secret %s/%s not found. Maybe the license was not set for this installation or was already deleted", clusterInstallation.Namespace, secretName)
 		}
+	}
+
+	databaseSpec, databaseSecret, err := provisioner.resourceUtil.GetDatabase(installation).GenerateDatabaseSpecAndSecret(provisioner.store, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to generate database configuration")
+	}
+	if databaseSpec != nil {
+		_, err = k8sClient.CreateOrUpdateSecret(clusterInstallation.Namespace, databaseSecret)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update the database secret %s/%s", clusterInstallation.Namespace, databaseSecret.Name)
+		}
+		cr.Spec.Database = *databaseSpec
+	}
+
+	filestoreSpec, filestoreSecret, err := provisioner.resourceUtil.GetFilestore(installation).GenerateFilestoreSpecAndSecret(provisioner.store, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to generate filestore configuration")
+	}
+	if filestoreSecret != nil {
+		_, err = k8sClient.CreateOrUpdateSecret(clusterInstallation.Namespace, filestoreSecret)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update the filestore secret %s/%s", clusterInstallation.Namespace, filestoreSecret.Name)
+		}
+		cr.Spec.Minio = *filestoreSpec
 	}
 
 	mattermostEnv := getMattermostEnvWithOverrides(installation)


### PR DESCRIPTION
Cluster installation secrets are now updated whenever the parent
installation is updated. This ensures that filestore and database
values are correct and allows for new entries to be created as
needed for existing installations.

Fixes https://mattermost.atlassian.net/browse/MM-29542

```release-note
Update cluster installation secrets on installation update
```
