### PR TITLE
Allow installation updates on OwnerID

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -38,8 +38,9 @@ func init() {
 	installationCreateCmd.MarkFlagRequired("dns")
 
 	installationUpdateCmd.Flags().String("installation", "", "The id of the installation to be updated.")
-	installationUpdateCmd.Flags().String("version", "stable", "The Mattermost version to target.")
+	installationUpdateCmd.Flags().String("owner", "", "The new owner value of this installation.")
 	installationUpdateCmd.Flags().String("image", "mattermost/mattermost-enterprise-edition", "The Mattermost container image to use.")
+	installationUpdateCmd.Flags().String("version", "stable", "The Mattermost version to target.")
 	installationUpdateCmd.Flags().String("size", model.InstallationDefaultSize, "The size of the installation. Accepts 100users, 1000users, 5000users, 10000users, 25000users, miniSingleton, or miniHA. Defaults to 100users.")
 	installationUpdateCmd.Flags().String("license", "", "The Mattermost License to use in the server.")
 	installationUpdateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
@@ -183,6 +184,7 @@ var installationUpdateCmd = &cobra.Command{
 		}
 
 		request := &model.PatchInstallationRequest{
+			OwnerID:       getStringFlagPointer(command, "owner"),
 			Version:       getStringFlagPointer(command, "version"),
 			Image:         getStringFlagPointer(command, "image"),
 			Size:          getStringFlagPointer(command, "size"),

--- a/model/installation.go
+++ b/model/installation.go
@@ -35,6 +35,7 @@ type Installation struct {
 	Size                       string
 	Affinity                   string
 	State                      string
+	CRVersion                  string
 	CreateAt                   int64
 	DeleteAt                   int64
 	APISecurityLock            bool
@@ -42,8 +43,6 @@ type Installation struct {
 	LockAcquiredAt             int64
 	GroupOverrides             map[string]string           `json:"GroupOverrides,omitempty"`
 	SingleTenantDatabaseConfig *SingleTenantDatabaseConfig `json:"SingleTenantDatabaseConfig,omitempty"`
-	// CRVersion is a Custom Resource version that should represent Installation on the cluster.
-	CRVersion string `json:"CRVersion,omitempty"`
 
 	// configconfigMergedWithGroup is set when the installation configuration
 	// has been overridden with group configuration. This value can then be

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -229,8 +229,9 @@ func (request *GetInstallationsRequest) ApplyToURL(u *url.URL) {
 
 // PatchInstallationRequest specifies the parameters for an updated installation.
 type PatchInstallationRequest struct {
-	Version       *string
+	OwnerID       *string
 	Image         *string
+	Version       *string
 	Size          *string
 	License       *string
 	MattermostEnv EnvVarMap
@@ -260,6 +261,10 @@ func (p *PatchInstallationRequest) Validate() error {
 func (p *PatchInstallationRequest) Apply(installation *Installation) bool {
 	var applied bool
 
+	if p.OwnerID != nil && *p.OwnerID != installation.OwnerID {
+		applied = true
+		installation.OwnerID = *p.OwnerID
+	}
 	if p.Version != nil && *p.Version != installation.Version {
 		applied = true
 		installation.Version = *p.Version

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -314,6 +314,17 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 			&model.Installation{},
 		},
 		{
+			"ownerID only",
+			true,
+			&model.PatchInstallationRequest{
+				OwnerID: sToP("new-owner"),
+			},
+			&model.Installation{},
+			&model.Installation{
+				OwnerID: "new-owner",
+			},
+		},
+		{
 			"version only",
 			true,
 			&model.PatchInstallationRequest{
@@ -434,6 +445,7 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 			"complex",
 			true,
 			&model.PatchInstallationRequest{
+				OwnerID: sToP("new-owner"),
 				Version: sToP("patch-version"),
 				Size:    sToP("miniSingleton"),
 				MattermostEnv: model.EnvVarMap{
@@ -442,6 +454,7 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 				},
 			},
 			&model.Installation{
+				OwnerID: "owner",
 				Version: "version1",
 				Image:   "image1",
 				License: "license1",
@@ -451,6 +464,7 @@ func TestPatchInstallationRequestApply(t *testing.T) {
 				},
 			},
 			&model.Installation{
+				OwnerID: "new-owner",
 				Version: "patch-version",
 				Image:   "image1",
 				License: "license1",


### PR DESCRIPTION
This change allows for the installation OwnerID value to be
updated in case it is no longer accurate.

This will be used by the cloud plugin import functionality.

Fixes https://mattermost.atlassian.net/browse/MM-32650

```release-note
Allow installation updates on OwnerID
```
