### PR TITLE
Do not cleanup Helm 2 directory

### DIFF
--- a/internal/provisioner/helm_migrate.go
+++ b/internal/provisioner/helm_migrate.go
@@ -44,8 +44,8 @@ func MigrateRelease(logger log.FieldLogger, kubeConfigPath string, release strin
 	return nil
 }
 
-// CleanupAll cleans up all Helm 2 releases together with Tiller
-func CleanupAll(logger log.FieldLogger, kubeConfigPath string) error {
+// CleanupTiller cleans up all Helm 2 releases together with Tiller
+func CleanupTiller(logger log.FieldLogger, kubeConfigPath string) error {
 	helm3, err := helm.NewV3(logger.WithField("helm-version", "v3"))
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize Helm 3 client")
@@ -97,6 +97,7 @@ func cleanupAll(helm3 *helm.Cmd, kubeConfigPath string, dryRun bool) error {
 		"cleanup",
 		"--skip-confirmation",
 		"--kubeconfig", kubeConfigPath,
+		"--tiller-cleanup",
 	}
 	args = withDryRun(args, dryRun)
 

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -330,5 +330,5 @@ func helm2Cleanup(logger log.FieldLogger, kubeConfigPath string) error {
 		return nil
 	}
 
-	return CleanupAll(log, kubeConfigPath)
+	return CleanupTiller(log, kubeConfigPath)
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This change will clean up only Tiller without cleaning up helm 2 directories.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
