### PR TITLE
MM-30529 Add ability to specify filestore, db type, and Installation size to load testing tool

### DIFF
--- a/cmd/tools/cloudburst/cloudburst.go
+++ b/cmd/tools/cloudburst/cloudburst.go
@@ -411,34 +411,17 @@ func (b *Blaster) createInstallation() (*cloud.Installation, error) {
 }
 
 func isValidInput(database, filestore, installSize string) error {
-	databaseCheck := func() error {
-		if !cloud.IsSupportedDatabase(database) {
-			return errors.Errorf("invalid database requested: unknown database type %s", database)
-		}
-		return nil
+	if !cloud.IsSupportedDatabase(database) {
+		return errors.Errorf("invalid database requested: unknown database type %s", database)
 	}
 
-	filestoreCheck := func() error {
-		if !cloud.IsSupportedFilestore(filestore) {
-			return errors.Errorf("invalid filestore requested: unknown filestore type %s", filestore)
-		}
-		return nil
+	if !cloud.IsSupportedFilestore(filestore) {
+		return errors.Errorf("invalid filestore requested: unknown filestore type %s", filestore)
 	}
 
-	installSizeCheck := func() error {
-		_, err := mmv1alpha1.GetClusterSize(installSize)
-		if err == nil {
-			return nil
-		}
+	_, err := mmv1alpha1.GetClusterSize(installSize)
+	if err != nil {
 		return errors.Wrapf(err, "%s", installSize)
-	}
-
-	validityChecks := []func() error{databaseCheck, filestoreCheck, installSizeCheck}
-	for _, check := range validityChecks {
-		err := check()
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/cmd/tools/cloudburst/cloudburst.go
+++ b/cmd/tools/cloudburst/cloudburst.go
@@ -412,32 +412,17 @@ func (b *Blaster) createInstallation() (*cloud.Installation, error) {
 
 func isValidInput(database, filestore, installSize string) error {
 	databaseCheck := func() error {
-		for _, validDB := range []string{
-			cloud.InstallationDatabaseMysqlOperator,
-			cloud.InstallationDatabaseSingleTenantRDSMySQL,
-			cloud.InstallationDatabaseSingleTenantRDSPostgres,
-			cloud.InstallationDatabaseMultiTenantRDSMySQL,
-			cloud.InstallationDatabaseMultiTenantRDSPostgres,
-		} {
-			if validDB == database {
-				return nil
-			}
+		if !cloud.IsSupportedDatabase(database) {
+			return errors.Errorf("invalid database requested: unknown database type %s", database)
 		}
-		return errors.Errorf("invalid database requested: unknown database type %s", database)
+		return nil
 	}
 
 	filestoreCheck := func() error {
-		for _, validFilestore := range []string{
-			cloud.InstallationFilestoreMinioOperator,
-			cloud.InstallationFilestoreAwsS3,
-			cloud.InstallationFilestoreMultiTenantAwsS3,
-			cloud.InstallationFilestoreBifrost,
-		} {
-			if validFilestore == filestore {
-				return nil
-			}
+		if !cloud.IsSupportedFilestore(filestore) {
+			return errors.Errorf("invalid filestore requested: unknown filestore type %s", filestore)
 		}
-		return errors.Errorf("invalid filestore requested: unknown filestore type %s", filestore)
+		return nil
 	}
 
 	installSizeCheck := func() error {

--- a/cmd/tools/cloudburst/cloudburst.go
+++ b/cmd/tools/cloudburst/cloudburst.go
@@ -57,6 +57,9 @@ func init() {
 	blastCommand.PersistentFlags().Int("runs", 1, "Number of times to repeat the test")
 	blastCommand.PersistentFlags().Int("batch", 5, "Specify the number of Installations in each batch. Installations in a batch are install serially and batches are installed in parallel.")
 	blastCommand.PersistentFlags().Int("total", 20, "Number of Installations to provision")
+	blastCommand.PersistentFlags().String("database", cloud.InstallationDatabaseMultiTenantRDSPostgres, "Specify the type of database with which to create Installations")
+	blastCommand.PersistentFlags().String("filestore", cloud.InstallationFilestoreMultiTenantAwsS3, "Specify the filestore type with which to create Installations")
+	blastCommand.PersistentFlags().String("size", mmv1alpha1.Size1000String, "Specify the size of the created Installations")
 }
 
 // Type returns ErrorReportType for errorReport objects
@@ -73,10 +76,13 @@ func (c *completedReport) Type() ReportType {
 // Blaster is aware of its own reports (errors and completed reports),
 // and contains internal state that pertains to the entire test run.
 type Blaster struct {
-	client  *cloud.Client
-	testID  string
-	group   *cloud.Group
-	reports []Report
+	client      *cloud.Client
+	testID      string
+	group       *cloud.Group
+	reports     []Report
+	database    string
+	filestore   string
+	installSize string
 }
 
 // NewBlaster creates a new Blaster with which to blast the
@@ -94,10 +100,17 @@ var blastCommand = &cobra.Command{
 		batchSize, _ := cmd.Flags().GetInt("batch")
 		total, _ := cmd.Flags().GetInt("total")
 		runs, _ := cmd.Flags().GetInt("runs")
+		database, _ := cmd.Flags().GetString("database")
+		filestore, _ := cmd.Flags().GetString("filestore")
+		installSize, _ := cmd.Flags().GetString("size")
 
 		logger.SetLevel(log.DebugLevel)
 		logger.Infof("Server address %s", serverAddress)
 		logger.WithField("server", serverAddress)
+		if err := isValidInput(database, filestore, installSize); err != nil {
+			return errors.Wrap(err, "failed user input validation")
+		}
+
 		blaster := NewBlaster(serverAddress)
 		err := blaster.createGroup()
 		if err != nil {
@@ -384,9 +397,9 @@ func (b *Blaster) createInstallation() (*cloud.Installation, error) {
 		&cloud.CreateInstallationRequest{
 			OwnerID:         b.testID,
 			GroupID:         b.group.ID,
-			Database:        cloud.InstallationDatabaseMultiTenantRDSPostgres,
-			Filestore:       cloud.InstallationFilestoreMultiTenantAwsS3,
-			Size:            mmv1alpha1.Size1000String,
+			Database:        b.database,
+			Filestore:       b.filestore,
+			Size:            b.installSize,
 			Affinity:        cloud.InstallationAffinityMultiTenant,
 			DNS:             fmt.Sprintf("%s-%s.loadtest.dev.cloud.mattermost.com", b.testID, cloud.NewID()[:6]),
 			APISecurityLock: false,
@@ -395,6 +408,55 @@ func (b *Blaster) createInstallation() (*cloud.Installation, error) {
 		return nil, errors.Wrap(err, "failed to create Installation")
 	}
 	return installationDTO.Installation, nil
+}
+
+func isValidInput(database, filestore, installSize string) error {
+	databaseCheck := func() error {
+		for _, validDB := range []string{
+			cloud.InstallationDatabaseMysqlOperator,
+			cloud.InstallationDatabaseSingleTenantRDSMySQL,
+			cloud.InstallationDatabaseSingleTenantRDSPostgres,
+			cloud.InstallationDatabaseMultiTenantRDSMySQL,
+			cloud.InstallationDatabaseMultiTenantRDSPostgres,
+		} {
+			if validDB == database {
+				return nil
+			}
+		}
+		return errors.Errorf("invalid database requested: unknown database type %s", database)
+	}
+
+	filestoreCheck := func() error {
+		for _, validFilestore := range []string{
+			cloud.InstallationFilestoreMinioOperator,
+			cloud.InstallationFilestoreAwsS3,
+			cloud.InstallationFilestoreMultiTenantAwsS3,
+			cloud.InstallationFilestoreBifrost,
+		} {
+			if validFilestore == filestore {
+				return nil
+			}
+		}
+		return errors.Errorf("invalid filestore requested: unknown filestore type %s", filestore)
+	}
+
+	installSizeCheck := func() error {
+		_, err := mmv1alpha1.GetClusterSize(installSize)
+		if err == nil {
+			return nil
+		}
+		return errors.Wrapf(err, "%s", installSize)
+	}
+
+	validityChecks := []func() error{databaseCheck, filestoreCheck, installSizeCheck}
+	for _, check := range validityChecks {
+		err := check()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func main() {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds the ability to specify the configuration of Installations created during a test run to the `cloudburst` load test tool, as requested in a comment from @gabrieljackson in PR #350 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-30529

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added ability to control Installation configuration to the load testing tool
```
