### PR TITLE
Update Mattermost operator to v1.11.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.8.0
-	github.com/mattermost/mattermost-operator v1.11.0
+	github.com/mattermost/mattermost-operator v1.11.1
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pborman/uuid v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mattermost/blubr v0.0.0-20200113232543-f0ce67760aeb/go.mod h1:Tk99160Gy8m4rJPKIgYZrYneLepPCx5KPB3rp9+iK00=
-github.com/mattermost/mattermost-operator v1.11.0 h1:LlKWU2UOSAUl3cR7zpH2Rb0s6a/jbb9HPyXcXrfjZHM=
-github.com/mattermost/mattermost-operator v1.11.0/go.mod h1:a6pSJI6bDaIfO65M/Hvuqg8kUNYQQYDHLayoT5XZx5o=
+github.com/mattermost/mattermost-operator v1.11.1 h1:tnUlFyuNwODjd2UtkntmQM7MbRQxql0+/tGS2UIiTTU=
+github.com/mattermost/mattermost-operator v1.11.1/go.mod h1:a6pSJI6bDaIfO65M/Hvuqg8kUNYQQYDHLayoT5XZx5o=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/helm-charts/prometheus_operator_values.yaml
+++ b/helm-charts/prometheus_operator_values.yaml
@@ -2020,10 +2020,10 @@ prometheus:
         interval: 30s
         path: /metrics
         scheme: http
-  - name: thanos-querier
+  - name: thanos-query
     selector:
       matchLabels:
-        app.kubernetes.io/component: querier
+        app.kubernetes.io/component: query
     namespaceSelector:
       matchNames:
       - prometheus

--- a/helm-charts/thanos_values.yaml
+++ b/helm-charts/thanos_values.yaml
@@ -57,10 +57,10 @@ clusterDomain: cluster.local
 ##
 # existingServiceAccount: my-service-account
 
-## Thanos Querier parameters
+## Thanos Query parameters
 ##
-querier:
-  ## Set to true to enable Thanos Querier component
+query:
+  ## Set to true to enable Thanos Query component
   ##
   enabled: true
 
@@ -72,9 +72,9 @@ querier:
   ##
   serviceAccount:
     annotations: {}
-    ## Provide an existing service account for querier
+    ## Provide an existing service account for query
     ##
-    # existingServiceAccount: querier-service-account
+    # existingServiceAccount: query-service-account
 
   ## Labels to treat as a replica indicator along which data is deduplicated
   ##
@@ -92,26 +92,26 @@ querier:
     ## Evaluated as a template.
     sidecarsNamespace: "{{ .Release.Namespace }}"
 
-  ## Statically configure store APIs to connect with Thanos Querier
+  ## Statically configure store APIs to connect with Thanos Query
   ##
   stores: []
     # - prometheus-operated.prometheus-operator:10901
 
-  ## Querier Service Discovery Configuration
+  ## Query Service Discovery Configuration
   ## Specify content for servicediscovery.yml
   ##
   # sdConfig:
 
-  ## ConfigMap with Querier Service Discovery Configuration
-  ## NOTE: This will override querier.sdConfig
+  ## ConfigMap with Query Service Discovery Configuration
+  ## NOTE: This will override query.sdConfig
   ##
   # existingSDConfigmap:
 
-  ## Extra Flags to passed to Thanos Querier
+  ## Extra Flags to passed to Thanos Query
   ##
   extraFlags: []
 
-  ## Number of Thanos Querier replicas to deploy
+  ## Number of Thanos Query replicas to deploy
   ##
   replicaCount: 2
 
@@ -132,7 +132,7 @@ querier:
             - key: app.kubernetes.io/component
               operator: In
               values:
-              - querier
+              - query
           topologyKey: kubernetes.io/hostname
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -157,7 +157,7 @@ querier:
   ##
   nodeSelector: {}
 
-  ## Annotations for querier pods
+  ## Annotations for query pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
@@ -167,7 +167,7 @@ querier:
   ##
   # priorityClassName: ""
 
-  ## K8s Security Context for Thanos Querier pods
+  ## K8s Security Context for Thanos Query pods
   ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext:
@@ -175,7 +175,7 @@ querier:
     fsGroup: 1001
     runAsUser: 1001
 
-  ## Thanos Querier containers' resource requests and limits
+  ## Thanos Query containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
   resources:
@@ -190,7 +190,7 @@ querier:
       cpu: 50m
       memory: 128Mi
 
-  ## Thanos Querier pods' liveness and readiness probes. Evaluated as a template.
+  ## Thanos Query pods' liveness and readiness probes. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
   livenessProbe:
@@ -212,7 +212,7 @@ querier:
     # successThreshold: 1
     # failureThreshold: 6
 
-  ## Thanos Querier GRPC TLS parameters
+  ## Thanos Query GRPC TLS parameters
   ## to configure --grpc-server-tls-cert, --grpc-server-tls-key, --grpc-server-tls-client-ca, --grpc-client-tls-secure, --grpc-client-tls-cert, --grpc-client-tls-key, --grpc-client-tls-ca, --grpc-client-server-name
   ## ref: https://github.com/thanos-io/thanos/blob/master/docs/components/query.md#flags
   grpcTLS:
@@ -247,7 +247,7 @@ querier:
     # type: ClusterIP
     # type: ClusterIP
     type: LoadBalancer
-    ## Thanos Querier service clusterIP IP
+    ## Thanos Query service clusterIP IP
     ##
     # clusterIP: None
     ## HTTP Port
