### PR TITLE
Add kops client caching

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -228,6 +228,7 @@ var serverCmd = &cobra.Command{
 			logger,
 			sqlStore,
 		)
+		defer kopsProvisioner.Teardown()
 
 		cloudMetrics := metrics.New()
 

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+// KopsProvisioner provisions clusters using kops+terraform.
+type KopsProvisioner struct {
+	s3StateStore            string
+	allowCIDRRangeList      []string
+	vpnCIDRList             []string
+	owner                   string
+	useExistingAWSResources bool
+	resourceUtil            *utils.ResourceUtil
+	logger                  log.FieldLogger
+	store                   model.InstallationDatabaseStoreInterface
+	kopsCache               map[string]*kops.Cmd
+}
+
+// NewKopsProvisioner creates a new KopsProvisioner.
+func NewKopsProvisioner(s3StateStore, owner string, useExistingAWSResources bool, allowCIDRRangeList, vpnCIDRList []string,
+	resourceUtil *utils.ResourceUtil, logger log.FieldLogger, store model.InstallationDatabaseStoreInterface) *KopsProvisioner {
+	logger = logger.WithField("provisioner", "kops")
+
+	return &KopsProvisioner{
+		s3StateStore:            s3StateStore,
+		useExistingAWSResources: useExistingAWSResources,
+		allowCIDRRangeList:      allowCIDRRangeList,
+		vpnCIDRList:             vpnCIDRList,
+		logger:                  logger,
+		resourceUtil:            resourceUtil,
+		owner:                   owner,
+		store:                   store,
+		kopsCache:               make(map[string]*kops.Cmd),
+	}
+}
+
+// Teardown cleans up cached kops provisioner data.
+func (provisioner *KopsProvisioner) Teardown() {
+	provisioner.logger.Debug("Performing kops provisioner cleanup")
+	for name, kops := range provisioner.kopsCache {
+		provisioner.logger.Debugf("Cleaning up kops cache for %s", name)
+		kops.Close()
+	}
+}
+
+// getKopsClusterConfigLocationFromCache returns the cached kubecfg for a k8s
+// cluster. If the config is not cached, it is fetched with kops.
+func (provisioner *KopsProvisioner) getCachedKopsClusterKubecfg(name string, logger log.FieldLogger) (string, error) {
+	kopsClient, err := provisioner.getCachedKopsClient(name, logger)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get cached kops client")
+	}
+
+	return kopsClient.GetKubeConfigPath(), nil
+}
+
+func (provisioner *KopsProvisioner) getCachedKopsClient(name string, logger log.FieldLogger) (*kops.Cmd, error) {
+	if kopsClient, ok := provisioner.kopsCache[name]; ok {
+		logger.Debugf("Using cached kops client for %s", name)
+		kopsClient.SetLogger(logger)
+		return kopsClient, nil
+	}
+
+	logger.Debugf("Building kops client cache for %s", name)
+	kopsClient, err := kops.New(provisioner.s3StateStore, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create kops wrapper")
+	}
+	err = kopsClient.ExportKubecfg(name)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to export kubecfg")
+	}
+
+	provisioner.kopsCache[name] = kopsClient
+	logger.Debugf("Kops config cached at %s for %s", kopsClient.GetKubeConfigPath(), name)
+
+	return kopsClient, nil
+}
+
+func (provisioner *KopsProvisioner) invalidateCachedKopsClient(name string, logger log.FieldLogger) error {
+	kopsClient, ok := provisioner.kopsCache[name]
+	if !ok {
+		logger.Errorf("Could not find kops client cache for %s to invalidate", name)
+		return errors.Errorf("could not find kops client cache for %s to invalidate", name)
+	}
+
+	logger.Debugf("Invalidating kops client cache for %s and cleaning up %s", name, kopsClient.GetOutputDirectory())
+	kopsClient.Close()
+	delete(provisioner.kopsCache, name)
+
+	return nil
+}
+
+// invalidateCachedKopsClientOnError can be used to invalidate cache when the
+// provided error is not nil. This can be used with defer to perform cache
+// cleanup if an error is encountered that may have been due to a bad cached config.
+func (provisioner *KopsProvisioner) invalidateCachedKopsClientOnError(err error, name string, logger log.FieldLogger) {
+	if err == nil {
+		return
+	}
+
+	provisioner.invalidateCachedKopsClient(name, logger)
+}

--- a/internal/provisioner/kops_provisioner_test.go
+++ b/internal/provisioner/kops_provisioner_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCachedKopsClient(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	provisioner := NewKopsProvisioner("s3statestore", "test", true, []string{}, []string{}, nil, logger, nil)
+
+	// Using &kops.Cmd{} here because kops.New() checks for the binary in your
+	// PATH which isn't needed for the test and fails in CI/CD.
+	provisioner.kopsCache["test"] = &kops.Cmd{}
+
+	t.Run("get cached client", func(t *testing.T) {
+		cachedClient, err := provisioner.getCachedKopsClient("test", logger)
+		require.NoError(t, err)
+		assert.NotNil(t, cachedClient)
+	})
+
+	t.Run("get cached kubecfg", func(t *testing.T) {
+		config, err := provisioner.getCachedKopsClusterKubecfg("test", logger)
+		require.NoError(t, err)
+		assert.NotEmpty(t, config)
+	})
+
+	t.Run("invalidate cache", func(t *testing.T) {
+		err := provisioner.invalidateCachedKopsClient("test", logger)
+		require.NoError(t, err)
+		require.Nil(t, provisioner.kopsCache["test"])
+	})
+
+	t.Run("invalidate missing cache", func(t *testing.T) {
+		err := provisioner.invalidateCachedKopsClient("test1", logger)
+		require.Error(t, err)
+	})
+
+	provisioner.kopsCache["test"] = &kops.Cmd{}
+
+	t.Run("invalidate cache on error; error is nil", func(t *testing.T) {
+		var cacheError error
+		provisioner.invalidateCachedKopsClientOnError(cacheError, "test", logger)
+		require.NotNil(t, provisioner.kopsCache["test"])
+	})
+
+	t.Run("invalidate cache on error; error is not nil", func(t *testing.T) {
+		cacheError := errors.New("not nil")
+		provisioner.invalidateCachedKopsClientOnError(cacheError, "test", logger)
+		require.Nil(t, provisioner.kopsCache["test"])
+	})
+}

--- a/internal/tools/kops/cmd.go
+++ b/internal/tools/kops/cmd.go
@@ -47,6 +47,11 @@ func New(s3StateStore string, logger log.FieldLogger) (*Cmd, error) {
 	}, nil
 }
 
+// SetLogger sets a new logger for kops commands.
+func (c *Cmd) SetLogger(logger log.FieldLogger) {
+	c.logger = logger
+}
+
 // GetTempDir returns the root temporary directory used by kops.
 func (c *Cmd) GetTempDir() string {
 	return c.tempDir


### PR DESCRIPTION
This change allows the provisioner to cache kops clients and cluster
configuration in order to increase performance when rapidly managing
external resources. Logic is also added for cache invalidation when
an issue is encountered that may be caused by outdated cache data.

Fixes https://mattermost.atlassian.net/browse/MM-31363

```release-note
Add kops client caching
```
