### PR TITLE
MM-32053 Remove --debug in call to helm update to avoid overflowing Scanner buffer bug

### DIFF
--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -144,7 +144,6 @@ func upgradeHelmChart(chart helmDeployment, configPath string, logger log.FieldL
 	chart.desiredVersion.ValuesPath = applyGitlabTokenIfPresent(chart.desiredVersion.ValuesPath)
 
 	arguments := []string{
-		"--debug",
 		"upgrade",
 		chart.chartDeploymentName,
 		chart.chartName,
@@ -180,7 +179,6 @@ func upgradeHelmChart(chart helmDeployment, configPath string, logger log.FieldL
 // deleteHelmChart is used to delete Helm charts.
 func deleteHelmChart(chart helmDeployment, configPath string, logger log.FieldLogger) error {
 	arguments := []string{
-		"--debug",
 		"delete",
 		"--kubeconfig", configPath,
 		"--namespace", chart.namespace,


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
@stylianosrigas hit an issue while trying to run `cloud cluster provision` that produced the following error:

```
ERRO[2021-01-19T15:18:06-06:00] failed to scan stdout                         cluster=ou9z9cfuz3nk9y8jt7zgnnwmia cluster-utility=prometheus-operator error="bufio.Scanner: token too long" helm-update=prometheus-community/kube-prometheus-stack instance=wxo7stu54ty7ze55bum4uw4ahe provisioner=kops run=pac7t1mqm7gj9gxsjoxgious6r utility-group=create-handle
```

The root cause is a limitation in the default standard library bufio.Scanner, which produces an error after calling Scan() if it gets a token that is too large, which happens with our current Prometheus Chart. This is because Helm outputs (to stdout) the whole computed chart at the end of the operation and some line in it must be larger than the buffer.

The real and correct solution is to update `bufferAndLog` in `internal/tools/exechelper/run.go` to be a more manual implementation that doesn't use `scanner.Scan()` and can handle arbitrarily long lines. [See the docs here for information about this limitation of the Scanner](https://golang.org/pkg/bufio/#Scanner), specifically the docs say "Scanning stops unrecoverably at EOF, the first I/O error, **or a token too large to fit in the buffer.**"

I believe the proper fix will take a little while to implement though, as it's a little bit involved, so this will allow the Provisioner to function normally again in the meantime by simply reducing the amount of output from Helm so that we don't hit the error from the Scanner, and we can discuss the value and priority of making the exec helper a bit more robust once this immediate bug is resolved.

HOWEVER if others feel that it is important and worth the time to go ahead and make the 'correct' change, I can do that instead of merging this one.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-32053

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
