### PR TITLE
add mattermost job check to allow to talk with bifrost

### DIFF
--- a/manifests/bifrost/bifrost.yaml
+++ b/manifests/bifrost/bifrost.yaml
@@ -84,3 +84,7 @@ spec:
         podSelector:
           matchLabels:
             app: mattermost
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            app: mattermost-update-check


### PR DESCRIPTION
#### Summary
Need to add the job as allowed to talk with bifrost 


#### Ticket Link
none

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
add mattermost job check to allow to talk with bifrost
```
