### PR TITLE
[MM-33040] Reduce the limit for workspace from 3 to 2 chars

### DIFF
--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -121,7 +121,7 @@ func isValidDNS(dns string) error {
 		return errors.Errorf("fully qualified domain names must be less than 254 characters in length. Provided name %s was %d characters long", dns, len(dns))
 	}
 	subdomain := strings.SplitN(dns, ".", 2)[0]
-	if len(subdomain) >= 64 || len(subdomain) < 3 {
+	if len(subdomain) >= 64 || len(subdomain) < 2 {
 		return errors.Errorf("DNS subdomain names must be between 3 and 64 characters, but name was %d long. DNS=%s", len(dns), dns)
 	}
 	// check that domain matches regex for valid names


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

We're reducing the limit of characters for the workspace name from 3 to 2 chars

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-33040

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Reduced the limit for DNS names from 3 to 2 characters
```
