### PR TITLE
MM-30849 - Preserve order of Env variables to not to trigger installation rollout

### DIFF
--- a/model/env.go
+++ b/model/env.go
@@ -6,6 +6,7 @@ package model
 
 import (
 	"encoding/json"
+	"sort"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -120,6 +121,13 @@ func (em *EnvVarMap) ToEnvList() []corev1.EnvVar {
 			ValueFrom: env.ValueFrom,
 		})
 	}
+
+	// To retain consistent order of environment variables - sort the array.
+	// Changing the order of env vars, even if they did not change will cause
+	// rotation of Cluster Installation's pods.
+	sort.Slice(envList, func(i, j int) bool {
+		return envList[i].Name < envList[j].Name
+	})
 
 	return envList
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When iterating through `map` the order of elements is not preserved. This causes the Provisioner to change the order of environment variables on `ClusterInstallation` even if no env changed. This in turn causes rotation of the Installation's pods. Sorting envs prevents unnecesary rollouts.

I decide to do the sorting on Provisioner side not in the Operator as the order of environment variables might matter for the Operator user, but in our case we know, that it does not.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-30849

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Sort Installation Env vars passed to ClusterInstallation
```
