### PR TITLE
MM-29237 - Schedule Installations based on Annotations

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -127,7 +127,7 @@ var clusterCreateCmd = &cobra.Command{
 			Zones:                  strings.Split(zones, ","),
 			AllowInstallations:     allowInstallations,
 			DesiredUtilityVersions: processUtilityFlags(command),
-			Annotations:       annotations,
+			Annotations:            annotations,
 		}
 
 		size, _ := command.Flags().GetString("size")

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -107,18 +107,18 @@ var installationCreateCmd = &cobra.Command{
 		}
 
 		request := &model.CreateInstallationRequest{
-			OwnerID:          ownerID,
-			GroupID:          groupID,
-			Version:          version,
-			Image:            image,
-			Size:             size,
-			DNS:              dns,
-			License:          license,
-			Affinity:         affinity,
-			Database:         database,
-			Filestore:        filestore,
-			MattermostEnv:    envVarMap,
-			Annotations: annotations,
+			OwnerID:       ownerID,
+			GroupID:       groupID,
+			Version:       version,
+			Image:         image,
+			Size:          size,
+			DNS:           dns,
+			License:       license,
+			Affinity:      affinity,
+			Database:      database,
+			Filestore:     filestore,
+			MattermostEnv: envVarMap,
+			Annotations:   annotations,
 		}
 
 		dryRun, _ := command.Flags().GetBool("dry-run")

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -1,0 +1,69 @@
+# Annotation
+
+## Overview
+
+Both Clusters and Installations can be annotated with a set of Annotations. The Annotations take part during the scheduling of Installations to the Clusters.
+
+## Scheduling with Annotations
+
+Annotations constrain on which Clusters the Installations can be scheduled.
+
+The scheduling is guided by the following principles:
+- Installations can be scheduled on any Cluster which contains all Annotations present on the Installation.
+- Clusters can contain any additional Annotations not present on the Installation.
+- Installation without any Annotations can be scheduled on any available Cluster.
+
+### Examples 
+
+1.
+    - Given and Installation: **IA** with Annotations: **private**, **customer-a**.
+    - Given Clusters: 
+        - **CA** with Annotations: **private**, **customer-a**.
+        - **CB** with Annotations: **private**, **customer-b**.
+        - **CC** with Annotations: **private**, **customer-a**, **aws-eu**.
+    - The Installation can be scheduled on Clusters: **CA** and **CC**.
+
+2.
+    - Given and Installation: **IA** with Annotations: **private**, **customer-a**, **aws-us**
+    - Given Clusters: 
+        - **CA** with Annotations: **private**, **customer-a**.
+        - **CB** with Annotations: **private**, **customer-b**, **aws-us**.
+        - **CC** with no Annotations.
+    - The Installation cannot be scheduled on any Cluster.
+
+
+## Assigning annotations
+
+Annotations can be assigned to the Cluster and Installation during the creation.
+
+ 
+### With REST API
+
+In the REST API, Annotations are passed as an array of strings to the JSON payload:
+- For Clusters:  
+`POST /api/clusters`
+    ```json
+    {
+      ...
+      "annotations": ["multi-tenant", "test1"],
+      ...
+    }
+    ```
+- For Installations:  
+`POST /api/installations`
+    ```json
+    {
+      ...
+      "Annotations": ["multi-tenant", "test1"],
+      ...
+    }
+    ```
+The name capitalisation differ for the sake of consistency with the rest of the payload. 
+
+
+### With cloud CLI
+
+To assign annotations via `cloud` CLI, use `--annotation` flag:
+```bash 
+cloud installation create --owner example --size 100users --affinity multitenant --dns dns.example.com --annotation multi-tenant --annotation test1
+```

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -87,8 +87,8 @@ func TestClusters(t *testing.T) {
 
 	t.Run("clusters", func(t *testing.T) {
 		cluster1, err := client.CreateCluster(&model.CreateClusterRequest{
-			Provider:         model.ProviderAWS,
-			Zones:            []string{"zone"},
+			Provider:    model.ProviderAWS,
+			Zones:       []string{"zone"},
 			Annotations: []string{"my-annotation"},
 		})
 		require.NoError(t, err)
@@ -308,8 +308,8 @@ func TestCreateCluster(t *testing.T) {
 
 	t.Run("invalid annotation", func(t *testing.T) {
 		_, err := client.CreateCluster(&model.CreateClusterRequest{
-			Provider:         model.ProviderAWS,
-			Zones:            []string{"zone"},
+			Provider:    model.ProviderAWS,
+			Zones:       []string{"zone"},
 			Annotations: []string{"my invalid annotation"},
 		})
 		require.EqualError(t, err, "failed with status code 400")
@@ -317,8 +317,8 @@ func TestCreateCluster(t *testing.T) {
 
 	t.Run("valid", func(t *testing.T) {
 		cluster, err := client.CreateCluster(&model.CreateClusterRequest{
-			Provider:         model.ProviderAWS,
-			Zones:            []string{"zone"},
+			Provider:    model.ProviderAWS,
+			Zones:       []string{"zone"},
 			Annotations: []string{"my-annotation"},
 		})
 		require.NoError(t, err)
@@ -350,8 +350,8 @@ func TestCreateCluster(t *testing.T) {
 		} {
 			t.Run(testCase.description, func(t *testing.T) {
 				cluster, err := client.CreateCluster(&model.CreateClusterRequest{
-					Provider:         model.ProviderAWS,
-					Zones:            []string{"zone"},
+					Provider:    model.ProviderAWS,
+					Zones:       []string{"zone"},
 					Annotations: testCase.annotations,
 				})
 				require.NoError(t, err)
@@ -379,8 +379,8 @@ func TestRetryCreateCluster(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	cluster1, err := client.CreateCluster(&model.CreateClusterRequest{
-		Provider:         model.ProviderAWS,
-		Zones:            []string{"zone"},
+		Provider:    model.ProviderAWS,
+		Zones:       []string{"zone"},
 		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
@@ -464,8 +464,8 @@ func TestProvisionCluster(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	cluster1, err := client.CreateCluster(&model.CreateClusterRequest{
-		Provider:         model.ProviderAWS,
-		Zones:            []string{"zone"},
+		Provider:    model.ProviderAWS,
+		Zones:       []string{"zone"},
 		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
@@ -608,8 +608,8 @@ func TestUpgradeCluster(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	cluster1, err := client.CreateCluster(&model.CreateClusterRequest{
-		Provider:         model.ProviderAWS,
-		Zones:            []string{"zone"},
+		Provider:    model.ProviderAWS,
+		Zones:       []string{"zone"},
 		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
@@ -785,7 +785,7 @@ func TestUpdateClusterConfiguration(t *testing.T) {
 		Provider:           model.ProviderAWS,
 		Zones:              []string{"zone"},
 		AllowInstallations: true,
-		Annotations:   []string{"my-annotation"},
+		Annotations:        []string{"my-annotation"},
 	})
 	require.NoError(t, err)
 
@@ -866,8 +866,8 @@ func TestResizeCluster(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	cluster1, err := client.CreateCluster(&model.CreateClusterRequest{
-		Provider:         model.ProviderAWS,
-		Zones:            []string{"zone"},
+		Provider:    model.ProviderAWS,
+		Zones:       []string{"zone"},
 		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -390,10 +390,10 @@ func TestCreateInstallation(t *testing.T) {
 
 	t.Run("invalid annotations", func(t *testing.T) {
 		_, err := client.CreateInstallation(&model.CreateInstallationRequest{
-			OwnerID:          "owner",
-			Version:          "version",
-			DNS:              "dns.example.com",
-			Affinity:         model.InstallationAffinityIsolated,
+			OwnerID:     "owner",
+			Version:     "version",
+			DNS:         "dns.example.com",
+			Affinity:    model.InstallationAffinityIsolated,
 			Annotations: []string{"my invalid annotation"},
 		})
 		require.EqualError(t, err, "failed with status code 400")
@@ -401,10 +401,10 @@ func TestCreateInstallation(t *testing.T) {
 
 	t.Run("valid", func(t *testing.T) {
 		installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
-			OwnerID:          "owner",
-			Version:          "version",
-			DNS:              "dns.example.com",
-			Affinity:         model.InstallationAffinityIsolated,
+			OwnerID:     "owner",
+			Version:     "version",
+			DNS:         "dns.example.com",
+			Affinity:    model.InstallationAffinityIsolated,
 			Annotations: []string{"my-annotation"},
 		})
 		require.NoError(t, err)
@@ -508,9 +508,9 @@ func TestCreateInstallation(t *testing.T) {
 		} {
 			t.Run(testCase.description, func(t *testing.T) {
 				installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
-					OwnerID:          "owner1",
-					Version:          "version",
-					DNS:              fmt.Sprintf("dns-annotation%d.example.com", i),
+					OwnerID:     "owner1",
+					Version:     "version",
+					DNS:         fmt.Sprintf("dns-annotation%d.example.com", i),
 					Annotations: testCase.annotations,
 				})
 				require.NoError(t, err)
@@ -538,10 +538,10 @@ func TestRetryCreateInstallation(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	installation1, err := client.CreateInstallation(&model.CreateInstallationRequest{
-		OwnerID:          "owner",
-		Version:          "version",
-		DNS:              "dns.example.com",
-		Affinity:         model.InstallationAffinityIsolated,
+		OwnerID:     "owner",
+		Version:     "version",
+		DNS:         "dns.example.com",
+		Affinity:    model.InstallationAffinityIsolated,
 		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)
@@ -625,10 +625,10 @@ func TestUpdateInstallation(t *testing.T) {
 	client := model.NewClient(ts.URL)
 
 	installation1, err := client.CreateInstallation(&model.CreateInstallationRequest{
-		OwnerID:          "owner",
-		Version:          "version",
-		DNS:              "dns.example.com",
-		Affinity:         model.InstallationAffinityIsolated,
+		OwnerID:     "owner",
+		Version:     "version",
+		DNS:         "dns.example.com",
+		Affinity:    model.InstallationAffinityIsolated,
 		Annotations: []string{"my-annotation"},
 	})
 	require.NoError(t, err)

--- a/internal/store/annotation.go
+++ b/internal/store/annotation.go
@@ -6,10 +6,16 @@ package store
 
 import (
 	"database/sql"
+	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
+)
+
+const (
+	clusterAnnotationTable      = "ClusterAnnotation"
+	installationAnnotationTable = "InstallationAnnotation"
 )
 
 var annotationSelect sq.SelectBuilder
@@ -100,7 +106,7 @@ func (sqlStore *SQLStore) CreateClusterAnnotations(clusterID string, annotations
 }
 
 func (sqlStore *SQLStore) createClusterAnnotations(db execer, clusterID string, annotations []*model.Annotation) ([]*model.Annotation, error) {
-	builder := sq.Insert("ClusterAnnotation").
+	builder := sq.Insert(clusterAnnotationTable).
 		Columns("ID", "ClusterID", "AnnotationID")
 
 	for _, a := range annotations {
@@ -119,7 +125,7 @@ func (sqlStore *SQLStore) GetAnnotationsForCluster(clusterID string) ([]*model.A
 	var annotations []*model.Annotation
 
 	builder := sq.Select(annotationColumns...).
-		From("ClusterAnnotation").
+		From(clusterAnnotationTable).
 		Where("ClusterID = ?", clusterID).
 		LeftJoin("Annotation ON Annotation.ID=AnnotationID")
 	err := sqlStore.selectBuilder(sqlStore.db, &annotations, builder)
@@ -145,7 +151,7 @@ func (sqlStore *SQLStore) GetAnnotationsForClusters(filter *model.ClusterFilter)
 		"Annotation.ID as AnnotationID",
 		"Annotation.Name as AnnotationName").
 		From("Cluster").
-		LeftJoin("ClusterAnnotation ON ClusterAnnotation.ClusterID = Cluster.ID").
+		LeftJoin(fmt.Sprintf("%s ON %s.ClusterID = Cluster.ID", clusterAnnotationTable, clusterAnnotationTable)).
 		Join("Annotation ON Annotation.ID=AnnotationID")
 	builder = sqlStore.applyClustersFilter(builder, filter)
 
@@ -170,7 +176,7 @@ func (sqlStore *SQLStore) GetAnnotationsForInstallation(installationID string) (
 	var annotations []*model.Annotation
 
 	builder := sq.Select(annotationColumns...).
-		From("InstallationAnnotation").
+		From(installationAnnotationTable).
 		Where("InstallationID = ?", installationID).
 		LeftJoin("Annotation ON Annotation.ID=AnnotationID")
 	err := sqlStore.selectBuilder(sqlStore.db, &annotations, builder)
@@ -196,7 +202,7 @@ func (sqlStore *SQLStore) GetAnnotationsForInstallations(filter *model.Installat
 		"Annotation.ID as AnnotationID",
 		"Annotation.Name as AnnotationName").
 		From("Installation").
-		LeftJoin("InstallationAnnotation ON InstallationAnnotation.InstallationID = Installation.ID").
+		LeftJoin(fmt.Sprintf("%s ON %s.InstallationID = Installation.ID", installationAnnotationTable, installationAnnotationTable)).
 		Join("Annotation ON Annotation.ID=AnnotationID")
 	builder = sqlStore.applyInstallationFilter(builder, filter)
 
@@ -222,7 +228,7 @@ func (sqlStore *SQLStore) CreateInstallationAnnotations(installationID string, a
 }
 
 func (sqlStore *SQLStore) createInstallationAnnotations(db execer, installationID string, annotations []*model.Annotation) ([]*model.Annotation, error) {
-	builder := sq.Insert("InstallationAnnotation").
+	builder := sq.Insert(installationAnnotationTable).
 		Columns("ID", "InstallationID", "AnnotationID")
 
 	for _, a := range annotations {

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -50,6 +50,8 @@ type installationStore interface {
 	LockMultitenantDatabase(multitenantdatabaseID, lockerID string) (bool, error)
 	UnlockMultitenantDatabase(multitenantdatabaseID, lockerID string, force bool) (bool, error)
 
+	GetAnnotationsForInstallation(installationID string) ([]*model.Annotation, error)
+
 	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
 }
 
@@ -251,11 +253,24 @@ func (s *InstallationSupervisor) createInstallation(installation *model.Installa
 		return s.preProvisionInstallation(installation, instanceID, logger)
 	}
 
-	// Proceed to requesting cluster installation creation on any available clusters.
-	clusters, err := s.store.GetClusters(&model.ClusterFilter{
+	clusterFilter := &model.ClusterFilter{
 		PerPage:        model.AllPerPage,
 		IncludeDeleted: false,
-	})
+	}
+
+	// Get only clusters that have all annotations present on the installation.
+	// Clusters can have additional annotations not present on the installation.
+	annotations, err := s.store.GetAnnotationsForInstallation(installation.ID)
+	if err != nil {
+		logger.WithError(err).Warn("Failed to get annotations for Installation")
+		return model.InstallationStateCreationRequested
+	}
+	if len(annotations) > 0 {
+		clusterFilter.Annotations = &model.AnnotationsFilter{MatchAllIDs: annotationsToIDs(annotations)}
+	}
+
+	// Proceed to requesting cluster installation creation on any available clusters.
+	clusters, err := s.store.GetClusters(clusterFilter)
 	if err != nil {
 		logger.WithError(err).Warn("Failed to query clusters")
 		return model.InstallationStateCreationRequested
@@ -862,4 +877,13 @@ func (s *InstallationSupervisor) checkIfClusterInstallationsAreStable(installati
 	}
 
 	return false, nil
+}
+
+// annotationsToIDs parses slice of annotations to slice of strings containing annotations IDs.
+func annotationsToIDs(annotations []*model.Annotation) []string {
+	ids := make([]string, 0, len(annotations))
+	for _, ann := range annotations {
+		ids = append(ids, ann.ID)
+	}
+	return ids
 }

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -143,6 +143,10 @@ func (s *mockInstallationStore) GetMultitenantDatabaseForInstallationID(installa
 	return nil, nil
 }
 
+func (s *mockInstallationStore) GetAnnotationsForInstallation(installationID string) ([]*model.Annotation, error) {
+	return nil, nil
+}
+
 type mockInstallationProvisioner struct {
 	UseCustomClusterResources bool
 	CustomClusterResources    *k8s.ClusterResources
@@ -1613,5 +1617,88 @@ func TestInstallationSupervisor(t *testing.T) {
 		expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationInProgress)
 		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationRequested)
 		expectClusterInstallationsOnCluster(t, sqlStore, cluster, 1)
+	})
+
+	t.Run("cluster with proper annotations selected", func(t *testing.T) {
+		annotations := []*model.Annotation{
+			{Name: "multi-tenant"}, {Name: "customer-abc"},
+		}
+
+		installationInCreationRequestedState := func() *model.Installation {
+			groupID := model.NewID()
+
+			return &model.Installation{
+				OwnerID:  model.NewID(),
+				Version:  "version",
+				DNS:      "dns.example.com",
+				Size:     mmv1alpha1.Size100String,
+				Affinity: model.InstallationAffinityMultiTenant,
+				GroupID:  &groupID,
+				State:    model.InstallationStateCreationRequested,
+			}
+		}
+
+		t.Run("cluster with matching annotations exists", func(t *testing.T) {
+			logger := testlib.MakeLogger(t)
+			sqlStore := store.MakeTestSQLStore(t, logger)
+			defer store.CloseConnection(t, sqlStore)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
+
+			cluster := standardStableTestCluster()
+			err := sqlStore.CreateCluster(cluster, annotations)
+			require.NoError(t, err)
+
+			installation := installationInCreationRequestedState()
+
+			err = sqlStore.CreateInstallation(installation, annotations)
+			require.NoError(t, err)
+
+			supervisor.Supervise(installation)
+			expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationInProgress)
+			expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationRequested)
+			expectClusterInstallationsOnCluster(t, sqlStore, cluster, 1)
+		})
+
+		t.Run("cluster with matching annotations does not exists", func(t *testing.T) {
+			logger := testlib.MakeLogger(t)
+			sqlStore := store.MakeTestSQLStore(t, logger)
+			defer store.CloseConnection(t, sqlStore)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
+
+			cluster := standardStableTestCluster()
+			err := sqlStore.CreateCluster(cluster, nil)
+			require.NoError(t, err)
+
+			installation := installationInCreationRequestedState()
+
+			err = sqlStore.CreateInstallation(installation, annotations)
+			require.NoError(t, err)
+
+			supervisor.Supervise(installation)
+			expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationNoCompatibleClusters)
+			expectClusterInstallations(t, sqlStore, installation, 0, "")
+			expectClusterInstallationsOnCluster(t, sqlStore, cluster, 0)
+		})
+
+		t.Run("annotations filter ignored when installation without annotations", func(t *testing.T) {
+			logger := testlib.MakeLogger(t)
+			sqlStore := store.MakeTestSQLStore(t, logger)
+			defer store.CloseConnection(t, sqlStore)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", 80, 0, false, false, &utils.ResourceUtil{}, logger)
+
+			cluster := standardStableTestCluster()
+			err := sqlStore.CreateCluster(cluster, annotations)
+			require.NoError(t, err)
+
+			installation := installationInCreationRequestedState()
+
+			err = sqlStore.CreateInstallation(installation, nil)
+			require.NoError(t, err)
+
+			supervisor.Supervise(installation)
+			expectInstallationState(t, sqlStore, installation, model.InstallationStateCreationInProgress)
+			expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationRequested)
+			expectClusterInstallationsOnCluster(t, sqlStore, cluster, 1)
+		})
 	})
 }

--- a/model/annotation_test.go
+++ b/model/annotation_test.go
@@ -71,7 +71,6 @@ func TestAnnotationsFromStringSlice(t *testing.T) {
 			})
 		}
 	})
-
 }
 
 func TestSortAnnotations(t *testing.T) {
@@ -96,5 +95,4 @@ func TestSortAnnotations(t *testing.T) {
 			assert.Equal(t, testCase.expected, testCase.annotations)
 		})
 	}
-
 }

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -74,6 +74,13 @@ type ClusterFilter struct {
 	Page           int
 	PerPage        int
 	IncludeDeleted bool
+	Annotations    *AnnotationsFilter
+}
+
+// AnnotationsFilter describes filter based on Annotations.
+type AnnotationsFilter struct {
+	// MatchAllIDs contains all Annotation IDs which need to be set on a Cluster for it to be included in the result.
+	MatchAllIDs []string
 }
 
 var clusterVersionMatcher = regexp.MustCompile(`^(([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3})|(latest))$`)

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -27,7 +27,7 @@ type CreateClusterRequest struct {
 	AllowInstallations     bool              `json:"allow-installations,omitempty"`
 	APISecurityLock        bool              `json:"api-security-lock,omitempty"`
 	DesiredUtilityVersions map[string]string `json:"utility-versions,omitempty"`
-	Annotations       []string          `json:"annotations,omitempty"`
+	Annotations            []string          `json:"annotations,omitempty"`
 }
 
 // SetDefaults sets the default values for a cluster create request.

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -22,19 +22,19 @@ import (
 
 // CreateInstallationRequest specifies the parameters for a new installation.
 type CreateInstallationRequest struct {
-	OwnerID          string
-	GroupID          string
-	Version          string
-	Image            string
-	DNS              string
-	License          string
-	Size             string
-	Affinity         string
-	Database         string
-	Filestore        string
-	APISecurityLock  bool
-	MattermostEnv    EnvVarMap
-	Annotations []string
+	OwnerID         string
+	GroupID         string
+	Version         string
+	Image           string
+	DNS             string
+	License         string
+	Size            string
+	Affinity        string
+	Database        string
+	Filestore       string
+	APISecurityLock bool
+	MattermostEnv   EnvVarMap
+	Annotations     []string
 }
 
 // https://man7.org/linux/man-pages/man7/hostname.7.html


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR makes use of Annotations during the scheduling of Installation to the Cluster.
The filtering of clusters is guided by the following principles:
- Installations can be scheduled on any cluster which contains all Annotations present on the Installation.
- Clusters can contain any additional Annotations not present on the Installation.
- Installation without Annotations can be scheduled on any available cluster.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-29237

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Schedule Installations on Clusters based on the Annotations
```
