### PR TITLE
Installation group improvements

### DIFF
--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -50,7 +50,7 @@ type Store interface {
 	CreateGroup(group *model.Group) error
 	GetGroup(groupID string) (*model.Group, error)
 	GetGroups(filter *model.GroupFilter) ([]*model.Group, error)
-	UpdateGroup(group *model.Group) error
+	UpdateGroup(group *model.Group, forceSequenceUpdate bool) error
 	LockGroup(groupID, lockerID string) (bool, error)
 	UnlockGroup(groupID, lockerID string, force bool) (bool, error)
 	LockGroupAPI(groupID string) error

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -141,7 +141,7 @@ func handleUpdateGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if patchGroupRequest.Apply(group) {
-		err := c.Store.UpdateGroup(group)
+		err := c.Store.UpdateGroup(group, patchGroupRequest.ForceSequenceUpdate)
 		if err != nil {
 			c.Logger.WithError(err).Error("failed to update group")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/store/group_test.go
+++ b/internal/store/group_test.go
@@ -356,7 +356,7 @@ func TestGetUnlockedGroupsPendingWork(t *testing.T) {
 	require.Len(t, groups, 1)
 
 	group1.Version = "new-version"
-	err = sqlStore.UpdateGroup(group1)
+	err = sqlStore.UpdateGroup(group1, false)
 	require.NoError(t, err)
 
 	groups, err = sqlStore.GetUnlockedGroupsPendingWork()
@@ -499,7 +499,7 @@ func TestUpdateGroup(t *testing.T) {
 
 	oldSequence := group1.Sequence
 
-	err = sqlStore.UpdateGroup(group1)
+	err = sqlStore.UpdateGroup(group1, false)
 	require.NoError(t, err)
 	assert.Equal(t, oldSequence+1, group1.Sequence)
 
@@ -507,9 +507,25 @@ func TestUpdateGroup(t *testing.T) {
 	group1.Sequence = 9001
 	group1.Version = "version4"
 
-	err = sqlStore.UpdateGroup(group1)
+	err = sqlStore.UpdateGroup(group1, false)
 	require.NoError(t, err)
 	assert.Equal(t, oldSequence+1, group1.Sequence)
+
+	oldSequence = group1.Sequence
+	group1.Name = "name4"
+	err = sqlStore.UpdateGroup(group1, false)
+	require.NoError(t, err)
+	assert.Equal(t, oldSequence, group1.Sequence)
+
+	group1.Description = "description4"
+	err = sqlStore.UpdateGroup(group1, false)
+	require.NoError(t, err)
+	assert.Equal(t, oldSequence, group1.Sequence)
+
+	group1.MaxRolling = 9001
+	err = sqlStore.UpdateGroup(group1, false)
+	require.NoError(t, err)
+	assert.Equal(t, oldSequence, group1.Sequence)
 
 	actualGroup1, err := sqlStore.GetGroup(group1.ID)
 	require.NoError(t, err)

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -943,8 +943,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		err = sqlStore.CreateGroup(group)
 		require.NoError(t, err)
 		// Group Sequence always set to 0 when created so we need to update it.
-		group.Sequence = 2
-		err = sqlStore.UpdateGroup(group)
+		err = sqlStore.UpdateGroup(group, true)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1388,7 +1387,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		// Group Sequence always set to 0 when created so we need to update it
 		// by calling group update once.
 		oldSequence := group.Sequence
-		err = sqlStore.UpdateGroup(group)
+		err = sqlStore.UpdateGroup(group, true)
 		require.NoError(t, err)
 		require.NotEqual(t, oldSequence, group.Sequence)
 

--- a/model/group_request.go
+++ b/model/group_request.go
@@ -24,20 +24,13 @@ type CreateGroupRequest struct {
 	MattermostEnv   EnvVarMap
 }
 
-// SetDefaults sets the default values for a group create request.
-func (request *CreateGroupRequest) SetDefaults() {
-	if request.MaxRolling == 0 {
-		request.MaxRolling = 1
-	}
-}
-
 // Validate validates the values of a group create request.
 func (request *CreateGroupRequest) Validate() error {
 	if len(request.Name) == 0 {
 		return errors.New("must specify name")
 	}
-	if request.MaxRolling < 1 {
-		return errors.New("max rolling must be 1 or greater")
+	if request.MaxRolling < 0 {
+		return errors.New("max rolling must be 0 or greater")
 	}
 	err := request.MattermostEnv.Validate()
 	if err != nil {
@@ -55,7 +48,6 @@ func NewCreateGroupRequestFromReader(reader io.Reader) (*CreateGroupRequest, err
 		return nil, errors.Wrap(err, "failed to decode create group request")
 	}
 
-	createGroupRequest.SetDefaults()
 	err = createGroupRequest.Validate()
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid group create request")
@@ -121,8 +113,8 @@ func (p *PatchGroupRequest) Validate() error {
 	if p.Name != nil && len(*p.Name) == 0 {
 		return errors.New("provided name update value was blank")
 	}
-	if p.MaxRolling != nil && *p.MaxRolling < 1 {
-		return errors.New("max rolling must be 1 or greater")
+	if p.MaxRolling != nil && *p.MaxRolling < 0 {
+		return errors.New("max rolling must be 0 or greater")
 	}
 	// EnvVarMap validation is skipped as all configurations of this now imply
 	// a specific patch action should be taken.

--- a/model/group_request_test.go
+++ b/model/group_request_test.go
@@ -55,8 +55,6 @@ func TestCreateGroupRequestValid(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			tc.request.SetDefaults()
-
 			if tc.requireError {
 				assert.Error(t, tc.request.Validate())
 			} else {


### PR DESCRIPTION
This change contains two important changes to group behavior:
 - Setting group MaxRolling to 0 is now allowed and will pause
   the rollout of installations until it is raised again later.
 - Installations that are rolled out are now ordered randomly to
   assist in spreading changes across all clusters and backing
   services if they are shared.

Fixes https://mattermost.atlassian.net/browse/MM-30957 and https://mattermost.atlassian.net/browse/MM-30963 and https://mattermost.atlassian.net/browse/MM-30848

```release-note
 - Allow for pausing group rollout with MaxRolling=0
 - Randomize group rollout order
 - Don't roll group for group metadata-only changes
```
