### PR TITLE
Fix Nginx ingress chart prefix to show correct version in metadata

### DIFF
--- a/internal/provisioner/nginx_internal.go
+++ b/internal/provisioner/nginx_internal.go
@@ -91,7 +91,7 @@ func (n *nginxInternal) ActualVersion() *model.HelmUtilityVersion {
 	}
 
 	return &model.HelmUtilityVersion{
-		Chart:      strings.TrimPrefix(n.actualVersion.Version(), "ingress-nginx-internal"),
+		Chart:      strings.TrimPrefix(n.actualVersion.Version(), "ingress-nginx-"),
 		ValuesPath: n.actualVersion.Values(),
 	}
 }


### PR DESCRIPTION
#### Summary
- Fix Nginx ingress chart prefix to show correct version in metadata

#### Release Note

```release-note
- Fix Nginx ingress chart prefix to show correct version in metadata
```
