### PR TITLE
webhooks: add environment to the webhooks payload

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -199,6 +199,11 @@ var serverCmd = &cobra.Command{
 		}
 		awsClient := toolsAWS.NewAWSClientWithConfig(awsConfig, logger)
 
+		environment, err := awsClient.GetCloudEnvironmentName()
+		if err != nil {
+			return errors.Wrap(err, "getting the AWS Cloud environment")
+		}
+
 		err = checkRequirements(awsConfig, s3StateStore)
 		if err != nil {
 			return errors.Wrap(err, "failed health check")
@@ -252,6 +257,7 @@ var serverCmd = &cobra.Command{
 			Store:       sqlStore,
 			Supervisor:  supervisor,
 			Provisioner: kopsProvisioner,
+			Environment: environment,
 			Logger:      logger,
 		})
 

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -160,6 +160,7 @@ func handleCreateCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 		NewState:  model.ClusterStateCreationRequested,
 		OldState:  "n/a",
 		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"Environment": c.Environment},
 	}
 	err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {
@@ -205,6 +206,7 @@ func handleRetryCreateCluster(c *Context, w http.ResponseWriter, r *http.Request
 			NewState:  newState,
 			OldState:  clusterDTO.State,
 			Timestamp: time.Now().UnixNano(),
+			ExtraData: map[string]string{"Environment": c.Environment},
 		}
 		clusterDTO.State = newState
 
@@ -278,6 +280,7 @@ func handleProvisionCluster(c *Context, w http.ResponseWriter, r *http.Request) 
 			NewState:  newState,
 			OldState:  clusterDTO.State,
 			Timestamp: time.Now().UnixNano(),
+			ExtraData: map[string]string{"Environment": c.Environment},
 		}
 		clusterDTO.State = newState
 
@@ -399,6 +402,7 @@ func handleUpgradeKubernetes(c *Context, w http.ResponseWriter, r *http.Request)
 				NewState:  newState,
 				OldState:  oldState,
 				Timestamp: time.Now().UnixNano(),
+				ExtraData: map[string]string{"Environment": c.Environment},
 			}
 
 			err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
@@ -477,6 +481,7 @@ func handleResizeCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 				NewState:  newState,
 				OldState:  oldState,
 				Timestamp: time.Now().UnixNano(),
+				ExtraData: map[string]string{"Environment": c.Environment},
 			}
 
 			err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
@@ -546,6 +551,7 @@ func handleDeleteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 			NewState:  newState,
 			OldState:  clusterDTO.State,
 			Timestamp: time.Now().UnixNano(),
+			ExtraData: map[string]string{"Environment": c.Environment},
 		}
 		clusterDTO.State = newState
 

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -89,6 +89,7 @@ type Context struct {
 	Supervisor  Supervisor
 	Provisioner Provisioner
 	RequestID   string
+	Environment string
 	Logger      logrus.FieldLogger
 }
 

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -198,7 +198,7 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		NewState:  model.InstallationStateCreationRequested,
 		OldState:  "n/a",
 		Timestamp: time.Now().UnixNano(),
