### PR TITLE
Add cloud dashboard command

### DIFF
--- a/cmd/cloud/dashboard.go
+++ b/cmd/cloud/dashboard.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -148,5 +149,5 @@ var dashboardCmd = &cobra.Command{
 }
 
 func toStr(i int) string {
-	return fmt.Sprintf("%d", i)
+	return strconv.Itoa(i)
 }

--- a/cmd/cloud/dashboard.go
+++ b/cmd/cloud/dashboard.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gosuri/uilive"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+func init() {
+	dashboardCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
+
+	dashboardCmd.PersistentFlags().Int("refresh-seconds", 10, "The amount of seconds before the dashboard is refreshed with new data.")
+}
+
+var dashboardCmd = &cobra.Command{
+	Use:   "dashboard",
+	Short: "View an auto-refreshing dashboard of all cloud server resources.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		refreshSeconds, _ := command.Flags().GetInt("refresh-seconds")
+		if refreshSeconds < 1 {
+			return errors.Errorf("refresh seconds (%d) must be set to 1 or higher", refreshSeconds)
+		}
+
+		writer := uilive.New()
+		writer.Start()
+
+		for {
+			tableString := &strings.Builder{}
+			table := tablewriter.NewWriter(tableString)
+			table.SetAlignment(tablewriter.ALIGN_LEFT)
+			table.SetHeader([]string{"TYPE", "TOTAL", "STABLE", "WIP"})
+
+			var unstableList []string
+
+			// Clusters
+			clusters, err := client.GetClusters(&model.GetClustersRequest{
+				Page:           0,
+				PerPage:        model.AllPerPage,
+				IncludeDeleted: false,
+			})
+			if err != nil {
+				return errors.Wrap(err, "failed to query clusters")
+			}
+
+			clusterCount := len(clusters)
+			var clusterStableCount int
+			for _, cluster := range clusters {
+				if cluster.State == model.ClusterStateStable {
+					clusterStableCount++
+				} else {
+					unstableList = append(unstableList, fmt.Sprintf("Cluster: %s (%s)", cluster.ID, cluster.State))
+				}
+			}
+
+			table.Append([]string{
+				"Cluster",
+				toStr(clusterCount),
+				toStr(clusterStableCount),
+				toStr(clusterCount - clusterStableCount),
+			})
+
+			// Installations
+			installations, err := client.GetInstallations(&model.GetInstallationsRequest{
+				Page:           0,
+				PerPage:        model.AllPerPage,
+				IncludeDeleted: false,
+			})
+			if err != nil {
+				return errors.Wrap(err, "failed to query installations")
+			}
+
+			installationCount := len(installations)
+			var installationStableCount int
+			for _, installation := range installations {
+				if installation.State == model.InstallationStateStable {
+					installationStableCount++
+				} else {
+					unstableList = append(unstableList, fmt.Sprintf("Installation: %s (%s)", installation.ID, installation.State))
+				}
+			}
+
+			table.Append([]string{
+				"Installation",
+				toStr(installationCount),
+				toStr(installationStableCount),
+				toStr(installationCount - installationStableCount),
+			})
+
+			clusterInstallations, err := client.GetClusterInstallations(&model.GetClusterInstallationsRequest{
+				Page:           0,
+				PerPage:        model.AllPerPage,
+				IncludeDeleted: false,
+			})
+			if err != nil {
+				return errors.Wrap(err, "failed to query clusters")
+			}
+
+			// Cluster Installations
+			clusterInstallationCount := len(clusterInstallations)
+			var clusterInstallationStableCount int
+			for _, clusterInstallation := range clusterInstallations {
+				if clusterInstallation.State == model.ClusterInstallationStateStable {
+					clusterInstallationStableCount++
+				} else {
+					unstableList = append(unstableList, fmt.Sprintf("Cluster Installation: %s (%s)", clusterInstallation.ID, clusterInstallation.State))
+				}
+			}
+
+			table.Append([]string{
+				"Cluster Installation",
+				toStr(clusterInstallationCount),
+				toStr(clusterInstallationStableCount),
+				toStr(clusterInstallationCount - clusterInstallationStableCount),
+			})
+
+			table.Render()
+			renderedDashboard := fmt.Sprintf("\n### CLOUD DASHBOARD\n\n")
+			renderedDashboard += tableString.String()
+			for _, entry := range unstableList {
+				renderedDashboard += fmt.Sprintf("%s\n", entry)
+			}
+			if len(unstableList) != 0 {
+				renderedDashboard += "\n"
+			}
+
+			for i := refreshSeconds; i > 0; i-- {
+				fmt.Fprintf(writer, "%s\nUpdating in %d seconds...\n", renderedDashboard, i)
+				time.Sleep(time.Second)
+			}
+		}
+	},
+}
+
+func toStr(i int) string {
+	return fmt.Sprintf("%d", i)
+}

