### PR TITLE
MM-31628 - Implement migration of ClusterInstallations to Mattermost resource 

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -26,6 +26,7 @@ const hibernationReplicaCount = -1
 // ClusterInstallationProvisioner is an interface for provisioning and managing ClusterInstallations.
 type ClusterInstallationProvisioner interface {
 	CreateClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) error
+	EnsureCRMigrated(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation) (bool, error)
 	HibernateClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) error
 	UpdateClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) error
 	VerifyClusterInstallationMatchesConfig(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) (bool, error)
@@ -45,6 +46,15 @@ func (provisioner *KopsProvisioner) ClusterInstallationProvisioner(crVersion str
 
 type kopsCIAlpha struct {
 	*KopsProvisioner
+}
+
+func (provisioner *kopsCIAlpha) EnsureCRMigrated(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation) (bool, error) {
+	logger := provisioner.logger.WithFields(log.Fields{
+		"cluster":      clusterInstallation.ClusterID,
+		"installation": clusterInstallation.InstallationID,
+	})
+	logger.Info("Ensuring migration for v1alpha1 is not supported")
+	return true, nil
 }
 
 // CreateClusterInstallation creates a Mattermost installation within the given cluster.

--- a/internal/provisioner/kops_provisioner_cluster_installation_beta.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation_beta.go
@@ -467,7 +467,7 @@ func (provisioner *kopsCIBeta) waitForMigration(name string, mmClient v1beta1.Ma
 	for {
 		migrated, err := isMigrated(name, mmClient)
 		if err != nil {
-			errCount += 1
+			errCount ++
 			logger.Errorf("failed to check %d times if ClusterInstallation is migrated: %s", errCount, err.Error())
 			// Do not fail on first error in case of some minor API Server hiccup
 			if errCount >= 3 {

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -407,6 +407,22 @@ func (sqlStore *SQLStore) UpdateInstallationState(installation *model.Installati
 	return nil
 }
 
+// UpdateInstallationCRVersion updates the given installation CRVersion.
+func (sqlStore *SQLStore) UpdateInstallationCRVersion(installationID, crVersion string) error {
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Update("Installation").
+		SetMap(map[string]interface{}{
+			"CRVersion": crVersion,
+		}).
+		Where("ID = ?", installationID),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to update installation")
+	}
+
+	return nil
+}
+
 // DeleteInstallation marks the given installation as deleted, but does not remove the record from the
 // database.
 func (sqlStore *SQLStore) DeleteInstallation(id string) error {

--- a/internal/supervisor/cluster_installation_test.go
+++ b/internal/supervisor/cluster_installation_test.go
@@ -63,31 +63,7 @@ func (s *mockClusterInstallationStore) GetWebhooks(filter *model.WebhookFilter) 
 type mockClusterInstallationProvisioner struct{}
 
 func (p *mockClusterInstallationProvisioner) ClusterInstallationProvisioner(version string) provisioner.ClusterInstallationProvisioner {
-	return p
-}
-
-func (p *mockClusterInstallationProvisioner) CreateClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) error {
-	return nil
-}
-
-func (p *mockClusterInstallationProvisioner) DeleteClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterIntallation *model.ClusterInstallation) error {
-	return nil
-}
-
-func (p *mockClusterInstallationProvisioner) UpdateClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterIntallation *model.ClusterInstallation) error {
-	return nil
-}
-
-func (p *mockClusterInstallationProvisioner) IsResourceReady(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation) (bool, error) {
-	return true, nil
-}
-
-func (p *mockClusterInstallationProvisioner) HibernateClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) error {
-	return nil
-}
-
-func (p *mockClusterInstallationProvisioner) VerifyClusterInstallationMatchesConfig(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) (bool, error) {
-	return false, nil
+	return &mockInstallationProvisioner{}
 }
 
 func TestClusterInstallationSupervisorDo(t *testing.T) {

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -772,6 +772,17 @@ func (s *InstallationSupervisor) updateInstallation(installation *model.Installa
 			return failedClusterInstallationState(clusterInstallation.State)
 		}
 
+		isReady, err := s.provisioner.ClusterInstallationProvisioner(installation.CRVersion).
+			EnsureCRMigrated(cluster, clusterInstallation)
+		if err != nil {
+			logger.WithError(err).Error("Failed to migrate cluster installation CR")
+			return installation.State
+		}
+		if !isReady {
+			logger.Info("Cluster installation CR migration not finished")
+			return installation.State
+		}
+
 		err = s.provisioner.ClusterInstallationProvisioner(installation.CRVersion).
 			UpdateClusterInstallation(cluster, installation, clusterInstallation)
 		if err != nil {

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -21,6 +21,10 @@ import (
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
 )
 
+const (
+	latestCRVersion = model.V1betaCRVersion
+)
+
 // installationStore abstracts the database operations required to query installations.
 type installationStore interface {
 	GetClusters(clusterFilter *model.ClusterFilter) ([]*model.Cluster, error)
@@ -34,6 +38,7 @@ type installationStore interface {
 	UpdateInstallation(installation *model.Installation) error
 	UpdateInstallationGroupSequence(installation *model.Installation) error
 	UpdateInstallationState(*model.Installation) error
+	UpdateInstallationCRVersion(installationID, crVersion string) error
 	LockInstallation(installationID, lockerID string) (bool, error)
 	UnlockInstallation(installationID, lockerID string, force bool) (bool, error)
 	DeleteInstallation(installationID string) error
@@ -85,6 +90,7 @@ type InstallationSupervisor struct {
 	resourceUtil      *utils.ResourceUtil
 	logger            log.FieldLogger
 	metrics           *metrics.CloudMetrics
+	forceCRUpgrade    bool
 }
 
 // InstallationSupervisorSchedulingOptions are the various options that control
@@ -96,7 +102,18 @@ type InstallationSupervisorSchedulingOptions struct {
 }
 
 // NewInstallationSupervisor creates a new InstallationSupervisor.
-func NewInstallationSupervisor(store installationStore, installationProvisioner installationProvisioner, aws aws.AWS, instanceID string, keepDatabaseData, keepFilestoreData bool, scheduling InstallationSupervisorSchedulingOptions, resourceUtil *utils.ResourceUtil, logger log.FieldLogger, metrics *metrics.CloudMetrics) *InstallationSupervisor {
+func NewInstallationSupervisor(
+	store installationStore,
+	installationProvisioner installationProvisioner,
+	aws aws.AWS,
+	instanceID string,
+	keepDatabaseData,
+	keepFilestoreData bool,
+	scheduling InstallationSupervisorSchedulingOptions,
+	resourceUtil *utils.ResourceUtil,
+	logger log.FieldLogger,
+	metrics *metrics.CloudMetrics,
+	forceCRUpgrade bool) *InstallationSupervisor {
 	return &InstallationSupervisor{
 		store:             store,
 		provisioner:       installationProvisioner,
@@ -108,6 +125,7 @@ func NewInstallationSupervisor(store installationStore, installationProvisioner 
 		resourceUtil:      resourceUtil,
 		logger:            logger,
 		metrics:           metrics,
+		forceCRUpgrade:    forceCRUpgrade,
 	}
 }
 
@@ -691,6 +709,17 @@ func (s *InstallationSupervisor) updateInstallation(installation *model.Installa
 		err = s.store.UpdateInstallationGroupSequence(installation)
 		if err != nil {
 			logger.WithError(err).Errorf("Failed to set installation sequence to %d", *installation.GroupSequence)
+			return installation.State
+		}
+	}
+
+	if s.forceCRUpgrade && installation.CRVersion != latestCRVersion {
+		installation.CRVersion = latestCRVersion
+		logger.Infof("Updating Installation CR Version to '%s'", latestCRVersion)
+
+		err := s.store.UpdateInstallationCRVersion(installation.ID, latestCRVersion)
+		if err != nil {
+			logger.WithError(err).Error("Failed to update installation CRVersion")
 			return installation.State
 		}
 	}

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -81,6 +81,10 @@ func (s *mockInstallationStore) UpdateInstallationState(installation *model.Inst
 	return nil
 }
 
+func (s *mockInstallationStore) UpdateInstallationCRVersion(installationID, crVersion string) error {
+	return nil
+}
+
 func (s *mockInstallationStore) LockInstallation(installationID, lockerID string) (bool, error) {
 	return true, nil
 }
@@ -347,7 +351,7 @@ func TestInstallationSupervisorDo(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		mockStore := &mockInstallationStore{}
 
-		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 		err := supervisor.Do()
 		require.NoError(t, err)
 
@@ -365,7 +369,7 @@ func TestInstallationSupervisorDo(t *testing.T) {
 		mockStore.Installation = mockStore.UnlockedInstallationsPendingWork[0]
 		mockStore.UnlockChan = make(chan interface{})
 
-		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 		err := supervisor.Do()
 		require.NoError(t, err)
 
@@ -423,7 +427,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("unexpected state", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -461,7 +465,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("state has changed since installation was selected to be worked on", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -494,7 +498,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations not yet created, no clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		owner := model.NewID()
 		groupID := model.NewID()
@@ -519,7 +523,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations not yet created, cluster doesn't allow scheduling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		cluster.AllowInstallations = false
@@ -549,7 +553,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations not yet created, no empty clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -587,7 +591,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -625,7 +629,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -663,7 +667,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation DNS, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -701,7 +705,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -739,7 +743,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations stable, in group with different sequence", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -790,7 +794,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("pre provisioning requested, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -828,7 +832,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations failed", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -866,7 +870,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation in progress, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -904,7 +908,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation in progress, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -942,7 +946,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation in progress, cluster installations stable, in group with same sequence", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1000,7 +1004,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation in progress, cluster installations failed", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1038,7 +1042,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation final tasks, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1076,7 +1080,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("no compatible clusters, cluster installations not yet created, no clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		owner := model.NewID()
 		groupID := model.NewID()
@@ -1101,7 +1105,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("no compatible clusters, cluster installations not yet created, no available clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1139,7 +1143,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("no compatible clusters, cluster installations not yet created, available cluster", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1168,7 +1172,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1206,7 +1210,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update requested, cluster installations stable, in group with different sequence", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1257,7 +1261,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update in progress, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1295,7 +1299,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update requested, cluster installations reconciling, in group with different sequence", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1346,7 +1350,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update in progress, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1384,7 +1388,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update requested, cluster installations stable, in group with same sequence", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1445,7 +1449,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("hibernation requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1483,7 +1487,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("hibernation in progress, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1521,7 +1525,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("hibernation in progress, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1559,7 +1563,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1597,7 +1601,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion requested, cluster installations deleting", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1635,7 +1639,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion in progress, cluster installations failed", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1673,7 +1677,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion requested, cluster installations failed, so retry", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1711,7 +1715,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations deleted", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1750,7 +1754,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		t.Run("creation requested, cluster installations not yet created, available cluster", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
-			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 			cluster := standardStableTestCluster()
 			err := sqlStore.CreateCluster(cluster, nil)
@@ -1780,7 +1784,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		t.Run("creation requested, cluster installations not yet created, 3 installations, available cluster", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
-			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 			cluster := standardStableTestCluster()
 			err := sqlStore.CreateCluster(cluster, nil)
@@ -1814,7 +1818,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		t.Run("creation requested, cluster installations not yet created, 1 isolated and 1 multitenant, available cluster", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
-			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 			cluster := standardStableTestCluster()
 			err := sqlStore.CreateCluster(cluster, nil)
@@ -1873,7 +1877,7 @@ func TestInstallationSupervisor(t *testing.T) {
 					MilliUsedMemory:  100,
 				},
 			}
-			supervisor := supervisor.NewInstallationSupervisor(sqlStore, mockInstallationProvisioner, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, mockInstallationProvisioner, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 			cluster := standardStableTestCluster()
 			err := sqlStore.CreateCluster(cluster, nil)
@@ -1914,7 +1918,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			},
 		}
 		schedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(false, 80, 2)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, mockInstallationProvisioner, &mockAWS{}, "instanceID", false, false, schedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, mockInstallationProvisioner, &mockAWS{}, "instanceID", false, false, schedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -1945,7 +1949,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
 		schedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 0)
-		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, schedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, schedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 		cluster1 := standardStableTestCluster()
 		err := sqlStore.CreateCluster(cluster1, nil)
@@ -1999,7 +2003,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
 			defer store.CloseConnection(t, sqlStore)
-			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 			cluster := standardStableTestCluster()
 			err := sqlStore.CreateCluster(cluster, annotations)
@@ -2020,7 +2024,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
 			defer store.CloseConnection(t, sqlStore)
-			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 			cluster := standardStableTestCluster()
 			err := sqlStore.CreateCluster(cluster, nil)
@@ -2041,7 +2045,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
 			defer store.CloseConnection(t, sqlStore)
-			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics)
+			supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
 
 			cluster := standardStableTestCluster()
 			err := sqlStore.CreateCluster(cluster, annotations)
@@ -2057,5 +2061,34 @@ func TestInstallationSupervisor(t *testing.T) {
 			expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateCreationRequested)
 			expectClusterInstallationsOnCluster(t, sqlStore, cluster, 1)
 		})
+	})
+
+	t.Run("force CR upgrade to v1Beta", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, true)
+
+		cluster := standardStableTestCluster()
+		err := sqlStore.CreateCluster(cluster, nil)
+		require.NoError(t, err)
+
+		installation := &model.Installation{
+			Version:   "version",
+			DNS:       "dns.example.com",
+			Size:      mmv1alpha1.Size100String,
+			Affinity:  model.InstallationAffinityMultiTenant,
+			State:     model.InstallationStateUpdateRequested,
+			CRVersion: model.V1alphaCRVersion,
+		}
+
+		err = sqlStore.CreateInstallation(installation, nil)
+		require.NoError(t, err)
+
+		supervisor.Supervise(installation)
+
+		updatedInstallation, err := sqlStore.GetInstallation(installation.ID, false, false)
+		require.NoError(t, err)
+		require.Equal(t, model.V1betaCRVersion, updatedInstallation.CRVersion)
 	})
 }

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -200,6 +200,10 @@ func (p *mockInstallationProvisioner) UpdateClusterInstallation(cluster *model.C
 	return nil
 }
 
+func (p *mockInstallationProvisioner) EnsureCRMigrated(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation) (bool, error) {
+	return true, nil
+}
+
 func (p *mockInstallationProvisioner) HibernateClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) error {
 	return nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The PR implements possibility of automatically migrating `ClusterInstallation` resources to `Mattermost`.
For Provisioner to run the migration `--force-cr-upgrade` flag needs to be set to `true`. The migration will be run if Installation's `CRVersion` does not match the latest version.

During the migration there will be extra pods for each Installation, therefore we should be careful with the load on the clusters and databases.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-31628

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Implement migration from ClusterInstallation to Mattermost resources
```