-		ExtraData: map[string]string{"DNS": installation.DNS},
+		ExtraData: map[string]string{"DNS": installation.DNS, "Environment": c.Environment},
 	}
 	err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {
@@ -245,7 +245,7 @@ func handleRetryCreateInstallation(c *Context, w http.ResponseWriter, r *http.Re
 			NewState:  newState,
 			OldState:  installationDTO.State,
 			Timestamp: time.Now().UnixNano(),
-			ExtraData: map[string]string{"DNS": installationDTO.DNS},
+			ExtraData: map[string]string{"DNS": installationDTO.DNS, "Environment": c.Environment},
 		}
 		installationDTO.State = newState
 
@@ -323,7 +323,7 @@ func handleUpdateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 			NewState:  newState,
 			OldState:  oldState,
 			Timestamp: time.Now().UnixNano(),
-			ExtraData: map[string]string{"DNS": installationDTO.DNS},
+			ExtraData: map[string]string{"DNS": installationDTO.DNS, "Environment": c.Environment},
 		}
 		err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
 		if err != nil {
@@ -507,7 +507,7 @@ func handleHibernateInstallation(c *Context, w http.ResponseWriter, r *http.Requ
 		NewState:  newState,
 		OldState:  oldState,
 		Timestamp: time.Now().UnixNano(),
-		ExtraData: map[string]string{"DNS": installationDTO.DNS},
+		ExtraData: map[string]string{"DNS": installationDTO.DNS, "Environment": c.Environment},
 	}
 	err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {
@@ -566,7 +566,7 @@ func handleWakeupInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		NewState:  newState,
 		OldState:  oldState,
 		Timestamp: time.Now().UnixNano(),
-		ExtraData: map[string]string{"DNS": installationDTO.DNS},
+		ExtraData: map[string]string{"DNS": installationDTO.DNS, "Environment": c.Environment},
 	}
 	err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {
@@ -616,7 +616,7 @@ func handleDeleteInstallation(c *Context, w http.ResponseWriter, r *http.Request
 			NewState:  newState,
 			OldState:  installationDTO.State,
 			Timestamp: time.Now().UnixNano(),
-			ExtraData: map[string]string{"DNS": installationDTO.DNS},
+			ExtraData: map[string]string{"DNS": installationDTO.DNS, "Environment": c.Environment},
 		}
 		installationDTO.State = newState
 

--- a/internal/supervisor/cluster.go
+++ b/internal/supervisor/cluster.go
@@ -129,12 +129,19 @@ func (s *ClusterSupervisor) Supervise(cluster *model.Cluster) {
 		return
 	}
 
+	environment, err := s.aws.GetCloudEnvironmentName()
+	if err != nil {
+		logger.WithError(err).Error("getting the AWS Cloud environment")
+		return
+	}
+
 	webhookPayload := &model.WebhookPayload{
 		Type:      model.TypeCluster,
 		ID:        cluster.ID,
 		NewState:  newState,
 		OldState:  oldState,
 		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"Environment": environment},
 	}
 	err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {

--- a/internal/supervisor/cluster_installation.go
+++ b/internal/supervisor/cluster_installation.go
@@ -132,13 +132,19 @@ func (s *ClusterInstallationSupervisor) Supervise(clusterInstallation *model.Clu
 		return
 	}
 
+	environment, err := s.aws.GetCloudEnvironmentName()
+	if err != nil {
+		logger.WithError(err).Error("getting the AWS Cloud environment")
+		return
+	}
+
 	webhookPayload := &model.WebhookPayload{
 		Type:      model.TypeClusterInstallation,
 		ID:        clusterInstallation.ID,
 		NewState:  newState,
 		OldState:  oldState,
 		Timestamp: time.Now().UnixNano(),
-		ExtraData: map[string]string{"ClusterID": clusterInstallation.ClusterID},
+		ExtraData: map[string]string{"ClusterID": clusterInstallation.ClusterID, "Environment": environment},
 	}
 	err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -214,13 +214,19 @@ func (s *InstallationSupervisor) Supervise(installation *model.Installation) {
 		return
 	}
 
+	environment, err := s.aws.GetCloudEnvironmentName()
+	if err != nil {
+		logger.WithError(err).Error("getting the AWS Cloud environment")
+		return
+	}
+
 	webhookPayload := &model.WebhookPayload{
 		Type:      model.TypeInstallation,
 		ID:        installation.ID,
 		NewState:  installation.State,
 		OldState:  oldState,
 		Timestamp: time.Now().UnixNano(),
-		ExtraData: map[string]string{"DNS": installation.DNS},
+		ExtraData: map[string]string{"DNS": installation.DNS, "Environment": environment},
 	}
 	err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {
@@ -479,12 +485,19 @@ func (s *InstallationSupervisor) createClusterInstallation(cluster *model.Cluste
 			return nil
 		}
 
+		environment, err := s.aws.GetCloudEnvironmentName()
+		if err != nil {
+			logger.WithError(err).Error("getting the AWS Cloud environment")
+			return nil
+		}
+
 		webhookPayload := &model.WebhookPayload{
 			Type:      model.TypeCluster,
 			ID:        cluster.ID,
 			NewState:  model.ClusterStateResizeRequested,
 			OldState:  model.ClusterStateStable,
 			Timestamp: time.Now().UnixNano(),
+			ExtraData: map[string]string{"Environment": environment},
 		}
 
 		err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
@@ -508,12 +521,19 @@ func (s *InstallationSupervisor) createClusterInstallation(cluster *model.Cluste
 		return nil
 	}
 
+	environment, err := s.aws.GetCloudEnvironmentName()
+	if err != nil {
+		logger.WithError(err).Error("getting the AWS Cloud environment")
+		return nil
+	}
+
 	webhookPayload := &model.WebhookPayload{
 		Type:      model.TypeClusterInstallation,
 		ID:        clusterInstallation.ID,
 		NewState:  model.ClusterInstallationStateCreationRequested,
 		OldState:  "n/a",
 		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"Environment": environment},
 	}
 	err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
 	if err != nil {
@@ -735,12 +755,19 @@ func (s *InstallationSupervisor) updateInstallation(installation *model.Installa
 				return installation.State
 			}
 
+			environment, err := s.aws.GetCloudEnvironmentName()
+			if err != nil {
+				logger.WithError(err).Error("getting the AWS Cloud environment")
+				return installation.State
+			}
+
 			webhookPayload := &model.WebhookPayload{
 				Type:      model.TypeClusterInstallation,
 				ID:        clusterInstallation.ID,
 				NewState:  clusterInstallation.State,
 				OldState:  oldState,
 				Timestamp: time.Now().UnixNano(),
+				ExtraData: map[string]string{"Environment": environment},
 			}
 			err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
 			if err != nil {


### PR DESCRIPTION
#### Summary
Today we have a microservice that receives and parse the provisioner webhooks and then sends a notification to the Mattermost community instance.

The issue is we need to deploy this microservice in the environments we want to track, and today we have deployed on staging and production, and this is redundant and cost expensive because we have two replicas of the same thing.

This PR adds the environment in the extra data so we can refactor the micro service to parse the messages per environment and have just one deployment of the microservice.

After we merge this I will refactor the microservice to deal with that and redeploy that in the core cloud aws account instead of in staging and production accounts


#### Ticket Link
None

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
webhooks: add environment to the webhooks payload
```
