### PR TITLE
Add 'state' as an installation list filter

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -51,13 +51,14 @@ func init() {
 
 	installationListCmd.Flags().String("owner", "", "The owner by which to filter installations.")
 	installationListCmd.Flags().String("group", "", "The group ID by which to filter installations.")
+	installationListCmd.Flags().String("state", "", "The state by which to filter results by.")
+	installationListCmd.Flags().String("dns", "", "The dns by which to filter results by.")
 	installationListCmd.Flags().Bool("include-group-config", true, "Whether to include group configuration in the installations or not.")
 	installationListCmd.Flags().Bool("include-group-config-overrides", true, "Whether to include a group configuration override summary in the installations or not.")
 	installationListCmd.Flags().Int("page", 0, "The page of installations to fetch, starting at 0.")
 	installationListCmd.Flags().Int("per-page", 100, "The number of installations to fetch per page.")
 	installationListCmd.Flags().Bool("include-deleted", false, "Whether to include deleted installations.")
 	installationListCmd.Flags().Bool("table", false, "Whether to display the returned installation list in a table or not.")
-	installationListCmd.Flags().String("dns", "", "The dns to filter results by.")
 
 	installationHibernateCmd.Flags().String("installation", "", "The id of the installation to put into hibernation.")
 	installationHibernateCmd.MarkFlagRequired("installation")
@@ -318,20 +319,22 @@ var installationListCmd = &cobra.Command{
 
 		owner, _ := command.Flags().GetString("owner")
 		group, _ := command.Flags().GetString("group")
+		state, _ := command.Flags().GetString("state")
+		dns, _ := command.Flags().GetString("dns")
 		includeGroupConfig, _ := command.Flags().GetBool("include-group-config")
 		includeGroupConfigOverrides, _ := command.Flags().GetBool("include-group-config-overrides")
 		page, _ := command.Flags().GetInt("page")
 		perPage, _ := command.Flags().GetInt("per-page")
 		includeDeleted, _ := command.Flags().GetBool("include-deleted")
-		dns, _ := command.Flags().GetString("dns")
 		installations, err := client.GetInstallations(&model.GetInstallationsRequest{
 			OwnerID:                     owner,
 			GroupID:                     group,
+			State:                       state,
+			DNS:                         dns,
 			IncludeGroupConfig:          includeGroupConfig,
 			IncludeGroupConfigOverrides: includeGroupConfigOverrides,
 			Page:                        page,
 			PerPage:                     perPage,
-			DNS:                         dns,
 			IncludeDeleted:              includeDeleted,
 		})
 		if err != nil {

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -72,8 +72,6 @@ func handleGetInstallation(c *Context, w http.ResponseWriter, r *http.Request) {
 // handleGetInstallations responds to GET /api/installations, returning the specified page of installations.
 func handleGetInstallations(c *Context, w http.ResponseWriter, r *http.Request) {
 	var err error
-	owner := r.URL.Query().Get("owner")
-	group := r.URL.Query().Get("group")
 
 	page, perPage, includeDeleted, err := parsePaging(r.URL)
 	if err != nil {
@@ -89,11 +87,15 @@ func handleGetInstallations(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	owner := r.URL.Query().Get("owner")
+	group := r.URL.Query().Get("group")
+	state := r.URL.Query().Get("state")
 	dns := r.URL.Query().Get("dns_name")
 
 	filter := &model.InstallationFilter{
 		OwnerID:        owner,
 		GroupID:        group,
+		State:          state,
 		Page:           page,
 		PerPage:        perPage,
 		IncludeDeleted: includeDeleted,

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -136,6 +136,7 @@ func TestGetInstallations(t *testing.T) {
 			DNS:      "dns.example.com",
 			Size:     "1000users",
 			Affinity: model.InstallationAffinityIsolated,
+			State:    model.InstallationStateCreationRequested,
 		}
 		err := sqlStore.CreateInstallation(installation1, annotations)
 		require.NoError(t, err)
@@ -147,6 +148,7 @@ func TestGetInstallations(t *testing.T) {
 			Version:  "version",
 			DNS:      "dns2.example.com",
 			Affinity: model.InstallationAffinityIsolated,
+			State:    model.InstallationStateCreationRequested,
 		}
 		err = sqlStore.CreateInstallation(installation2, nil)
 		require.NoError(t, err)
@@ -158,6 +160,7 @@ func TestGetInstallations(t *testing.T) {
 			Version:  "version",
 			DNS:      "dns3.example.com",
 			Affinity: model.InstallationAffinityIsolated,
+			State:    model.InstallationStateCreationRequested,
 		}
 		err = sqlStore.CreateInstallation(installation3, nil)
 		require.NoError(t, err)
@@ -169,6 +172,7 @@ func TestGetInstallations(t *testing.T) {
 			Version:  "version",
 			DNS:      "dns4.example.com",
 			Affinity: model.InstallationAffinityIsolated,
+			State:    model.InstallationStateCreationRequested,
 		}
 		err = sqlStore.CreateInstallation(installation4, nil)
 		require.NoError(t, err)
@@ -256,12 +260,42 @@ func TestGetInstallations(t *testing.T) {
 				{
 					"filter by owner",
 					&model.GetInstallationsRequest{
+						OwnerID:        ownerID1,
 						Page:           0,
 						PerPage:        100,
-						OwnerID:        ownerID1,
 						IncludeDeleted: false,
 					},
 					[]*model.Installation{installation1, installation3},
+				},
+				{
+					"filter by dns",
+					&model.GetInstallationsRequest{
+						DNS:            installation1.DNS,
+						Page:           0,
+						PerPage:        100,
+						IncludeDeleted: false,
+					},
+					[]*model.Installation{installation1},
+				},
+				{
+					"filter by state creation-requested",
+					&model.GetInstallationsRequest{
+						State:          model.InstallationStateCreationRequested,
+						Page:           0,
+						PerPage:        100,
+						IncludeDeleted: false,
+					},
+					[]*model.Installation{installation1, installation2, installation3},
+				},
+				{
+					"filter by state stable",
+					&model.GetInstallationsRequest{
+						State:          model.InstallationStateStable,
+						Page:           0,
+						PerPage:        100,
+						IncludeDeleted: false,
+					},
+					[]*model.Installation{},
 				},
 			}
 

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -150,11 +150,14 @@ func (sqlStore *SQLStore) applyInstallationFilter(builder sq.SelectBuilder, filt
 	if filter.GroupID != "" {
 		builder = builder.Where("GroupID = ?", filter.GroupID)
 	}
-	if !filter.IncludeDeleted {
-		builder = builder.Where("DeleteAt = 0")
+	if filter.State != "" {
+		builder = builder.Where("State = ?", filter.State)
 	}
 	if filter.DNS != "" {
 		builder = builder.Where("DNS = ?", filter.DNS)
+	}
+	if !filter.IncludeDeleted {
+		builder = builder.Where("DeleteAt = 0")
 	}
 
 	return builder

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -148,20 +148,6 @@ func TestInstallations(t *testing.T) {
 		require.Equal(t, installation3, installation)
 	})
 
-	t.Run("get installation 3 by name", func(t *testing.T) {
-		installations, err := sqlStore.GetInstallations(
-			&model.InstallationFilter{
-				DNS:     installation3.DNS,
-				PerPage: model.AllPerPage,
-			}, false, false)
-
-		require.Equal(t, 1, len(installations))
-		installation := installations[0]
-
-		require.NoError(t, err)
-		require.Equal(t, installation.ID, installation3.ID)
-	})
-
 	t.Run("get and delete installation 4", func(t *testing.T) {
 		installation, err := sqlStore.GetInstallation(installation4.ID, false, false)
 		require.NoError(t, err)
@@ -296,6 +282,36 @@ func TestInstallations(t *testing.T) {
 				IncludeDeleted: true,
 			},
 			[]*model.Installation{installation4},
+		},
+		{
+			"dns 3",
+			&model.InstallationFilter{
+				DNS:            installation3.DNS,
+				Page:           0,
+				PerPage:        10,
+				IncludeDeleted: false,
+			},
+			[]*model.Installation{installation3},
+		},
+		{
+			"state stable",
+			&model.InstallationFilter{
+				State:          model.InstallationStateStable,
+				Page:           0,
+				PerPage:        10,
+				IncludeDeleted: false,
+			},
+			[]*model.Installation{installation2},
+		},
+		{
+			"state creation-requested",
+			&model.InstallationFilter{
+				State:          model.InstallationStateCreationRequested,
+				Page:           0,
+				PerPage:        10,
+				IncludeDeleted: false,
+			},
+			[]*model.Installation{installation1, installation3},
 		},
 	}
 

--- a/model/installation.go
+++ b/model/installation.go
@@ -65,10 +65,11 @@ type InstallationsCount struct {
 type InstallationFilter struct {
 	OwnerID        string
 	GroupID        string
+	State          string
+	DNS            string
 	Page           int
 	PerPage        int
 	IncludeDeleted bool
-	DNS            string
 }
 
 // Clone returns a deep copy the installation.

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -197,12 +197,13 @@ func (request *GetInstallationRequest) ApplyToURL(u *url.URL) {
 type GetInstallationsRequest struct {
 	OwnerID                     string
 	GroupID                     string
+	State                       string
+	DNS                         string
 	IncludeGroupConfig          bool
 	IncludeGroupConfigOverrides bool
 	Page                        int
 	PerPage                     int
 	IncludeDeleted              bool
-	DNS                         string
 }
 
 // ApplyToURL modifies the given url to include query string parameters for the request.
@@ -210,6 +211,8 @@ func (request *GetInstallationsRequest) ApplyToURL(u *url.URL) {
 	q := u.Query()
 	q.Add("owner", request.OwnerID)
 	q.Add("group", request.GroupID)
+	q.Add("state", request.State)
+	q.Add("dns_name", request.DNS)
 	if !request.IncludeGroupConfig {
 		q.Add("include_group_config", "false")
 	}
@@ -220,9 +223,6 @@ func (request *GetInstallationsRequest) ApplyToURL(u *url.URL) {
 	q.Add("per_page", strconv.Itoa(request.PerPage))
 	if request.IncludeDeleted {
 		q.Add("include_deleted", "true")
-	}
-	if request.DNS != "" {
-		q.Add("dns_name", request.DNS)
 	}
 	u.RawQuery = q.Encode()
 }


### PR DESCRIPTION
This new filter option further enhances the ability for the
provisioner to return only relevant installation resources.

This change also includes some additional tests and test cleanup.

Fixes https://mattermost.atlassian.net/browse/MM-32285

```release-note
Add 'state' as an installation list filter
```