@@ -291,7 +291,7 @@ querier:
     targetCPU: 50
     targetMemory: 50
 
-  ## Querier Pod Disruption Budget configuration
+  ## Query Pod Disruption Budget configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   pdb:
@@ -303,7 +303,7 @@ querier:
     ##
     # maxUnavailable: 1
 
-  ## Configure the ingress resource that allows you to access Thanos Querier
+  ## Configure the ingress resource that allows you to access Thanos Query
   ## ref: http://kubernetes.io/docs/user-guide/ingress/
   ##
   ingress:

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -28,7 +28,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"fluentbit":           {Chart: "2.8.7", ValuesPath: "helm-charts/fluent-bit_values.yaml"},
 				"nginx":               {Chart: "2.15.0", ValuesPath: "helm-charts/nginx_values.yaml"},
 				"prometheus-operator": {Chart: "9.4.4", ValuesPath: "helm-charts/prometheus_operator_values.yaml"},
-				"thanos":              {Chart: "2.4.3", ValuesPath: "helm-charts/thanos_values.yaml"},
+				"thanos":              {Chart: "3.2.2", ValuesPath: "helm-charts/thanos_values.yaml"},
 				"teleport":            {Chart: "0.3.0", ValuesPath: "helm-charts/teleport_values.yaml"}},
 		}
 	}
@@ -86,7 +86,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"fluentbit":           {Chart: "2.8.7", ValuesPath: "helm-charts/fluent-bit_values.yaml"},
 				"nginx":               {Chart: "2.15.0", ValuesPath: "helm-charts/nginx_values.yaml"},
 				"prometheus-operator": {Chart: "9.4.4", ValuesPath: "helm-charts/prometheus_operator_values.yaml"},
-				"thanos":              {Chart: "2.4.3", ValuesPath: "helm-charts/thanos_values.yaml"},
+				"thanos":              {Chart: "3.2.2", ValuesPath: "helm-charts/thanos_values.yaml"},
 				"teleport":            {Chart: "0.3.0", ValuesPath: "helm-charts/teleport_values.yaml"},
 			},
 		}, clusterRequest)

--- a/internal/provisioner/kops_utils.go
+++ b/internal/provisioner/kops_utils.go
@@ -103,7 +103,7 @@ func getPrivateLoadBalancerEndpoint(ctx context.Context, namespace string, logge
 			return "", err
 		}
 		for _, service := range services.Items {
-			if strings.HasSuffix(service.Name, "internal") || strings.HasSuffix(service.Name, "querier") {
+			if strings.HasSuffix(service.Name, "internal") || strings.HasSuffix(service.Name, "query") {
 				if service.Status.LoadBalancer.Ingress != nil {
 					endpoint := service.Status.LoadBalancer.Ingress[0].Hostname
 					if endpoint == "" {

--- a/internal/provisioner/thanos.go
+++ b/internal/provisioner/thanos.go
@@ -178,7 +178,7 @@ func (t *thanos) Migrate() error {
 }
 
 func (t *thanos) NewHelmDeployment(thanosDNS, thanosDNSGRPC string) *helmDeployment {
-	helmValueArguments := fmt.Sprintf("querier.ingress.hostname=%s,querier.ingress.grpc.hostname=%s,querier.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", thanosDNS, thanosDNSGRPC, strings.Join(t.provisioner.allowCIDRRangeList, "\\,"))
+	helmValueArguments := fmt.Sprintf("query.ingress.hostname=%s,query.ingress.grpc.hostname=%s,query.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", thanosDNS, thanosDNSGRPC, strings.Join(t.provisioner.allowCIDRRangeList, "\\,"))
 
 	return &helmDeployment{
 		chartDeploymentName: "thanos",

--- a/manifests/operator-manifests/mattermost/operator.yaml
+++ b/manifests/operator-manifests/mattermost/operator.yaml
@@ -22,7 +22,7 @@ spec:
           value: "20"
         - name: REQUEUE_ON_LIMIT_DELAY
           value: 20s
-        image: mattermost/mattermost-operator:v1.11.0
+        image: mattermost/mattermost-operator:v1.11.1
         imagePullPolicy: IfNotPresent
         name: mattermost-operator
       serviceAccountName: mattermost-operator

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -29,7 +29,7 @@ var (
 	// PrometheusOperatorDefaultVersion defines the default version for the Helm chart
 	PrometheusOperatorDefaultVersion = &HelmUtilityVersion{Chart: "9.4.4", ValuesPath: "helm-charts/prometheus_operator_values.yaml"}
 	// ThanosDefaultVersion defines the default version for the Helm chart
-	ThanosDefaultVersion = &HelmUtilityVersion{Chart: "2.4.3", ValuesPath: "helm-charts/thanos_values.yaml"}
+	ThanosDefaultVersion = &HelmUtilityVersion{Chart: "3.2.2", ValuesPath: "helm-charts/thanos_values.yaml"}
 	// NginxDefaultVersion defines the default version for the Helm chart
 	NginxDefaultVersion = &HelmUtilityVersion{Chart: "2.15.0", ValuesPath: "helm-charts/nginx_values.yaml"}
 	// FluentbitDefaultVersion defines the default version for the Helm chart


### PR DESCRIPTION
#### Summary
- Update Mattermost operator to v1.11.1
- Update Thanos to 3.2.2 version
- Rename Thanos querier to Thanos query

#### Release Note
```release-note
- Update Mattermost operator to v1.11.1
- Update Thanos to 3.2.2 version
- Rename Thanos querier to Thanos query
```
