### PR TITLE
Fix CnC vpc name from <env-command-control to mattermost-cloud-<env>-command-control

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -92,7 +92,7 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 		return errors.Wrap(err, "getting the AWS Cloud environment")
 	}
 
-	cncVPCName := fmt.Sprintf("%s-command-control", environment)
+	cncVPCName := fmt.Sprintf("mattermost-cloud-%s-command-control", environment)
 	cncVPCCIDR, err := awsClient.GetCIDRByVPCTag(cncVPCName, logger)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get the CIDR for the VPC Name %s", cncVPCName)


### PR DESCRIPTION
#### Summary
- Fix CnC vpc name from <env-command-control to mattermost-cloud-<env>-command-control

#### Release Note

```release-note
- Fix CnC vpc name from <env-command-control to mattermost-cloud-<env>-command-control
```
