### PR TITLE
split nginx deployments in two

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -35,12 +35,14 @@ func init() {
 	clusterCreateCmd.Flags().String("prometheus-operator-version", model.PrometheusOperatorDefaultVersion.Version(), "The version of Prometheus Operator to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("thanos-version", model.ThanosDefaultVersion.Version(), "The version of Thanos to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("fluentbit-version", model.FluentbitDefaultVersion.Version(), "The version of Fluentbit to provision. Use 'stable' to provision the latest stable version published upstream.")
-	clusterCreateCmd.Flags().String("nginx-version", model.NginxDefaultVersion.Version(), "The version of Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().String("nginx-version", model.NginxDefaultVersion.Version(), "The version of Nginx Internal to provision. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().String("nginx-internal-version", model.NginxIntenalDefaultVersion.Version(), "The version of Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("teleport-version", model.TeleportDefaultVersion.Version(), "The version of Teleport to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("prometheus-operator-values", model.PrometheusOperatorDefaultVersion.Values(), "The branch name of the desired chart value file's version for Prometheus Operator")
 	clusterCreateCmd.Flags().String("thanos-values", model.ThanosDefaultVersion.Values(), "The branch name of the desired chart value file's version for Thanos")
 	clusterCreateCmd.Flags().String("fluentbit-values", model.FluentbitDefaultVersion.Values(), "The branch name of the desired chart value file's version for Fluent-Bit")
 	clusterCreateCmd.Flags().String("nginx-values", model.NginxDefaultVersion.Values(), "The branch name of the desired chart value file's version for NGINX")
+	clusterCreateCmd.Flags().String("nginx-internal-values", model.NginxIntenalDefaultVersion.Values(), "The branch name of the desired chart value file's version for NGINX Internal")
 	clusterCreateCmd.Flags().String("teleport-values", model.TeleportDefaultVersion.Values(), "The branch name of the desired chart value file's version for Teleport")
 
 	clusterCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the cluster. Accepts multiple values, for example: '... --annotation abc --annotation def'")
@@ -56,6 +58,7 @@ func init() {
 	clusterProvisionCmd.Flags().String("thanos-values", "", "The branch name of the desired chart value file's version for Thanos")
 	clusterProvisionCmd.Flags().String("fluentbit-values", "", "The branch name of the desired chart value file's version for Fluent-Bit")
 	clusterProvisionCmd.Flags().String("nginx-values", "", "The branch name of the desired chart value file's version for NGINX")
+	clusterProvisionCmd.Flags().String("nginx-internal-values", "", "The branch name of the desired chart value file's version for NGINX Internal")
 	clusterProvisionCmd.Flags().String("teleport-values", "", "The branch name of the desired chart value file's version for Teleport")
 
 	clusterProvisionCmd.MarkFlagRequired("cluster")
@@ -529,12 +532,14 @@ func processUtilityFlags(command *cobra.Command) map[string]*model.HelmUtilityVe
 	thanosVersion, _ := command.Flags().GetString("thanos-version")
 	fluentbitVersion, _ := command.Flags().GetString("fluentbit-version")
 	nginxVersion, _ := command.Flags().GetString("nginx-version")
+	nginxInternalVersion, _ := command.Flags().GetString("nginx-internal-version")
 	teleportVersion, _ := command.Flags().GetString("teleport-version")
 
 	prometheusOperatorValues, _ := command.Flags().GetString("prometheus-operator-values")
 	thanosValues, _ := command.Flags().GetString("thanos-values")
 	fluentbitValues, _ := command.Flags().GetString("fluentbit-values")
 	nginxValues, _ := command.Flags().GetString("nginx-values")
+	nginxInternalValues, _ := command.Flags().GetString("nginx-internal-values")
 	teleportValues, _ := command.Flags().GetString("teleport-values")
 
 	utilityVersions := make(map[string]*model.HelmUtilityVersion)
@@ -553,6 +558,10 @@ func processUtilityFlags(command *cobra.Command) map[string]*model.HelmUtilityVe
 
 	if nginxVersion != "" && nginxValues != "" {
 		utilityVersions[model.NginxCanonicalName] = &model.HelmUtilityVersion{Chart: nginxVersion, ValuesPath: nginxValues}
+	}
+
+	if nginxInternalVersion != "" && nginxInternalValues != "" {
+		utilityVersions[model.NginxInternalCanonicalName] = &model.HelmUtilityVersion{Chart: nginxInternalVersion, ValuesPath: nginxInternalValues}
 	}
 
 	if teleportVersion != "" && teleportValues != "" {

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -36,13 +36,13 @@ func init() {
 	clusterCreateCmd.Flags().String("thanos-version", model.ThanosDefaultVersion.Version(), "The version of Thanos to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("fluentbit-version", model.FluentbitDefaultVersion.Version(), "The version of Fluentbit to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("nginx-version", model.NginxDefaultVersion.Version(), "The version of Nginx Internal to provision. Use 'stable' to provision the latest stable version published upstream.")
-	clusterCreateCmd.Flags().String("nginx-internal-version", model.NginxIntenalDefaultVersion.Version(), "The version of Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().String("nginx-internal-version", model.NginxInternalDefaultVersion.Version(), "The version of Nginx to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("teleport-version", model.TeleportDefaultVersion.Version(), "The version of Teleport to provision. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("prometheus-operator-values", model.PrometheusOperatorDefaultVersion.Values(), "The branch name of the desired chart value file's version for Prometheus Operator")
 	clusterCreateCmd.Flags().String("thanos-values", model.ThanosDefaultVersion.Values(), "The branch name of the desired chart value file's version for Thanos")
 	clusterCreateCmd.Flags().String("fluentbit-values", model.FluentbitDefaultVersion.Values(), "The branch name of the desired chart value file's version for Fluent-Bit")
 	clusterCreateCmd.Flags().String("nginx-values", model.NginxDefaultVersion.Values(), "The branch name of the desired chart value file's version for NGINX")
-	clusterCreateCmd.Flags().String("nginx-internal-values", model.NginxIntenalDefaultVersion.Values(), "The branch name of the desired chart value file's version for NGINX Internal")
+	clusterCreateCmd.Flags().String("nginx-internal-values", model.NginxInternalDefaultVersion.Values(), "The branch name of the desired chart value file's version for NGINX Internal")
 	clusterCreateCmd.Flags().String("teleport-values", model.TeleportDefaultVersion.Values(), "The branch name of the desired chart value file's version for Teleport")
 
 	clusterCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the cluster. Accepts multiple values, for example: '... --annotation abc --annotation def'")
@@ -52,6 +52,7 @@ func init() {
 	clusterProvisionCmd.Flags().String("thanos-version", "", "The version of the Thanos Helm chart")
 	clusterProvisionCmd.Flags().String("fluentbit-version", "", "The version of the Fluent-Bit Helm chart")
 	clusterProvisionCmd.Flags().String("nginx-version", "", "The version of the NGINX Helm chart")
+	clusterProvisionCmd.Flags().String("nginx-internal-version", "", "The version of the internal NGINX Helm chart")
 	clusterProvisionCmd.Flags().String("teleport-version", "", "The version of the Teleport Helm chart")
 
 	clusterProvisionCmd.Flags().String("prometheus-operator-values", "", "The branch name of the desired chart value file's version for Prometheus Operator")

--- a/helm-charts/nginx_internal_values.yaml
+++ b/helm-charts/nginx_internal_values.yaml
@@ -1,0 +1,63 @@
+## nginx configuration
+## Ref: https://github.com/kubernetes/ingress/blob/master/controllers/nginx/configuration.md
+##
+controller:
+  ingressClass: nginx-internal
+  publishService:
+    enabled: true
+  metrics:
+    enabled: true
+
+  service:
+    enabled: true
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+      service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+
+    enableHttp: true
+    enableHttps: true
+    targetPorts:
+      http: 80
+      https: special
+    type: LoadBalancer
+
+  containerPort:
+    http: 80
+    https: 443
+    special: 8000
+
+  config:
+    keep-alive: "3600"
+    proxy-max-temp-file-size: "0"
+    # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
+    ssl-redirect: "false"
+    force-ssl-redirect: "false"
+    # remove the version of nginx from the responses
+    server-tokens: "false"
+    server-snippet: |
+      listen 8000;
+      if ( $server_port = 80 ) {
+         return 308 https://$host$request_uri;
+      }
+
+  resources:
+   limits:
+     cpu: 1000m
+     memory: 500Mi
+   requests:
+     cpu: 500m
+     memory: 250Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 150
+    targetMemoryUtilizationPercentage: 150
+
+
+defaultBackend:
+  enabled: true
+  replicaCount: 1

--- a/helm-charts/nginx_internal_values.yaml
+++ b/helm-charts/nginx_internal_values.yaml
@@ -15,6 +15,7 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
       service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+    externalTrafficPolicy: Local
 
     enableHttp: true
     enableHttps: true

--- a/helm-charts/nginx_values.yaml
+++ b/helm-charts/nginx_values.yaml
@@ -3,34 +3,23 @@
 ##
 controller:
   ingressClass: nginx-controller
+  image:
+    pullPolicy: IfNotPresent
+  publishService:
+    enabled: true
+  metrics:
+    enabled: true
 
   service:
-    enabled: true
     annotations:
-      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
+      service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '3600'
 
-    internal:
-      enabled: true
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-        service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-        service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-      externalTrafficPolicy: Local
-
-    enableHttp: true
-    enableHttps: true
     targetPorts:
-      http: 80
-      https: special
+      https: http
     type: LoadBalancer
-
-  containerPort:
-    http: 80
-    https: 443
-    special: 8000
 
   extraVolumeMounts:
   ## Additional volumeMounts to the controller main container.
@@ -50,18 +39,16 @@ controller:
     http-snippet: |
       proxy_cache_path /cache/nginx levels=1:2 keys_zone=mattermost_test_cache:10m max_size=10g inactive=120m use_temp_path=off;
       proxy_cache_path /cache/mattermost levels=1:2 keys_zone=mattermost_cache:10m max_size=10g inactive=120m use_temp_path=off;
+    server-tokens: "false"
     keep-alive: "3600"
     proxy-max-temp-file-size: "0"
-    # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
-    ssl-redirect: "false"
+    use-proxy-protocol: "true"
+    real-ip-header: "proxy_protocol"
+    set-real-ip-from: "0.0.0.0/0"
+    proxy-read-timeout: "3600"
+    proxy-send-timeout: "3600"
+    use-forwarded-headers: "true"
     force-ssl-redirect: "false"
-    # remove the version of nginx from the responses
-    server-tokens: "false"
-    server-snippet: |
-      listen 8000;
-      if ( $server_port = 80 ) {
-         return 308 https://$host$request_uri;
-      }
 
   resources:
    limits:
@@ -77,8 +64,6 @@ controller:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 200
     targetMemoryUtilizationPercentage: 200
-  metrics:
-     enabled: true
 
 defaultBackend:
   enabled: true

--- a/helm-charts/prometheus_operator_values.yaml
+++ b/helm-charts/prometheus_operator_values.yaml
@@ -1502,7 +1502,7 @@ prometheus:
   ingress:
     enabled: true
     annotations:
-      kubernetes.io/ingress.class: nginx-controller
+      kubernetes.io/ingress.class: nginx-internal
     labels: {}
     ## Hostnames.
     ## Must be provided if Ingress is enabled.

--- a/helm-charts/thanos_values.yaml
+++ b/helm-charts/thanos_values.yaml
@@ -327,7 +327,7 @@ query:
     ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
     ##
     annotations:
-      kubernetes.io/ingress.class: nginx-controller
+      kubernetes.io/ingress.class: nginx-internal
 
     ## The list of additional hostnames to be covered with this ingress record.
     ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -27,9 +27,11 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			DesiredUtilityVersions: map[string]*model.HelmUtilityVersion{
 				"fluentbit":           {Chart: "2.8.7", ValuesPath: "helm-charts/fluent-bit_values.yaml"},
 				"nginx":               {Chart: "2.15.0", ValuesPath: "helm-charts/nginx_values.yaml"},
+				"nginx-internal":      {Chart: "2.15.0", ValuesPath: "helm-charts/nginx_internal_values.yaml"},
 				"prometheus-operator": {Chart: "9.4.4", ValuesPath: "helm-charts/prometheus_operator_values.yaml"},
 				"thanos":              {Chart: "3.2.2", ValuesPath: "helm-charts/thanos_values.yaml"},
-				"teleport":            {Chart: "0.3.0", ValuesPath: "helm-charts/teleport_values.yaml"}},
+				"teleport":            {Chart: "0.3.0", ValuesPath: "helm-charts/teleport_values.yaml"},
+			},
 		}
 	}
 
@@ -85,6 +87,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			DesiredUtilityVersions: map[string]*model.HelmUtilityVersion{
 				"fluentbit":           {Chart: "2.8.7", ValuesPath: "helm-charts/fluent-bit_values.yaml"},
 				"nginx":               {Chart: "2.15.0", ValuesPath: "helm-charts/nginx_values.yaml"},
+				"nginx-internal":      {Chart: "2.15.0", ValuesPath: "helm-charts/nginx_internal_values.yaml"},
 				"prometheus-operator": {Chart: "9.4.4", ValuesPath: "helm-charts/prometheus_operator_values.yaml"},
 				"thanos":              {Chart: "3.2.2", ValuesPath: "helm-charts/thanos_values.yaml"},
 				"teleport":            {Chart: "0.3.0", ValuesPath: "helm-charts/teleport_values.yaml"},

--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -100,6 +100,21 @@ func (mr *MockAWSMockRecorder) GetAndClaimVpcResources(clusterID, owner, logger 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAndClaimVpcResources", reflect.TypeOf((*MockAWS)(nil).GetAndClaimVpcResources), clusterID, owner, logger)
 }
 
+// GetVpcResources mocks base method
+func (m *MockAWS) GetVpcResources(clusterID string, logger logrus.FieldLogger) (aws.ClusterResources, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVpcResources", clusterID, logger)
+	ret0, _ := ret[0].(aws.ClusterResources)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVpcResources indicates an expected call of GetVpcResources
+func (mr *MockAWSMockRecorder) GetVpcResources(clusterID, logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVpcResources", reflect.TypeOf((*MockAWS)(nil).GetVpcResources), clusterID, logger)
+}
+
 // ReleaseVpc mocks base method
 func (m *MockAWS) ReleaseVpc(clusterID string, logger logrus.FieldLogger) error {
 	m.ctrl.T.Helper()

--- a/internal/provisioner/kops_utils.go
+++ b/internal/provisioner/kops_utils.go
@@ -103,7 +103,7 @@ func getPrivateLoadBalancerEndpoint(ctx context.Context, namespace string, logge
 			return "", err
 		}
 		for _, service := range services.Items {
-			if strings.HasSuffix(service.Name, "internal") || strings.HasSuffix(service.Name, "query") {
+			if service.Spec.Type == "LoadBalancer" || strings.HasSuffix(service.Name, "query") {
 				if service.Status.LoadBalancer.Ingress != nil {
 					endpoint := service.Status.LoadBalancer.Ingress[0].Hostname
 					if endpoint == "" {

--- a/internal/provisioner/nginx_internal.go
+++ b/internal/provisioner/nginx_internal.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type nginxInternal struct {
+	awsClient      aws.AWS
+	provisioner    *KopsProvisioner
+	kops           *kops.Cmd
+	logger         log.FieldLogger
+	cluster        *model.Cluster
+	actualVersion  *model.HelmUtilityVersion
+	desiredVersion *model.HelmUtilityVersion
+}
+
+func newNginxInternalHandle(version *model.HelmUtilityVersion, cluster *model.Cluster, provisioner *KopsProvisioner, awsClient aws.AWS, kops *kops.Cmd, logger log.FieldLogger) (*nginxInternal, error) {
+	if logger == nil {
+		return nil, errors.New("cannot instantiate NGINX INTERNAL handle with nil logger")
+	}
+
+	if cluster == nil {
+		return nil, errors.New("cannot create a connection to Nginx internal if the cluster provided is nil")
+	}
+
+	if provisioner == nil {
+		return nil, errors.New("cannot create a connection to Nginx internal if the provisioner provided is nil")
+	}
+
+	if awsClient == nil {
+		return nil, errors.New("cannot create a connection to Nginx internal if the awsClient provided is nil")
+	}
+
+	if kops == nil {
+		return nil, errors.New("cannot create a connection to Nginx internal if the Kops command provided is nil")
+	}
+
+	return &nginxInternal{
+		awsClient:      awsClient,
+		provisioner:    provisioner,
+		kops:           kops,
+		cluster:        cluster,
+		logger:         logger.WithField("cluster-utility", model.NginxCanonicalName),
+		desiredVersion: version,
+	}, nil
+}
+
+func (n *nginxInternal) updateVersion(h *helmDeployment) error {
+	actualVersion, err := h.Version()
+	if err != nil {
+		return err
+	}
+
+	n.actualVersion = actualVersion
+	return nil
+}
+
+func (n *nginxInternal) CreateOrUpgrade() error {
+	h, err := n.NewHelmDeployment()
+	if err != nil {
+		return errors.Wrap(err, "failed to generate nginx internal helm deployment")
+	}
+
+	err = h.Update()
+	if err != nil {
+		return err
+	}
+
+	err = n.updateVersion(h)
+	return err
+}
+
+func (n *nginxInternal) DesiredVersion() *model.HelmUtilityVersion {
+	return n.desiredVersion
+}
+
+func (n *nginxInternal) ActualVersion() *model.HelmUtilityVersion {
+	if n.actualVersion == nil {
+		return nil
+	}
+
+	return &model.HelmUtilityVersion{
+		Chart:      strings.TrimPrefix(n.actualVersion.Version(), "ingress-nginx-internal"),
+		ValuesPath: n.actualVersion.Values(),
+	}
+}
+
+func (n *nginxInternal) Destroy() error {
+	return nil
+}
+
+func (n *nginxInternal) ValuesPath() string {
+	if n.desiredVersion == nil {
+		return ""
+	}
+	return n.desiredVersion.Values()
+}
+
+func (n *nginxInternal) Migrate() error {
+	return nil
+}
+
+func (n *nginxInternal) NewHelmDeployment() (*helmDeployment, error) {
+
+	awsACMPrivateCert, err := n.awsClient.GetCertificateSummaryByTag(aws.DefaultInstallPrivateCertificatesTagKey, aws.DefaultInstallPrivateCertificatesTagValue, n.logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to retrive the AWS Private ACM")
+	}
+
+	return &helmDeployment{
+		chartDeploymentName: "nginx-internal",
+		chartName:           "ingress-nginx/ingress-nginx",
+		namespace:           "nginx-internal",
+		setArgument:         fmt.Sprintf("controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-ssl-cert=%s", *awsACMPrivateCert.CertificateArn),
+		desiredVersion:      n.desiredVersion,
+
+		cluster:         n.cluster,
+		kopsProvisioner: n.provisioner,
+		kops:            n.kops,
+		logger:          n.logger,
+	}, nil
+}
+
+func (n *nginxInternal) Name() string {
+	return model.NginxInternalCanonicalName
+}

--- a/internal/provisioner/prometheus_operator.go
+++ b/internal/provisioner/prometheus_operator.go
@@ -148,7 +148,7 @@ func (p *prometheusOperator) CreateOrUpgrade() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(180)*time.Second)
 	defer cancel()
 
-	endpoint, err := getPrivateLoadBalancerEndpoint(ctx, "nginx", logger.WithField("prometheus-action", "create"), p.kops.GetKubeConfigPath())
+	endpoint, err := getPrivateLoadBalancerEndpoint(ctx, "nginx-internal", logger.WithField("prometheus-action", "create"), p.kops.GetKubeConfigPath())
 	if err != nil {
 		return errors.Wrap(err, "couldn't get the load balancer endpoint (nginx) for Prometheus")
 	}

--- a/internal/provisioner/thanos.go
+++ b/internal/provisioner/thanos.go
@@ -113,7 +113,7 @@ func (t *thanos) CreateOrUpgrade() error {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(120)*time.Second)
 		defer cancel()
 
-		endpoint, err := getPrivateLoadBalancerEndpoint(ctx, "nginx", logger.WithField("thanos-action", "create"), t.kops.GetKubeConfigPath())
+		endpoint, err := getPrivateLoadBalancerEndpoint(ctx, "nginx-internal", logger.WithField("thanos-action", "create"), t.kops.GetKubeConfigPath())
 		if err != nil {
 			return errors.Wrap(err, "couldn't get the load balancer endpoint (nginx) for Thanos")
 		}

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -72,9 +72,16 @@ func newUtilityGroupHandle(kops *kops.Cmd, provisioner *KopsProvisioner, cluster
 
 	nginx, err := newNginxHandle(
 		cluster.DesiredUtilityVersion(model.NginxCanonicalName),
-		provisioner, awsClient, kops, logger)
+		cluster, provisioner, awsClient, kops, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get handle for NGINX")
+	}
+
+	nginxInternal, err := newNginxInternalHandle(
+		cluster.DesiredUtilityVersion(model.NginxInternalCanonicalName),
+		cluster, provisioner, awsClient, kops, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get handle for NGINX INTERNAL")
 	}
 
 	prometheusOperator, err := newPrometheusOperatorHandle(cluster, provisioner, awsClient, kops, logger)
@@ -104,7 +111,7 @@ func newUtilityGroupHandle(kops *kops.Cmd, provisioner *KopsProvisioner, cluster
 	// the order of utilities here matters; the utilities are deployed
 	// in order to resolve dependencies between them
 	return &utilityGroup{
-		utilities:   []Utility{nginx, prometheusOperator, thanos, fluentbit, teleport},
+		utilities:   []Utility{nginx, nginxInternal, prometheusOperator, thanos, fluentbit, teleport},
 		kops:        kops,
 		provisioner: provisioner,
 		cluster:     cluster,

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -255,6 +255,10 @@ func (a *mockAWS) GetAndClaimVpcResources(clusterID, owner string, logger log.Fi
 	return aws.ClusterResources{}, nil
 }
 
+func (a *mockAWS) GetVpcResources(clusterID string, logger log.FieldLogger) (aws.ClusterResources, error) {
+	return aws.ClusterResources{}, nil
+}
+
 func (a *mockAWS) ReleaseVpc(clusterID string, logger log.FieldLogger) error {
 	return nil
 }

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -49,6 +49,7 @@ type AWS interface {
 	GetCloudEnvironmentName() (string, error)
 
 	GetAndClaimVpcResources(clusterID, owner string, logger log.FieldLogger) (ClusterResources, error)
+	GetVpcResources(clusterID string, logger log.FieldLogger) (ClusterResources, error)
 	ReleaseVpc(clusterID string, logger log.FieldLogger) error
 	AttachPolicyToRole(roleName, policyName string, logger log.FieldLogger) error
 	DetachPolicyFromRole(roleName, policyName string, logger log.FieldLogger) error

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -69,7 +69,7 @@ func (request *CreateClusterRequest) SetDefaults() {
 		request.DesiredUtilityVersions[NginxCanonicalName] = NginxDefaultVersion
 	}
 	if _, ok := request.DesiredUtilityVersions[NginxInternalCanonicalName]; !ok {
-		request.DesiredUtilityVersions[NginxInternalCanonicalName] = NginxIntenalDefaultVersion
+		request.DesiredUtilityVersions[NginxInternalCanonicalName] = NginxInternalDefaultVersion
 	}
 	if _, ok := request.DesiredUtilityVersions[FluentbitCanonicalName]; !ok {
 		request.DesiredUtilityVersions[FluentbitCanonicalName] = FluentbitDefaultVersion

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -68,6 +68,9 @@ func (request *CreateClusterRequest) SetDefaults() {
 	if _, ok := request.DesiredUtilityVersions[NginxCanonicalName]; !ok {
 		request.DesiredUtilityVersions[NginxCanonicalName] = NginxDefaultVersion
 	}
+	if _, ok := request.DesiredUtilityVersions[NginxInternalCanonicalName]; !ok {
+		request.DesiredUtilityVersions[NginxInternalCanonicalName] = NginxIntenalDefaultVersion
+	}
 	if _, ok := request.DesiredUtilityVersions[FluentbitCanonicalName]; !ok {
 		request.DesiredUtilityVersions[FluentbitCanonicalName] = FluentbitDefaultVersion
 	}

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -19,6 +19,8 @@ const (
 	ThanosCanonicalName = "thanos"
 	// NginxCanonicalName is the canonical string representation of nginx
 	NginxCanonicalName = "nginx"
+	// NginxInternalCanonicalName is the canonical string representation of nginx internal
+	NginxInternalCanonicalName = "nginx-internal"
 	// FluentbitCanonicalName is the canonical string representation of fluentbit
 	FluentbitCanonicalName = "fluentbit"
 	// TeleportCanonicalName is the canonical string representation of teleport
@@ -32,6 +34,8 @@ var (
 	ThanosDefaultVersion = &HelmUtilityVersion{Chart: "3.2.2", ValuesPath: "helm-charts/thanos_values.yaml"}
 	// NginxDefaultVersion defines the default version for the Helm chart
 	NginxDefaultVersion = &HelmUtilityVersion{Chart: "2.15.0", ValuesPath: "helm-charts/nginx_values.yaml"}
+	// NginxIntenalDefaultVersion defines the default version for the Helm chart
+	NginxIntenalDefaultVersion = &HelmUtilityVersion{Chart: "2.15.0", ValuesPath: "helm-charts/nginx_internal_values.yaml"}
 	// FluentbitDefaultVersion defines the default version for the Helm chart
 	FluentbitDefaultVersion = &HelmUtilityVersion{Chart: "2.8.7", ValuesPath: "helm-charts/fluent-bit_values.yaml"}
 	// TeleportDefaultVersion defines the default version for the Helm chart
@@ -48,6 +52,7 @@ func (h *UtilityGroupVersions) UnmarshalJSON(bytes []byte) error {
 		PrometheusOperator *HelmUtilityVersion
 		Thanos             *HelmUtilityVersion
 		Nginx              *HelmUtilityVersion
+		NginxInternal      *HelmUtilityVersion
 		Fluentbit          *HelmUtilityVersion
 		Teleport           *HelmUtilityVersion
 	}
@@ -55,6 +60,7 @@ func (h *UtilityGroupVersions) UnmarshalJSON(bytes []byte) error {
 		PrometheusOperator string
 		Thanos             string
 		Nginx              string
+		NginxInternal      string
 		Fluentbit          string
 		Teleport           string
 	}
@@ -71,6 +77,7 @@ func (h *UtilityGroupVersions) UnmarshalJSON(bytes []byte) error {
 		h.PrometheusOperator = &HelmUtilityVersion{Chart: oldUtilGrpVers.PrometheusOperator}
 		h.Thanos = &HelmUtilityVersion{Chart: oldUtilGrpVers.Thanos}
 		h.Nginx = &HelmUtilityVersion{Chart: oldUtilGrpVers.Nginx}
+		h.NginxInternal = &HelmUtilityVersion{Chart: oldUtilGrpVers.NginxInternal}
 		h.Fluentbit = &HelmUtilityVersion{Chart: oldUtilGrpVers.Fluentbit}
 		h.Teleport = &HelmUtilityVersion{Chart: oldUtilGrpVers.Teleport}
 		return nil
@@ -79,6 +86,7 @@ func (h *UtilityGroupVersions) UnmarshalJSON(bytes []byte) error {
 	h.PrometheusOperator = utilGrpVers.PrometheusOperator
 	h.Thanos = utilGrpVers.Thanos
 	h.Nginx = utilGrpVers.Nginx
+	h.NginxInternal = utilGrpVers.NginxInternal
 	h.Fluentbit = utilGrpVers.Fluentbit
 	h.Teleport = utilGrpVers.Teleport
 	return nil
@@ -90,6 +98,7 @@ type UtilityGroupVersions struct {
 	PrometheusOperator *HelmUtilityVersion
 	Thanos             *HelmUtilityVersion
 	Nginx              *HelmUtilityVersion
+	NginxInternal      *HelmUtilityVersion
 	Fluentbit          *HelmUtilityVersion
 	Teleport           *HelmUtilityVersion
 }
@@ -205,6 +214,8 @@ func getUtilityVersion(versions UtilityGroupVersions, utility string) *HelmUtili
 		return versions.Thanos
 	case NginxCanonicalName:
 		return versions.Nginx
+	case NginxInternalCanonicalName:
+		return versions.NginxInternal
 	case FluentbitCanonicalName:
 		return versions.Fluentbit
 	case TeleportCanonicalName:
@@ -230,6 +241,8 @@ func setUtilityVersion(versions *UtilityGroupVersions, utility string, desiredVe
 		versions.Thanos = desiredVersion
 	case NginxCanonicalName:
 		versions.Nginx = desiredVersion
+	case NginxInternalCanonicalName:
+		versions.NginxInternal = desiredVersion
 	case FluentbitCanonicalName:
 		versions.Fluentbit = desiredVersion
 	case TeleportCanonicalName:

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -38,8 +38,8 @@ var (
 	ThanosDefaultVersion = &HelmUtilityVersion{Chart: "3.2.2", ValuesPath: "helm-charts/thanos_values.yaml"}
 	// NginxDefaultVersion defines the default version for the Helm chart
 	NginxDefaultVersion = &HelmUtilityVersion{Chart: "2.15.0", ValuesPath: "helm-charts/nginx_values.yaml"}
-	// NginxIntenalDefaultVersion defines the default version for the Helm chart
-	NginxIntenalDefaultVersion = &HelmUtilityVersion{Chart: "2.15.0", ValuesPath: "helm-charts/nginx_internal_values.yaml"}
+	// NginxInternalDefaultVersion defines the default version for the Helm chart
+	NginxInternalDefaultVersion = &HelmUtilityVersion{Chart: "2.15.0", ValuesPath: "helm-charts/nginx_internal_values.yaml"}
 	// FluentbitDefaultVersion defines the default version for the Helm chart
 	FluentbitDefaultVersion = &HelmUtilityVersion{Chart: "2.8.7", ValuesPath: "helm-charts/fluent-bit_values.yaml"}
 	// TeleportDefaultVersion defines the default version for the Helm chart
@@ -115,6 +115,7 @@ func (h *UtilityGroupVersions) AsMap() map[string]*HelmUtilityVersion {
 		PrometheusOperatorCanonicalName: h.PrometheusOperator,
 		ThanosCanonicalName:             h.Thanos,
 		NginxCanonicalName:              h.Nginx,
+		NginxInternalCanonicalName:      h.NginxInternal,
 		FluentbitCanonicalName:          h.Fluentbit,
 		TeleportCanonicalName:           h.Teleport,
 	}


### PR DESCRIPTION
#### Summary
Split Nginx on two deployments 
for the public one we need to have the real ips and other information and using the current solution we don't have those infos

This PR split nginx in two deployments


#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-29321

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
split nginx deployments in two deployments 
```
