### PR TITLE
MM-19774 - Support configuration of single-tenant RDS via Provisioner API

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -29,6 +29,9 @@ func init() {
 	installationCreateCmd.Flags().String("filestore", model.InstallationFilestoreMinioOperator, "The Mattermost server filestore type. Accepts minio-operator or aws-s3")
 	installationCreateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	installationCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the installation. Accepts multiple values, for example: '... --annotation abc --annotation def'")
+	installationCreateCmd.Flags().String("rds-primary-instance", "", "The machine instance type used for primary replica of database cluster. Works only with single tenant RDS databases.")
+	installationCreateCmd.Flags().String("rds-replica-instance", "", "The machine instance type used for reader replicas of database cluster. Works only with single tenant RDS databases.")
+	installationCreateCmd.Flags().Int("rds-replicas-count", 0, "The number of reader replicas of database cluster. Min: 0, Max: 15. Works only with single tenant RDS databases.")
 	installationCreateCmd.MarkFlagRequired("owner")
 	installationCreateCmd.MarkFlagRequired("dns")
 
@@ -120,6 +123,20 @@ var installationCreateCmd = &cobra.Command{
 			Filestore:     filestore,
 			MattermostEnv: envVarMap,
 			Annotations:   annotations,
+		}
+
+		if model.IsSingleTenantRDS(database) {
+			rdsPrimaryInstance, _ :=command.Flags().GetString("rds-primary-instance")
+			rdsReplicaInstance, _ :=command.Flags().GetString("rds-replica-instance")
+			rdsReplicasCount, _ :=command.Flags().GetInt("rds-replicas-count")
+
+			dbConfig := model.SingleTenantDatabaseRequest{
+				PrimaryInstanceType: rdsPrimaryInstance,
+				ReplicaInstanceType: rdsReplicaInstance,
+				ReplicasCount:       rdsReplicasCount,
+			}
+
+			request.SingleTenantDatabaseConfig = dbConfig
 		}
 
 		dryRun, _ := command.Flags().GetBool("dry-run")

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -126,9 +126,9 @@ var installationCreateCmd = &cobra.Command{
 		}
 
 		if model.IsSingleTenantRDS(database) {
-			rdsPrimaryInstance, _ :=command.Flags().GetString("rds-primary-instance")
-			rdsReplicaInstance, _ :=command.Flags().GetString("rds-replica-instance")
-			rdsReplicasCount, _ :=command.Flags().GetInt("rds-replicas-count")
+			rdsPrimaryInstance, _ := command.Flags().GetString("rds-primary-instance")
+			rdsReplicaInstance, _ := command.Flags().GetString("rds-replica-instance")
+			rdsReplicasCount, _ := command.Flags().GetInt("rds-replicas-count")
 
 			dbConfig := model.SingleTenantDatabaseRequest{
 				PrimaryInstanceType: rdsPrimaryInstance,

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -162,19 +162,20 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 	}
 
 	installation := model.Installation{
-		OwnerID:         createInstallationRequest.OwnerID,
-		GroupID:         &createInstallationRequest.GroupID,
-		Version:         createInstallationRequest.Version,
-		Image:           createInstallationRequest.Image,
-		DNS:             createInstallationRequest.DNS,
-		Database:        createInstallationRequest.Database,
-		Filestore:       createInstallationRequest.Filestore,
-		License:         createInstallationRequest.License,
-		Size:            createInstallationRequest.Size,
-		Affinity:        createInstallationRequest.Affinity,
-		APISecurityLock: createInstallationRequest.APISecurityLock,
-		MattermostEnv:   createInstallationRequest.MattermostEnv,
-		State:           model.InstallationStateCreationRequested,
+		OwnerID:                    createInstallationRequest.OwnerID,
+		GroupID:                    &createInstallationRequest.GroupID,
+		Version:                    createInstallationRequest.Version,
+		Image:                      createInstallationRequest.Image,
+		DNS:                        createInstallationRequest.DNS,
+		Database:                   createInstallationRequest.Database,
+		Filestore:                  createInstallationRequest.Filestore,
+		License:                    createInstallationRequest.License,
+		Size:                       createInstallationRequest.Size,
+		Affinity:                   createInstallationRequest.Affinity,
+		APISecurityLock:            createInstallationRequest.APISecurityLock,
+		MattermostEnv:              createInstallationRequest.MattermostEnv,
+		SingleTenantDatabaseConfig: createInstallationRequest.SingleTenantDatabaseConfig.ToDBConfig(createInstallationRequest.Database),
+		State:                      model.InstallationStateCreationRequested,
 	}
 
 	annotations, err := model.AnnotationsFromStringSlice(createInstallationRequest.Annotations)

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -558,6 +558,20 @@ func TestCreateInstallation(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, installation.SingleTenantDatabaseConfig)
 	})
