### PR TITLE
ctest upgrades and refactor

### DIFF
--- a/cmd/tools/ctest/logger.go
+++ b/cmd/tools/ctest/logger.go
@@ -24,3 +24,13 @@ func init() {
 func printSeparator() {
 	logger.Info("====================================================")
 }
+
+func printResults(results []string) {
+	printSeparator()
+	logger.Info("TEST RESULTS")
+	printSeparator()
+	for _, result := range results {
+		logger.Info(result)
+	}
+	printSeparator()
+}


### PR DESCRIPTION
This is a small cleanup of the ctest tool and includes:
 - Small refactor to reuse more code
 - Graceful webhook server startup and shutdown during test runs
 - Added missing license flag value to database tests
 - Print ping healthcheck response when it fails

Fixes https://mattermost.atlassian.net/browse/MM-30464

```release-note
ctest upgrades and refactor
```
