### PR TITLE
Add hibernated domain redirection to nginx ingress

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -35,9 +35,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	defaultLocalServerAPI = "http://localhost:8075"
-)
+const defaultLocalServerAPI = "http://localhost:8075"
 
 var instanceID string
 

--- a/helm-charts/nginx_values.yaml
+++ b/helm-charts/nginx_values.yaml
@@ -49,6 +49,9 @@ controller:
     proxy-send-timeout: "3600"
     use-forwarded-headers: "true"
     force-ssl-redirect: "true"
+    server-snippet: |
+      proxy_intercept_errors on;
+      error_page 410 "http://127.0.0.1:8076/api/v1/installation/wakeup?dns=$host&uri=$uri";
 
   resources:
    limits:

--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -230,6 +230,20 @@ func (mr *MockAWSMockRecorder) CreatePublicCNAME(dnsName, dnsEndpoints, logger i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePublicCNAME", reflect.TypeOf((*MockAWS)(nil).CreatePublicCNAME), dnsName, dnsEndpoints, logger)
 }
 
+// UpdatePublicRecordIDForCNAME mocks base method
+func (m *MockAWS) UpdatePublicRecordIDForCNAME(dnsName, newID string, logger logrus.FieldLogger) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdatePublicRecordIDForCNAME", dnsName, newID, logger)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdatePublicRecordIDForCNAME indicates an expected call of UpdatePublicRecordIDForCNAME
+func (mr *MockAWSMockRecorder) UpdatePublicRecordIDForCNAME(dnsName, newID, logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePublicRecordIDForCNAME", reflect.TypeOf((*MockAWS)(nil).UpdatePublicRecordIDForCNAME), dnsName, newID, logger)
+}
+
 // IsProvisionedPrivateCNAME mocks base method
 func (m *MockAWS) IsProvisionedPrivateCNAME(dnsName string, logger logrus.FieldLogger) bool {
 	m.ctrl.T.Helper()

--- a/internal/provisioner/kops_provisioner_cluster_installation_beta.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation_beta.go
@@ -121,9 +121,10 @@ func (provisioner *kopsCIBeta) HibernateClusterInstallation(cluster *model.Clust
 	// Hibernation is currently considered changing the Mattermost app deployment
 	// to 0 replicas in the pod. i.e. Scale down to no Mattermost apps running.
 	// The current way to do this is to set a negative replica count in the
-	// k8s custom resource.
+	// k8s custom resource. Custom ingress annotations are also used.
 	// TODO: enhance hibernation to include database and/or filestore.
 	cr.Spec.Replicas = int32Ptr(0)
+	cr.Spec.IngressAnnotations = getHibernatingIngressAnnotations()
 
 	_, err = k8sClient.MattermostClientsetV1Beta.MattermostV1beta1().Mattermosts(clusterInstallation.Namespace).Update(ctx, cr, metav1.UpdateOptions{})
 	if err != nil {
@@ -217,6 +218,8 @@ func (provisioner *kopsCIBeta) UpdateClusterInstallation(cluster *model.Cluster,
 
 	mattermostEnv := getMattermostEnvWithOverrides(installation)
 	mattermost.Spec.MattermostEnv = mattermostEnv.ToEnvList()
+
+	mattermost.Spec.IngressAnnotations = getIngressAnnotations()
 
 	_, err = k8sClient.MattermostClientsetV1Beta.MattermostV1beta1().Mattermosts(clusterInstallation.Namespace).Update(ctx, mattermost, metav1.UpdateOptions{})
 	if err != nil {

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -674,6 +674,12 @@ func (s *InstallationSupervisor) configureInstallationDNS(installation *model.In
 }
 
 func (s *InstallationSupervisor) updateInstallation(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
+	err := s.aws.UpdatePublicRecordIDForCNAME(installation.DNS, installation.DNS, logger)
+	if err != nil {
+		logger.WithError(err).Warn("Failed update installation route53 record to the standard ID value")
+		return installation.State
+	}
+
 	// Before starting, we check the installation and group sequence numbers and
 	// sync them if they are not already. This is used to check if the group
 	// configuration has changed during the upgrade process or not.
@@ -682,7 +688,7 @@ func (s *InstallationSupervisor) updateInstallation(installation *model.Installa
 
 		logger.Debugf("Updating installation to group configuration sequence %d", *installation.GroupSequence)
 
-		err := s.store.UpdateInstallationGroupSequence(installation)
+		err = s.store.UpdateInstallationGroupSequence(installation)
 		if err != nil {
 			logger.WithError(err).Errorf("Failed to set installation sequence to %d", *installation.GroupSequence)
 			return installation.State
@@ -840,6 +846,12 @@ func (s *InstallationSupervisor) verifyClusterInstallationResourcesMatchInstalla
 }
 
 func (s *InstallationSupervisor) hibernateInstallation(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
+	err := s.aws.UpdatePublicRecordIDForCNAME(installation.DNS, aws.HibernatingInstallationResourceRecordIDPrefix+installation.DNS, logger)
+	if err != nil {
+		logger.WithError(err).Warn("Failed update installation route53 record with hibernation prefix")
+		return installation.State
+	}
+
 	clusterInstallations, err := s.store.GetClusterInstallations(&model.ClusterInstallationFilter{
 		PerPage:        model.AllPerPage,
 		InstallationID: installation.ID,

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -292,6 +292,10 @@ func (a *mockAWS) CreatePublicCNAME(dnsName string, dnsEndpoints []string, logge
 	return nil
 }
 
+func (a *mockAWS) UpdatePublicRecordIDForCNAME(dnsName, newID string, logger log.FieldLogger) error {
+	return nil
+}
+
 func (a *mockAWS) IsProvisionedPrivateCNAME(dnsName string, logger log.FieldLogger) bool {
 	return false
 }

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -60,6 +60,7 @@ type AWS interface {
 
 	CreatePrivateCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error
 	CreatePublicCNAME(dnsName string, dnsEndpoints []string, logger log.FieldLogger) error
+	UpdatePublicRecordIDForCNAME(dnsName, newID string, logger log.FieldLogger) error
 	IsProvisionedPrivateCNAME(dnsName string, logger log.FieldLogger) bool
 	DeletePrivateCNAME(dnsName string, logger log.FieldLogger) error
 	DeletePublicCNAME(dnsName string, logger log.FieldLogger) error

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -132,6 +132,10 @@ const (
 	// zone ID in AWS Route53.
 	DefaultPublicCloudDNSTagValue = "public"
 
+	// HibernatingInstallationResourceRecordIDPrefix is a prefix given to AWS
+	// route53 resource records when the installation it points to is hibernating.
+	HibernatingInstallationResourceRecordIDPrefix = "[hybernating] "
+
 	// CustomNodePolicyName is the name of the custom IAM policy that will be
 	// attached in Kops Instance Profile.
 	CustomNodePolicyName = "cloud-provisioning-node-policy"

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -134,7 +134,7 @@ const (
 
 	// HibernatingInstallationResourceRecordIDPrefix is a prefix given to AWS
 	// route53 resource records when the installation it points to is hibernating.
-	HibernatingInstallationResourceRecordIDPrefix = "[hybernating] "
+	HibernatingInstallationResourceRecordIDPrefix = "[hibernating] "
 
 	// CustomNodePolicyName is the name of the custom IAM policy that will be
 	// attached in Kops Instance Profile.

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -252,7 +252,7 @@ func (a *Client) updateResourceRecordIDs(hostedZoneID, dnsName, newID string, lo
 	}
 
 	recordSet := recordSets[0]
-	if recordSet.SetIdentifier == aws.String(newID) {
+	if *recordSet.SetIdentifier == newID {
 		return nil
 	}
 
@@ -302,6 +302,9 @@ func (a *Client) deleteCNAME(hostedZoneID, dnsName string, logger log.FieldLogge
 	if len(changes) == 0 {
 		logger.Warn("Unable to find any DNS records; skipping...")
 		return nil
+	}
+	if len(recordSets) != 1 {
+		return errors.Errorf("expected exactly 1 resource record, but found %d", len(changes))
 	}
 
 	resp, err := a.Service().route53.ChangeResourceRecordSets(&route53.ChangeResourceRecordSetsInput{

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -176,13 +176,26 @@ func (a *Client) IsProvisionedPrivateCNAME(dnsName string, logger log.FieldLogge
 		Key:   DefaultCloudDNSTagKey,
 		Value: DefaultPrivateCloudDNSTagValue,
 	}, logger)
-
 	if err != nil {
 		logger.WithError(err).Debugf("couldn't look up zone ID for DNS name %s", dnsName)
 		return false
 	}
 
 	return a.isProvisionedCNAME(id, dnsName, logger)
+}
+
+// UpdatePublicRecordIDForCNAME updates the record ID for the record corresponding
+// to a DNS value in the public hosted zone.
+func (a *Client) UpdatePublicRecordIDForCNAME(dnsName, newID string, logger log.FieldLogger) error {
+	id, err := a.getHostedZoneIDWithTag(Tag{
+		Key:   DefaultCloudDNSTagKey,
+		Value: DefaultPublicCloudDNSTagValue,
+	}, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to find the public hosted zone")
+	}
+
+	return a.updateResourceRecordIDs(id, dnsName, newID, logger)
 }
 
 // DeletePublicCNAME deletes a AWS route53 record for a public domain name.
@@ -212,68 +225,79 @@ func (a *Client) DeletePrivateCNAME(dnsName string, logger log.FieldLogger) erro
 }
 
 func (a *Client) isProvisionedCNAME(hostedZoneID, dnsName string, logger log.FieldLogger) bool {
-	nextRecordName := dnsName
-	for {
-		recordList, err := a.Service().route53.ListResourceRecordSets(
-			&route53.ListResourceRecordSetsInput{
-				HostedZoneId:    &hostedZoneID,
-				StartRecordName: &nextRecordName,
-			})
+	recordSets, err := a.getRecordSetsForDNS(hostedZoneID, dnsName, logger)
+	if err != nil {
+		logger.WithError(err).Errorf("failed to get record sets for dns name %s", dnsName)
+		return false
+	}
 
-		if err != nil {
-			logger.WithError(err).Debugf("couldn't find record list for %s", dnsName)
-			return false
+	for _, recordSet := range recordSets {
+		if recordSet.Name != nil && dnsName == strings.TrimRight(*recordSet.Name, ".") {
+			return true
 		}
-
-		for _, recordSet := range recordList.ResourceRecordSets {
-			if recordSet.Name != nil && dnsName == strings.TrimRight(*recordSet.Name, ".") {
-				return true
-			}
-		}
-
-		if !*recordList.IsTruncated {
-			break
-		}
-
-		nextRecordName = *recordList.NextRecordName
-		logger.Debugf("DNS query found more than one page of records; running another query with record-name=%s", nextRecordName)
 	}
 
 	return false
 }
 
+func (a *Client) updateResourceRecordIDs(hostedZoneID, dnsName, newID string, logger log.FieldLogger) error {
+	recordSets, err := a.getRecordSetsForDNS(hostedZoneID, dnsName, logger)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get record sets for dns name %s", dnsName)
+	}
+
+	// There should only be one returned record.
+	if len(recordSets) != 1 {
+		return errors.Errorf("expected exactly 1 resource record, but found %d", len(recordSets))
+	}
+
+	recordSet := recordSets[0]
+	if recordSet.SetIdentifier == aws.String(newID) {
+		return nil
+	}
+
+	newRecordSet := *recordSet
+	newRecordSet.SetIdentifier = aws.String(newID)
+
+	resp, err := a.Service().route53.ChangeResourceRecordSets(&route53.ChangeResourceRecordSetsInput{
+		ChangeBatch: &route53.ChangeBatch{
+			Changes: []*route53.Change{
+				{
+					Action:            aws.String("UPSERT"),
+					ResourceRecordSet: &newRecordSet,
+				},
+				{
+					Action:            aws.String("DELETE"),
+					ResourceRecordSet: recordSet,
+				},
+			},
+		},
+		HostedZoneId: &hostedZoneID,
+	})
+	if err != nil {
+		return err
+	}
+
+	logger.WithFields(log.Fields{
+		"route53-dns-value":      dnsName,
+		"route53-hosted-zone-id": hostedZoneID,
+	}).Debugf("AWS route53 record update response: %s", prettyRoute53Response(resp))
+
+	return nil
+}
+
 func (a *Client) deleteCNAME(hostedZoneID, dnsName string, logger log.FieldLogger) error {
-	nextRecordName := dnsName
-	var recordSets []*route53.ResourceRecordSet
-	for {
-		recordList, err := a.Service().route53.ListResourceRecordSets(
-			&route53.ListResourceRecordSetsInput{
-				HostedZoneId:    &hostedZoneID,
-				StartRecordName: &nextRecordName,
-			})
-		if err != nil {
-			return err
-		}
-
-		recordSets = append(recordSets, recordList.ResourceRecordSets...)
-
-		if !*recordList.IsTruncated {
-			break
-		}
-
-		// Too many records were received. We need to keep going.
-		nextRecordName = *recordList.NextRecordName
-		logger.Debugf("DNS query found more than one page of records; running another query with record-name=%s", nextRecordName)
+	recordSets, err := a.getRecordSetsForDNS(hostedZoneID, dnsName, logger)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get record sets for dns name %s", dnsName)
 	}
 
 	var changes []*route53.Change
 	for _, recordSet := range recordSets {
-		if strings.Trim(*recordSet.Name, ".") == dnsName {
-			changes = append(changes, &route53.Change{
-				Action:            aws.String("DELETE"),
-				ResourceRecordSet: recordSet,
-			})
-		}
+		changes = append(changes, &route53.Change{
+			Action:            aws.String("DELETE"),
+			ResourceRecordSet: recordSet,
+		})
 	}
 	if len(changes) == 0 {
 		logger.Warn("Unable to find any DNS records; skipping...")
@@ -295,6 +319,37 @@ func (a *Client) deleteCNAME(hostedZoneID, dnsName string, logger log.FieldLogge
 	}).Debugf("AWS route53 delete response: %s", prettyRoute53Response(resp))
 
 	return nil
+}
+
+func (a *Client) getRecordSetsForDNS(hostedZoneID, dnsName string, logger log.FieldLogger) ([]*route53.ResourceRecordSet, error) {
+	nextRecordName := dnsName
+	var recordSets []*route53.ResourceRecordSet
+	for {
+		recordList, err := a.Service().route53.ListResourceRecordSets(
+			&route53.ListResourceRecordSetsInput{
+				HostedZoneId:    &hostedZoneID,
+				StartRecordName: &nextRecordName,
+			})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to list resource records")
+		}
+
+		for _, recordSet := range recordList.ResourceRecordSets {
+			if strings.TrimRight(*recordSet.Name, ".") == dnsName {
+				recordSets = append(recordSets, recordSet)
+			}
+		}
+
+		if !*recordList.IsTruncated {
+			break
+		}
+
+		// Too many records were received. We need to keep going.
+		nextRecordName = *recordList.NextRecordName
+		logger.Debugf("DNS query found more than one page of records; running another query with record-name=%s", nextRecordName)
+	}
+
+	return recordSets, nil
 }
 
 // getHostedZoneIDWithTag returns R53 hosted zone ID for a given tag


### PR DESCRIPTION
This new redirection ensures that requests for installations that
are hibernated are forwarded to another configurable target. This
new endpoint can perform further processing including waking up
the installation in question.

This new target can be configured per nginx ingress via helm values.

This change also refactors some route 53 logic and contains some
other cleanup.

Fixes https://mattermost.atlassian.net/browse/MM-32530

```release-note
Add hibernated domain redirection to nginx ingress
```
