### PR TITLE
Change required Helm client version to 3.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following is required to properly run the cloud server.
 2. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) version v0.11.14
    1. Try using [tfswitch](https://warrensbox.github.io/terraform-switcher/) for switching easily between versions
 3. Install [kops](https://github.com/kubernetes/kops/blob/master/docs/install.md) version 1.17.X
-4. Install [Helm](https://helm.sh/docs/intro/install/) version 2.16.X as `helm` and version 3.3.X as `helm3` with [2to3 plugin](https://github.com/helm/helm-2to3#install)
+4. Install [Helm](https://helm.sh/docs/intro/install/) version 2.16.X as `helm` and version 3.4.X as `helm3` with [2to3 plugin](https://github.com/helm/helm-2to3#install)
 5. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 6. Install [golang/mock](https://github.com/golang/mock#installation) version 1.4.x
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
I discovered that Helm version 3.3.x fails during `provision` if the `stable` repository already exists on the client machine. This problem is caused by this issue: https://github.com/helm/helm/issues/8771

This shouldn't be an issue running Helm in pods in production, but it does affect dev. This bug was addressed prior to Helm 3.4 and I've updated my dev machine to use Helm 3.4 and I'm able to `provision` without an issue, so this PR just changes the version of Helm that we require as displayed in the README.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
No ticket

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