--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -34,6 +34,7 @@ func init() {
 	rootCmd.AddCommand(securityCmd)
 	rootCmd.AddCommand(workbenchCmd)
 	rootCmd.AddCommand(completionCmd)
+	rootCmd.AddCommand(dashboardCmd)
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang/mock v1.4.4
 	github.com/gorilla/mux v1.7.4
+	github.com/gosuri/uilive v0.0.4
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.8.0
 	github.com/mattermost/mattermost-operator v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gosuri/uilive v0.0.4 h1:hUEBpQDj8D8jXgtCdBu7sWsy5sbW/5GhuO8KBwJ2jyY=
+github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tfZ74VI=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -316,6 +318,7 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -499,6 +499,7 @@ func TestGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          0,
 			InstallationsUpdated:        0,
+			InstallationsBeingUpdated:   0,
 			InstallationsAwaitingUpdate: 0,
 		}
 		groupStatus, err := client.GetGroupStatus(group.ID)
@@ -510,6 +511,7 @@ func TestGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          0,
 			InstallationsUpdated:        0,
+			InstallationsBeingUpdated:   0,
 			InstallationsAwaitingUpdate: 0,
 		}
 		ignoredGroup, err := client.CreateGroup(&model.CreateGroupRequest{
@@ -532,6 +534,7 @@ func TestGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          6,
 			InstallationsUpdated:        2,
+			InstallationsBeingUpdated:   3,
 			InstallationsAwaitingUpdate: 1,
 		}
 		var differentSequence int64 = -1

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -499,7 +499,7 @@ func TestGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          0,
 			InstallationsUpdated:        0,
-			InstallationsBeingUpdated:   0,
+			InstallationsUnstable:       0,
 			InstallationsAwaitingUpdate: 0,
 		}
 		groupStatus, err := client.GetGroupStatus(group.ID)
@@ -511,7 +511,7 @@ func TestGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          0,
 			InstallationsUpdated:        0,
-			InstallationsBeingUpdated:   0,
+			InstallationsUnstable:       0,
 			InstallationsAwaitingUpdate: 0,
 		}
 		ignoredGroup, err := client.CreateGroup(&model.CreateGroupRequest{
@@ -534,7 +534,7 @@ func TestGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          6,
 			InstallationsUpdated:        2,
-			InstallationsBeingUpdated:   3,
+			InstallationsUnstable:       3,
 			InstallationsAwaitingUpdate: 1,
 		}
 		var differentSequence int64 = -1

--- a/internal/store/group.go
+++ b/internal/store/group.go
@@ -219,12 +219,12 @@ func (sqlStore *SQLStore) GetGroupStatus(groupID string) (*model.GroupStatus, er
 		return nil, errors.Wrap(err, "failed to query for total installations count in a group")
 	}
 
-	beingUpdatedCount := totalCount - updatedCount - awaitingUpdateCount
+	unstableCount := totalCount - updatedCount - awaitingUpdateCount
 
 	return &model.GroupStatus{
 		InstallationsTotal:          totalCount,
 		InstallationsUpdated:        updatedCount,
-		InstallationsBeingUpdated:   beingUpdatedCount,
+		InstallationsUnstable:       unstableCount,
 		InstallationsAwaitingUpdate: awaitingUpdateCount,
 	}, nil
 }

--- a/internal/store/group.go
+++ b/internal/store/group.go
@@ -183,21 +183,21 @@ func (sqlStore *SQLStore) GetGroupStatus(groupID string) (*model.GroupStatus, er
 		return nil, nil
 	}
 
-	var toBeRolledResult countResult
+	var awaitingUpdateResult countResult
 	err = sqlStore.queryInstallationsToBeRolledOut(
 		[]string{"Count (*)"},
 		group,
-		&toBeRolledResult,
+		&awaitingUpdateResult,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to query for count of installation to be roll out")
+		return nil, errors.Wrap(err, "failed to query for count of installation to be rolled out")
 	}
-	installationsToBeRolled, err := toBeRolledResult.value()
+	awaitingUpdateCount, err := awaitingUpdateResult.value()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get count result of installations to be roll out")
+		return nil, errors.Wrap(err, "failed to get count result of installations to be rolled out")
 	}
 
-	var rolledOutResult countResult
+	var updatedResult countResult
 	installationBuilder := sq.
 		Select("Count (*)").
 		From("Installation").
@@ -205,24 +205,27 @@ func (sqlStore *SQLStore) GetGroupStatus(groupID string) (*model.GroupStatus, er
 		Where("GroupSequence = ?", group.Sequence).
 		Where("State = ?", model.InstallationStateStable).
 		Where("DeleteAt = 0")
-	err = sqlStore.selectBuilder(sqlStore.db, &rolledOutResult, installationBuilder)
+	err = sqlStore.selectBuilder(sqlStore.db, &updatedResult, installationBuilder)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query for rolled out installations")
 	}
-	rolledOutInstallations, err := rolledOutResult.value()
+	updatedCount, err := updatedResult.value()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get count result of rolled out installations")
 	}
 
-	totalInstallations, err := sqlStore.countInstallationsInGroup(group)
+	totalCount, err := sqlStore.countInstallationsInGroup(group)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query for total installations count in a group")
 	}
 
