### PR TITLE
MM-30591 Bump minor version of Helm to 3.4.1 from 3.3.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ DOCKER_BASE_IMAGE = alpine:3.12
 ## Tool Versions
 TERRAFORM_VERSION=0.11.14
 KOPS_VERSION=v1.17.1
-HELM_VERSION=v3.3.4
+HELM_VERSION=v3.4.1
 KUBECTL_VERSION=v1.18.3
 
 ################################################################################


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Change the version of Helm that's baked into the `Dockerfile` at build time to match the version specified in the README. This is a minor version upgrade; I've been using Helm 3.4.4 for development for several weeks without a problem.

On the SRE side please let me know if there's anywhere else this needs to be updated.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-30591

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Helm updated to version 3.4.4 from 3.3.1
```
