### PR TITLE
MM-32795: Avoid upgrade and resize removal of role policy attachment

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -553,13 +553,19 @@ func (provisioner *KopsProvisioner) UpgradeCluster(cluster *model.Cluster, awsCl
 		}
 	}
 
+	iamRole := fmt.Sprintf("nodes.%s", kopsMetadata.Name)
+	err = awsClient.AttachPolicyToRole(iamRole, aws.CustomNodePolicyName, logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to attach custom node policy")
+	}
+
 	logger.Info("Successfully upgraded cluster")
 
 	return nil
 }
 
 // ResizeCluster resizes a cluster.
-func (provisioner *KopsProvisioner) ResizeCluster(cluster *model.Cluster) error {
+func (provisioner *KopsProvisioner) ResizeCluster(cluster *model.Cluster, awsClient aws.AWS) error {
 	logger := provisioner.logger.WithField("cluster", cluster.ID)
 
 	kopsMetadata := cluster.ProvisionerMetadataKops
@@ -653,6 +659,12 @@ func (provisioner *KopsProvisioner) ResizeCluster(cluster *model.Cluster) error 
 			kops.ValidateCluster(kopsMetadata.Name, false)
 			return err
 		}
+	}
+
+	iamRole := fmt.Sprintf("nodes.%s", kopsMetadata.Name)
+	err = awsClient.AttachPolicyToRole(iamRole, aws.CustomNodePolicyName, logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to attach custom node policy")
 	}
 
 	logger.Info("Successfully resized cluster")

--- a/internal/supervisor/cluster.go
+++ b/internal/supervisor/cluster.go
@@ -32,7 +32,7 @@ type clusterProvisioner interface {
 	CreateCluster(cluster *model.Cluster, aws aws.AWS) error
 	ProvisionCluster(cluster *model.Cluster, aws aws.AWS) error
 	UpgradeCluster(cluster *model.Cluster, aws aws.AWS) error
-	ResizeCluster(cluster *model.Cluster) error
+	ResizeCluster(cluster *model.Cluster, aws aws.AWS) error
 	DeleteCluster(cluster *model.Cluster, aws aws.AWS) error
 	RefreshKopsMetadata(cluster *model.Cluster) error
 }
@@ -210,7 +210,7 @@ func (s *ClusterSupervisor) upgradeCluster(cluster *model.Cluster, logger log.Fi
 }
 
 func (s *ClusterSupervisor) resizeCluster(cluster *model.Cluster, logger log.FieldLogger) string {
-	err := s.provisioner.ResizeCluster(cluster)
+	err := s.provisioner.ResizeCluster(cluster, s.aws)
 	if err != nil {
 		logger.WithError(err).Error("Failed to resize cluster")
 		return model.ClusterStateResizeFailed

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -78,7 +78,7 @@ func (p *mockClusterProvisioner) UpgradeCluster(cluster *model.Cluster, aws aws.
 	return nil
 }
 
-func (p *mockClusterProvisioner) ResizeCluster(cluster *model.Cluster) error {
+func (p *mockClusterProvisioner) ResizeCluster(cluster *model.Cluster, aws aws.AWS) error {
 	return nil
 }
 


### PR DESCRIPTION
#### Summary
Bug fix: When upgrade or resize cluster a related AWS IAM role policy get's detached. This PR solves this issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32795

#### Release Note

```release-note
Bug-fix: Attach correct IAM role policy on upgrade and resize events.
```