+	beingUpdatedCount := totalCount - updatedCount - awaitingUpdateCount
+
 	return &model.GroupStatus{
-		InstallationsTotal:          totalInstallations,
-		InstallationsUpdated:        rolledOutInstallations,
-		InstallationsAwaitingUpdate: installationsToBeRolled,
+		InstallationsTotal:          totalCount,
+		InstallationsUpdated:        updatedCount,
+		InstallationsBeingUpdated:   beingUpdatedCount,
+		InstallationsAwaitingUpdate: awaitingUpdateCount,
 	}, nil
 }
 

--- a/internal/store/group_test.go
+++ b/internal/store/group_test.go
@@ -616,6 +616,7 @@ func TestGetGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          1,
 			InstallationsUpdated:        0,
+			InstallationsBeingUpdated:   1,
 			InstallationsAwaitingUpdate: 0,
 		}
 		groupStatus, err := sqlStore.GetGroupStatus(group1.ID)
@@ -632,6 +633,7 @@ func TestGetGroupStatus(t *testing.T) {
 		expectedStatus = &model.GroupStatus{
 			InstallationsTotal:          1,
 			InstallationsUpdated:        0,
+			InstallationsBeingUpdated:   0,
 			InstallationsAwaitingUpdate: 1,
 		}
 		groupStatus, err = sqlStore.GetGroupStatus(group1.ID)

--- a/internal/store/group_test.go
+++ b/internal/store/group_test.go
@@ -616,7 +616,7 @@ func TestGetGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          1,
 			InstallationsUpdated:        0,
-			InstallationsBeingUpdated:   1,
+			InstallationsUnstable:       1,
 			InstallationsAwaitingUpdate: 0,
 		}
 		groupStatus, err := sqlStore.GetGroupStatus(group1.ID)
@@ -633,7 +633,7 @@ func TestGetGroupStatus(t *testing.T) {
 		expectedStatus = &model.GroupStatus{
 			InstallationsTotal:          1,
 			InstallationsUpdated:        0,
-			InstallationsBeingUpdated:   0,
+			InstallationsUnstable:       0,
 			InstallationsAwaitingUpdate: 1,
 		}
 		groupStatus, err = sqlStore.GetGroupStatus(group1.ID)

--- a/model/group_status.go
+++ b/model/group_status.go
@@ -13,6 +13,7 @@ import (
 type GroupStatus struct {
 	InstallationsTotal          int64
 	InstallationsUpdated        int64
+	InstallationsBeingUpdated   int64
 	InstallationsAwaitingUpdate int64
 }
 

--- a/model/group_status.go
+++ b/model/group_status.go
@@ -13,7 +13,7 @@ import (
 type GroupStatus struct {
 	InstallationsTotal          int64
 	InstallationsUpdated        int64
-	InstallationsBeingUpdated   int64
+	InstallationsUnstable       int64
 	InstallationsAwaitingUpdate int64
 }
 

--- a/model/group_status_test.go
+++ b/model/group_status_test.go
@@ -32,14 +32,14 @@ func TestGroupStatusFromReader(t *testing.T) {
 		groupStatus, err := GroupStatusFromReader(bytes.NewReader([]byte(`{
 			"InstallationsTotal": 4,
 			"InstallationsUpdated": 2,
-			"InstallationsBeingUpdated": 1,
+			"InstallationsUnstable": 1,
 			"InstallationsAwaitingUpdate": 1
 		}`)))
 		require.NoError(t, err)
 		require.Equal(t, &GroupStatus{
 			InstallationsTotal:          4,
 			InstallationsUpdated:        2,
-			InstallationsBeingUpdated:   1,
+			InstallationsUnstable:       1,
 			InstallationsAwaitingUpdate: 1,
 		}, groupStatus)
 	})

--- a/model/group_status_test.go
+++ b/model/group_status_test.go
@@ -30,14 +30,16 @@ func TestGroupStatusFromReader(t *testing.T) {
 
 	t.Run("valid group status", func(t *testing.T) {
 		groupStatus, err := GroupStatusFromReader(bytes.NewReader([]byte(`{
-			"InstallationsTotal": 3,
+			"InstallationsTotal": 4,
 			"InstallationsUpdated": 2,
+			"InstallationsBeingUpdated": 1,
 			"InstallationsAwaitingUpdate": 1
 		}`)))
 		require.NoError(t, err)
 		require.Equal(t, &GroupStatus{
-			InstallationsTotal:          3,
+			InstallationsTotal:          4,
 			InstallationsUpdated:        2,
+			InstallationsBeingUpdated:   1,
 			InstallationsAwaitingUpdate: 1,
 		}, groupStatus)
 	})


### PR DESCRIPTION
The cloud dashboard allows for monitoring all important cloud
resources via auto-refreshing CLI output.

This change also enhances group status functionality by providing
a count for the number of installations currently being updated.

Fixes https://mattermost.atlassian.net/browse/MM-29580

```release-note
Add cloud dashboard command
```
