### PR TITLE
groups: add groups status endpoint

### DIFF
--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -66,6 +66,7 @@ func init() {
 	groupCmd.AddCommand(groupGetCmd)
 	groupCmd.AddCommand(groupListCmd)
 	groupCmd.AddCommand(groupGetStatusCmd)
+	groupCmd.AddCommand(groupGetGroupsStatusCmd)
 	groupCmd.AddCommand(groupJoinCmd)
 	groupCmd.AddCommand(groupLeaveCmd)
 }
@@ -332,6 +333,32 @@ var groupLeaveCmd = &cobra.Command{
 		err := client.LeaveGroup(installationID, request)
 		if err != nil {
 			return errors.Wrap(err, "failed to leave group")
+		}
+
+		return nil
+	},
+}
+
+var groupGetGroupsStatusCmd = &cobra.Command{
+	Use:   "statuses",
+	Short: "Get Status from all groups.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		groupStatus, err := client.GetGroupsStatus()
+		if err != nil {
+			return errors.Wrap(err, "failed to query group status")
+		}
+		if groupStatus == nil {
+			return nil
+		}
+
+		err = printJSON(groupStatus)
+		if err != nil {
+			return err
 		}
 
 		return nil

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -582,3 +582,127 @@ func TestGroupStatus(t *testing.T) {
 		require.Nil(t, err)
 	})
 }
+
+func TestGroupsStatus(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+	installationsCreated := 0
+
+	// helper function for creating installations
+	newInstallation := func(groupId *string, sequence *int64, state string) *model.Installation {
+		installationsCreated += 1 // Increment to generate unique DNS for each installation
+
+		createRequest := &model.CreateInstallationRequest{
+			OwnerID:  "owner",
+			Version:  "version",
+			DNS:      fmt.Sprintf("dns%d.example.com", installationsCreated),
+			Affinity: model.InstallationAffinityIsolated,
+		}
+		if groupId != nil {
+			createRequest.GroupID = *groupId
+		}
+
+		installation, err := client.CreateInstallation(createRequest)
+		require.NoError(t, err)
+
+		installation.State = state
+		installation.GroupSequence = sequence
+		err = sqlStore.UpdateInstallation(installation.Installation)
+		require.NoError(t, err)
+
+		return installation.Installation
+	}
+
+	group, err := client.CreateGroup(&model.CreateGroupRequest{
+		Name:        "group1",
+		Description: "description",
+		Version:     "version",
+		Image:       "sample/image",
+	})
+	require.NoError(t, err)
+
+	group2, err := client.CreateGroup(&model.CreateGroupRequest{
+		Name:        "group2",
+		Description: "description",
+		Version:     "version",
+		Image:       "sample/image",
+	})
+	require.NoError(t, err)
+
+	t.Run("empty groups", func(t *testing.T) {
+		expectedStatus := &[]model.GroupsStatus{
+			{
+				ID: group.ID,
+				Status: model.GroupStatus{
+					InstallationsTotal:          0,
+					InstallationsUpdated:        0,
+					InstallationsUnstable:       0,
+					InstallationsAwaitingUpdate: 0,
+				},
+			},
+			{
+				ID: group2.ID,
+				Status: model.GroupStatus{
+					InstallationsTotal:          0,
+					InstallationsUpdated:        0,
+					InstallationsUnstable:       0,
+					InstallationsAwaitingUpdate: 0,
+				},
+			},
+		}
+		groupsStatus, err := client.GetGroupsStatus()
+		require.NoError(t, err)
+		assert.Equal(t, expectedStatus, groupsStatus)
+	})
+
+	t.Run("count installations", func(t *testing.T) {
+		expectedStatus := &[]model.GroupsStatus{
+			{
+				ID: group.ID,
+				Status: model.GroupStatus{
+					InstallationsTotal:          6,
+					InstallationsUpdated:        2,
+					InstallationsUnstable:       3,
+					InstallationsAwaitingUpdate: 1,
+				},
+			},
+			{
+				ID: group2.ID,
+				Status: model.GroupStatus{
+					InstallationsTotal:          0,
+					InstallationsUpdated:        0,
+					InstallationsUnstable:       0,
+					InstallationsAwaitingUpdate: 0,
+				},
+			},
+		}
+		var differentSequence int64 = -1
+
+		// rolled out stable
+		newInstallation(&group.ID, &group.Sequence, model.InstallationStateStable)
+		newInstallation(&group.ID, &group.Sequence, model.InstallationStateStable)
+		// rolled out not stable
+		newInstallation(&group.ID, &group.Sequence, model.InstallationStateUpdateInProgress)
+		newInstallation(&group.ID, &group.Sequence, model.InstallationStateCreationDNS)
+		// not rolled out stable
+		newInstallation(&group.ID, &differentSequence, model.InstallationStateStable)
+		// not rolled out unstable
+		newInstallation(&group.ID, &differentSequence, model.InstallationStateUpdateInProgress)
+
+		groupsStatus, err := client.GetGroupsStatus()
+		require.NoError(t, err)
+		assert.Equal(t, expectedStatus, groupsStatus)
+	})
+
+}

