### PR TITLE
Add installation status API endpoint

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -83,6 +83,7 @@ func init() {
 	installationCmd.AddCommand(installationListCmd)
 	installationCmd.AddCommand(installationShowStateReport)
 	installationCmd.AddCommand(installationAnnotationCmd)
+	installationCmd.AddCommand(installationsGetStatuses)
 }
 
 var installationCmd = &cobra.Command{
@@ -375,6 +376,32 @@ var installationListCmd = &cobra.Command{
 		}
 
 		err = printJSON(installations)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var installationsGetStatuses = &cobra.Command{
+	Use:   "status",
+	Short: "Get status information for all installations.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		installationsStatus, err := client.GetInstallationsStatus()
+		if err != nil {
+			return errors.Wrap(err, "failed to query installation status")
+		}
+		if installationsStatus == nil {
+			return nil
+		}
+
+		err = printJSON(installationsStatus)
 		if err != nil {
 			return err
 		}

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -1146,8 +1146,8 @@ func TestGetAllUtilityMetadata(t *testing.T) {
 			Provider: model.ProviderAWS,
 			Zones:    []string{"zone"},
 			DesiredUtilityVersions: map[string]*model.HelmUtilityVersion{
-				"prometheus-operator": &model.HelmUtilityVersion{Chart: "9.4.4"},
-				"nginx":               &model.HelmUtilityVersion{Chart: "stable"},
+				"prometheus-operator": {Chart: "9.4.4"},
+				"nginx":               {Chart: "stable"},
 			},
 		})
 

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -34,7 +34,8 @@ type Store interface {
 	GetInstallationDTO(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.InstallationDTO, error)
 	GetInstallations(filter *model.InstallationFilter, includeGroupConfig, includeGroupConfigOverrides bool) ([]*model.Installation, error)
 	GetInstallationDTOs(filter *model.InstallationFilter, includeGroupConfig, includeGroupConfigOverrides bool) ([]*model.InstallationDTO, error)
-	GetInstallationsCount(includeDeleted bool) (int, error)
+	GetInstallationsCount(includeDeleted bool) (int64, error)
+	GetInstallationsStatus() (*model.InstallationsStatus, error)
 	UpdateInstallation(installation *model.Installation) error
 	LockInstallation(installationID, lockerID string) (bool, error)
 	UnlockInstallation(installationID, lockerID string, force bool) (bool, error)

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -641,7 +641,7 @@ func TestGroupsStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("empty groups", func(t *testing.T) {
-		expectedStatus := &[]model.GroupsStatus{
+		expectedStatus := []*model.GroupsStatus{
 			{
 				ID: group.ID,
 				Status: model.GroupStatus{
@@ -701,12 +701,12 @@ func TestGroupsStatus(t *testing.T) {
 		groupsStatus, err := client.GetGroupsStatus()
 		require.NoError(t, err)
 		require.NotNil(t, groupsStatus)
-		assert.Len(t, *groupsStatus, 2)
-		for _, gs := range *groupsStatus {
+		assert.Len(t, groupsStatus, 2)
+		for _, gs := range groupsStatus {
 			if gs.ID == group.ID {
-				assert.Equal(t, expectedStatusGroup1, &gs)
+				assert.Equal(t, expectedStatusGroup1, gs)
 			} else if gs.ID == group2.ID {
-				assert.Equal(t, expectedStatusGroup2, &gs)
+				assert.Equal(t, expectedStatusGroup2, gs)
 			}
 		}
 	})

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -24,8 +24,9 @@ func initInstallation(apiRouter *mux.Router, context *Context) {
 
 	installationsRouter := apiRouter.PathPrefix("/installations").Subrouter()
 	installationsRouter.Handle("", addContext(handleGetInstallations)).Methods("GET")
-	installationsRouter.Handle("/count", addContext(handleGetNumberOfInstallations)).Methods("GET")
 	installationsRouter.Handle("", addContext(handleCreateInstallation)).Methods("POST")
+	installationsRouter.Handle("/count", addContext(handleGetNumberOfInstallations)).Methods("GET")
+	installationsRouter.Handle("/status", addContext(handleGetInstallationsStatus)).Methods("GET")
 
 	installationRouter := apiRouter.PathPrefix("/installation/{installation:[A-Za-z0-9]{26}}").Subrouter()
 	installationRouter.Handle("", addContext(handleGetInstallation)).Methods("GET")
@@ -131,9 +132,25 @@ func handleGetNumberOfInstallations(c *Context, w http.ResponseWriter, r *http.R
 		return
 	}
 	result := model.InstallationsCount{Count: installationsCount}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, result)
+}
+
+// handleGetInstallationsStatus responds to GET /api/installations/status,
+// returning the status of all non-deleted installations
+func handleGetInstallationsStatus(c *Context, w http.ResponseWriter, r *http.Request) {
+	installationsStatus, err := c.Store.GetInstallationsStatus()
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query for installations status")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, installationsStatus)
 }
 
 // handleCreateInstallation responds to POST /api/installations, beginning the process of creating

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -312,7 +312,7 @@ func TestGetInstallations(t *testing.T) {
 			testCases := []struct {
 				Description    string
 				IncludeDeleted bool
-				Expected       int
+				Expected       int64
 			}{
 				{
 					"count without deleted",
@@ -332,6 +332,15 @@ func TestGetInstallations(t *testing.T) {
 					require.Equal(t, testCase.Expected, installations)
 				})
 			}
+		})
+
+		t.Run("check installations status", func(t *testing.T) {
+			status, err := client.GetInstallationsStatus()
+			require.NoError(t, err)
+			assert.Equal(t, int64(3), status.InstallationsTotal)
+			assert.Equal(t, int64(0), status.InstallationsStable)
+			assert.Equal(t, int64(0), status.InstallationsHibernating)
+			assert.Equal(t, int64(3), status.InstallationsUpdating)
 		})
 	})
 }

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -792,6 +792,96 @@ func TestUpdateInstallationState(t *testing.T) {
 	assert.NotEqual(t, storedInstallation.Version, installation1.Version)
 }
 
+func TestGetInstallationsStatus(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation1 := &model.Installation{
+		OwnerID:   model.NewID(),
+		Version:   "version",
+		DNS:       "dns1.example.com",
+		License:   "this-is-a-license",
+		Database:  model.InstallationDatabaseMysqlOperator,
+		Filestore: model.InstallationFilestoreMinioOperator,
+		Size:      mmv1alpha1.Size100String,
+		Affinity:  model.InstallationAffinityIsolated,
+		State:     model.InstallationStateCreationRequested,
+	}
+
+	err := sqlStore.CreateInstallation(installation1, nil)
+	require.NoError(t, err)
+
+	status, err := sqlStore.GetInstallationsStatus()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), status.InstallationsTotal)
+	assert.Equal(t, int64(0), status.InstallationsStable)
+	assert.Equal(t, int64(0), status.InstallationsHibernating)
+	assert.Equal(t, int64(1), status.InstallationsUpdating)
+
+	time.Sleep(1 * time.Millisecond)
+
+	installation2 := &model.Installation{
+		OwnerID:   model.NewID(),
+		Version:   "version",
+		DNS:       "dns2.example.com",
+		License:   "this-is-a-license",
+		Database:  model.InstallationDatabaseMysqlOperator,
+		Filestore: model.InstallationFilestoreMinioOperator,
+		Size:      mmv1alpha1.Size100String,
+		Affinity:  model.InstallationAffinityIsolated,
+		State:     model.ClusterInstallationStateStable,
+	}
+
+	err = sqlStore.CreateInstallation(installation2, nil)
+	require.NoError(t, err)
+
+	status, err = sqlStore.GetInstallationsStatus()
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), status.InstallationsTotal)
+	assert.Equal(t, int64(1), status.InstallationsStable)
+	assert.Equal(t, int64(0), status.InstallationsHibernating)
+	assert.Equal(t, int64(1), status.InstallationsUpdating)
+
+	time.Sleep(1 * time.Millisecond)
+
+	installation3 := &model.Installation{
+		OwnerID:   model.NewID(),
+		Version:   "version",
+		DNS:       "dns3.example.com",
+		License:   "this-is-a-license",
+		Database:  model.InstallationDatabaseMysqlOperator,
+		Filestore: model.InstallationFilestoreMinioOperator,
+		Size:      mmv1alpha1.Size100String,
+		Affinity:  model.InstallationAffinityIsolated,
+		State:     model.InstallationStateHibernating,
+	}
+
+	err = sqlStore.CreateInstallation(installation3, nil)
+	require.NoError(t, err)
+
+	status, err = sqlStore.GetInstallationsStatus()
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), status.InstallationsTotal)
+	assert.Equal(t, int64(1), status.InstallationsStable)
+	assert.Equal(t, int64(1), status.InstallationsHibernating)
+	assert.Equal(t, int64(1), status.InstallationsUpdating)
+
+	time.Sleep(1 * time.Millisecond)
+
+	err = sqlStore.DeleteInstallation(installation1.ID)
+	require.NoError(t, err)
+
+	status, err = sqlStore.GetInstallationsStatus()
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), status.InstallationsTotal)
+	assert.Equal(t, int64(1), status.InstallationsStable)
+	assert.Equal(t, int64(1), status.InstallationsHibernating)
+	assert.Equal(t, int64(0), status.InstallationsUpdating)
+
+	time.Sleep(1 * time.Millisecond)
+}
+
 func TestDeleteInstallation(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := MakeTestSQLStore(t, logger)

--- a/model/group_status.go
+++ b/model/group_status.go
@@ -37,13 +37,13 @@ func GroupStatusFromReader(reader io.Reader) (*GroupStatus, error) {
 }
 
 // GroupsStatusFromReader decodes a json-encoded groups status from the given io.Reader.
-func GroupsStatusFromReader(reader io.Reader) (*[]GroupsStatus, error) {
-	groupsStatus := []GroupsStatus{}
+func GroupsStatusFromReader(reader io.Reader) ([]*GroupsStatus, error) {
+	groupsStatus := []*GroupsStatus{}
 	decoder := json.NewDecoder(reader)
 	err := decoder.Decode(&groupsStatus)
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
 
-	return &groupsStatus, nil
+	return groupsStatus, nil
 }

--- a/model/installation.go
+++ b/model/installation.go
@@ -57,7 +57,7 @@ type Installation struct {
 
 // InstallationsCount represents the number of installations
 type InstallationsCount struct {
-	Count int
+	Count int64
 }
 
 // InstallationFilter describes the parameters used to constrain a set of installations.
@@ -191,7 +191,7 @@ func InstallationsFromReader(reader io.Reader) ([]*Installation, error) {
 
 // InstallationsCountFromReader decodes a json-encoded installations count data from the
 // given io.Reader
-func InstallationsCountFromReader(reader io.Reader) (int, error) {
+func InstallationsCountFromReader(reader io.Reader) (int64, error) {
 	installationsCount := InstallationsCount{}
 	decoder := json.NewDecoder(reader)
 	err := decoder.Decode(&installationsCount)

--- a/model/installation_status.go
+++ b/model/installation_status.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// InstallationsStatus represents the status of all installations.
+type InstallationsStatus struct {
+	InstallationsTotal       int64
+	InstallationsStable      int64
+	InstallationsHibernating int64
+	InstallationsUpdating    int64
+}
+
+// InstallationsStatusFromReader decodes a json-encoded InstallationsStatus from the given io.Reader.
+func InstallationsStatusFromReader(reader io.Reader) (*InstallationsStatus, error) {
+	installationsStatus := InstallationsStatus{}
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&installationsStatus)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &installationsStatus, nil
+}


### PR DESCRIPTION
The new endpoint returns the complete status of all non-deleted
installations managed by the provisioner. This can be used by other
cloud services to easily determine the amount of installation
processing happening at any moment so that they can make intelligent
decisions on when to request additional installation updates.

Fixes https://mattermost.atlassian.net/browse/MM-33308

```release-note
Add installation status API endpoint
```
