### PR TITLE
collect only the original node metadata information

### DIFF
--- a/internal/tools/kops/instance_groups.go
+++ b/internal/tools/kops/instance_groups.go
@@ -74,6 +74,12 @@ func (c *Cmd) UpdateMetadata(metadata *model.KopsMetadata) error {
 
 			masterIGCount++
 		case "Node":
+			// TODO: temp fix while we dont support multiple igs
+			if ig.Metadata.Name == "nodes-utilities" {
+				c.logger.Debug("Skipping utility group")
+				continue
+			}
+
 			if AMI == "" {
 				AMI = ig.Spec.Image
 			} else if AMI != ig.Spec.Image {


### PR DESCRIPTION
#### Summary
Since now we have an external instance group that the provisioner does not know about it we need to get the node that the provisioner know to report the metadata for now

I'm seeing this in the test account

```
"ProvisionerMetadataKops": {
...
        "MasterInstanceType": "t3.large",
        "MasterCount": 3,
        "NodeInstanceType": "r5.xlarge",
        "NodeMinCount": 2,
        "NodeMaxCount": 2,
        "ChangeRequest": {
            "Version": "latest"
        },
        "Warnings": [
            "expected exactly 1 node instance group, but found 2"
        ]
    },
```

which when the provisioner update the metadata if push the last node group

this PR make a workaround to only report the node group the provisioner knows

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
collect only the original node metadata information
```
