### PR TITLE
Installation database weighting

### DIFF
--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -563,7 +563,7 @@ func handleWakeupInstallation(c *Context, w http.ResponseWriter, r *http.Request
 	}
 
 	oldState := installationDTO.State
-	newState := model.InstallationStateUpdateRequested
+	newState := model.InstallationStateWakeUpRequested
 
 	if !installationDTO.ValidTransitionState(newState) {
 		c.Logger.Warnf("unable to wake up installation while in state %s", installationDTO.State)

--- a/internal/mocks/model/installation_database.go
+++ b/internal/mocks/model/installation_database.go
@@ -95,6 +95,20 @@ func (mr *MockDatabaseMockRecorder) GenerateDatabaseSecret(store, logger interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateDatabaseSecret", reflect.TypeOf((*MockDatabase)(nil).GenerateDatabaseSecret), store, logger)
 }
 
+// RefreshResourceMetadata mocks base method
+func (m *MockDatabase) RefreshResourceMetadata(store model.InstallationDatabaseStoreInterface, logger logrus.FieldLogger) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshResourceMetadata", store, logger)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RefreshResourceMetadata indicates an expected call of RefreshResourceMetadata
+func (mr *MockDatabaseMockRecorder) RefreshResourceMetadata(store, logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshResourceMetadata", reflect.TypeOf((*MockDatabase)(nil).RefreshResourceMetadata), store, logger)
+}
+
 // MockInstallationDatabaseStoreInterface is a mock of InstallationDatabaseStoreInterface interface
 type MockInstallationDatabaseStoreInterface struct {
 	ctrl     *gomock.Controller
@@ -176,6 +190,21 @@ func (m *MockInstallationDatabaseStoreInterface) GetMultitenantDatabaseForInstal
 func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetMultitenantDatabaseForInstallationID(installationID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultitenantDatabaseForInstallationID", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetMultitenantDatabaseForInstallationID), installationID)
+}
+
+// GetInstallationsTotalDatabaseWeight mocks base method
+func (m *MockInstallationDatabaseStoreInterface) GetInstallationsTotalDatabaseWeight(installationIDs []string) (float64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInstallationsTotalDatabaseWeight", installationIDs)
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInstallationsTotalDatabaseWeight indicates an expected call of GetInstallationsTotalDatabaseWeight
+func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetInstallationsTotalDatabaseWeight(installationIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallationsTotalDatabaseWeight", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetInstallationsTotalDatabaseWeight), installationIDs)
 }
 
 // CreateMultitenantDatabase mocks base method

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -911,6 +911,84 @@ func TestUpdateInstallationCRVersion(t *testing.T) {
 	assert.Equal(t, storedInstallation.CRVersion, model.V1betaCRVersion)
 }
 
+func TestGetInstallationsTotalDatabaseWeight(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation1 := &model.Installation{
+		OwnerID:   model.NewID(),
+		Version:   "version",
+		DNS:       "dns1.example.com",
+		License:   "this-is-a-license",
+		Database:  model.InstallationDatabaseMysqlOperator,
+		Filestore: model.InstallationFilestoreMinioOperator,
+		Size:      mmv1alpha1.Size100String,
+		Affinity:  model.InstallationAffinityIsolated,
+		State:     model.InstallationStateStable,
+		CRVersion: model.V1alphaCRVersion,
+	}
+
+	err := sqlStore.CreateInstallation(installation1, nil)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Millisecond)
+
+	installation2 := &model.Installation{
+		OwnerID:   model.NewID(),
+		Version:   "version",
+		DNS:       "dns2.example.com",
+		License:   "this-is-a-license",
+		Database:  model.InstallationDatabaseMysqlOperator,
+		Filestore: model.InstallationFilestoreMinioOperator,
+		Size:      mmv1alpha1.Size100String,
+		Affinity:  model.InstallationAffinityIsolated,
+		State:     model.InstallationStateStable,
+		CRVersion: model.V1alphaCRVersion,
+	}
+
+	err = sqlStore.CreateInstallation(installation2, nil)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Millisecond)
+
+	installation3 := &model.Installation{
+		OwnerID:   model.NewID(),
+		Version:   "version",
+		DNS:       "dns3.example.com",
+		License:   "this-is-a-license",
+		Database:  model.InstallationDatabaseMysqlOperator,
+		Filestore: model.InstallationFilestoreMinioOperator,
+		Size:      mmv1alpha1.Size100String,
+		Affinity:  model.InstallationAffinityIsolated,
+		State:     model.InstallationStateHibernating,
+		CRVersion: model.V1alphaCRVersion,
+	}
+
+	err = sqlStore.CreateInstallation(installation3, nil)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Millisecond)
+
+	totalWeight, err := sqlStore.GetInstallationsTotalDatabaseWeight([]string{installation1.ID})
+	require.NoError(t, err)
+	assert.Equal(t, installation1.GetDatabaseWeight(), totalWeight)
+	assert.Equal(t, model.DefaultDatabaseWeight, totalWeight)
+
+	totalWeight, err = sqlStore.GetInstallationsTotalDatabaseWeight([]string{installation3.ID})
+	require.NoError(t, err)
+	assert.Equal(t, installation3.GetDatabaseWeight(), totalWeight)
+	assert.Equal(t, model.HibernatingDatabaseWeight, totalWeight)
+
+	totalWeight, err = sqlStore.GetInstallationsTotalDatabaseWeight([]string{
+		installation1.ID,
+		installation2.ID,
+		installation3.ID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, installation1.GetDatabaseWeight()+installation2.GetDatabaseWeight()+installation3.GetDatabaseWeight(), totalWeight)
+}
+
 func TestDeleteInstallation(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := MakeTestSQLStore(t, logger)

--- a/internal/tools/aws/database.go
+++ b/internal/tools/aws/database.go
@@ -37,6 +37,11 @@ func NewRDSDatabase(databaseType, installationID string, client *Client) *RDSDat
 	}
 }
 
