### PR TITLE
MM-31627 - Add network policy for installations with beta spec

### DIFF
--- a/k8s/networkpolicy.go
+++ b/k8s/networkpolicy.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	allowMMExternal = "external-mm-allow"
+	allowMMExternalBeta = "external-mm-v1beta-allow"
 )
 
 func (kc *KubeClient) createOrUpdateNetworkPolicyV1(namespace string, networkPolicy *networkingv1.NetworkPolicy) (metav1.Object, error) {
@@ -31,12 +32,18 @@ func (kc *KubeClient) createOrUpdateNetworkPolicyV1(namespace string, networkPol
 }
 
 func (kc *KubeClient) updateLabelsNetworkPolicy(networkPolicy *networkingv1.NetworkPolicy, installationName string) {
-	if networkPolicy.GetName() != allowMMExternal {
+	if networkPolicy.GetName() == allowMMExternal {
+		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{
+			"v1alpha1.mattermost.com/installation": installationName,
+			"app":                                  "mattermost",
+		}
 		return
 	}
-
-	networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{
-		"v1alpha1.mattermost.com/installation": installationName,
-		"app":                                  "mattermost",
+	if networkPolicy.GetName() == allowMMExternalBeta {
+		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{
+			"installation.mattermost.com/installation": installationName,
+			"app":                                      "mattermost",
+		}
+		return
 	}
 }

--- a/manifests/network-policies/mm-installation-netpol.yaml
+++ b/manifests/network-policies/mm-installation-netpol.yaml
@@ -41,7 +41,21 @@ spec:
       - namespaceSelector:
           matchLabels:
             name: nginx
-
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: external-mm-v1beta-allow
+spec:
+  podSelector: {}
+  ingress:
+    - ports:
+        - port: 8065
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              name: nginx
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add new Network Policy for installations that works together with Beta spec Mattermost CRs.
As a part of new labels I decided to drop the version from names, to avoid complicated deployment migrations in the future (as the label is also immutable deployment selector). 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Part of: https://mattermost.atlassian.net/browse/MM-31627

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add Network Policy for Beta spec Mattermost CRs
```
