### PR TITLE
MM-32053 Properly fetch and decode values file from Gitlab API

### DIFF
--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -359,7 +359,7 @@ func fetchFromGitlabIfNecessary(path string) (string, func(string), error) {
 
 	return temporaryValuesFile.Name(), func(path string) {
 		if strings.HasPrefix(path, os.TempDir()) {
-			defer os.Remove(path)
+			os.Remove(path)
 		}
 	}, nil
 }

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -7,14 +7,16 @@ package provisioner
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
-
-	"net/url"
-	"os"
 
 	"github.com/mattermost/mattermost-cloud/internal/tools/helm"
 	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
@@ -141,7 +143,11 @@ func upgradeHelmChart(chart helmDeployment, configPath string, logger log.FieldL
 		chart.desiredVersion.ValuesPath = censoredPath
 	}(&chart, censoredPath)
 
-	chart.desiredVersion.ValuesPath = applyGitlabTokenIfPresent(chart.desiredVersion.ValuesPath)
+	var err error
+	chart.desiredVersion.ValuesPath, err = fetchFromGitlabIfNecessary(chart.desiredVersion.ValuesPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to get values file")
+	}
 
 	arguments := []string{
 		"--debug",
@@ -283,16 +289,66 @@ func (d *helmDeployment) Version() (*model.HelmUtilityVersion, error) {
 	return nil, errors.Errorf("unable to get version for chart %s", d.chartDeploymentName)
 }
 
-func applyGitlabTokenIfPresent(original string) string {
-	if os.Getenv(model.GitlabOAuthTokenKey) == "" {
-		return original
+type gitlabValuesFileResponse struct {
+	Content string `json:"content"`
+}
+
+const temporaryValuesFile string = "/tmp/helm-values.yaml"
+
+func fetchFromGitlabIfNecessary(path string) (string, error) {
+	gitlabKey := os.Getenv(model.GitlabOAuthTokenKey)
+	if gitlabKey == "" {
+		return path, nil
 	}
-	// gitlab token is set, so apply it to GitLab values path URLs
-	valPathURL, err := url.Parse(original)
-	if err == nil && strings.HasPrefix(valPathURL.Host, "gitlab") {
-		original = fmt.Sprintf("%s&private_token=$%s",
-			original,
-			model.GitlabOAuthTokenKey)
+
+	valPathURL, err := url.Parse(path)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse Helm values file path or URL")
 	}
-	return original
+
+	// silently allow other public non-Gitlab URLs
+	if !strings.HasPrefix(valPathURL.Host, "gitlab") {
+		return path, nil
+	}
+
+	// if Gitlab, fetch the file using the API
+	path = fmt.Sprintf("%s&private_token=%s", path, gitlabKey)
+
+	resp, err := http.Get(path)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to request the values file from Gitlab")
+	}
+	if resp.StatusCode >= 400 {
+		return "", errors.Errorf("request to Gitlab failed with status: %s", resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read body from Gitlab response")
+	}
+
+	valuesFileBytes := new(gitlabValuesFileResponse)
+	err = json.Unmarshal(body, valuesFileBytes)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to unmarshal JSON in Gitlab response")
+	}
+
+	if _, err = os.Stat(temporaryValuesFile); err == nil { // file exists
+		err = os.Remove(temporaryValuesFile)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to overwrite an existing Helm values file to store the new one")
+		}
+	}
+
+	content, err := base64.StdEncoding.DecodeString(valuesFileBytes.Content)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to decode base64-encoded YAML file")
+	}
+
+	err = ioutil.WriteFile(temporaryValuesFile, []byte(content), 0777)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to write values file to disk for Helm to read")
+	}
+
+	return temporaryValuesFile, nil
 }

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -144,7 +144,6 @@ func upgradeHelmChart(chart helmDeployment, configPath string, logger log.FieldL
 	chart.desiredVersion.ValuesPath = applyGitlabTokenIfPresent(chart.desiredVersion.ValuesPath)
 
 	arguments := []string{
-		"--debug",
 		"upgrade",
 		chart.chartDeploymentName,
 		chart.chartName,
@@ -180,7 +179,6 @@ func upgradeHelmChart(chart helmDeployment, configPath string, logger log.FieldL
 // deleteHelmChart is used to delete Helm charts.
 func deleteHelmChart(chart helmDeployment, configPath string, logger log.FieldLogger) error {
 	arguments := []string{
-		"--debug",
 		"delete",
 		"--kubeconfig", configPath,
 		"--namespace", chart.namespace,

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -144,6 +144,7 @@ func upgradeHelmChart(chart helmDeployment, configPath string, logger log.FieldL
 	chart.desiredVersion.ValuesPath = applyGitlabTokenIfPresent(chart.desiredVersion.ValuesPath)
 
 	arguments := []string{
+		"--debug",
 		"upgrade",
 		chart.chartDeploymentName,
 		chart.chartName,
@@ -179,6 +180,7 @@ func upgradeHelmChart(chart helmDeployment, configPath string, logger log.FieldL
 // deleteHelmChart is used to delete Helm charts.
 func deleteHelmChart(chart helmDeployment, configPath string, logger log.FieldLogger) error {
 	arguments := []string{
+		"--debug",
 		"delete",
 		"--kubeconfig", configPath,
 		"--namespace", chart.namespace,

--- a/internal/provisioner/helm_utils.go
+++ b/internal/provisioner/helm_utils.go
@@ -296,6 +296,12 @@ type gitlabValuesFileResponse struct {
 	Content string `json:"content"`
 }
 
+// fetchFromGitlabIfNecessary returns the path of the values file. If
+// this is a local path or a non-Gitlab URL, the path is simply
+// returned unchanged. If a Gitlab URL is provided, the values file is
+// fetched and stored in the OS's temp dir and the filename of the
+// file is returned. It is the responsibility of the caller to clean
+// up this file when it is no longer needed.
 func fetchFromGitlabIfNecessary(path string) (string, error) {
 	gitlabKey := os.Getenv(model.GitlabOAuthTokenKey)
 	if gitlabKey == "" {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Late in the development of this feature I switched the routine that fetches the values file from GitLab from fetching the raw permalink of the file directly to using the files API and missed a few steps with regard to how that API actually serves the file, namely, it serves the files base64-encoded as part of a JSON object.

This base64-encoded blob is what was blowing up golang's `Scanner`, causing the actual output and behavior we witnessed in test.

This change adds the necessary and missing steps to unmarshal the JSON and decode the YAML file to disk so that it can be used by Helm.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-32053

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fixed bug in Gitlab utility values paths fetching logic
```
