### PR TITLE
Fix AMI check and validate kops change requests

### DIFF
--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -6,6 +6,8 @@ package model
 
 import (
 	"encoding/json"
+
+	"github.com/pkg/errors"
 )
 
 // KopsMetadata is the provisioner metadata stored in a model.Cluster.
@@ -31,6 +33,26 @@ type KopsMetadataRequestedState struct {
 	NodeInstanceType   string `json:"NodeInstanceType,omitempty"`
 	NodeMinCount       int64  `json:"NodeMinCount,omitempty"`
 	NodeMaxCount       int64  `json:"NodeMaxCount,omitempty"`
+}
+
+// ValidateChangeRequest ensures that the ChangeRequest has at least one
+// actionable value.
+func (km *KopsMetadata) ValidateChangeRequest() error {
+	if km.ChangeRequest == nil {
+		return errors.New("the KopsMetadata ChangeRequest is nil")
+	}
+
+	if len(km.ChangeRequest.Version) == 0 &&
+		len(km.ChangeRequest.AMI) == 0 &&
+		len(km.ChangeRequest.MasterInstanceType) == 0 &&
+		len(km.ChangeRequest.NodeInstanceType) == 0 &&
+		km.MasterCount == 0 &&
+		km.NodeMinCount == 0 &&
+		km.NodeMaxCount == 0 {
+		return errors.New("the KopsMetadata ChangeRequest has no change values set")
+	}
+
+	return nil
 }
 
 // ClearChangeRequest clears the kops metadata change request.

--- a/model/kops_metadata_test.go
+++ b/model/kops_metadata_test.go
@@ -29,3 +29,21 @@ func TestNewKopsMetadata(t *testing.T) {
 		require.Equal(t, "name", kopsMetadata.Name)
 	})
 }
+
+func TestValidateChangeRequest(t *testing.T) {
+	var km model.KopsMetadata
+
+	t.Run("nil ChangeRequest", func(t *testing.T) {
+		require.Error(t, km.ValidateChangeRequest())
+	})
+
+	t.Run("empty ChangeRequest", func(t *testing.T) {
+		km.ChangeRequest = &model.KopsMetadataRequestedState{}
+		require.Error(t, km.ValidateChangeRequest())
+	})
+
+	t.Run("valid ChangeRequest", func(t *testing.T) {
+		km.ChangeRequest.Version = "1.0.0"
+		require.NoError(t, km.ValidateChangeRequest())
+	})
+}


### PR DESCRIPTION
This changes the following:
 - The AWS AMI check has been updated to check the new AMI instead
   of the existing AMI running in the cluster.
 - The KopsMetadata ChangeRequest now has basic validation to
   ensure there is at least one actionable value.

Fixes https://mattermost.atlassian.net/browse/MM-32440

```release-note
Fix AMI check and validate kops change requests
```
