### PR TITLE
MM-30167 Remove unnecessary error-prone DNS check

### DIFF
--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -82,14 +82,6 @@ func TestCreateInstallationRequestValid(t *testing.T) {
 			},
 		},
 		{
-			"DNS is a real FQDN that is in use already",
-			true,
-			&model.CreateInstallationRequest{
-				OwnerID: "owner1",
-				DNS:     "google.com",
-			},
-		},
-		{
 			"invalid installation size",
 			true,
 			&model.CreateInstallationRequest{


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
We saw a failure to create an instance due to an i/o timeout when looking up a name against 1.1.1.1. We have a number of Workspace availability checks in the Customer Web Server, which render this check unnecessary, and since it can cause creation to fail, it should be removed.

This PR removes this functionality.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-30167

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Removed DNS check for new Installations
```