--- a/model/client.go
+++ b/model/client.go
@@ -802,6 +802,26 @@ func (c *Client) GetGroupStatus(groupID string) (*GroupStatus, error) {
 	}
 }
 
+// GetGroupsStatus fetches the status for all groups.
+func (c *Client) GetGroupsStatus() (*[]GroupsStatus, error) {
+	resp, err := c.doGet(c.buildURL("/api/groups/status"))
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return GroupsStatusFromReader(resp.Body)
+
+	case http.StatusNotFound:
+		return nil, nil
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // JoinGroup joins an installation to the given group, leaving any existing group.
 func (c *Client) JoinGroup(groupID, installationID string) error {
 	resp, err := c.doPut(c.buildURL("/api/installation/%s/group/%s", installationID, groupID), nil)

--- a/model/group_status.go
+++ b/model/group_status.go
@@ -17,6 +17,12 @@ type GroupStatus struct {
 	InstallationsAwaitingUpdate int64
 }
 
+// GroupsStatus represents the status of a groups.
+type GroupsStatus struct {
+	ID     string
+	Status GroupStatus
+}
+
 // GroupStatusFromReader decodes a json-encoded group status from the given io.Reader.
 func GroupStatusFromReader(reader io.Reader) (*GroupStatus, error) {
 	groupStatus := GroupStatus{}
@@ -27,4 +33,16 @@ func GroupStatusFromReader(reader io.Reader) (*GroupStatus, error) {
 	}
 
 	return &groupStatus, nil
+}
+
+// GroupsStatusFromReader decodes a json-encoded groups status from the given io.Reader.
+func GroupsStatusFromReader(reader io.Reader) (*[]GroupsStatus, error) {
+	groupsStatus := []GroupsStatus{}
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&groupsStatus)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &groupsStatus, nil
 }


### PR DESCRIPTION
#### Summary
The SRE team was discussing and find a need to have a way to get all groups status information in one shot, instead of doing a call per each group.
This will help to automate the dashboards as well


This PR adds the new endpoint that retrieves the status of all groups.

will return for example

```
[
    {
        "ID": "y3zx4m6nd3dg7fi6h4g1mtqziy",
        "Status": {
            "InstallationsTotal": 0,
            "InstallationsUpdated": 0,
            "InstallationsUnstable": 0,
            "InstallationsAwaitingUpdate": 0
        }
    },
    {
        "ID": "1md4xj756iypidpqt57r91tiyy",
        "Status": {
            "InstallationsTotal": 0,
            "InstallationsUpdated": 0,
            "InstallationsUnstable": 0,
            "InstallationsAwaitingUpdate": 0
        }
    }
]
```

/cc @stafot @angeloskyratzakos 


#### Ticket Link
NONE

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
groups: add groups status endpoint
```