+
+	t.Run("set default values for single tenant database configuration", func(t *testing.T) {
+		installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
+			OwnerID:                    "owner1",
+			Version:                    "version",
+			DNS:                        "dns-db-config2.example.com",
+			SingleTenantDatabaseConfig: dbConfigRequest,
+			Database:                   model.InstallationDatabaseSingleTenantRDSMySQL,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, installation.SingleTenantDatabaseConfig)
+		assert.NotEmpty(t, installation.SingleTenantDatabaseConfig.PrimaryInstanceType)
+		assert.NotEmpty(t, installation.SingleTenantDatabaseConfig.ReplicaInstanceType)
+	})
 }
 
 func TestRetryCreateInstallation(t *testing.T) {

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -563,7 +563,7 @@ func TestCreateInstallation(t *testing.T) {
 		installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
 			OwnerID:                    "owner1",
 			Version:                    "version",
-			DNS:                        "dns-db-config2.example.com",
+			DNS:                        "dns-db-config3.example.com",
 			SingleTenantDatabaseConfig: dbConfigRequest,
 			Database:                   model.InstallationDatabaseSingleTenantRDSMySQL,
 		})

--- a/internal/mocks/model/installation_database.go
+++ b/internal/mocks/model/installation_database.go
@@ -237,3 +237,18 @@ func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) UnlockMultitenantD
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlockMultitenantDatabase", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).UnlockMultitenantDatabase), multitenantdatabaseID, lockerID, force)
 }
