### PR TITLE
Improved server startup check

### DIFF
--- a/internal/tools/helm/commands.go
+++ b/internal/tools/helm/commands.go
@@ -5,8 +5,10 @@
 package helm
 
 import (
-	"github.com/pkg/errors"
 	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // RunGenericCommand runs any given helm command.
@@ -23,4 +25,15 @@ func (c *Cmd) RunGenericCommand(arg ...string) error {
 func (c *Cmd) RunCommandRaw(arg ...string) ([]byte, error) {
 	cmd := exec.Command(c.helmPath, arg...)
 	return cmd.Output()
+}
+
+// Version invokes helm version and returns the value.
+func (c *Cmd) Version() (string, error) {
+	stdout, _, err := c.run("version")
+	trimmed := strings.TrimSuffix(string(stdout), "\n")
+	if err != nil {
+		return trimmed, errors.Wrap(err, "failed to invoke helm version")
+	}
+
+	return trimmed, nil
 }

--- a/internal/tools/terraform/plan.go
+++ b/internal/tools/terraform/plan.go
@@ -126,11 +126,17 @@ func (c *Cmd) Output(variable string) (string, bool, error) {
 }
 
 // Version invokes terraform version and returns the value.
-func (c *Cmd) Version() (string, error) {
+func (c *Cmd) Version(removeUpgradeWarning bool) (string, error) {
 	stdout, _, err := c.run("version")
 	trimmed := strings.TrimSuffix(string(stdout), "\n")
 	if err != nil {
 		return trimmed, errors.Wrap(err, "failed to invoke terraform version")
+	}
+
+	// The terraform version command will print an upgrade warning if running
+	// an older version. Optionally attempt to remove the warning before returning.
+	if removeUpgradeWarning {
+		trimmed = strings.Split(trimmed, "\n")[0]
 	}
 
 	return trimmed, nil


### PR DESCRIPTION
This change includes the following:
 - Removes duplicate AWS environment check on startup.
 - Uses client wrappers on the startup check for all available
   binaries to ensure that there is no mismatch when the clients
   are later rebuilt and used.
 - Logs terraform, kops, and helm versions on startup.

Fixes https://mattermost.atlassian.net/browse/MM-32473

```release-note
Improved server startup check
```
