### PR TITLE
Add group no-op update sequence bump option

### DIFF
--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -34,6 +34,7 @@ func init() {
 	groupUpdateCmd.Flags().Int64("max-rolling", 0, "The maximum number of installations that can be updated at one time when a group is updated")
 	groupUpdateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	groupUpdateCmd.Flags().Bool("mattermost-env-clear", false, "Clears all env var data.")
+	groupUpdateCmd.Flags().Bool("force-sequence-update", false, "Forces the group version sequence to be increased by 1 even when no updates are present")
 	groupUpdateCmd.MarkFlagRequired("group")
 
 	groupDeleteCmd.Flags().String("group", "", "The id of the group to be deleted.")
@@ -135,20 +136,22 @@ var groupUpdateCmd = &cobra.Command{
 		groupID, _ := command.Flags().GetString("group")
 		mattermostEnv, _ := command.Flags().GetStringArray("mattermost-env")
 		mattermostEnvClear, _ := command.Flags().GetBool("mattermost-env-clear")
+		forceSequenceUpdate, _ := command.Flags().GetBool("force-sequence-update")
 
 		envVarMap, err := parseEnvVarInput(mattermostEnv, mattermostEnvClear)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to parse env var input")
 		}
 
 		request := &model.PatchGroupRequest{
-			ID:            groupID,
-			Name:          getStringFlagPointer(command, "name"),
-			Description:   getStringFlagPointer(command, "description"),
-			Version:       getStringFlagPointer(command, "version"),
-			Image:         getStringFlagPointer(command, "image"),
-			MaxRolling:    getInt64FlagPointer(command, "max-rolling"),
-			MattermostEnv: envVarMap,
+			ID:                  groupID,
+			Name:                getStringFlagPointer(command, "name"),
+			Description:         getStringFlagPointer(command, "description"),
+			Version:             getStringFlagPointer(command, "version"),
+			Image:               getStringFlagPointer(command, "image"),
+			MaxRolling:          getInt64FlagPointer(command, "max-rolling"),
+			MattermostEnv:       envVarMap,
+			ForceSequenceUpdate: forceSequenceUpdate,
 		}
 
 		dryRun, _ := command.Flags().GetBool("dry-run")

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -319,6 +319,27 @@ func TestUpdateGroup(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("only sequence updated", func(t *testing.T) {
+		group1, err = client.GetGroup(group1.ID)
+		require.NoError(t, err)
+		oldSequence := group1.Sequence
+
+		updateResponseGroup, err := client.UpdateGroup(&model.PatchGroupRequest{
+			ID:                  group1.ID,
+			ForceSequenceUpdate: true,
+		})
+		require.NoError(t, err)
+
+		group1, err = client.GetGroup(group1.ID)
+		require.NoError(t, err)
+		require.Equal(t, "name", group1.Name)
+		require.Equal(t, "description", group1.Description)
+		require.Equal(t, "version", group1.Version)
+		require.EqualValues(t, group1.MattermostEnv, mattermostEnvFooBar)
+		require.Equal(t, updateResponseGroup, group1)
+		require.Equal(t, oldSequence+1, group1.Sequence)
+	})
+
 	t.Run("partial update", func(t *testing.T) {
 		updateResponseGroup, err := client.UpdateGroup(&model.PatchGroupRequest{
 			ID:      group1.ID,

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -73,10 +73,7 @@ func (provisioner *KopsProvisioner) CreateClusterInstallation(cluster *model.Clu
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      installationName,
 			Namespace: clusterInstallation.Namespace,
-			Labels: map[string]string{
-				"installation":         installation.ID,
-				"cluster-installation": clusterInstallation.ID,
-			},
+			Labels:    generateClusterInstallationResourceLabels(installation, clusterInstallation),
 		},
 		Spec: mmv1alpha1.ClusterInstallationSpec{
 			Size:          installation.Size,
@@ -251,6 +248,8 @@ func (provisioner *KopsProvisioner) UpdateClusterInstallation(cluster *model.Clu
 	}
 
 	logger.WithField("status", fmt.Sprintf("%+v", cr.Status)).Debug("Got cluster installation")
+
+	cr.ObjectMeta.Labels = generateClusterInstallationResourceLabels(installation, clusterInstallation)
 
 	version := translateMattermostVersion(installation.Version)
 	if cr.Spec.Version == version {
@@ -587,6 +586,23 @@ func (provisioner *KopsProvisioner) ExecClusterInstallationCLI(cluster *model.Cl
 	logger.Debugf("Command `%s` on pod %s finished in %.0f seconds", strings.Join(args, " "), pod.Name, time.Since(now).Seconds())
 
 	return output, err
+}
+
+// generateClusterInstallationResourceLabels generates standard resource labels
+// for ClusterInstallation resources.
+func generateClusterInstallationResourceLabels(installation *model.Installation, clusterInstallation *model.ClusterInstallation) map[string]string {
+	labels := map[string]string{
+		"installation-id":         installation.ID,
+		"cluster-installation-id": clusterInstallation.ID,
+	}
+	if installation.GroupID != nil {
+		labels["group-id"] = *installation.GroupID
+	}
+	if installation.GroupSequence != nil {
+		labels["group-sequence"] = fmt.Sprintf("%d", *installation.GroupSequence)
+	}
+
+	return labels
 }
 
 // Set env overrides that are required from installations for function correctly

--- a/internal/store/group.go
+++ b/internal/store/group.go
@@ -6,7 +6,6 @@ package store
 
 import (
 	"database/sql"
-	"reflect"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-cloud/model"
@@ -332,17 +331,14 @@ func (sqlStore *SQLStore) CreateGroup(group *model.Group) error {
 // that will possibly affect installation config then update the group sequence
 // number.
 func (sqlStore *SQLStore) UpdateGroup(group *model.Group) error {
+	// Update the sequence number, but don't trust the group sequence number
+	// that was passed in.
 	originalGroup, err := sqlStore.GetGroup(group.ID)
 	if err != nil {
 		return err
 	}
-	if originalGroup.Version != group.Version ||
-		originalGroup.Image != group.Image ||
-		!reflect.DeepEqual(originalGroup.MattermostEnv, group.MattermostEnv) {
-		// Update the sequence number, but don't trust the group sequence number
-		// that was passed in.
-		group.Sequence = originalGroup.Sequence + 1
-	}
+	group.Sequence = originalGroup.Sequence + 1
+
 	envVarMap, err := group.MattermostEnv.ToJSON()
 	if err != nil {
 		return err

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -178,7 +178,7 @@ func (s *InstallationSupervisor) Supervise(installation *model.Installation) {
 
 		group, err := s.store.GetGroup(*installation.GroupID)
 		if err != nil {
-			logger.Error("Failed to get group for final configuration check")
+			logger.WithError(err).Error("Failed to get group for final configuration check")
 			return
 		}
 		if *installation.GroupSequence != group.Sequence {

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -1258,10 +1258,12 @@ func TestInstallationSupervisor(t *testing.T) {
 
 		err = sqlStore.CreateGroup(group)
 		require.NoError(t, err)
-		// Group Sequence always set to 0 when created so we need to update it.
-		group.Sequence = 2
+		// Group Sequence always set to 0 when created so we need to update it
+		// by calling group update once.
+		oldSequence := group.Sequence
 		err = sqlStore.UpdateGroup(group)
 		require.NoError(t, err)
+		require.NotEqual(t, oldSequence, group.Sequence)
 
 		owner := model.NewID()
 		installation := &model.Installation{

--- a/model/group_request.go
+++ b/model/group_request.go
@@ -73,6 +73,8 @@ type PatchGroupRequest struct {
 	Version       *string
 	Image         *string
 	MattermostEnv EnvVarMap
+
+	ForceSequenceUpdate bool
 }
 
 // Apply applies the patch to the given group.
@@ -103,6 +105,12 @@ func (p *PatchGroupRequest) Apply(group *Group) bool {
 		if group.MattermostEnv.ClearOrPatch(&p.MattermostEnv) {
 			applied = true
 		}
+	}
+
+	// This special value allows us to bump the group sequence number even when
+	// the patch contains no group modifications.
+	if p.ForceSequenceUpdate {
+		applied = true
 	}
 
 	return applied

--- a/model/group_request_test.go
+++ b/model/group_request_test.go
@@ -135,6 +135,15 @@ func TestPatchGroupRequestApply(t *testing.T) {
 			&model.Group{},
 		},
 		{
+			"force sequence bump",
+			true,
+			&model.PatchGroupRequest{
+				ForceSequenceUpdate: true,
+			},
+			&model.Group{},
+			&model.Group{},
+		},
+		{
 			"name only",
 			true,
 			&model.PatchGroupRequest{


### PR DESCRIPTION
The group update API now allows for a group's sequence number to
be increased by one with no changes to the group. This allows for
a clean way to ensure all installations in a group have the latest
baseline configuration and resources without making any changes to
the group.

This change also includes a change where GroupID and Sequence
number will be added as manifest labels on the ClusterInstallation
custom resource. These labels can be used for more efficient
troubleshooting.

Fixes https://mattermost.atlassian.net/browse/MM-27272

```release-note
Add group no-op update sequence bump option
```
