### PR TITLE
Improve hibernation logic

### DIFF
--- a/cmd/cloud/dashboard.go
+++ b/cmd/cloud/dashboard.go
@@ -87,11 +87,14 @@ var dashboardCmd = &cobra.Command{
 			}
 
 			installationCount := len(installations)
-			var installationStableCount int
+			var installationStableCount, installationsHibernatingCount int
 			for _, installation := range installations {
-				if installation.State == model.InstallationStateStable {
+				switch installation.State {
+				case model.ClusterInstallationStateStable:
 					installationStableCount++
-				} else {
+				case model.InstallationStateHibernating:
+					installationsHibernatingCount++
+				default:
 					unstableList = append(unstableList, fmt.Sprintf("Installation: %s (%s)", installation.ID, installation.State))
 				}
 			}
@@ -99,8 +102,8 @@ var dashboardCmd = &cobra.Command{
 			table.Append([]string{
 				"Installation",
 				toStr(installationCount),
-				toStr(installationStableCount),
-				toStr(installationCount - installationStableCount),
+				fmt.Sprintf("%d (H=%d)", installationStableCount+installationsHibernatingCount, installationsHibernatingCount),
+				toStr(installationCount - (installationStableCount + installationsHibernatingCount)),
 			})
 
 			clusterInstallations, err := client.GetClusterInstallations(&model.GetClusterInstallationsRequest{

--- a/internal/supervisor/group.go
+++ b/internal/supervisor/group.go
@@ -101,12 +101,12 @@ func (s *GroupSupervisor) Supervise(group *model.Group) {
 	}
 
 	logger = logger.WithFields(log.Fields{
-		"installations-total":   groupMetadata.InstallationTotalCount,
-		"installations-rolling": groupMetadata.InstallationNonStableCount,
+		"installations-total":   groupMetadata.InstallationsTotalCount,
+		"installations-rolling": groupMetadata.InstallationsRolling,
 	})
 
-	if int64(groupMetadata.InstallationNonStableCount) >= group.MaxRolling {
-		logger.Infof("Group already has %d rolling installations with a max of %d", groupMetadata.InstallationNonStableCount, group.MaxRolling)
+	if int64(groupMetadata.InstallationsRolling) >= group.MaxRolling {
+		logger.Infof("Group already has %d rolling installations with a max of %d", groupMetadata.InstallationsRolling, group.MaxRolling)
 		return
 	}
 
@@ -118,7 +118,7 @@ func (s *GroupSupervisor) Supervise(group *model.Group) {
 
 	var moved int64
 	for _, id := range groupMetadata.InstallationIDsToBeRolled {
-		if groupMetadata.InstallationNonStableCount+moved >= group.MaxRolling {
+		if groupMetadata.InstallationsRolling+moved >= group.MaxRolling {
 			// We have bumped up against the max rolling count with the new
 			// installations added to the rolling pool.
 			break

--- a/model/group_status.go
+++ b/model/group_status.go
@@ -14,6 +14,7 @@ type GroupStatus struct {
 	InstallationsTotal          int64
 	InstallationsUpdated        int64
 	InstallationsUpdating       int64
+	InstallationsHibernating    int64
 	InstallationsAwaitingUpdate int64
 }
 


### PR DESCRIPTION
This change includes the following:
 - Improve group supervisor logic related to installation updates
   when the group contains hibernating installations.
 - Corrects group status information provided via the API when
   the group contains hibernating installations.
 - Updates the dashboard cloud CLI command to properly present
   installations stats when hibernating installations are present.

Fixes https://mattermost.atlassian.net/browse/MM-32740

```release-note
Improve hibernation logic
```
