### PR TITLE
Hibernate prometheus_adapter

### DIFF
--- a/manifests/prometheus-adapter/prometheus-adapter.yaml
+++ b/manifests/prometheus-adapter/prometheus-adapter.yaml
@@ -220,7 +220,7 @@ metadata:
   name: prometheus-adapter
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       name: prometheus-adapter
@@ -233,6 +233,15 @@ spec:
       labels:
         name: prometheus-adapter
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: kops.k8s.io/instancegroup
+                operator: In
+                values:
+                - nodes-utilities
       containers:
         - args:
             - --cert-dir=/var/run/serving-cert


### PR DESCRIPTION
Use more replicas when we have in place custom metrics to use in
autoscaling

#### Summary

Hibernate prometheus_adapter
#### Ticket Link
`NONE`

#### Release Note

```release-note
NONE
```
