### PR TITLE
MM-31043 Allow utility values to be fetched from authenticated sources

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/supervisor"
 	toolsAWS "github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/internal/tools/helm"
 	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
@@ -47,6 +48,7 @@ func init() {
 	serverCmd.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
 	serverCmd.PersistentFlags().StringSlice("allow-list-cidr-range", []string{"0.0.0.0/0"}, "The list of CIDRs to allow communication with the private ingress.")
 	serverCmd.PersistentFlags().Bool("debug", false, "Whether to output debug logs.")
+	serverCmd.PersistentFlags().Bool("debug-helm", false, "Whether to include Helm output in debug logs.")
 	serverCmd.PersistentFlags().Bool("machine-readable-logs", false, "Output the logs in machine readable format.")
 	serverCmd.PersistentFlags().Bool("dev", false, "Set sane defaults for development")
 
@@ -80,6 +82,9 @@ var serverCmd = &cobra.Command{
 		if debugMode {
 			logger.SetLevel(logrus.DebugLevel)
 		}
+
+		debugHelm, _ := command.Flags().GetBool("debug-helm")
+		helm.SetVerboseHelmLogging(debugHelm)
 
 		machineLogs, _ := command.Flags().GetBool("machine-readable-logs")
 		if machineLogs {

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -67,6 +67,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("keep-database-data", true, "Whether to preserve database data after installation deletion or not.")
 	serverCmd.PersistentFlags().Bool("keep-filestore-data", true, "Whether to preserve filestore data after installation deletion or not.")
 	serverCmd.PersistentFlags().Bool("require-annotated-installations", false, "Require new installations to have at least one annotation.")
+	serverCmd.PersistentFlags().String("gitlab-oauth", "", "If Helm charts are stored in a Gitlab instance that requires authentication, provide the token here and it will be automatically set in the environment.")
 }
 
 var serverCmd = &cobra.Command{
@@ -85,6 +86,11 @@ var serverCmd = &cobra.Command{
 
 		debugHelm, _ := command.Flags().GetBool("debug-helm")
 		helm.SetVerboseHelmLogging(debugHelm)
+
+		gitlabOAuthToken, _ := command.Flags().GetString("gitlab-oauth")
+		if gitlabOAuthToken != "" {
+			os.Setenv(model.GitlabOAuthTokenKey, gitlabOAuthToken)
+		}
 
 		machineLogs, _ := command.Flags().GetBool("machine-readable-logs")
 		if machineLogs {

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -120,10 +120,13 @@ func helmRepoUpdate(logger log.FieldLogger) error {
 
 // upgradeHelmChart is used to upgrade Helm deployments.
 func upgradeHelmChart(chart helmDeployment, configPath string, logger log.FieldLogger) error {
-	if chart.desiredVersion.Version() == "" {
+	if chart.desiredVersion == nil || chart.desiredVersion.Version() == "" {
 		currentVersion, err := chart.Version()
 		if err != nil {
 			return errors.Wrap(err, "failed to determine current chart version and no desired target version specified")
+		}
+		if currentVersion.Values() == "" {
+			return errors.New("path to values file must not be empty")
 		}
 		chart.desiredVersion = currentVersion
 	}

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -290,9 +290,9 @@ func applyGitlabTokenIfPresent(original string) string {
 	// gitlab token is set, so apply it to GitLab values path URLs
 	valPathURL, err := url.Parse(original)
 	if err == nil && strings.HasPrefix(valPathURL.Host, "gitlab") {
-		original = os.ExpandEnv(fmt.Sprintf("%s&private_token=$%s",
+		original = fmt.Sprintf("%s&private_token=$%s",
 			original,
-			model.GitlabOAuthTokenKey))
+			model.GitlabOAuthTokenKey)
 	}
 	return original
 }

--- a/internal/tools/exechelper/run.go
+++ b/internal/tools/exechelper/run.go
@@ -12,6 +12,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"os"
 	"os/exec"
 	"sync"
 
@@ -53,6 +54,12 @@ func Run(cmd *exec.Cmd, logger log.FieldLogger, outputLogger OutputLogger) ([]by
 		"cmd":  cmd.Path,
 		"args": cmd.Args,
 	}).Info("Invoking command")
+
+	expandedArgs := []string{}
+	for _, arg := range cmd.Args {
+		expandedArgs = append(expandedArgs, os.ExpandEnv(arg))
+	}
+	cmd.Args = expandedArgs
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/internal/tools/exechelper/run.go
+++ b/internal/tools/exechelper/run.go
@@ -24,6 +24,27 @@ import (
 // OutputLogger allows custom logging of the run command output.
 type OutputLogger func(line string, logger log.FieldLogger)
 
+// RunWithEnv applies environment variables in the command arguments list and
+// then invokes cmd.Run, both logging and returning STDOUT and STDERR,
+// optionally transforming the output first.
+func RunWithEnv(cmd *exec.Cmd, logger log.FieldLogger, outputLogger OutputLogger) ([]byte, []byte, error) {
+	logger = setupLogger(logger, cmd)
+
+	expandedArgs := []string{}
+	for _, arg := range cmd.Args {
+		expandedArgs = append(expandedArgs, os.ExpandEnv(arg))
+	}
+	cmd.Args = expandedArgs
+
+	return run(cmd, logger, outputLogger)
+}
+
+// Run invokes cmd.Run, both logging and returning STDOUT and STDERR, optionally transforming the output first.
+func Run(cmd *exec.Cmd, logger log.FieldLogger, outputLogger OutputLogger) ([]byte, []byte, error) {
+	logger = setupLogger(logger, cmd)
+	return run(cmd, logger, outputLogger)
+}
+
 func bufferAndLog(reader io.Reader, buffer *bytes.Buffer, logger log.FieldLogger, outputLogger OutputLogger) error {
 	scanner := bufio.NewScanner(io.TeeReader(reader, buffer))
 	for scanner.Scan() {
@@ -41,26 +62,7 @@ func bufferAndLog(reader io.Reader, buffer *bytes.Buffer, logger log.FieldLogger
 	return nil
 }
 
-// Run invokes cmd.Run, both logging and returning STDOUT and STDERR, optionally transforming the output first.
-func Run(cmd *exec.Cmd, logger log.FieldLogger, outputLogger OutputLogger) ([]byte, []byte, error) {
-	// Generate a unique identifier for the command invocation by which to group logs.
-	runID := model.NewID()
-
-	logger = logger.WithFields(log.Fields{
-		"run": runID,
-	})
-
-	logger.WithFields(log.Fields{
-		"cmd":  cmd.Path,
-		"args": cmd.Args,
-	}).Info("Invoking command")
-
-	expandedArgs := []string{}
-	for _, arg := range cmd.Args {
-		expandedArgs = append(expandedArgs, os.ExpandEnv(arg))
-	}
-	cmd.Args = expandedArgs
-
+func run(cmd *exec.Cmd, logger log.FieldLogger, outputLogger OutputLogger) ([]byte, []byte, error) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	rStdout, wStdout := io.Pipe()
@@ -105,4 +107,20 @@ func Run(cmd *exec.Cmd, logger log.FieldLogger, outputLogger OutputLogger) ([]by
 	}
 
 	return stdout.Bytes(), stderr.Bytes(), nil
+}
+
+func setupLogger(logger log.FieldLogger, cmd *exec.Cmd) log.FieldLogger {
+	// Generate a unique identifier for the command invocation by which to group logs.
+	runID := model.NewID()
+
+	logger = logger.WithFields(log.Fields{
+		"run": runID,
+	})
+
+	logger.WithFields(log.Fields{
+		"cmd":  cmd.Path,
+		"args": cmd.Args,
+	}).Info("Invoking command")
+
+	return logger
 }

--- a/internal/tools/helm/run.go
+++ b/internal/tools/helm/run.go
@@ -32,14 +32,14 @@ func outputLogger(line string, logger log.FieldLogger) {
 	if len(line) == 0 {
 		return
 	}
-
-	if os.Getenv("MM_CLOUD_VERBOSE_HELM_OUTPUT") != "" {
-		logger.Debugf("[helm] %s", line)
-	}
+	logger.Debugf("[helm] %s", line)
 }
 
 func (c *Cmd) run(arg ...string) ([]byte, []byte, error) {
 	cmd := exec.Command(c.helmPath, arg...)
 
-	return exechelper.Run(cmd, c.logger, outputLogger)
+	if os.Getenv("MM_CLOUD_VERBOSE_HELM_OUTPUT") != "" {
+		return exechelper.Run(cmd, c.logger, outputLogger)
+	}
+	return exechelper.Run(cmd, c.logger, func(line string, logger log.FieldLogger) {})
 }

--- a/internal/tools/helm/run.go
+++ b/internal/tools/helm/run.go
@@ -39,7 +39,7 @@ func (c *Cmd) run(arg ...string) ([]byte, []byte, error) {
 	cmd := exec.Command(c.helmPath, arg...)
 
 	if os.Getenv("MM_CLOUD_VERBOSE_HELM_OUTPUT") != "" {
-		return exechelper.Run(cmd, c.logger, outputLogger)
+		return exechelper.RunWithEnv(cmd, c.logger, outputLogger)
 	}
-	return exechelper.Run(cmd, c.logger, func(line string, logger log.FieldLogger) {})
+	return exechelper.RunWithEnv(cmd, c.logger, func(line string, logger log.FieldLogger) {})
 }

--- a/internal/tools/helm/run.go
+++ b/internal/tools/helm/run.go
@@ -5,6 +5,7 @@
 package helm
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 
@@ -12,13 +13,25 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const helmLoggingEnvironmentVariable string = "MM_CLOUD_VERBOSE_HELM_OUTPUT"
+
+func SetVerboseHelmLogging(enable bool) {
+	if enable {
+		os.Setenv(helmLoggingEnvironmentVariable, "true")
+	} else {
+		os.Setenv(helmLoggingEnvironmentVariable, "")
+	}
+}
+
 func outputLogger(line string, logger log.FieldLogger) {
 	line = strings.TrimSpace(line)
 	if len(line) == 0 {
 		return
 	}
 
-	logger.Debugf("[helm] %s", line)
+	if os.Getenv("MM_CLOUD_VERBOSE_HELM_OUTPUT") != "" {
+		logger.Debugf("[helm] %s", line)
+	}
 }
 
 func (c *Cmd) run(arg ...string) ([]byte, []byte, error) {

--- a/internal/tools/helm/run.go
+++ b/internal/tools/helm/run.go
@@ -15,6 +15,10 @@ import (
 
 const helmLoggingEnvironmentVariable string = "MM_CLOUD_VERBOSE_HELM_OUTPUT"
 
+// SetVerboseHelmLogging controls an environment variable which
+// signals whether or not the stdout output from Helm should be
+// included as DEBUG level logs or not. True turns them on, false
+// turns them off.
 func SetVerboseHelmLogging(enable bool) {
 	if enable {
 		os.Setenv(helmLoggingEnvironmentVariable, "true")

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -94,6 +94,16 @@ type UtilityGroupVersions struct {
 	Teleport           *HelmUtilityVersion
 }
 
+func (u UtilityGroupVersions) AsMap() map[string]*HelmUtilityVersion {
+	return map[string]*HelmUtilityVersion{
+		PrometheusOperatorCanonicalName: u.PrometheusOperator,
+		ThanosCanonicalName:             u.Thanos,
+		NginxCanonicalName:              u.Nginx,
+		FluentbitCanonicalName:          u.Fluentbit,
+		TeleportCanonicalName:           u.Teleport,
+	}
+}
+
 // UtilityMetadata is a container struct for any metadata related to
 // cluster utilities that needs to be persisted in the database
 type UtilityMetadata struct {
@@ -130,6 +140,7 @@ func (c *Cluster) SetUtilityActualVersion(utility string, version *HelmUtilityVe
 	}
 
 	setUtilityVersion(&metadata.ActualVersions, utility, version)
+	setUtilityVersion(&metadata.DesiredVersions, utility, nil)
 
 	c.UtilityMetadata = metadata
 	return nil
@@ -139,27 +150,24 @@ func (c *Cluster) SetUtilityActualVersion(utility string, version *HelmUtilityVe
 // any metadata related to the utility group and stores it as a []byte
 // in Cluster so that it can be inserted into the database
 func (c *Cluster) SetUtilityDesiredVersions(versions map[string]*HelmUtilityVersion) error {
-	// If a version is originally not provided, we want to install the
-	// "stable" version. However, if a version is specified, the user
-	// might later want to move the version back to tracking the stable
-	// release.
+	desiredVersions := make(map[string]*HelmUtilityVersion)
+	if c.UtilityMetadata == nil {
+		c.UtilityMetadata = new(UtilityMetadata)
+	}
+	// at create time there will be no actual versions and it's ok
+	// create will have defaults
+	for k, v := range c.UtilityMetadata.ActualVersions.AsMap() {
+		desiredVersions[k] = v
+	}
+
 	for utility, version := range versions {
-		if version == nil {
-			versions[utility] = nil
-		}
+		desiredVersions[utility] = version
 	}
 
-	metadata := &UtilityMetadata{}
-	if c.UtilityMetadata != nil {
-		metadata = c.UtilityMetadata
+	for utility, version := range desiredVersions {
+		setUtilityVersion(&c.UtilityMetadata.DesiredVersions, utility, version)
 	}
 
-	// assign new desired versions to the object
-	for utility, version := range versions {
-		setUtilityVersion(&metadata.DesiredVersions, utility, version)
-	}
-
-	c.UtilityMetadata = metadata
 	return nil
 }
 
@@ -219,10 +227,6 @@ func getUtilityVersion(versions UtilityGroupVersions, utility string) *HelmUtili
 // utilities with a version field in utilityVersion struct in the
 // first argument
 func setUtilityVersion(versions *UtilityGroupVersions, utility string, desiredVersion *HelmUtilityVersion) {
-	if desiredVersion == nil {
-		return
-	}
-
 	switch utility {
 	case PrometheusOperatorCanonicalName:
 		versions.PrometheusOperator = desiredVersion

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -98,13 +98,16 @@ type UtilityGroupVersions struct {
 	Teleport           *HelmUtilityVersion
 }
 
-func (u UtilityGroupVersions) AsMap() map[string]*HelmUtilityVersion {
+// AsMap returns the UtilityGroupVersion represented as a map with the
+// canonical names for each utility as the keys and the members of the
+// struct making up the values
+func (h *UtilityGroupVersions) AsMap() map[string]*HelmUtilityVersion {
 	return map[string]*HelmUtilityVersion{
-		PrometheusOperatorCanonicalName: u.PrometheusOperator,
-		ThanosCanonicalName:             u.Thanos,
-		NginxCanonicalName:              u.Nginx,
-		FluentbitCanonicalName:          u.Fluentbit,
-		TeleportCanonicalName:           u.Teleport,
+		PrometheusOperatorCanonicalName: h.PrometheusOperator,
+		ThanosCanonicalName:             h.Thanos,
+		NginxCanonicalName:              h.Nginx,
+		FluentbitCanonicalName:          h.Fluentbit,
+		TeleportCanonicalName:           h.Teleport,
 	}
 }
 

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -23,6 +23,10 @@ const (
 	FluentbitCanonicalName = "fluentbit"
 	// TeleportCanonicalName is the canonical string representation of teleport
 	TeleportCanonicalName = "teleport"
+	// GitlabOAuthTokenKey is the name of the Environment Variable which
+	// may contain an OAuth token for accessing GitLab repositories over
+	// HTTPS, used for fetching values files
+	GitlabOAuthTokenKey = "GITLAB_OAUTH_TOKEN"
 )
 
 var (


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR contains 3 changes (and my apologies for a single PR that does several things):

1) Allows the SRE or developer to specify the environment variable `GITLAB_OAUTH_TOKEN` and set that token to an access token generated in the GitLab UI. When the Provisioner detects that a values path is in Gitlab and the OAuth token is present, it will add it on to the end of the URL in order to authenticate with GitLab to fetch the file.

2) Allows the Provisioner to set the `DesiredVersion` struct values to `null` when provisioning is completed. This is the first step towards renaming `ActualVersion` to `Version` and changing `DesiredVersion` to be renamed to `UtilityGroupChangeRequest` (per our discussion @gabrieljackson )

3) Introduces a command line flag and env variable to control Helm debug logging so that it can be toggled on and off at startup or during runtime.

Example of a `stable` cluster object after this change:
```json
    {
        "ID": "s3g97j84w3dqmbk4izifw6g4ma",
        "State": "stable",
        "Provider": "aws",
        "ProviderMetadataAWS": {
            "Zones": [
                "us-east-1a"
            ]
        },
        "Provisioner": "kops",
        "ProvisionerMetadataKops": {
            "Name": "s3g97j84w3dqmbk4izifw6g4ma-kops.k8s.local",
            "Version": "1.17.14",
            "AMI": "kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-11-19",
            "MasterInstanceType": "t3.large",
            "MasterCount": 1,
            "NodeInstanceType": "m5.large",
            "NodeMinCount": 4,
            "NodeMaxCount": 4
        },
        "UtilityMetadata": {
            "DesiredVersions": {
                "PrometheusOperator": null,
                "Thanos": null,
                "Nginx": null,
                "Fluentbit": null,
                "Teleport": null
            },
            "ActualVersions": {
                "PrometheusOperator": {
                    "Chart": "9.4.4",
                    "ValuesPath": "helm-charts/prometheus_operator_values.yaml"
                },
                "Thanos": {
                    "Chart": "2.4.3",
                    "ValuesPath": "helm-charts/thanos_values.yaml"
                },
                "Nginx": {
                    "Chart": "2.15.0",
                    "ValuesPath": "helm-charts/nginx_values.yaml"
                },
                "Fluentbit": {
                    "Chart": "2.8.7",
                    "ValuesPath": "helm-charts/fluent-bit_values.yaml"
                },
                "Teleport": {
                    "Chart": "0.3.0",
                    "ValuesPath": "https://gitlab.internal.core.cloud.mattermost.com/api/v4/projects/33/repository/files/test%2Fnginx_values.yaml?ref=master"
                }
            }
        },
        "AllowInstallations": true,
        "CreateAt": 1607040631646,
        "DeleteAt": 0,
        "APISecurityLock": false,
        "LockAcquiredBy": null,
        "LockAcquiredAt": 0
    }
```

Finally, it must be noted that **GitLab URLs need to refer to the API and be URL encoded**. Entering the path to the file, e.g. `test/nginx_values.yaml?ref=master`, has to be done manually, so the `%2F` in the above example was actually entered verbatim on the command line when passed to `provision`. For extra clarity, this are the commands that were executed:
```
$ export GITLAB_OAUTH_TOKEN=mytoken
$ cloud cluster provision --cluster s3g97j84w3dqmbk4izifw6g4ma \
--teleport-version 0.3.0 --teleport-values 'https://gitlab.internal.core.cloud.mattermost.com/api/v4/projects/33/repository/files/test%2Fnginx_values.yaml?ref=master' \
--thanos-version 2.4.3 --thanos-values helm-charts/thanos_values.yaml \
--nginx-version 2.15.0 --nginx-values helm-charts/nginx_values.yaml \
--fluentbit-version 2.8.7 --fluentbit-values helm-charts/fluent-bit_values.yaml \
--prometheus-operator-version 9.4.4 --prometheus-operator-values helm-charts/prometheus_operator_values.yaml
```

If that's a usability issue let me know and I will think harder about how I can make it easier to input the path to the file. The URL must refer to the API because the regularly accessible URLs browseable from the UI do not accept tokens as URL parameters and I could not discover a way to specify that Helm should use a custom HTTP header when fetching the file.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-31043

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added ability to use authenticated GitLab instances with utility values
DesiredVersion in UtilitiesMetadata now empties when provisioning or creation completes
Verbose Helm debugging can now be controlled with --debug-helm at startup
```
