### PR TITLE
MM-29860 - Add flag to require annotated installations

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -59,6 +59,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("debug", false, "Whether to output debug logs.")
 	serverCmd.PersistentFlags().Bool("machine-readable-logs", false, "Output the logs in machine readable format.")
 	serverCmd.PersistentFlags().Bool("dev", false, "Set sane defaults for development")
+	serverCmd.PersistentFlags().Bool("require-annotated-installations", false, "Require new installations to have at least one annotation.")
 }
 
 var serverCmd = &cobra.Command{
@@ -79,6 +80,9 @@ var serverCmd = &cobra.Command{
 		if machineLogs {
 			logger.SetFormatter(&logrus.JSONFormatter{})
 		}
+
+		requireAnnotatedInstallations, _ := command.Flags().GetBool("require-annotated-installations")
+		model.SetRequireAnnotatedInstallations(requireAnnotatedInstallations)
 
 		allowListCIDRRange, _ := command.Flags().GetStringSlice("allow-list-cidr-range")
 		if len(allowListCIDRRange) == 0 {

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -20,6 +20,14 @@ import (
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
 )
 
+// requireAnnotatedInstallations if set, installations need to be annotated with at least one annotation.
+var requireAnnotatedInstallations bool
+
+// SetRequireAnnotatedInstallations is called with a value based on a CLI flag.
+func SetRequireAnnotatedInstallations(val bool) {
+	requireAnnotatedInstallations = val
+}
+
 // CreateInstallationRequest specifies the parameters for a new installation.
 type CreateInstallationRequest struct {
 	OwnerID         string
@@ -88,6 +96,12 @@ func (request *CreateInstallationRequest) Validate() error {
 		return errors.Errorf("unsupported filestore %s", request.Filestore)
 	}
 	err = request.MattermostEnv.Validate()
+	if requireAnnotatedInstallations {
+		if len(request.Annotations) == 0 {
+			return errors.Errorf("at least one annotation is required")
+		}
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "invalid env var settings")
 	}

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -168,6 +168,22 @@ func TestCreateInstallationRequestValid(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("require annotated installation", func(t *testing.T) {
+		request := 	&model.CreateInstallationRequest{
+			OwnerID: "owner1",
+			DNS:     "domain4321.com",
+		}
+		request.SetDefaults()
+
+		assert.NoError(t, request.Validate())
+
+		model.SetRequireAnnotatedInstallations(true)
+		assert.Error(t, request.Validate())
+
+		request.Annotations = []string{"my-annotation"}
+		assert.NoError(t, request.Validate())
+	})
 }
 
 func TestCreateInstallationRequestFromReader(t *testing.T) {

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -170,7 +170,7 @@ func TestCreateInstallationRequestValid(t *testing.T) {
 	}
 
 	t.Run("require annotated installation", func(t *testing.T) {
-		request := 	&model.CreateInstallationRequest{
+		request := &model.CreateInstallationRequest{
 			OwnerID: "owner1",
 			DNS:     "domain4321.com",
 		}
@@ -183,6 +183,7 @@ func TestCreateInstallationRequestValid(t *testing.T) {
 
 		request.Annotations = []string{"my-annotation"}
 		assert.NoError(t, request.Validate())
+		model.SetRequireAnnotatedInstallations(false)
 	})
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add a new flag `--require-annotated-installations` to the `server` command which specifies whether new Installations need to be annotated.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-29860

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add flag specifying whether new Installations need to be annotated.
```
