### PR TITLE
Rename InstallationsUnstable to InstallationsUpdating in group status

### DIFF
--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -667,24 +667,22 @@ func TestGroupsStatus(t *testing.T) {
 	})
 
 	t.Run("count installations", func(t *testing.T) {
-		expectedStatus := &[]model.GroupsStatus{
-			{
-				ID: group.ID,
-				Status: model.GroupStatus{
-					InstallationsTotal:          6,
-					InstallationsUpdated:        2,
-					InstallationsUpdating:       3,
-					InstallationsAwaitingUpdate: 1,
-				},
+		expectedStatusGroup1 := &model.GroupsStatus{
+			ID: group.ID,
+			Status: model.GroupStatus{
+				InstallationsTotal:          6,
+				InstallationsUpdated:        2,
+				InstallationsUpdating:       3,
+				InstallationsAwaitingUpdate: 1,
 			},
-			{
-				ID: group2.ID,
-				Status: model.GroupStatus{
-					InstallationsTotal:          0,
-					InstallationsUpdated:        0,
-					InstallationsUpdating:       0,
-					InstallationsAwaitingUpdate: 0,
-				},
+		}
+		expectedStatusGroup2 := &model.GroupsStatus{
+			ID: group2.ID,
+			Status: model.GroupStatus{
+				InstallationsTotal:          0,
+				InstallationsUpdated:        0,
+				InstallationsUpdating:       0,
+				InstallationsAwaitingUpdate: 0,
 			},
 		}
 		var differentSequence int64 = -1
@@ -702,7 +700,15 @@ func TestGroupsStatus(t *testing.T) {
 
 		groupsStatus, err := client.GetGroupsStatus()
 		require.NoError(t, err)
-		assert.Equal(t, expectedStatus, groupsStatus)
+		require.NotNil(t, groupsStatus)
+		assert.Len(t, *groupsStatus, 2)
+		for _, gs := range *groupsStatus {
+			if gs.ID == group.ID {
+				assert.Equal(t, expectedStatusGroup1, &gs)
+			} else if gs.ID == group2.ID {
+				assert.Equal(t, expectedStatusGroup2, &gs)
+			}
+		}
 	})
 
 }

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -520,7 +520,7 @@ func TestGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          0,
 			InstallationsUpdated:        0,
-			InstallationsUnstable:       0,
+			InstallationsUpdating:       0,
 			InstallationsAwaitingUpdate: 0,
 		}
 		groupStatus, err := client.GetGroupStatus(group.ID)
@@ -532,7 +532,7 @@ func TestGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          0,
 			InstallationsUpdated:        0,
-			InstallationsUnstable:       0,
+			InstallationsUpdating:       0,
 			InstallationsAwaitingUpdate: 0,
 		}
 		ignoredGroup, err := client.CreateGroup(&model.CreateGroupRequest{
@@ -555,7 +555,7 @@ func TestGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          6,
 			InstallationsUpdated:        2,
-			InstallationsUnstable:       3,
+			InstallationsUpdating:       3,
 			InstallationsAwaitingUpdate: 1,
 		}
 		var differentSequence int64 = -1
@@ -647,7 +647,7 @@ func TestGroupsStatus(t *testing.T) {
 				Status: model.GroupStatus{
 					InstallationsTotal:          0,
 					InstallationsUpdated:        0,
-					InstallationsUnstable:       0,
+					InstallationsUpdating:       0,
 					InstallationsAwaitingUpdate: 0,
 				},
 			},
@@ -656,7 +656,7 @@ func TestGroupsStatus(t *testing.T) {
 				Status: model.GroupStatus{
 					InstallationsTotal:          0,
 					InstallationsUpdated:        0,
-					InstallationsUnstable:       0,
+					InstallationsUpdating:       0,
 					InstallationsAwaitingUpdate: 0,
 				},
 			},
@@ -673,7 +673,7 @@ func TestGroupsStatus(t *testing.T) {
 				Status: model.GroupStatus{
 					InstallationsTotal:          6,
 					InstallationsUpdated:        2,
-					InstallationsUnstable:       3,
+					InstallationsUpdating:       3,
 					InstallationsAwaitingUpdate: 1,
 				},
 			},
@@ -682,7 +682,7 @@ func TestGroupsStatus(t *testing.T) {
 				Status: model.GroupStatus{
 					InstallationsTotal:          0,
 					InstallationsUpdated:        0,
-					InstallationsUnstable:       0,
+					InstallationsUpdating:       0,
 					InstallationsAwaitingUpdate: 0,
 				},
 			},

--- a/internal/store/group.go
+++ b/internal/store/group.go
@@ -223,7 +223,7 @@ func (sqlStore *SQLStore) GetGroupStatus(groupID string) (*model.GroupStatus, er
 	return &model.GroupStatus{
 		InstallationsTotal:          totalCount,
 		InstallationsUpdated:        updatedCount,
-		InstallationsUnstable:       unstableCount,
+		InstallationsUpdating:       unstableCount,
 		InstallationsAwaitingUpdate: awaitingUpdateCount,
 	}, nil
 }

--- a/internal/store/group_test.go
+++ b/internal/store/group_test.go
@@ -616,7 +616,7 @@ func TestGetGroupStatus(t *testing.T) {
 		expectedStatus := &model.GroupStatus{
 			InstallationsTotal:          1,
 			InstallationsUpdated:        0,
-			InstallationsUnstable:       1,
+			InstallationsUpdating:       1,
 			InstallationsAwaitingUpdate: 0,
 		}
 		groupStatus, err := sqlStore.GetGroupStatus(group1.ID)
@@ -633,7 +633,7 @@ func TestGetGroupStatus(t *testing.T) {
 		expectedStatus = &model.GroupStatus{
 			InstallationsTotal:          1,
 			InstallationsUpdated:        0,
-			InstallationsUnstable:       0,
+			InstallationsUpdating:       0,
 			InstallationsAwaitingUpdate: 1,
 		}
 		groupStatus, err = sqlStore.GetGroupStatus(group1.ID)

--- a/model/group_status.go
+++ b/model/group_status.go
@@ -13,7 +13,7 @@ import (
 type GroupStatus struct {
 	InstallationsTotal          int64
 	InstallationsUpdated        int64
-	InstallationsUnstable       int64
+	InstallationsUpdating       int64
 	InstallationsAwaitingUpdate int64
 }
 

--- a/model/group_status_test.go
+++ b/model/group_status_test.go
@@ -32,14 +32,14 @@ func TestGroupStatusFromReader(t *testing.T) {
 		groupStatus, err := GroupStatusFromReader(bytes.NewReader([]byte(`{
 			"InstallationsTotal": 4,
 			"InstallationsUpdated": 2,
-			"InstallationsUnstable": 1,
+			"InstallationsUpdating": 1,
 			"InstallationsAwaitingUpdate": 1
 		}`)))
 		require.NoError(t, err)
 		require.Equal(t, &GroupStatus{
 			InstallationsTotal:          4,
 			InstallationsUpdated:        2,
-			InstallationsUnstable:       1,
+			InstallationsUpdating:       1,
 			InstallationsAwaitingUpdate: 1,
 		}, groupStatus)
 	})


### PR DESCRIPTION
#### Summary
Not sure if this was bothering anyone else but it always scared me to see `InstallationsUnstable` as the name for installations that are reconciling. Updated it to `InstallationsUpdating` to be less scary and to match the other nomenclature.

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Rename "InstallationsUnstable" to "InstallationsUpdating" in group status
```
