### PR TITLE
[MM-30618] Release Mattermost Operator v1.11.0.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.8.0
-	github.com/mattermost/mattermost-operator v1.10.0
+	github.com/mattermost/mattermost-operator v1.11.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pborman/uuid v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mattermost/blubr v0.0.0-20200113232543-f0ce67760aeb/go.mod h1:Tk99160Gy8m4rJPKIgYZrYneLepPCx5KPB3rp9+iK00=
-github.com/mattermost/mattermost-operator v1.10.0 h1:ZwRpf40rRNA+GMMgGNI3yC5xl5Wr74ZtYquxu46Tk9I=
-github.com/mattermost/mattermost-operator v1.10.0/go.mod h1:a6pSJI6bDaIfO65M/Hvuqg8kUNYQQYDHLayoT5XZx5o=
+github.com/mattermost/mattermost-operator v1.11.0 h1:LlKWU2UOSAUl3cR7zpH2Rb0s6a/jbb9HPyXcXrfjZHM=
+github.com/mattermost/mattermost-operator v1.11.0/go.mod h1:a6pSJI6bDaIfO65M/Hvuqg8kUNYQQYDHLayoT5XZx5o=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/manifests/operator-manifests/mattermost/operator.yaml
+++ b/manifests/operator-manifests/mattermost/operator.yaml
@@ -22,7 +22,7 @@ spec:
           value: "20"
         - name: REQUEUE_ON_LIMIT_DELAY
           value: 20s
-        image: mattermost/mattermost-operator:v1.10.0
+        image: mattermost/mattermost-operator:v1.11.0
         imagePullPolicy: IfNotPresent
         name: mattermost-operator
       serviceAccountName: mattermost-operator

--- a/manifests/operator-manifests/mattermost/role.yaml
+++ b/manifests/operator-manifests/mattermost/role.yaml
@@ -52,6 +52,7 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
+  - roles
   verbs:
   - get
   - create


### PR DESCRIPTION
#### Summary
- Release Mattermost Operator v1.11.0

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30618

#### Release Note

```release-note
- Release Mattermost Operator v1.11.0

```
