### PR TITLE
remove ssh access from 0.0.0.0/0

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -46,6 +46,7 @@ func init() {
 	serverCmd.PersistentFlags().String("listen", ":8075", "The interface and port on which to listen.")
 	serverCmd.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
 	serverCmd.PersistentFlags().StringSlice("allow-list-cidr-range", []string{"0.0.0.0/0"}, "The list of CIDRs to allow communication with the private ingress.")
+	serverCmd.PersistentFlags().StringSlice("vpn-list-cidr", []string{"0.0.0.0/0"}, "The list of VPN CIDRs to allow communication with the clusters.")
 	serverCmd.PersistentFlags().Bool("debug", false, "Whether to output debug logs.")
 	serverCmd.PersistentFlags().Bool("machine-readable-logs", false, "Output the logs in machine readable format.")
 	serverCmd.PersistentFlags().Bool("dev", false, "Set sane defaults for development")
@@ -92,6 +93,11 @@ var serverCmd = &cobra.Command{
 		allowListCIDRRange, _ := command.Flags().GetStringSlice("allow-list-cidr-range")
 		if len(allowListCIDRRange) == 0 {
 			return errors.New("allow-list-cidr-range must have at least one value")
+		}
+
+		vpnListCIDR, _ := command.Flags().GetStringSlice("vpn-list-cidr")
+		if len(vpnListCIDR) == 0 {
+			return errors.New("vpn-list-cidr must have at least one value")
 		}
 
 		logger := logger.WithField("instance", instanceID)
@@ -206,6 +212,7 @@ var serverCmd = &cobra.Command{
 			owner,
 			useExistingResources,
 			allowListCIDRRange,
+			vpnListCIDR,
 			resourceUtil,
 			logger,
 			sqlStore,

--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -342,3 +342,18 @@ func (mr *MockAWSMockRecorder) GenerateBifrostUtilitySecret(clusterID, logger in
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateBifrostUtilitySecret", reflect.TypeOf((*MockAWS)(nil).GenerateBifrostUtilitySecret), clusterID, logger)
 }
+
+// GetCIDRByVPCTag mocks base method
+func (m *MockAWS) GetCIDRByVPCTag(vpcTagName string, logger logrus.FieldLogger) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCIDRByVPCTag", vpcTagName, logger)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCIDRByVPCTag indicates an expected call of GetCIDRByVPCTag
+func (mr *MockAWSMockRecorder) GetCIDRByVPCTag(vpcTagName, logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCIDRByVPCTag", reflect.TypeOf((*MockAWS)(nil).GetCIDRByVPCTag), vpcTagName, logger)
+}

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -329,6 +329,10 @@ func (a *mockAWS) GenerateBifrostUtilitySecret(clusterID string, logger log.Fiel
 	return nil, nil
 }
 
+func (a *mockAWS) GetCIDRByVPCTag(vpcTagName string, logger log.FieldLogger) (string, error) {
+	return "", nil
+}
+
 func TestInstallationSupervisorDo(t *testing.T) {
 	standardSchedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(false, 80, 0)
 

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -71,6 +71,7 @@ type AWS interface {
 	S3EnsureBucketDeleted(bucketName string, logger log.FieldLogger) error
 
 	GenerateBifrostUtilitySecret(clusterID string, logger log.FieldLogger) (*corev1.Secret, error)
+	GetCIDRByVPCTag(vpcTagName string, logger log.FieldLogger) (string, error)
 }
 
 // NewAWSClientWithConfig returns a new instance of Client with a custom configuration.

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -31,6 +31,9 @@ const (
 	// cluster's human name so that the VPC's owner can be identified
 	VpcClusterOwnerKey = "tag:CloudClusterOwner"
 
+	// VpcNameTagKey is the tag key used to store name of the VPC.
+	VpcNameTagKey = "tag:Name"
+
 	// VpcClusterOwnerValueNone is the tag value for VpcClusterOwnerKey when
 	// there is no cluster running in the VPC.
 	VpcClusterOwnerValueNone = "none"

--- a/internal/tools/aws/vpc.go
+++ b/internal/tools/aws/vpc.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package aws
+
+import (
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// GetCIDRByVPCTag creates a record in Route53 for a public domain name.
+func (a *Client) GetCIDRByVPCTag(vpcTagName string, logger log.FieldLogger) (string, error) {
+	vpcInput := ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String(VpcNameTagKey),
+				Values: []*string{aws.String(vpcTagName)},
+			},
+		},
+	}
+
+	vpcOut, err := a.Service().ec2.DescribeVpcs(&vpcInput)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to fetch the VPC information using tag %s", vpcTagName)
+	}
+
+	if len(vpcOut.Vpcs) != 1 {
+		return "", errors.Errorf("expected exactly one VPC in the list, got %d", len(vpcOut.Vpcs))
+	}
+
+	return *vpcOut.Vpcs[0].CidrBlock, nil
+}

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CreateCluster invokes kops create cluster, using the context of the created Cmd.
-func (c *Cmd) CreateCluster(name, cloud string, kopsRequest *model.KopsMetadataRequestedState, zones, privateSubnetIds, publicSubnetIds, masterSecurityGroups, workerSecurityGroups []string) error {
+func (c *Cmd) CreateCluster(name, cloud string, kopsRequest *model.KopsMetadataRequestedState, zones, privateSubnetIds, publicSubnetIds, masterSecurityGroups, workerSecurityGroups, allowSSHCIDRS []string) error {
 	if len(zones) == 0 {
 		return fmt.Errorf("must supply at least one zone")
 	}
@@ -31,6 +31,7 @@ func (c *Cmd) CreateCluster(name, cloud string, kopsRequest *model.KopsMetadataR
 		arg("master-size", kopsRequest.MasterInstanceType),
 		arg("target", "terraform"),
 		arg("out", c.GetOutputDirectory()),
+		arg("ssh-access", strings.Join(allowSSHCIDRS, ",")),
 		arg("output", "json"),
 	}
 


### PR DESCRIPTION
#### Summary
remove ssh access from 0.0.0.0/0 when creating new clusters and set the CIDRs from the VPN and from the Command and control cluster

two new flags need to be provided:
- env - which env it is running (default `dev`) possible values for us: `test` / `staging` / `prod`
- vpn-list-cidr - the cidrs for the VPN - Mandatory

For the existing clusters, we agree to do the process manually

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-28913

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
remove ssh access from 0.0.0.0/0 for new kops clusters
```