+// RefreshResourceMetadata ensures various database resource's metadata are correct.
+func (d *RDSDatabase) RefreshResourceMetadata(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	return nil
+}
+
 // Provision completes all the steps necessary to provision a RDS database.
 func (d *RDSDatabase) Provision(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
 	d.client.AddSQLStore(store)

--- a/internal/tools/aws/database_multitenant.go
+++ b/internal/tools/aws/database_multitenant.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -92,6 +93,45 @@ func (d *RDSMultitenantDatabase) MaxSupportedDatabases() int {
 	return DefaultRDSMultitenantDatabasePostgresCountLimit
 }
 
+// RefreshResourceMetadata ensures various multitenant database resource's
+// metadata are correct.
+func (d *RDSMultitenantDatabase) RefreshResourceMetadata(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	return d.updateMultitenantDatabase(store, logger)
+}
+
+func (d *RDSMultitenantDatabase) updateMultitenantDatabase(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	database, unlockFn, err := d.getAndLockAssignedMultitenantDatabase(store, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to get and lock assigned database")
+	}
+	if database == nil {
+		return errors.Wrap(err, "failed to find assigned multitenant database")
+	}
+	defer unlockFn()
+
+	logger = logger.WithField("assigned-database", database.ID)
+
+	rdsCluster, err := d.describeRDSCluster(database.ID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to describe the multitenant RDS cluster ID %s", database.ID)
+	}
+
+	weight, err := store.GetInstallationsTotalDatabaseWeight(database.Installations)
+	if err != nil {
+		return errors.Wrap(err, "failed to calculate total database weight")
+	}
+	roundedUpWeight := int(math.Ceil(weight))
+
+	err = d.updateCounterTag(rdsCluster.DBClusterArn, roundedUpWeight)
+	if err != nil {
+		return errors.Wrapf(err, "failed to update tag:counter in RDS cluster ID %s", *rdsCluster.DBClusterIdentifier)
+	}
+
+	logger.Debugf("Multitenant database %s counter value updated to %d", database.ID, roundedUpWeight)
+
+	return nil
+}
+
 // Provision claims a multitenant RDS cluster and creates a database schema for
 // the installation.
 func (d *RDSMultitenantDatabase) Provision(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
@@ -143,11 +183,17 @@ func (d *RDSMultitenantDatabase) Provision(store model.InstallationDatabaseStore
 		return errors.Wrap(err, "failed to run provisioning sql commands")
 	}
 
-	err = d.updateCounterTag(rdsCluster.DBClusterArn, database.Installations.Count())
+	weight, err := store.GetInstallationsTotalDatabaseWeight(database.Installations)
+	if err != nil {
+		return errors.Wrap(err, "failed to calculate total database weight")
+	}
+	roundedUpWeight := int(math.Ceil(weight))
+
+	err = d.updateCounterTag(rdsCluster.DBClusterArn, roundedUpWeight)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update tag:counter in RDS cluster ID %s", *rdsCluster.DBClusterIdentifier)
 	}
-	logger.Debugf("Multitenant database %s counter value updated to %d", database.ID, database.Installations.Count())
+	logger.Debugf("Multitenant database %s counter value updated to %d", database.ID, roundedUpWeight)
 
 	logger.Infof("Installation %s assigned to multitenant database", d.installationID)
 
@@ -626,25 +672,22 @@ func (d *RDSMultitenantDatabase) removeInstallationFromMultitenantDatabase(datab
 		return errors.Wrap(err, "failed to drop database or delete secret")
 	}
 
-	numInstallations := database.Installations.Count()
-
-	err = d.updateCounterTag(rdsCluster.DBClusterArn, numInstallations-1)
+	database.Installations.Remove(d.installationID)
+	weight, err := store.GetInstallationsTotalDatabaseWeight(database.Installations)
 	if err != nil {
-		return errors.Wrap(err, "failed to update counter tag")
+		return errors.Wrap(err, "failed to calculate total database weight")
+	}
+	roundedUpWeight := int(math.Ceil(weight))
+
+	err = d.updateCounterTag(rdsCluster.DBClusterArn, roundedUpWeight)
+	if err != nil {
+		return errors.Wrapf(err, "failed to update tag:counter in RDS cluster ID %s", *rdsCluster.DBClusterIdentifier)
 	}
 
-	// We need to update the tag before removing the installation ID from the
-	// datastore. However, if this operation fails, tag:counter in RDS needs to
-	// return to the original value.
-	// TODO: improve handling this.
-	database.Installations.Remove(d.installationID)
+	logger.Debugf("Multitenant database %s counter value updated to %d", database.ID, roundedUpWeight)
+
 	err = store.UpdateMultitenantDatabase(database)
 	if err != nil {
-		logger.WithError(err).Warnf("Failed to remove multitenant database from datastore. Rolling tag:counter value back to %d", numInstallations)
-		updateTagErr := d.updateCounterTag(rdsCluster.DBClusterArn, numInstallations)
-		if updateTagErr != nil {
-			logger.WithError(err).Errorf("Failed to roll back tag:counter. Value is still %d", numInstallations-1)
-		}
 		return errors.Wrapf(err, "failed to remove installation ID %s from multitenant datastore", d.installationID)
 	}
 

--- a/model/installation.go
+++ b/model/installation.go
@@ -17,6 +17,11 @@ const (
 	V1betaCRVersion = "installation.mattermost.com/v1beta1"
 	// DefaultCRVersion is a default CR version used for new installations.
 	DefaultCRVersion = V1betaCRVersion
+	// DefaultDatabaseWeight is the default weight of a small or average-sized
+	// installation that isn't hibernating.
+	DefaultDatabaseWeight float64 = 1
+	// HibernatingDatabaseWeight is the weight of a hibernating installation.
+	HibernatingDatabaseWeight float64 = .75
 )
 
 // Installation represents a Mattermost installation.
@@ -62,13 +67,14 @@ type InstallationsCount struct {
 
 // InstallationFilter describes the parameters used to constrain a set of installations.
 type InstallationFilter struct {
-	OwnerID        string
-	GroupID        string
-	State          string
-	DNS            string
-	Page           int
-	PerPage        int
-	IncludeDeleted bool
+	InstallationIDs []string
+	OwnerID         string
+	GroupID         string
+	State           string
+	DNS             string
+	Page            int
+	PerPage         int
+	IncludeDeleted  bool
 }
 
 // Clone returns a deep copy the installation.
@@ -86,6 +92,18 @@ func (i *Installation) ToDTO(annotations []*Annotation) *InstallationDTO {
 		Installation: i,
 		Annotations:  annotations,
 	}
+}
+
+// GetDatabaseWeight returns a value corresponding to the
+// TODO: maybe consider installation size in the future as well?
+func (i *Installation) GetDatabaseWeight() float64 {
+	if i.State == InstallationStateHibernationRequested ||
+		i.State == InstallationStateHibernationInProgress ||
+		i.State == InstallationStateHibernating {
+		return HibernatingDatabaseWeight
+	}
+
+	return DefaultDatabaseWeight
 }
 
 // IsInGroup returns if the installation is in a group or not.

--- a/model/installation_database.go
+++ b/model/installation_database.go
@@ -40,6 +40,7 @@ type Database interface {
 	Teardown(store InstallationDatabaseStoreInterface, keepData bool, logger log.FieldLogger) error
 	Snapshot(store InstallationDatabaseStoreInterface, logger log.FieldLogger) error
 	GenerateDatabaseSecret(store InstallationDatabaseStoreInterface, logger log.FieldLogger) (*corev1.Secret, error)
+	RefreshResourceMetadata(store InstallationDatabaseStoreInterface, logger log.FieldLogger) error
 }
 
 // InstallationDatabaseStoreInterface is the interface necessary for SQLStore
@@ -51,6 +52,7 @@ type InstallationDatabaseStoreInterface interface {
 	GetMultitenantDatabase(multitenantdatabaseID string) (*MultitenantDatabase, error)
 	GetMultitenantDatabases(filter *MultitenantDatabaseFilter) ([]*MultitenantDatabase, error)
 	GetMultitenantDatabaseForInstallationID(installationID string) (*MultitenantDatabase, error)
+	GetInstallationsTotalDatabaseWeight(installationIDs []string) (float64, error)
 	CreateMultitenantDatabase(multitenantDatabase *MultitenantDatabase) error
 	UpdateMultitenantDatabase(multitenantDatabase *MultitenantDatabase) error
 	LockMultitenantDatabase(multitenantdatabaseID, lockerID string) (bool, error)
@@ -94,6 +96,12 @@ func (d *MysqlOperatorDatabase) Teardown(store InstallationDatabaseStoreInterfac
 // accessing the MySQL operator database.
 func (d *MysqlOperatorDatabase) GenerateDatabaseSecret(store InstallationDatabaseStoreInterface, logger log.FieldLogger) (*corev1.Secret, error) {
 	return nil, nil
+}
+
+// RefreshResourceMetadata ensures various operator database resource's metadata
+// are correct.
+func (d *MysqlOperatorDatabase) RefreshResourceMetadata(store InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	return nil
 }
 
 // InternalDatabase returns true if the installation's database is internal

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -34,6 +34,9 @@ const (
 	InstallationStateHibernationInProgress = "hibernation-in-progress"
 	// InstallationStateHibernating is an installation that is hibernating.
 	InstallationStateHibernating = "hibernating"
+	// InstallationStateWakeUpRequested is an installation that is about to be
+	// woken up from hibernation.
+	InstallationStateWakeUpRequested = "wake-up-requested"
 	// InstallationStateUpdateRequested is an installation that is about to undergo an update.
 	InstallationStateUpdateRequested = "update-requested"
 	// InstallationStateUpdateInProgress is an installation that is being updated.
@@ -72,6 +75,7 @@ var AllInstallationStates = []string{
 	InstallationStateHibernationRequested,
 	InstallationStateHibernationInProgress,
 	InstallationStateHibernating,
+	InstallationStateWakeUpRequested,
 	InstallationStateUpdateRequested,
 	InstallationStateUpdateInProgress,
 	InstallationStateUpdateFailed,
@@ -96,6 +100,7 @@ var AllInstallationStatesPendingWork = []string{
 	InstallationStateCreationDNS,
 	InstallationStateHibernationRequested,
 	InstallationStateHibernationInProgress,
+	InstallationStateWakeUpRequested,
 	InstallationStateUpdateRequested,
 	InstallationStateUpdateInProgress,
 	InstallationStateDeletionRequested,
@@ -111,6 +116,7 @@ var AllInstallationStatesPendingWork = []string{
 var AllInstallationRequestStates = []string{
 	InstallationStateCreationRequested,
 	InstallationStateHibernationRequested,
+	InstallationStateWakeUpRequested,
 	InstallationStateUpdateRequested,
 	InstallationStateDeletionRequested,
 }
@@ -151,10 +157,18 @@ func validTransitionToInstallationStateHibernationRequested(currentState string)
 	return false
 }
 
+func validTransitionToInstallationStateWakeUpRequested(currentState string) bool {
+	switch currentState {
+	case InstallationStateHibernating:
+		return true
+	}
+
+	return false
+}
+
 func validTransitionToInstallationStateUpdateRequested(currentState string) bool {
 	switch currentState {
 	case InstallationStateStable,
-		InstallationStateHibernating,
 		InstallationStateUpdateRequested,
 		InstallationStateUpdateInProgress,
 		InstallationStateUpdateFailed:

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -129,6 +129,8 @@ func (i *Installation) ValidTransitionState(newState string) bool {
 		return validTransitionToInstallationStateCreationRequested(i.State)
 	case InstallationStateHibernationRequested:
 		return validTransitionToInstallationStateHibernationRequested(i.State)
+	case InstallationStateWakeUpRequested:
+		return validTransitionToInstallationStateWakeUpRequested(i.State)
 	case InstallationStateUpdateRequested:
 		return validTransitionToInstallationStateUpdateRequested(i.State)
 	case InstallationStateDeletionRequested:


### PR DESCRIPTION
This change introduces the concept of database weights to
installations. Installations that are hibernating now reserve less
space in a shared database than other states. This allows for
the spare capacity of multiple hibernating installations to be
allocated to new installations while still offering some protection
if these installations wake up.

Fixes https://mattermost.atlassian.net/browse/MM-33653

```release-note
Installation database weighting
```
