### PR TITLE
Handle group updates during installation rollouts

### DIFF
--- a/internal/supervisor/group_test.go
+++ b/internal/supervisor/group_test.go
@@ -71,6 +71,10 @@ func (s *mockGroupStore) UnlockInstallation(installationID, lockerID string, for
 	return true, nil
 }
 
+func (s *mockGroupStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error) {
+	return nil, nil
+}
+
 func TestGroupSupervisorDo(t *testing.T) {
 	t.Run("no groups pending work", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)

--- a/model/common_test.go
+++ b/model/common_test.go
@@ -7,3 +7,7 @@ package model
 func sToP(s string) *string {
 	return &s
 }
+
+func iToP(i int64) *int64 {
+	return &i
+}

--- a/model/installation.go
+++ b/model/installation.go
@@ -79,6 +79,20 @@ func (i *Installation) ConfigMergedWithGroup() bool {
 	return i.configMergedWithGroup
 }
 
+// InstallationSequenceMatchesMergedGroupSequence returns if the installation's
+// group sequence number matches the sequence number of the merged group config
+// or not.
+func (i *Installation) InstallationSequenceMatchesMergedGroupSequence() bool {
+	if !i.configMergedWithGroup {
+		return true
+	}
+	if i.GroupSequence == nil {
+		return false
+	}
+
+	return i.configMergeGroupSequence == *i.GroupSequence
+}
+
 // SyncGroupAndInstallationSequence updates the installation GroupSequence value
 // to reflect the hidden group Sequence value from the time the configuration
 // was origianlly merged.

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -124,7 +124,7 @@ func (i *Installation) ValidTransitionState(newState string) bool {
 	case InstallationStateHibernationRequested:
 		return validTransitionToInstallationStateHibernationRequested(i.State)
 	case InstallationStateUpdateRequested:
-		return validTransitionToInstallationStateUpgradeRequested(i.State)
+		return validTransitionToInstallationStateUpdateRequested(i.State)
 	case InstallationStateDeletionRequested:
 		return validTransitionToInstallationStateDeletionRequested(i.State)
 	}
@@ -151,11 +151,12 @@ func validTransitionToInstallationStateHibernationRequested(currentState string)
 	return false
 }
 
-func validTransitionToInstallationStateUpgradeRequested(currentState string) bool {
+func validTransitionToInstallationStateUpdateRequested(currentState string) bool {
 	switch currentState {
 	case InstallationStateStable,
 		InstallationStateHibernating,
 		InstallationStateUpdateRequested,
+		InstallationStateUpdateInProgress,
 		InstallationStateUpdateFailed:
 		return true
 	}


### PR DESCRIPTION
This change allows the provisioner to dynamically handle group
configuration updates while installations belonging to that group
are being upgraded. This allows bad group configuration changes to
be corrected and for affected installations to be repaired. To
accomplish this, the following changes were made:

 - Update installation group sequence numbers when resource changes
   are made. This allows the provisioner to then reference the group
   sequence number on the installation to know if the group has
   been changed since the updates began.
 - Check group sequence number multiple times during upgrades. Each
   "tick" now checks that group configuration hasn't changed. When
   the installation goes to the stable state, one final group check
   is performed with the group under lock to confirm that the
   installation update is complete.
 - Rollback to `update-requested` whenever any group changes are
   made before the installation becomes stable. This ensures that
   the installation update happens again in full.
 - Send out more webhooks for important state change events.
 - Provide a cluster installation k8s resource check method. This
   method can be used in the future for additional checks as needed.
   (This is currently unused, but is planned for the future and I don't
   want the code to become lost)

Here is a snippet from manual testing with webhooks captured in `cwl`:

```
2020/10/18 20:44:14 [ INST | 6fir ] stable -> update-requested
2020/10/18 20:44:17 [ CLIN | j6zr ] stable -> reconciling
2020/10/18 20:44:17 [ INST | 6fir ] update-requested -> update-in-progress
2020/10/18 20:44:55 [ INST | 6fir ] update-in-progress -> update-requested
2020/10/18 20:44:59 [ CLIN | j6zr ] reconciling -> stable
2020/10/18 20:45:07 [ CLIN | j6zr ] stable -> reconciling
2020/10/18 20:45:07 [ INST | 6fir ] update-requested -> update-in-progress
2020/10/18 20:47:21 [ CLIN | j6zr ] reconciling -> stable
2020/10/18 20:47:26 [ INST | 6fir ] update-in-progress -> stable
```

Multiple changes to the group object were made resulting in multiple reverts on the installation update process.

Fixes https://mattermost.atlassian.net/browse/MM-29866

```release-note
Handle group updates during installation rollouts
```
