### PR TITLE
MM-32264 - Switch Provisioner to use Operator beta CR by default

### DIFF
--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -77,7 +77,7 @@ func TestInstallations(t *testing.T) {
 		Size:      mmv1alpha1.Size100String,
 		Affinity:  model.InstallationAffinityIsolated,
 		GroupID:   &groupID2,
-		CRVersion: model.V1alphaCRVersion,
+		CRVersion: model.DefaultCRVersion,
 		State:     model.InstallationStateStable,
 	}
 
@@ -621,7 +621,7 @@ func TestUpdateInstallation(t *testing.T) {
 		Size:      mmv1alpha1.Size100String,
 		Affinity:  model.InstallationAffinityIsolated,
 		GroupID:   &groupID1,
-		CRVersion: model.V1alphaCRVersion,
+		CRVersion: model.DefaultCRVersion,
 		State:     model.InstallationStateCreationRequested,
 	}
 

--- a/model/installation.go
+++ b/model/installation.go
@@ -16,7 +16,7 @@ const (
 	// V1betaCRVersion is a Mattermost CR beta version.
 	V1betaCRVersion = "installation.mattermost.com/v1beta1"
 	// DefaultCRVersion is a default CR version used for new installations.
-	DefaultCRVersion = V1alphaCRVersion
+	DefaultCRVersion = V1betaCRVersion
 )
 
 // Installation represents a Mattermost installation.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Switch Provisioner to use `Mattermost` resource instead of `ClusterInstallation` by default.
This change will make all new Installations to be created with `Mattermost` CR but will not migrate existing Installations which will continue to operate.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-32264

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Use Mattermost CR instead of ClusterInstallation for new Installation
```
