### PR TITLE
Refactor AWS database connection string logic

### DIFF
--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -54,7 +54,7 @@ const (
 	DefaultDBSubnetGroupName = "mattermost-databases"
 
 	// DatabaseTypeMySQLAurora is a MySQL database running on AWS RDS Aurora.
-	DatabaseTypeMySQLAurora = "MYSQL/Aurora"
+	DatabaseTypeMySQLAurora = "MySQL/Aurora"
 
 	// DatabaseTypePostgresSQLAurora is a PostgreSQL database running on AWS
 	// RDS Aurora.

--- a/internal/tools/aws/database.go
+++ b/internal/tools/aws/database.go
@@ -22,11 +22,6 @@ import (
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
 )
 
-const mysqlConnStringTemplate = "mysql://%s:%s@tcp(%s:3306)/mattermost?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
-const mysqlConnReaderStringTemplate = "%s:%s@tcp(%s:3306)/mattermost?readTimeout=30s&writeTimeout=30s"
-const postgresConnStringTemplate = "postgres://%s:%s@%s:5432/mattermost?sslmode=disable&connect_timeout=10"
-const postgresConnReaderStringTemplate = "postgres://%s:%s@%s:5432/mattermost?sslmode=disable&connect_timeout=10"
-
 // RDSDatabase is a database backed by AWS RDS.
 type RDSDatabase struct {
 	databaseType   string
@@ -145,7 +140,7 @@ func (d *RDSDatabase) GenerateDatabaseSpecAndSecret(store model.InstallationData
 		"database-type":   d.databaseType,
 	})
 
-	rdsSecret, err := d.client.secretsManagerGetRDSSecret(awsID, logger)
+	installationSecret, err := d.client.secretsManagerGetRDSSecret(awsID, logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -160,26 +155,35 @@ func (d *RDSDatabase) GenerateDatabaseSpecAndSecret(store model.InstallationData
 	if len(dbClusters.DBClusters) != 1 {
 		return nil, nil, fmt.Errorf("expected 1 DB cluster, but got %d", len(dbClusters.DBClusters))
 	}
+	rdsCluster := dbClusters.DBClusters[0]
 
-	var connTemplate, readerTemplate, databaseConnectionCheck string
+	var databaseConnectionString, databaseReadReplicasString, databaseConnectionCheck string
 	switch d.databaseType {
 	case model.DatabaseEngineTypeMySQL:
-		connTemplate = mysqlConnStringTemplate
-		readerTemplate = mysqlConnReaderStringTemplate
-		databaseConnectionCheck = fmt.Sprintf("http://%s:3306", *dbClusters.DBClusters[0].Endpoint)
+		databaseConnectionString, databaseReadReplicasString =
+			MattermostMySQLConnStrings(
+				"mattermost",
+				installationSecret.MasterUsername,
+				installationSecret.MasterPassword,
+				rdsCluster,
+			)
+		databaseConnectionCheck = fmt.Sprintf("http://%s:3306", *rdsCluster.Endpoint)
 	case model.DatabaseEngineTypePostgres:
-		connTemplate = postgresConnStringTemplate
-		readerTemplate = postgresConnReaderStringTemplate
+		databaseConnectionString, databaseReadReplicasString =
+			MattermostPostgresConnStrings(
+				"mattermost",
+				installationSecret.MasterUsername,
+				installationSecret.MasterPassword,
+				rdsCluster,
+			)
 	default:
 		return nil, nil, errors.Errorf("%s is an invalid database engine type", d.databaseType)
 	}
 
 	databaseSecretName := fmt.Sprintf("%s-rds", d.installationID)
-	databaseConnectionString := fmt.Sprintf(connTemplate, rdsSecret.MasterUsername, rdsSecret.MasterPassword, *dbClusters.DBClusters[0].Endpoint)
-	databaseConnectionReaderString := fmt.Sprintf(readerTemplate, rdsSecret.MasterUsername, rdsSecret.MasterPassword, *dbClusters.DBClusters[0].ReaderEndpoint)
 	secretStringData := map[string]string{
 		"DB_CONNECTION_STRING":              databaseConnectionString,
-		"MM_SQLSETTINGS_DATASOURCEREPLICAS": databaseConnectionReaderString,
+		"MM_SQLSETTINGS_DATASOURCEREPLICAS": databaseReadReplicasString,
 	}
 	if len(databaseConnectionCheck) != 0 {
 		secretStringData["DB_CONNECTION_CHECK_URL"] = databaseConnectionCheck

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -112,9 +112,9 @@ func MattermostRDSDatabaseName(installationID string) string {
 // MattermostMySQLConnStrings formats the connection string used for accessing a
 // Mattermost database.
 func MattermostMySQLConnStrings(schema, username, password string, dbCluster *rds.DBCluster) (string, string) {
-	dbConnection := fmt.Sprintf("mysql://%s:%s@tcp(%s:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
+	dbConnection := fmt.Sprintf("mysql://%s:%s@tcp(%s:3306)/%s?charset=utf8mb4%%2Cutf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
 		username, password, *dbCluster.Endpoint, schema)
-	readReplicas := fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
+	readReplicas := fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?charset=utf8mb4%%2Cutf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
 		username, password, *dbCluster.ReaderEndpoint, schema)
 
 	return dbConnection, readReplicas


### PR DESCRIPTION
This change moves AWS connection string generation for all database
types to shared helper methods. This standardizes how the connection
strings are injected into the Mattermost environments.

Also, a bug related to URL encoding commas in the MySQL connection
string was resolved.

The changes were verified with a new database test suite tool I wrote:

```
2020/10/25 19:20:52 ====================================================
2020/10/25 19:20:52 DATABASE TEST RESULTS
2020/10/25 19:20:52 ====================================================
2020/10/25 19:20:52 PASS: aws-multitenant-rds-postgres (0.88 minutes)
2020/10/25 19:20:52 PASS: aws-multitenant-rds (0.84 minutes)
2020/10/25 19:20:52 PASS: aws-rds-postgres (6.60 minutes)
2020/10/25 19:20:52 PASS: aws-rds (6.33 minutes)
2020/10/25 19:20:52 PASS: mysql-operator (3.63 minutes)
2020/10/25 19:20:52 ====================================================
```

There is a matching terraform change that should be deployed in our
other accounts when this is merged that @stylianosrigas is aware of.

Fixes https://mattermost.atlassian.net/browse/MM-29964

```release-note
Refactor AWS database connection string logic
```