+
+// GetSingleTenantDatabaseConfigForInstallation mocks base method
+func (m *MockInstallationDatabaseStoreInterface) GetSingleTenantDatabaseConfigForInstallation(installationID string) (*model.SingleTenantDatabaseConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSingleTenantDatabaseConfigForInstallation", installationID)
+	ret0, _ := ret[0].(*model.SingleTenantDatabaseConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSingleTenantDatabaseConfigForInstallation indicates an expected call of GetSingleTenantDatabaseConfigForInstallation
+func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetSingleTenantDatabaseConfigForInstallation(installationID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSingleTenantDatabaseConfigForInstallation", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetSingleTenantDatabaseConfigForInstallation), installationID)
+}

--- a/internal/store/installation_dto_test.go
+++ b/internal/store/installation_dto_test.go
@@ -33,18 +33,25 @@ func TestInstallationDTOs(t *testing.T) {
 	require.NoError(t, err)
 	annotations := []*model.Annotation{&annotation1, &annotation2}
 
+	singleTenantDBConfig := &model.SingleTenantDatabaseConfig{
+		PrimaryInstanceType: "db.r5.large",
+		ReplicaInstanceType: "db.r5.xlarge",
+		ReplicasCount:       11,
+	}
+
 	groupID1 := model.NewID()
 
 	installation1 := &model.Installation{
-		OwnerID:   "owner1",
-		Version:   "version",
-		DNS:       "dns.example.com",
-		Database:  model.InstallationDatabaseMysqlOperator,
-		Filestore: model.InstallationFilestoreMinioOperator,
-		Size:      mmv1alpha1.Size100String,
-		Affinity:  model.InstallationAffinityIsolated,
-		GroupID:   &groupID1,
-		State:     model.InstallationStateCreationRequested,
+		OwnerID:                    "owner1",
+		Version:                    "version",
+		DNS:                        "dns.example.com",
+		Database:                   model.InstallationDatabaseMysqlOperator,
+		Filestore:                  model.InstallationFilestoreMinioOperator,
+		Size:                       mmv1alpha1.Size100String,
+		Affinity:                   model.InstallationAffinityIsolated,
+		GroupID:                    &groupID1,
+		State:                      model.InstallationStateCreationRequested,
+		SingleTenantDatabaseConfig: singleTenantDBConfig,
 	}
 
 	installation2 := &model.Installation{

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1170,4 +1170,16 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.22.0"), semver.MustParse("0.23.0"), func(e execer) error {
+		// Add SingleTenantDatabaseConfigRaw column for installations.
+		_, err := e.Exec(`
+				ALTER TABLE Installation
+				ADD COLUMN SingleTenantDatabaseConfigRaw BYTEA NULL;
+				`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -53,6 +53,7 @@ type installationStore interface {
 	UpdateMultitenantDatabase(multitenantDatabase *model.MultitenantDatabase) error
 	LockMultitenantDatabase(multitenantdatabaseID, lockerID string) (bool, error)
 	UnlockMultitenantDatabase(multitenantdatabaseID, lockerID string, force bool) (bool, error)
+	GetSingleTenantDatabaseConfigForInstallation(installationID string) (*model.SingleTenantDatabaseConfig, error)
 
 	GetAnnotationsForInstallation(installationID string) ([]*model.Annotation, error)
 

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -162,6 +162,10 @@ func (s *mockInstallationStore) GetMultitenantDatabaseForInstallationID(installa
 	return nil, nil
 }
 
+func (s *mockInstallationStore) GetSingleTenantDatabaseConfigForInstallation(installationID string) (*model.SingleTenantDatabaseConfig, error) {
+	return nil, nil
+}
+
 func (s *mockInstallationStore) GetAnnotationsForInstallation(installationID string) ([]*model.Annotation, error) {
 	return nil, nil
 }

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -5,10 +5,11 @@
 package aws
 
 import (
-	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
-	"github.com/aws/aws-sdk-go/service/applicationautoscaling/applicationautoscalingiface"
 	"strings"
 	"sync"
+
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling/applicationautoscalingiface"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -5,6 +5,8 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling/applicationautoscalingiface"
 	"strings"
 	"sync"
 
@@ -92,6 +94,7 @@ type Service struct {
 	kms                   kmsiface.KMSAPI
 	dynamodb              dynamodbiface.DynamoDBAPI
 	sts                   stsiface.STSAPI
+	appAutoscaling        applicationautoscalingiface.ApplicationAutoScalingAPI
 }
 
 // NewService creates a new instance of Service.
@@ -108,6 +111,7 @@ func NewService(sess *session.Session) *Service {
 		kms:                   kms.New(sess),
 		dynamodb:              dynamodb.New(sess),
 		sts:                   sts.New(sess),
+		appAutoscaling:        applicationautoscaling.New(sess),
 	}
 }
 

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -73,9 +73,14 @@ func KMSKeyDescriptionRDS(awsID string) string {
 	return fmt.Sprintf("Key used for encrypting databases in the RDS cluster %v", awsID)
 }
 
-// RDSMasterInstanceID formats the name used for RDS database instances.
+// RDSMasterInstanceID formats the name used for RDS database master instances.
 func RDSMasterInstanceID(installationID string) string {
 	return fmt.Sprintf("%s-master", CloudID(installationID))
+}
+
+// RDSReplicaInstanceID formats the name used for RDS database replica instances.
+func RDSReplicaInstanceID(installationID string, id int) string {
+	return fmt.Sprintf("%s-replica-%d", CloudID(installationID), id)
 }
 
 // RDSMigrationInstanceID formats the name used for migrated RDS database instances.

--- a/internal/tools/aws/rds_test.go
+++ b/internal/tools/aws/rds_test.go
@@ -211,7 +211,7 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterInstanceCreated() {
 			}).
 			Times(1))
 
-	err := a.Mocks.AWS.rdsEnsureDBClusterInstanceCreated(CloudID(a.InstallationA.ID), RDSMasterInstanceID(a.InstallationA.ID), a.RDSEngineType, a.Mocks.Log.Logger)
+	err := a.Mocks.AWS.rdsEnsureDBClusterInstanceCreated(CloudID(a.InstallationA.ID), RDSMasterInstanceID(a.InstallationA.ID), a.RDSEngineType, "db.r5.large", a.Mocks.Log.Logger)
 	a.Assert().NoError(err)
 }
 
@@ -232,7 +232,7 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterInstanceAlreadyExistError() {
 		Return(testlib.NewLoggerEntry()).
 		Times(1)
 
-	err := a.Mocks.AWS.rdsEnsureDBClusterInstanceCreated(CloudID(a.InstallationA.ID), RDSMasterInstanceID(a.InstallationA.ID), a.RDSEngineType, a.Mocks.Log.Logger)
+	err := a.Mocks.AWS.rdsEnsureDBClusterInstanceCreated(CloudID(a.InstallationA.ID), RDSMasterInstanceID(a.InstallationA.ID), a.RDSEngineType, "db.r5.large", a.Mocks.Log.Logger)
 	a.Assert().NoError(err)
 }
 
@@ -260,7 +260,7 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterInstanceCreateError() {
 			}).
 			Times(1))
 
-	err := a.Mocks.AWS.rdsEnsureDBClusterInstanceCreated(CloudID(a.InstallationA.ID), RDSMasterInstanceID(a.InstallationA.ID), a.RDSEngineType, a.Mocks.Log.Logger)
+	err := a.Mocks.AWS.rdsEnsureDBClusterInstanceCreated(CloudID(a.InstallationA.ID), RDSMasterInstanceID(a.InstallationA.ID), a.RDSEngineType, "db.r5.large", a.Mocks.Log.Logger)
 
 	a.Assert().Error(err)
 	a.Assert().Equal(err.Error(), "instance creation failure")

--- a/model/installation.go
+++ b/model/installation.go
@@ -12,26 +12,27 @@ import (
 
 // Installation represents a Mattermost installation.
 type Installation struct {
-	ID              string
-	OwnerID         string
-	GroupID         *string
-	GroupSequence   *int64 `json:"GroupSequence,omitempty"`
-	Version         string
-	Image           string
-	DNS             string
-	Database        string
-	Filestore       string
-	License         string
-	MattermostEnv   EnvVarMap
-	Size            string
-	Affinity        string
-	State           string
-	CreateAt        int64
-	DeleteAt        int64
-	APISecurityLock bool
-	LockAcquiredBy  *string
-	LockAcquiredAt  int64
-	GroupOverrides  map[string]string `json:"GroupOverrides,omitempty"`
+	ID                         string
+	OwnerID                    string
+	GroupID                    *string
+	GroupSequence              *int64 `json:"GroupSequence,omitempty"`
+	Version                    string
+	Image                      string
+	DNS                        string
+	Database                   string
+	Filestore                  string
+	License                    string
+	MattermostEnv              EnvVarMap
+	Size                       string
+	Affinity                   string
+	State                      string
+	CreateAt                   int64
+	DeleteAt                   int64
+	APISecurityLock            bool
+	LockAcquiredBy             *string
+	LockAcquiredAt             int64
+	GroupOverrides             map[string]string           `json:"GroupOverrides,omitempty"`
+	SingleTenantDatabaseConfig *SingleTenantDatabaseConfig `json:"SingleTenantDatabaseConfig,omitempty"`
 
 	// configconfigMergedWithGroup is set when the installation configuration
 	// has been overridden with group configuration. This value can then be

--- a/model/installation_database.go
+++ b/model/installation_database.go
@@ -56,6 +56,7 @@ type InstallationDatabaseStoreInterface interface {
 	UpdateMultitenantDatabase(multitenantDatabase *MultitenantDatabase) error
 	LockMultitenantDatabase(multitenantdatabaseID, lockerID string) (bool, error)
 	UnlockMultitenantDatabase(multitenantdatabaseID, lockerID string, force bool) (bool, error)
+	GetSingleTenantDatabaseConfigForInstallation(installationID string) (*SingleTenantDatabaseConfig, error)
 }
 
 // MysqlOperatorDatabase is a database backed by the MySQL operator.
@@ -110,6 +111,18 @@ func IsSupportedDatabase(database string) bool {
 	case InstallationDatabaseMultiTenantRDSMySQL:
 	case InstallationDatabaseMultiTenantRDSPostgres:
 	case InstallationDatabaseMysqlOperator:
+	default:
+		return false
+	}
+
+	return true
+}
+
+// IsSingleTenantRDS returns true if the given database is single tenant db.
+func IsSingleTenantRDS(database string) bool {
+	switch database {
+	case InstallationDatabaseSingleTenantRDSMySQL:
+	case InstallationDatabaseSingleTenantRDSPostgres:
 	default:
 		return false
 	}

--- a/model/installation_database_test.go
+++ b/model/installation_database_test.go
@@ -52,3 +52,24 @@ func TestIsSupportedDatabase(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSingleTenantDatabase(t *testing.T) {
+	var testCases = []struct {
+		database       string
+		isSingleTenant bool
+	}{
+		{"", false},
+		{"unknown", false},
+		{model.InstallationDatabaseMysqlOperator, false},
+		{model.InstallationDatabaseMultiTenantRDSPostgres, false},
+		{model.InstallationDatabaseMultiTenantRDSMySQL, false},
+		{model.InstallationDatabaseSingleTenantRDSMySQL, true},
+		{model.InstallationDatabaseSingleTenantRDSPostgres, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.database, func(t *testing.T) {
+			assert.Equal(t, tc.isSingleTenant, model.IsSingleTenantRDS(tc.database))
+		})
+	}
+}

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -40,6 +40,8 @@ type CreateInstallationRequest struct {
 	APISecurityLock bool
 	MattermostEnv   EnvVarMap
 	Annotations     []string
+	// SingleTenantDatabaseConfig is ignored if Database is not single tenant mysql or postgres.
+	SingleTenantDatabaseConfig SingleTenantDatabaseRequest
 }
 
 // https://man7.org/linux/man-pages/man7/hostname.7.html
@@ -64,6 +66,9 @@ func (request *CreateInstallationRequest) SetDefaults() {
 	}
 	if request.Filestore == "" {
 		request.Filestore = InstallationFilestoreMinioOperator
+	}
+	if IsSingleTenantRDS(request.Database) {
+		request.SingleTenantDatabaseConfig.SetDefaults()
 	}
 }
 
@@ -102,7 +107,12 @@ func (request *CreateInstallationRequest) Validate() error {
 	if err != nil {
 		return errors.Wrap(err, "invalid env var settings")
 	}
-
+	if IsSingleTenantRDS(request.Database) {
+		err = request.SingleTenantDatabaseConfig.Validate()
+		if err != nil {
+			return errors.Wrap(err, "single tenant database config is invalid")
+		}
+	}
 	return checkSpaces(request)
 }
 

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -129,6 +129,30 @@ func TestCreateInstallationRequestValid(t *testing.T) {
 			},
 		},
 		{
+			"invalid single tenant db replicas",
+			true,
+			&model.CreateInstallationRequest{
+				OwnerID:  "owner1",
+				DNS:      "domain4321.com",
+				Database: model.InstallationDatabaseSingleTenantRDSPostgres,
+				SingleTenantDatabaseConfig: model.SingleTenantDatabaseRequest{
+					ReplicasCount: 33,
+				},
+			},
+		},
+		{
+			"ignore invalid replicas if db not single tenant",
+			false,
+			&model.CreateInstallationRequest{
+				OwnerID:  "owner1",
+				DNS:      "domain4321.com",
+				Database: model.InstallationDatabaseMultiTenantRDSPostgres,
+				SingleTenantDatabaseConfig: model.SingleTenantDatabaseRequest{
+					ReplicasCount: 33,
+				},
+			},
+		},
+		{
 			"dns has space",
 			true,
 			&model.CreateInstallationRequest{

--- a/model/single_tenant_database.go
+++ b/model/single_tenant_database.go
@@ -19,7 +19,7 @@ type SingleTenantDatabaseConfig struct {
 	ReplicasCount       int
 }
 
-// SingleTenantDatabaseConfig marshals database configuration to JSON if it is not nil.
+// ToJSON marshals database configuration to JSON if it is not nil.
 func (cfg *SingleTenantDatabaseConfig) ToJSON() ([]byte, error) {
 	if cfg == nil {
 		return nil, nil

--- a/model/single_tenant_database.go
+++ b/model/single_tenant_database.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"io"
+)
+
+// SingleTenantDatabaseConfig represents configuration for the database when used
+// in single tenant mode.
+type SingleTenantDatabaseConfig struct {
+	PrimaryInstanceType string
+	ReplicaInstanceType string
+	ReplicasCount       int
+}
+
+// SingleTenantDatabaseConfig marshals database configuration to JSON if it is not nil.
+func (cfg *SingleTenantDatabaseConfig) ToJSON() ([]byte, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	return json.Marshal(cfg)
+}
+
+// NewSingleTenantDatabaseConfigurationFromReader will create a SingleTenantDatabaseConfig
+// from an io.Reader with JSON data.
+func NewSingleTenantDatabaseConfigurationFromReader(reader io.Reader) (*SingleTenantDatabaseConfig, error) {
+	singleTenantDBConfig := SingleTenantDatabaseConfig{}
+	err := json.NewDecoder(reader).Decode(&singleTenantDBConfig)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode single tenant database configuration")
+	}
+
+	return &singleTenantDBConfig, nil
+}
+
+// SingleTenantDatabaseRequest represents requested configuration of single tenant database.
+type SingleTenantDatabaseRequest struct {
+	PrimaryInstanceType string
+	ReplicaInstanceType string
+	ReplicasCount       int
+}
+
+// NewSingleTenantDatabaseRequestFromReader will create a SingleTenantDatabaseRequest from an io.Reader with JSON data.
+func NewSingleTenantDatabaseRequestFromReader(reader io.Reader) (*SingleTenantDatabaseRequest, error) {
+	var singleTenantDBRequest SingleTenantDatabaseRequest
+	err := json.NewDecoder(reader).Decode(&singleTenantDBRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode single tenant database request")
+	}
+
+	singleTenantDBRequest.SetDefaults()
+	err = singleTenantDBRequest.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "single tenant database request failed validation")
+	}
+
+	return &singleTenantDBRequest, nil
+}
+
+// SetDefaults sets the default values for a single tenant database configuration request.
+func (request *SingleTenantDatabaseRequest) SetDefaults() {
+	if len(request.PrimaryInstanceType) == 0 {
+		request.PrimaryInstanceType = "db.r5.large"
+	}
+	if len(request.ReplicaInstanceType) == 0 {
+		request.ReplicaInstanceType = "db.r5.large"
+	}
+}
+
+// Validate validates the values of single tenant database configuration request.
+func (request *SingleTenantDatabaseRequest) Validate() error {
+	if request.ReplicasCount < 0 || request.ReplicasCount > 15 {
+		return fmt.Errorf("single tenant database replicas count must be between 0 and 15")
+	}
+
+	return nil
+}
+
+// ToDBConfig converts SingleTenantDatabaseRequest to SingleTenantDatabaseConfig
+// if database type is single tenant.
+func (request *SingleTenantDatabaseRequest) ToDBConfig(database string) *SingleTenantDatabaseConfig {
+	if !IsSingleTenantRDS(database) || request == nil {
+		return nil
+	}
+
+	return &SingleTenantDatabaseConfig{
+		PrimaryInstanceType: request.PrimaryInstanceType,
+		ReplicaInstanceType: request.ReplicaInstanceType,
+		ReplicasCount:       request.ReplicasCount,
+	}
+}

--- a/model/single_tenant_database_test.go
+++ b/model/single_tenant_database_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model_test
+
+import (
+	"bytes"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNewSingleTenantDatabaseConfigurationFromReader(t *testing.T) {
+	t.Run("empty data", func(t *testing.T) {
+		config, err := model.NewSingleTenantDatabaseConfigurationFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &model.SingleTenantDatabaseConfig{}, config)
+	})
+
+	t.Run("invalid data", func(t *testing.T) {
+		config, err := model.NewSingleTenantDatabaseConfigurationFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, config)
+	})
+
+	t.Run("valid data", func(t *testing.T) {
+		config, err := model.NewSingleTenantDatabaseConfigurationFromReader(bytes.NewReader([]byte(`{
+			"PrimaryInstanceType":"db.r5.xlarge",
+			"ReplicaInstanceType":"db.r5.large",
+			"ReplicasCount":3
+		}`)))
+		require.NoError(t, err)
+
+		expected := &model.SingleTenantDatabaseConfig{
+			PrimaryInstanceType: "db.r5.xlarge",
+			ReplicaInstanceType: "db.r5.large",
+			ReplicasCount:       3,
+		}
+		require.Equal(t, expected, config)
+	})
+}
+
+func TestNewSingleTenantDatabaseRequestFromReader(t *testing.T) {
+	t.Run("empty data", func(t *testing.T) {
+		request, err := model.NewSingleTenantDatabaseRequestFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+
+		expected := &model.SingleTenantDatabaseRequest{
+			PrimaryInstanceType: "db.r5.large",
+			ReplicaInstanceType: "db.r5.large",
+			ReplicasCount:       0,
+		}
+		require.Equal(t, expected, request)
+	})
+
+	t.Run("invalid data", func(t *testing.T) {
+		request, err := model.NewSingleTenantDatabaseRequestFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, request)
+	})
+
+	t.Run("valid data", func(t *testing.T) {
+		request, err := model.NewSingleTenantDatabaseRequestFromReader(bytes.NewReader([]byte(`{
+			"PrimaryInstanceType":"db.r5.xlarge",
+			"ReplicaInstanceType":"db.r5.large",
+			"ReplicasCount":3
+		}`)))
+		require.NoError(t, err)
+
+		expected := &model.SingleTenantDatabaseRequest{
+			PrimaryInstanceType: "db.r5.xlarge",
+			ReplicaInstanceType: "db.r5.large",
+			ReplicasCount:       3,
+		}
+		expected.SetDefaults()
+		require.Equal(t, expected, request)
+	})
+}
+
+func TestValidateSingleTenantDatabaseRequest(t *testing.T) {
+	for _, testCase := range []struct {
+		description string
+		request     model.SingleTenantDatabaseRequest
+		valid       bool
+	}{
+		{
+			description: "valid request",
+			request:     model.SingleTenantDatabaseRequest{ReplicasCount: 2},
+			valid:       true,
+		},
+		{
+			description: "default request",
+			request:     model.SingleTenantDatabaseRequest{},
+			valid:       true,
+		},
+		{
+			description: "replicas < 0",
+			request:     model.SingleTenantDatabaseRequest{ReplicasCount: -1},
+			valid:       false,
+		},
+		{
+			description: "replicas > 15",
+			request:     model.SingleTenantDatabaseRequest{ReplicasCount: 16},
+			valid:       false,
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			err := testCase.request.Validate()
+			if testCase.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestToDBConfig(t *testing.T) {
+
+	for _, testCase := range []struct {
+		description    string
+		request        model.SingleTenantDatabaseRequest
+		database       string
+		expectedConfig *model.SingleTenantDatabaseConfig
+	}{
+		{
+			description:    "not single tenant RDS",
+			request:        model.SingleTenantDatabaseRequest{PrimaryInstanceType: "db.r5.xlarge"},
+			database:       model.InstallationDatabaseMultiTenantRDSPostgres,
+			expectedConfig: nil,
+		},
+		{
+			description: "single tenant RDS",
+			request: model.SingleTenantDatabaseRequest{
+				PrimaryInstanceType: "db.r5.xlarge",
+				ReplicaInstanceType: "db.r5.large",
+				ReplicasCount:       10,
+			},
+			database: model.InstallationDatabaseSingleTenantRDSPostgres,
+			expectedConfig: &model.SingleTenantDatabaseConfig{
+				PrimaryInstanceType: "db.r5.xlarge",
+				ReplicaInstanceType: "db.r5.large",
+				ReplicasCount:       10,
+			},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			config := testCase.request.ToDBConfig(testCase.database)
+			require.Equal(t, testCase.expectedConfig, config)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add an option to pass configuration for single-tenant RDS.
The configuration that can be provided:
- `PrimaryInstanceType` - AWS instance type for writer.
- `ReplicaInstanceType` - AWS instance type for reader replicas.
- `ReplicasCount` - The number of reader replicas.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-19774

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Support configuration of single-tenant RDS via Provisioner API
```
