### PR TITLE
MM 33398 - Implement Backup supervisor

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -52,7 +52,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("debug-helm", false, "Whether to include Helm output in debug logs.")
 	serverCmd.PersistentFlags().Bool("machine-readable-logs", false, "Output the logs in machine readable format.")
 	serverCmd.PersistentFlags().Bool("dev", false, "Set sane defaults for development")
-	serverCmd.PersistentFlags().String("backup-restore-tool-image", "mattermost/backup-restore-tool:latest", "Image of InstallationBackup Restore Tool to use.")
+	serverCmd.PersistentFlags().String("backup-restore-tool-image", "mattermost/backup-restore-tool:latest", "Image of Backup Restore Tool to use.")
 	serverCmd.PersistentFlags().Int32("backup-job-ttl-seconds", 3600, "Number of seconds after which finished backup jobs will be cleaned up. Set to negative value to not cleanup or 0 to cleanup immediately.")
 
 	// Supervisors
@@ -233,7 +233,7 @@ var serverCmd = &cobra.Command{
 
 		resourceUtil := utils.NewResourceUtil(instanceID, awsClient)
 
-		kopsProvisionerConf := provisioner.ProvisioningParams{
+		provisioningParams := provisioner.ProvisioningParams{
 			S3StateStore:            s3StateStore,
 			AllowCIDRRangeList:      allowListCIDRRange,
 			VpnCIDRList:             vpnListCIDR,
@@ -243,7 +243,7 @@ var serverCmd = &cobra.Command{
 
 		// Setup the provisioner for actually effecting changes to clusters.
 		kopsProvisioner := provisioner.NewKopsProvisioner(
-			kopsProvisionerConf,
+			provisioningParams,
 			resourceUtil,
 			logger,
 			sqlStore,

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -52,6 +52,8 @@ func init() {
 	serverCmd.PersistentFlags().Bool("debug-helm", false, "Whether to include Helm output in debug logs.")
 	serverCmd.PersistentFlags().Bool("machine-readable-logs", false, "Output the logs in machine readable format.")
 	serverCmd.PersistentFlags().Bool("dev", false, "Set sane defaults for development")
+	serverCmd.PersistentFlags().String("backup-restore-tool-image", "mattermost/backup-restore-tool:latest", "Image of InstallationBackup Restore Tool to use.")
+	serverCmd.PersistentFlags().Int32("backup-job-ttl-seconds", 3600, "Number of seconds after which finished backup jobs will be cleaned up. Set to negative value to not cleanup or 0 to cleanup immediately.")
 
 	// Supervisors
 	serverCmd.PersistentFlags().Int("poll", 30, "The interval in seconds to poll for background work.")
@@ -59,6 +61,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("group-supervisor", false, "Whether this server will run an installation group supervisor or not.")
 	serverCmd.PersistentFlags().Bool("installation-supervisor", true, "Whether this server will run an installation supervisor or not.")
 	serverCmd.PersistentFlags().Bool("cluster-installation-supervisor", true, "Whether this server will run a cluster installation supervisor or not.")
+	serverCmd.PersistentFlags().Bool("backup-supervisor", false, "Whether this server will run a backup supervisor or not.")
 
 	// Scheduling and installation options
 	serverCmd.PersistentFlags().Bool("balanced-installation-scheduling", false, "Whether to schedule installations on the cluster with the greatest percentage of available resources or not. (slows down scheduling speed as cluster count increases)")
@@ -147,7 +150,8 @@ var serverCmd = &cobra.Command{
 		groupSupervisor, _ := command.Flags().GetBool("group-supervisor")
 		installationSupervisor, _ := command.Flags().GetBool("installation-supervisor")
 		clusterInstallationSupervisor, _ := command.Flags().GetBool("cluster-installation-supervisor")
-		if !clusterSupervisor && !installationSupervisor && !clusterInstallationSupervisor && !groupSupervisor {
+		backupSupervisor, _ := command.Flags().GetBool("backup-supervisor")
+		if !clusterSupervisor && !installationSupervisor && !clusterInstallationSupervisor && !groupSupervisor && !backupSupervisor {
 			logger.Warn("Server will be running with no supervisors. Only API functionality will work.")
 		}
 
@@ -156,6 +160,8 @@ var serverCmd = &cobra.Command{
 		keepFilestoreData, _ := command.Flags().GetBool("keep-filestore-data")
 		useExistingResources, _ := command.Flags().GetBool("use-existing-aws-resources")
 		balancedInstallationScheduling, _ := command.Flags().GetBool("balanced-installation-scheduling")
+		backupRestoreToolImage, _ := command.Flags().GetString("backup-restore-tool-image")
+		backupJobTTL, _ := command.Flags().GetInt32("backup-job-ttl-seconds")
 
 		wd, err := os.Getwd()
 		if err != nil {
@@ -178,6 +184,7 @@ var serverCmd = &cobra.Command{
 			"group-supervisor":                       groupSupervisor,
 			"installation-supervisor":                installationSupervisor,
 			"cluster-installation-supervisor":        clusterInstallationSupervisor,
+			"backup-supervisor":                      backupSupervisor,
 			"store-version":                          currentVersion,
 			"state-store":                            s3StateStore,
 			"working-directory":                      wd,
@@ -188,6 +195,8 @@ var serverCmd = &cobra.Command{
 			"keep-database-data":                     keepDatabaseData,
 			"keep-filestore-data":                    keepFilestoreData,
 			"force-cr-upgrade":                       forceCRUpgrade,
+			"backup-restore-tool-image":              backupRestoreToolImage,
+			"backup-job-ttl-seconds":                 backupJobTTL,
 			"debug":                                  debugMode,
 			"dev-mode":                               devMode,
 		}).Info("Starting Mattermost Provisioning Server")
@@ -224,16 +233,21 @@ var serverCmd = &cobra.Command{
 
 		resourceUtil := utils.NewResourceUtil(instanceID, awsClient)
 
+		kopsProvisionerConf := provisioner.ProvisioningParams{
+			S3StateStore:            s3StateStore,
+			AllowCIDRRangeList:      allowListCIDRRange,
+			VpnCIDRList:             vpnListCIDR,
+			Owner:                   owner,
+			UseExistingAWSResources: useExistingResources,
+		}
+
 		// Setup the provisioner for actually effecting changes to clusters.
 		kopsProvisioner := provisioner.NewKopsProvisioner(
-			s3StateStore,
-			owner,
-			useExistingResources,
-			allowListCIDRRange,
-			vpnListCIDR,
+			kopsProvisionerConf,
 			resourceUtil,
 			logger,
 			sqlStore,
+			provisioner.NewBackupOperator(backupRestoreToolImage, awsRegion, backupJobTTL),
 		)
 		defer kopsProvisioner.Teardown()
 
@@ -252,6 +266,9 @@ var serverCmd = &cobra.Command{
 		}
 		if clusterInstallationSupervisor {
 			multiDoer = append(multiDoer, supervisor.NewClusterInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, logger))
+		}
+		if backupSupervisor {
+			multiDoer = append(multiDoer, supervisor.NewBackupSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, logger))
 		}
 
 		// Setup the supervisor to effect any requested changes. It is wrapped in a

--- a/internal/provisioner/backup_restore.go
+++ b/internal/provisioner/backup_restore.go
@@ -26,7 +26,7 @@ import (
 const (
 	// Run job with only one attempt to avoid possibility of waking up workspace before retry.
 	backupRestoreBackoffLimit int32 = 0
-	backupAction = "backup"
+	backupAction                    = "backup"
 )
 
 // ErrJobBackoffLimitReached indicates that job failed all possible attempts and there is no reason for retrying.
@@ -152,8 +152,8 @@ func (o BackupOperator) CheckBackupStatus(jobsClient v1.JobInterface, backup *mo
 	return -1, nil
 }
 
-// CleanupBackup removes backup job from the cluster if it exists.
-func (o BackupOperator) CleanupBackup(jobsClient v1.JobInterface, backup *model.InstallationBackup, logger log.FieldLogger) error {
+// CleanupBackupJob removes backup job from the cluster if it exists.
+func (o BackupOperator) CleanupBackupJob(jobsClient v1.JobInterface, backup *model.InstallationBackup, logger log.FieldLogger) error {
 	backupJobName := jobName(backupAction, backup.ID)
 
 	ctx := context.Background()

--- a/internal/provisioner/backup_restore.go
+++ b/internal/provisioner/backup_restore.go
@@ -1,0 +1,308 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/batch/v1"
+)
+
+const (
+	// Run job with only one attempt to avoid possibility of waking up workspace before retry.
+	backupRestoreBackoffLimit int32 = 0
+)
+
+// ErrJobBackoffLimitReached indicates that job failed all possible attempts and there is no reason for retrying.
+var ErrJobBackoffLimitReached = errors.New("job reached backoff limit")
+
+// BackupOperator provides methods to run, check and cleanup backup jobs.
+type BackupOperator struct {
+	jobTTLSecondsAfterFinish *int32
+	backupRestoreImage       string
+	awsRegion                string
+}
+
+// NewBackupOperator creates new BackupOperator.
+func NewBackupOperator(image, region string, jobTTLSeconds int32) *BackupOperator {
+	jobTTL := &jobTTLSeconds
+	if jobTTLSeconds < 0 {
+		jobTTL = nil
+	}
+
+	return &BackupOperator{
+		jobTTLSecondsAfterFinish: jobTTL,
+		backupRestoreImage:       image,
+		awsRegion:                region,
+	}
+}
+
+// TriggerBackup creates new backup job and waits for it to start.
+func (o BackupOperator) TriggerBackup(
+	jobsClient v1.JobInterface,
+	backup *model.InstallationBackup,
+	installation *model.Installation,
+	fileStoreCfg *model.FilestoreConfig,
+	dbSecret string,
+	logger log.FieldLogger) (*model.S3DataResidence, error) {
+
+	dataResidence := model.S3DataResidence{
+		Region:    o.awsRegion,
+		Bucket:    fileStoreCfg.Bucket,
+		URL:       fileStoreCfg.URL,
+		ObjectKey: backupObjectKey(backup.ID),
+	}
+	storageEndpoint := fileStoreCfg.URL
+
+	var envVars []corev1.EnvVar
+
+	if installation.Filestore == model.InstallationFilestoreBifrost {
+		storageEndpoint = bifrostEndpoint
+		envVars = bifrostEnvs()
+	}
+	if installation.Filestore == model.InstallationFilestoreBifrost ||
+		installation.Filestore == model.InstallationFilestoreMultiTenantAwsS3 {
+		dataResidence.PathPrefix = installation.ID
+	}
+
+	envVars = append(envVars, o.prepareEnvs(dataResidence, storageEndpoint, fileStoreCfg.Secret, dbSecret)...)
+
+	backupJobName := jobName("backup", backup.ID)
+	job := o.createBackupRestoreJob(backupJobName, installation.ID, "backup", envVars)
+
+	ctx := context.Background()
+	job, err := jobsClient.Create(ctx, job, metav1.CreateOptions{})
+	if err != nil {
+		if !k8sErrors.IsAlreadyExists(err) {
+			return nil, errors.Wrap(err, "failed to create backup job")
+		}
+		logger.Warn("Backup job already exists")
+	}
+
+	// Wait for 5 seconds for job to start, if it won't it will be caught on next round.
+	err = wait.Poll(time.Second, 5*time.Second, func() (bool, error) {
+		job, err = jobsClient.Get(ctx, backupJobName, metav1.GetOptions{})
+		if err != nil {
+			return false, errors.Wrap(err, "failed to get backup job")
+		}
+		if job.Status.Active == 0 && job.Status.CompletionTime == nil {
+			logger.Info("Backup job not yet started")
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "Backup job not yet started")
+	}
+
+	return &dataResidence, nil
+}
+
+// CheckBackupStatus checks status of backup job,
+// returns job start time, when the job finished or -1 if it is still running.
+func (o BackupOperator) CheckBackupStatus(jobsClient v1.JobInterface, backup *model.InstallationBackup, logger log.FieldLogger) (int64, error) {
+	ctx := context.Background()
+	job, err := jobsClient.Get(ctx, jobName("backup", backup.ID), metav1.GetOptions{})
+	if err != nil {
+		return -1, errors.Wrap(err, "failed to get backup job")
+	}
+
+	if job.Status.Succeeded > 0 {
+		logger.Info("Backup finished with success")
+		return o.extractStartTime(job, logger), nil
+	}
+
+	if job.Status.Failed > 0 {
+		logger.Warnf("Backup job failed %d times", job.Status.Failed)
+	}
+
+	if job.Status.Active > 0 {
+		logger.Info("Backup job is still running")
+		return -1, nil
+	}
+
+	if job.Status.Failed == 0 {
+		logger.Info("Backup job not started yet")
+		return -1, nil
+	}
+
+	backoffLimit := getInt32(job.Spec.BackoffLimit)
+	if job.Status.Failed > backoffLimit {
+		logger.Error("Backup job reached backoff limit")
+		return -1, ErrJobBackoffLimitReached
+	}
+
+	logger.Infof("Backup job waiting for retry, will be retried at most %d more times", backoffLimit+1-job.Status.Failed)
+	return -1, nil
+}
+
+// CleanupBackup removes backup job from the cluster if it exists.
+func (o BackupOperator) CleanupBackup(jobsClient v1.JobInterface, backup *model.InstallationBackup, logger log.FieldLogger) error {
+	backupJobName := jobName("backup", backup.ID)
+
+	ctx := context.Background()
+	err := jobsClient.Delete(ctx, backupJobName, metav1.DeleteOptions{})
+	if k8sErrors.IsNotFound(err) {
+		logger.Warnf("backup job %q does not exist, assuming already deleted", backupJobName)
+		return nil
+	}
+	if err != nil {
+		return errors.Wrap(err, "failed to delete backup job")
+	}
+
+	logger.Info("backup job successfully marked for deletion")
+	return nil
+}
+
+func (o BackupOperator) extractStartTime(job *batchv1.Job, logger log.FieldLogger) int64 {
+	if job.Status.StartTime != nil {
+		return asMillis(*job.Status.StartTime)
+	}
+
+	logger.Warn("failed to get job start time, using creation timestamp")
+	return asMillis(job.CreationTimestamp)
+}
+
+func (o BackupOperator) createBackupRestoreJob(name, namespace, action string, envs []corev1.EnvVar) *batchv1.Job {
+	backoff := backupRestoreBackoffLimit
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "backup-restore"},
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "backup-restore"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						o.createBackupRestoreContainer(action, envs),
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+			BackoffLimit:            &backoff,
+			TTLSecondsAfterFinished: o.jobTTLSecondsAfterFinish,
+		},
+	}
+
+	return job
+}
+
+func (o BackupOperator) createBackupRestoreContainer(action string, envs []corev1.EnvVar) corev1.Container {
+	return corev1.Container{
+		Name:  "backup-restore",
+		Image: o.backupRestoreImage,
+		Args:  []string{action},
+		Env:   envs,
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"), // This should be enough even for very large installations
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+			},
+		},
+	}
+}
+
+func (o BackupOperator) prepareEnvs(dataRes model.S3DataResidence, endpoint string, fileStoreSecret, dbSecret string) []corev1.EnvVar {
+	envs := []corev1.EnvVar{
+		{
+			Name:  "BRT_STORAGE_REGION",
+			Value: o.awsRegion,
+		},
+		{
+			Name:  "BRT_STORAGE_BUCKET",
+			Value: dataRes.Bucket,
+		},
+		{
+			Name:  "BRT_STORAGE_ENDPOINT",
+			Value: endpoint,
+		},
+		{
+			Name:  "BRT_STORAGE_PATH_PREFIX",
+			Value: dataRes.PathPrefix,
+		},
+		{
+			Name:  "BRT_STORAGE_OBJECT_KEY",
+			Value: dataRes.ObjectKey,
+		},
+		{
+			Name:      "BRT_DATABASE",
+			ValueFrom: envSourceFromSecret(dbSecret, "DB_CONNECTION_STRING"),
+		},
+		{
+			Name:      "BRT_STORAGE_ACCESS_KEY",
+			ValueFrom: envSourceFromSecret(fileStoreSecret, "accesskey"),
+		},
+		{
+			Name:      "BRT_STORAGE_SECRET_KEY",
+			ValueFrom: envSourceFromSecret(fileStoreSecret, "secretkey"),
+		},
+	}
+
+	return envs
+}
+
+func bifrostEnvs() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "BRT_STORAGE_TLS",
+			Value: strconv.FormatBool(false),
+		},
+		{
+			Name:  "BRT_STORAGE_TYPE",
+			Value: "bifrost",
+		},
+	}
+}
+
+func envSourceFromSecret(secretName, key string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: secretName,
+			},
+			Key: key,
+		},
+	}
+}
+
+func backupObjectKey(id string) string {
+	return fmt.Sprintf("backup-%s", id)
+}
+
+func jobName(action, id string) string {
+	return fmt.Sprintf("database-%s-%s", action, id)
+}
+
+func getInt32(i32 *int32) int32 {
+	if i32 == nil {
+		return 0
+	}
+	return *i32
+}
+
+// asMillis returns metav1.Time as milliseconds.
+func asMillis(t metav1.Time) int64 {
+	return t.UnixNano() / int64(time.Millisecond)
+}

--- a/internal/provisioner/backup_restore_test.go
+++ b/internal/provisioner/backup_restore_test.go
@@ -242,7 +242,7 @@ func TestBackupOperator_CleanupBackup(t *testing.T) {
 		k8sClient := fake.NewSimpleClientset()
 		jobClinet := k8sClient.BatchV1().Jobs("installation-1")
 
-		err := operator.CleanupBackup(jobClinet, backup, logrus.New())
+		err := operator.CleanupBackupJob(jobClinet, backup, logrus.New())
 		require.NoError(t, err)
 	})
 
@@ -254,7 +254,7 @@ func TestBackupOperator_CleanupBackup(t *testing.T) {
 		k8sClient := fake.NewSimpleClientset(existing)
 		jobClinet := k8sClient.BatchV1().Jobs("installation-1")
 
-		err := operator.CleanupBackup(jobClinet, backup, logrus.New())
+		err := operator.CleanupBackupJob(jobClinet, backup, logrus.New())
 		require.NoError(t, err)
 
 		_, err = jobClinet.Get(context.Background(), "database-backup-backup-1", metav1.GetOptions{})

--- a/internal/provisioner/backup_restore_test.go
+++ b/internal/provisioner/backup_restore_test.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	v1 "k8s.io/client-go/kubernetes/typed/batch/v1"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestOperator_TriggerBackup(t *testing.T) {
+	fileStoreSecret := "file-store-secret"
+	fileStoreCfg := &model.FilestoreConfig{
+		URL:    "filestore.com",
+		Bucket: "plastic",
+		Secret: fileStoreSecret,
+	}
+	databaseSecret := "database-secret"
+
+	backupMeta := &model.InstallationBackup{
+		ID:             "backup-1",
+		InstallationID: "installation-1",
+		State:          model.InstallationBackupStateBackupRequested,
+		RequestAt:      1,
+	}
+
+	operator := NewBackupOperator("mattermost/backup-restore:test", "us", 100)
+
+	for _, testCase := range []struct {
+		description          string
+		installation         *model.Installation
+		expectedFileStoreURL string
+		extraEnvs            map[string]string
+	}{
+		{
+			description:          "s3 installation",
+			installation:         &model.Installation{ID: "installation-1", Filestore: model.InstallationFilestoreAwsS3},
+			expectedFileStoreURL: "filestore.com",
+		},
+		{
+			description:          "bifrost installation",
+			installation:         &model.Installation{ID: "installation-1", Filestore: model.InstallationFilestoreBifrost},
+			expectedFileStoreURL: "bifrost.bifrost:80",
+			extraEnvs: map[string]string{
+				"BRT_STORAGE_PATH_PREFIX": "installation-1",
+				"BRT_STORAGE_TLS":         "false",
+				"BRT_STORAGE_TYPE":        "bifrost",
+			},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			k8sClient := fake.NewSimpleClientset()
+			jobClinet := k8sClient.BatchV1().Jobs("installation-1")
+			go setJobActiveWhenExists(t, jobClinet, "database-backup-backup-1")
+
+			dataRes, err := operator.TriggerBackup(
+				jobClinet,
+				backupMeta,
+				testCase.installation,
+				fileStoreCfg,
+				databaseSecret,
+				logrus.New())
+			require.NoError(t, err)
+
+			assert.Equal(t, "filestore.com", dataRes.URL)
+			assert.Equal(t, "us", dataRes.Region)
+			assert.Equal(t, "plastic", dataRes.Bucket)
+			assert.Equal(t, "backup-backup-1", dataRes.ObjectKey)
+
+			createdJob, err := jobClinet.Get(context.Background(), "database-backup-backup-1", metav1.GetOptions{})
+			require.NoError(t, err)
+
+			assert.Equal(t, "backup-restore", createdJob.Labels["app"])
+			assert.Equal(t, "installation-1", createdJob.Namespace)
+			assert.Equal(t, backupRestoreBackoffLimit, *createdJob.Spec.BackoffLimit)
+			assert.Equal(t, int32(100), *createdJob.Spec.TTLSecondsAfterFinished)
+
+			podTemplate := createdJob.Spec.Template
+			assert.Equal(t, "backup-restore", podTemplate.Labels["app"])
+			assert.Equal(t, "mattermost/backup-restore:test", podTemplate.Spec.Containers[0].Image)
+
+			envs := podTemplate.Spec.Containers[0].Env
+			assertEnvVarEqual(t, "BRT_STORAGE_REGION", "us", envs)
+			assertEnvVarEqual(t, "BRT_STORAGE_BUCKET", "plastic", envs)
+			assertEnvVarEqual(t, "BRT_STORAGE_ENDPOINT", testCase.expectedFileStoreURL, envs)
+			assertEnvVarEqual(t, "BRT_STORAGE_OBJECT_KEY", "backup-backup-1", envs)
+			assertEnvVarFromSecret(t, "BRT_STORAGE_ACCESS_KEY", fileStoreSecret, "accesskey", envs)
+			assertEnvVarFromSecret(t, "BRT_STORAGE_SECRET_KEY", fileStoreSecret, "secretkey", envs)
+			assertEnvVarFromSecret(t, "BRT_DATABASE", databaseSecret, "DB_CONNECTION_STRING", envs)
+
+			for k, v := range testCase.extraEnvs {
+				assertEnvVarEqual(t, k, v, envs)
+			}
+		})
+	}
+
+	t.Run("succeed if job already exists", func(t *testing.T) {
+		existing := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "database-backup-backup-1", Namespace: "installation-1"},
+			Status:     batchv1.JobStatus{Active: 1},
+		}
+		k8sClient := fake.NewSimpleClientset(existing)
+		jobClinet := k8sClient.BatchV1().Jobs("installation-1")
+
+		installation := &model.Installation{ID: "installation-1", Filestore: model.InstallationFilestoreMultiTenantAwsS3}
+
+		dataRes, err := operator.TriggerBackup(
+			jobClinet,
+			backupMeta,
+			installation,
+			fileStoreCfg,
+			databaseSecret,
+			logrus.New())
+		require.NoError(t, err)
+
+		assert.Equal(t, "filestore.com", dataRes.URL)
+		assert.Equal(t, "us", dataRes.Region)
+		assert.Equal(t, "plastic", dataRes.Bucket)
+		assert.Equal(t, "backup-backup-1", dataRes.ObjectKey)
+	})
+
+	t.Run("set ttl to nil if negative value", func(t *testing.T) {
+		k8sClient := fake.NewSimpleClientset()
+		jobClinet := k8sClient.BatchV1().Jobs("installation-1")
+		go setJobActiveWhenExists(t, jobClinet, "database-backup-backup-1")
+
+		installation := &model.Installation{ID: "installation-1", Filestore: model.InstallationFilestoreMultiTenantAwsS3}
+
+		operator := NewBackupOperator("image", "us", -1)
+
+		_, err := operator.TriggerBackup(
+			jobClinet,
+			backupMeta,
+			installation,
+			fileStoreCfg,
+			databaseSecret,
+			logrus.New())
+		require.NoError(t, err)
+
+		createdJob, err := jobClinet.Get(context.Background(), "database-backup-backup-1", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Nil(t, createdJob.Spec.TTLSecondsAfterFinished)
+	})
+
+	t.Run("fail if job not ready", func(t *testing.T) {
+		k8sClient := fake.NewSimpleClientset()
+		jobClinet := k8sClient.BatchV1().Jobs("installation-1")
+		installation := &model.Installation{ID: "installation-1", Filestore: model.InstallationFilestoreMultiTenantAwsS3}
+
+		_, err := operator.TriggerBackup(
+			jobClinet,
+			backupMeta,
+			installation,
+			fileStoreCfg,
+			databaseSecret,
+			logrus.New())
+		require.Error(t, err)
+	})
+}
+
+func TestOperator_CheckBackupStatus(t *testing.T) {
+	backupMeta := &model.InstallationBackup{
+		ID:             "backup-1",
+		InstallationID: "installation-1",
+		State:          model.InstallationBackupStateBackupRequested,
+		RequestAt:      1,
+	}
+
+	k8sClient := fake.NewSimpleClientset()
+	jobClinet := k8sClient.BatchV1().Jobs("installation-1")
+
+	operator := NewBackupOperator("mattermost/backup-restore:test", "us", 0)
+
+	t.Run("error when job does not exists", func(t *testing.T) {
+		_, err := operator.CheckBackupStatus(jobClinet, backupMeta, logrus.New())
+		require.Error(t, err)
+	})
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "database-backup-backup-1"},
+		Spec:       batchv1.JobSpec{},
+		Status:     batchv1.JobStatus{},
+	}
+	var err error
+	job, err = jobClinet.Create(context.Background(), job, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Run("return -1 start time if not finished", func(t *testing.T) {
+		startTime, err := operator.CheckBackupStatus(jobClinet, backupMeta, logrus.New())
+		require.NoError(t, err)
+		assert.Equal(t, int64(-1), startTime)
+	})
+
+	job.Status.Failed = backupRestoreBackoffLimit + 1
+	job, err = jobClinet.Update(context.Background(), job, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Run("ErrJobBackoffLimitReached when failed enough times", func(t *testing.T) {
+		_, err = operator.CheckBackupStatus(jobClinet, backupMeta, logrus.New())
+		require.Error(t, err)
+		assert.Equal(t, ErrJobBackoffLimitReached, err)
+	})
+
+	expectedStartTime := metav1.Now()
+	job.Status.Succeeded = 1
+	job.Status.StartTime = &expectedStartTime
+	job, err = jobClinet.Update(context.Background(), job, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Run("return start time when succeeded", func(t *testing.T) {
+		startTime, err := operator.CheckBackupStatus(jobClinet, backupMeta, logrus.New())
+		require.NoError(t, err)
+		assert.Equal(t, asMillis(expectedStartTime), startTime)
+	})
+}
+
+func TestBackupOperator_CleanupBackup(t *testing.T) {
+	operator := NewBackupOperator("mattermost/backup-restore:test", "us", 100)
+	backup := &model.InstallationBackup{
+		ID:             "backup-1",
+		InstallationID: "installation-1",
+	}
+
+	t.Run("no error when job does not exist", func(t *testing.T) {
+		k8sClient := fake.NewSimpleClientset()
+		jobClinet := k8sClient.BatchV1().Jobs("installation-1")
+
+		err := operator.CleanupBackup(jobClinet, backup, logrus.New())
+		require.NoError(t, err)
+	})
+
+	t.Run("delete job when exists", func(t *testing.T) {
+		existing := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "database-backup-backup-1", Namespace: "installation-1"},
+			Status:     batchv1.JobStatus{Active: 1},
+		}
+		k8sClient := fake.NewSimpleClientset(existing)
+		jobClinet := k8sClient.BatchV1().Jobs("installation-1")
+
+		err := operator.CleanupBackup(jobClinet, backup, logrus.New())
+		require.NoError(t, err)
+
+		_, err = jobClinet.Get(context.Background(), "database-backup-backup-1", metav1.GetOptions{})
+		require.Error(t, err)
+		assert.True(t, k8sErrors.IsNotFound(err))
+	})
+}
+
+func setJobActiveWhenExists(t *testing.T, client v1.JobInterface, name string) {
+	ctx := context.Background()
+	err := wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
+		job, err := client.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		job.Status.Active = 1
+		_, err = client.Update(ctx, job, metav1.UpdateOptions{})
+		if err != nil {
+			return false, nil
+		}
+		return true, err
+	})
+	require.NoError(t, err)
+}
+
+func assertEnvVarEqual(t *testing.T, name, val string, env []corev1.EnvVar) {
+	for _, e := range env {
+		if e.Name == name {
+			assert.Equal(t, e.Value, val)
+			return
+		}
+	}
+
+	assert.Fail(t, fmt.Sprintf("failed to find env var %s", name))
+}
+
+func assertEnvVarFromSecret(t *testing.T, name, secret, key string, env []corev1.EnvVar) {
+	for _, e := range env {
+		if e.Name == name {
+			valFrom := e.ValueFrom
+			require.NotNil(t, valFrom)
+			require.NotNil(t, valFrom.SecretKeyRef)
+			assert.Equal(t, secret, valFrom.SecretKeyRef.Name)
+			assert.Equal(t, key, valFrom.SecretKeyRef.Key)
+			return
+		}
+	}
+
+	assert.Fail(t, fmt.Sprintf("failed to find env var %s", name))
+}

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/model"
 )
 
+// ProvisioningParams represent configuration used during various provisioning operations.
 type ProvisioningParams struct {
 	S3StateStore            string
 	AllowCIDRRangeList      []string

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -5,6 +5,7 @@
 package provisioner
 
 import (
+	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
@@ -13,34 +14,40 @@ import (
 	"github.com/mattermost/mattermost-cloud/model"
 )
 
+type ProvisioningParams struct {
+	S3StateStore            string
+	AllowCIDRRangeList      []string
+	VpnCIDRList             []string
+	Owner                   string
+	UseExistingAWSResources bool
+}
+
 // KopsProvisioner provisions clusters using kops+terraform.
 type KopsProvisioner struct {
-	s3StateStore            string
-	allowCIDRRangeList      []string
-	vpnCIDRList             []string
-	owner                   string
-	useExistingAWSResources bool
-	resourceUtil            *utils.ResourceUtil
-	logger                  log.FieldLogger
-	store                   model.InstallationDatabaseStoreInterface
-	kopsCache               map[string]*kops.Cmd
+	params         ProvisioningParams
+	resourceUtil   *utils.ResourceUtil
+	logger         log.FieldLogger
+	store          model.InstallationDatabaseStoreInterface
+	backupOperator *BackupOperator
+	kopsCache      map[string]*kops.Cmd
 }
 
 // NewKopsProvisioner creates a new KopsProvisioner.
-func NewKopsProvisioner(s3StateStore, owner string, useExistingAWSResources bool, allowCIDRRangeList, vpnCIDRList []string,
-	resourceUtil *utils.ResourceUtil, logger log.FieldLogger, store model.InstallationDatabaseStoreInterface) *KopsProvisioner {
+func NewKopsProvisioner(
+	provisioningParams ProvisioningParams,
+	resourceUtil *utils.ResourceUtil,
+	logger log.FieldLogger,
+	store model.InstallationDatabaseStoreInterface,
+	backupOperator *BackupOperator) *KopsProvisioner {
 	logger = logger.WithField("provisioner", "kops")
 
 	return &KopsProvisioner{
-		s3StateStore:            s3StateStore,
-		useExistingAWSResources: useExistingAWSResources,
-		allowCIDRRangeList:      allowCIDRRangeList,
-		vpnCIDRList:             vpnCIDRList,
-		logger:                  logger,
-		resourceUtil:            resourceUtil,
-		owner:                   owner,
-		store:                   store,
-		kopsCache:               make(map[string]*kops.Cmd),
+		params:         provisioningParams,
+		logger:         logger,
+		resourceUtil:   resourceUtil,
+		store:          store,
+		backupOperator: backupOperator,
+		kopsCache:      make(map[string]*kops.Cmd),
 	}
 }
 
@@ -72,7 +79,7 @@ func (provisioner *KopsProvisioner) getCachedKopsClient(name string, logger log.
 	}
 
 	logger.Debugf("Building kops client cache for %s", name)
-	kopsClient, err := kops.New(provisioner.s3StateStore, logger)
+	kopsClient, err := kops.New(provisioner.params.S3StateStore, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create kops wrapper")
 	}
@@ -110,4 +117,23 @@ func (provisioner *KopsProvisioner) invalidateCachedKopsClientOnError(err error,
 	}
 
 	provisioner.invalidateCachedKopsClient(name, logger)
+}
+
+func (provisioner *KopsProvisioner) k8sClient(clusterName string, logger log.FieldLogger) (*k8s.KubeClient, func(err error), error) {
+	configLocation, err := provisioner.getCachedKopsClusterKubecfg(clusterName, logger)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get kops config from cache")
+	}
+	invalidateOnError := func(err error) {
+		provisioner.invalidateCachedKopsClientOnError(err, clusterName, logger)
+	}
+	defer invalidateOnError(err)
+
+	var k8sClient *k8s.KubeClient
+	k8sClient, err = k8s.NewFromFile(configLocation, logger)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create k8s client from file")
+	}
+
+	return k8sClient, invalidateOnError, nil
 }

--- a/internal/provisioner/kops_provisioner_backup_restore.go
+++ b/internal/provisioner/kops_provisioner_backup_restore.go
@@ -32,7 +32,7 @@ func (provisioner *KopsProvisioner) TriggerBackup(backup *model.InstallationBack
 	}
 	// InstallationBackup is not supported for local MinIO storage, therefore this should not happen
 	if filestoreCfg == nil || filestoreSecret == nil {
-		return nil, errors.New("file store secret and config cannot be empty for backup")
+		return nil, errors.New("filestore secret and config cannot be empty for backup")
 	}
 	dbSecret, err := provisioner.resourceUtil.GetDatabase(installation).GenerateDatabaseSecret(provisioner.store, logger)
 	if err != nil {
@@ -69,14 +69,14 @@ func (provisioner *KopsProvisioner) CheckBackupStatus(backup *model.Installation
 	return provisioner.backupOperator.CheckBackupStatus(jobsClient, backup, logger)
 }
 
-// CleanupBackup deletes backup job from the cluster if it exists.
-func (provisioner *KopsProvisioner) CleanupBackup(backup *model.InstallationBackup, cluster *model.Cluster) error {
+// CleanupBackupJob deletes backup job from the cluster if it exists.
+func (provisioner *KopsProvisioner) CleanupBackupJob(backup *model.InstallationBackup, cluster *model.Cluster) error {
 	logger := provisioner.logger.WithFields(log.Fields{
 		"cluster":      cluster.ID,
 		"installation": backup.InstallationID,
 		"backup":       backup.ID,
 	})
-	logger.Info("Cleaning up backup for installation")
+	logger.Info("Cleaning up backup job for installation")
 
 	k8sClient, invalidateCache, err := provisioner.k8sClient(cluster.ProvisionerMetadataKops.Name, logger)
 	if err != nil {
@@ -86,5 +86,5 @@ func (provisioner *KopsProvisioner) CleanupBackup(backup *model.InstallationBack
 
 	jobsClient := k8sClient.Clientset.BatchV1().Jobs(backup.InstallationID)
 
-	return provisioner.backupOperator.CleanupBackup(jobsClient, backup, logger)
+	return provisioner.backupOperator.CleanupBackupJob(jobsClient, backup, logger)
 }

--- a/internal/provisioner/kops_provisioner_backup_restore.go
+++ b/internal/provisioner/kops_provisioner_backup_restore.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// TriggerBackup triggers backup job for specific installation on the cluster.
+func (provisioner *KopsProvisioner) TriggerBackup(backup *model.InstallationBackup, cluster *model.Cluster, installation *model.Installation) (*model.S3DataResidence, error) {
+	logger := provisioner.logger.WithFields(log.Fields{
+		"cluster":      cluster.ID,
+		"installation": installation.ID,
+		"backup":       backup.ID,
+	})
+	logger.Info("Triggering backup for installation")
+
+	k8sClient, invalidateCache, err := provisioner.k8sClient(cluster.ProvisionerMetadataKops.Name, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create k8s client")
+	}
+	defer invalidateCache(err)
+
+	filestoreCfg, filestoreSecret, err := provisioner.resourceUtil.GetFilestore(installation).
+		GenerateFilestoreSpecAndSecret(provisioner.store, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get files store configuration for installation")
+	}
+	// InstallationBackup is not supported for local MinIO storage, therefore this should not happen
+	if filestoreCfg == nil || filestoreSecret == nil {
+		return nil, errors.New("file store secret and config cannot be empty for backup")
+	}
+	dbSecret, err := provisioner.resourceUtil.GetDatabase(installation).GenerateDatabaseSecret(provisioner.store, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get database configuration")
+	}
+	// InstallationBackup is not supported for local MySQL, therefore this should not happen
+	if dbSecret == nil {
+		return nil, errors.New("database secret cannot be empty for backup")
+	}
+
+	jobsClient := k8sClient.Clientset.BatchV1().Jobs(installation.ID)
+
+	return provisioner.backupOperator.TriggerBackup(jobsClient, backup, installation, filestoreCfg, dbSecret.Name, logger)
+}
+
+// CheckBackupStatus checks status of running backup job,
+// returns job start time, when the job finished or -1 if it is still running.
+func (provisioner *KopsProvisioner) CheckBackupStatus(backup *model.InstallationBackup, cluster *model.Cluster) (int64, error) {
+	logger := provisioner.logger.WithFields(log.Fields{
+		"cluster":      cluster.ID,
+		"installation": backup.InstallationID,
+		"backup":       backup.ID,
+	})
+	logger.Info("Checking backup status for installation")
+
+	k8sClient, invalidateCache, err := provisioner.k8sClient(cluster.ProvisionerMetadataKops.Name, logger)
+	if err != nil {
+		return -1, errors.Wrap(err, "failed to create k8s client")
+	}
+	defer invalidateCache(err)
+
+	jobsClient := k8sClient.Clientset.BatchV1().Jobs(backup.InstallationID)
+
+	return provisioner.backupOperator.CheckBackupStatus(jobsClient, backup, logger)
+}
+
+// CleanupBackup deletes backup job from the cluster if it exists.
+func (provisioner *KopsProvisioner) CleanupBackup(backup *model.InstallationBackup, cluster *model.Cluster) error {
+	logger := provisioner.logger.WithFields(log.Fields{
+		"cluster":      cluster.ID,
+		"installation": backup.InstallationID,
+		"backup":       backup.ID,
+	})
+	logger.Info("Cleaning up backup for installation")
+
+	k8sClient, invalidateCache, err := provisioner.k8sClient(cluster.ProvisionerMetadataKops.Name, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to create k8s client")
+	}
+	defer invalidateCache(err)
+
+	jobsClient := k8sClient.Clientset.BatchV1().Jobs(backup.InstallationID)
+
+	return provisioner.backupOperator.CleanupBackup(jobsClient, backup, logger)
+}

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -71,18 +71,18 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 		return errors.Wrapf(err, "failed to get the CIDR for the VPC Name %s", cncVPCName)
 	}
 	allowSSHCIDRS := []string{cncVPCCIDR}
-	allowSSHCIDRS = append(allowSSHCIDRS, provisioner.vpnCIDRList...)
+	allowSSHCIDRS = append(allowSSHCIDRS, provisioner.params.VpnCIDRList...)
 
 	logger.WithField("name", kopsMetadata.Name).Info("Creating cluster")
-	kops, err := kops.New(provisioner.s3StateStore, logger)
+	kops, err := kops.New(provisioner.params.S3StateStore, logger)
 	if err != nil {
 		return err
 	}
 	defer kops.Close()
 
 	var clusterResources aws.ClusterResources
-	if provisioner.useExistingAWSResources {
-		clusterResources, err = awsClient.GetAndClaimVpcResources(cluster.ID, provisioner.owner, logger)
+	if provisioner.params.UseExistingAWSResources {
+		clusterResources, err = awsClient.GetAndClaimVpcResources(cluster.ID, provisioner.params.Owner, logger)
 		if err != nil {
 			return err
 		}
@@ -108,7 +108,7 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 		return errors.Wrap(err, "unable to create kops cluster")
 	}
 
-	terraformClient, err := terraform.New(kops.GetOutputDirectory(), provisioner.s3StateStore, logger)
+	terraformClient, err := terraform.New(kops.GetOutputDirectory(), provisioner.params.S3StateStore, logger)
 	if err != nil {
 		return err
 	}
@@ -463,7 +463,7 @@ func (provisioner *KopsProvisioner) UpgradeCluster(cluster *model.Cluster, awsCl
 		}
 	}
 
-	kops, err := kops.New(provisioner.s3StateStore, logger)
+	kops, err := kops.New(provisioner.params.S3StateStore, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to create kops wrapper")
 	}
@@ -511,7 +511,7 @@ func (provisioner *KopsProvisioner) UpgradeCluster(cluster *model.Cluster, awsCl
 		return err
 	}
 
-	terraformClient, err := terraform.New(kops.GetOutputDirectory(), provisioner.s3StateStore, logger)
+	terraformClient, err := terraform.New(kops.GetOutputDirectory(), provisioner.params.S3StateStore, logger)
 	if err != nil {
 		return err
 	}
@@ -627,7 +627,7 @@ func (provisioner *KopsProvisioner) ResizeCluster(cluster *model.Cluster, awsCli
 		return errors.Wrap(err, "KopsMetadata ChangeRequest failed validation")
 	}
 
-	kops, err := kops.New(provisioner.s3StateStore, logger)
+	kops, err := kops.New(provisioner.params.S3StateStore, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to create kops wrapper")
 	}
@@ -638,7 +638,7 @@ func (provisioner *KopsProvisioner) ResizeCluster(cluster *model.Cluster, awsCli
 		return err
 	}
 
-	terraformClient, err := terraform.New(kops.GetOutputDirectory(), provisioner.s3StateStore, logger)
+	terraformClient, err := terraform.New(kops.GetOutputDirectory(), provisioner.params.S3StateStore, logger)
 	if err != nil {
 		return err
 	}
@@ -772,7 +772,7 @@ func (provisioner *KopsProvisioner) DeleteCluster(cluster *model.Cluster, awsCli
 	}
 
 	if !skipDeleteTerraform {
-		terraformClient, err := terraform.New(kopsClient.GetOutputDirectory(), provisioner.s3StateStore, logger)
+		terraformClient, err := terraform.New(kopsClient.GetOutputDirectory(), provisioner.params.S3StateStore, logger)
 		if err != nil {
 			return errors.Wrap(err, "failed to create terraform wrapper")
 		}

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -21,7 +21,10 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-const hibernationReplicaCount = -1
+const (
+	hibernationReplicaCount = -1
+	bifrostEndpoint         = "bifrost.bifrost:80"
+)
 
 // ClusterInstallationProvisioner is an interface for provisioning and managing ClusterInstallations.
 type ClusterInstallationProvisioner interface {
@@ -632,7 +635,7 @@ func getMattermostEnvWithOverrides(installation *model.Installation) model.EnvVa
 	}
 	if installation.Filestore == model.InstallationFilestoreBifrost {
 		mattermostEnv["MM_CLOUD_FILESTORE_BIFROST"] = model.EnvVar{Value: "true"}
-		mattermostEnv["MM_FILESETTINGS_AMAZONS3ENDPOINT"] = model.EnvVar{Value: "bifrost.bifrost:80"}
+		mattermostEnv["MM_FILESETTINGS_AMAZONS3ENDPOINT"] = model.EnvVar{Value: bifrostEndpoint}
 		mattermostEnv["MM_FILESETTINGS_AMAZONS3SIGNV2"] = model.EnvVar{Value: "false"}
 		mattermostEnv["MM_FILESETTINGS_AMAZONS3SSE"] = model.EnvVar{Value: "false"}
 		mattermostEnv["MM_FILESETTINGS_AMAZONS3SSL"] = model.EnvVar{Value: "false"}

--- a/internal/provisioner/kops_provisioner_test.go
+++ b/internal/provisioner/kops_provisioner_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGetCachedKopsClient(t *testing.T) {
 	logger := testlib.MakeLogger(t)
-	provisioner := NewKopsProvisioner("s3statestore", "test", true, []string{}, []string{}, nil, logger, nil)
+	provisioner := NewKopsProvisioner(ProvisioningParams{}, nil, logger, nil, nil)
 
 	// Using &kops.Cmd{} here because kops.New() checks for the binary in your
 	// PATH which isn't needed for the test and fails in CI/CD.

--- a/internal/provisioner/prometheus_operator.go
+++ b/internal/provisioner/prometheus_operator.go
@@ -185,7 +185,7 @@ func (p *prometheusOperator) Migrate() error {
 }
 
 func (p *prometheusOperator) NewHelmDeployment(prometheusDNS string) *helmDeployment {
-	helmValueArguments := fmt.Sprintf("prometheus.prometheusSpec.externalLabels.clusterID=%s,prometheus.ingress.hosts={%s},prometheus.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", p.cluster.ID, prometheusDNS, strings.Join(p.provisioner.allowCIDRRangeList, "\\,"))
+	helmValueArguments := fmt.Sprintf("prometheus.prometheusSpec.externalLabels.clusterID=%s,prometheus.ingress.hosts={%s},prometheus.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", p.cluster.ID, prometheusDNS, strings.Join(p.provisioner.params.AllowCIDRRangeList, "\\,"))
 
 	return &helmDeployment{
 		chartDeploymentName: "prometheus-operator",

--- a/internal/provisioner/thanos.go
+++ b/internal/provisioner/thanos.go
@@ -169,7 +169,7 @@ func (t *thanos) Migrate() error {
 }
 
 func (t *thanos) NewHelmDeployment(thanosDNS, thanosDNSGRPC string) *helmDeployment {
-	helmValueArguments := fmt.Sprintf("query.ingress.hostname=%s,query.ingress.grpc.hostname=%s,query.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", thanosDNS, thanosDNSGRPC, strings.Join(t.provisioner.allowCIDRRangeList, "\\,"))
+	helmValueArguments := fmt.Sprintf("query.ingress.hostname=%s,query.ingress.grpc.hostname=%s,query.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", thanosDNS, thanosDNSGRPC, strings.Join(t.provisioner.params.AllowCIDRRangeList, "\\,"))
 
 	return &helmDeployment{
 		chartDeploymentName: "thanos",

--- a/internal/supervisor/backup.go
+++ b/internal/supervisor/backup.go
@@ -43,7 +43,7 @@ type installationBackupStore interface {
 type BackupProvisioner interface {
 	TriggerBackup(backupMeta *model.InstallationBackup, cluster *model.Cluster, installation *model.Installation) (*model.S3DataResidence, error)
 	CheckBackupStatus(backupMeta *model.InstallationBackup, cluster *model.Cluster) (int64, error)
-	CleanupBackup(backup *model.InstallationBackup, cluster *model.Cluster) error
+	CleanupBackupJob(backup *model.InstallationBackup, cluster *model.Cluster) error
 }
 
 // BackupSupervisor finds backup pending work and effects the required changes.

--- a/internal/supervisor/backup.go
+++ b/internal/supervisor/backup.go
@@ -39,8 +39,8 @@ type installationBackupStore interface {
 	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
 }
 
-// BackupOperator operates backup jobs on a cluster.
-type BackupOperator interface {
+// BackupProvisioner provisions backup jobs on a cluster.
+type BackupProvisioner interface {
 	TriggerBackup(backupMeta *model.InstallationBackup, cluster *model.Cluster, installation *model.Installation) (*model.S3DataResidence, error)
 	CheckBackupStatus(backupMeta *model.InstallationBackup, cluster *model.Cluster) (int64, error)
 	CleanupBackup(backup *model.InstallationBackup, cluster *model.Cluster) error
@@ -56,13 +56,13 @@ type BackupSupervisor struct {
 	instanceID string
 	logger     log.FieldLogger
 
-	backupOperator BackupOperator
+	backupOperator BackupProvisioner
 }
 
 // NewBackupSupervisor creates a new BackupSupervisor.
 func NewBackupSupervisor(
 	store installationBackupStore,
-	backupOperator BackupOperator,
+	backupOperator BackupProvisioner,
 	aws aws.AWS,
 	instanceID string,
 	logger log.FieldLogger) *BackupSupervisor {
@@ -146,7 +146,7 @@ func (s *BackupSupervisor) Supervise(backup *model.InstallationBackup) {
 	}
 
 	webhookPayload := &model.WebhookPayload{
-		Type:      model.TypeInstallation,
+		Type:      model.TypeInstallationBackup,
 		ID:        backup.ID,
 		NewState:  string(backup.State),
 		OldState:  string(oldState),

--- a/internal/supervisor/backup.go
+++ b/internal/supervisor/backup.go
@@ -1,0 +1,287 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package supervisor
+
+import (
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/provisioner"
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/internal/webhook"
+	"github.com/mattermost/mattermost-cloud/model"
+	log "github.com/sirupsen/logrus"
+)
+
+// installationBackupStore abstracts the database operations required to query installations backup.
+type installationBackupStore interface {
+	GetUnlockedInstallationBackupPendingWork() ([]*model.InstallationBackup, error)
+	GetInstallationBackup(id string) (*model.InstallationBackup, error)
+	UpdateInstallationBackupState(backupMeta *model.InstallationBackup) error
+	UpdateInstallationBackupSchedulingData(backupMeta *model.InstallationBackup) error
+	UpdateInstallationBackupStartTime(backupMeta *model.InstallationBackup) error
+
+	LockInstallationBackup(installationID, lockerID string) (bool, error)
+	UnlockInstallationBackup(installationID, lockerID string, force bool) (bool, error)
+
+	GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error)
+	LockInstallation(installationID, lockerID string) (bool, error)
+	UnlockInstallation(installationID, lockerID string, force bool) (bool, error)
+
+	GetClusterInstallations(*model.ClusterInstallationFilter) ([]*model.ClusterInstallation, error)
+	GetClusterInstallation(clusterInstallationID string) (*model.ClusterInstallation, error)
+	LockClusterInstallations(clusterInstallationID []string, lockerID string) (bool, error)
+	UnlockClusterInstallations(clusterInstallationID []string, lockerID string, force bool) (bool, error)
+
+	GetCluster(id string) (*model.Cluster, error)
+
+	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
+}
+
+// BackupOperator operates backup jobs on a cluster.
+type BackupOperator interface {
+	TriggerBackup(backupMeta *model.InstallationBackup, cluster *model.Cluster, installation *model.Installation) (*model.S3DataResidence, error)
+	CheckBackupStatus(backupMeta *model.InstallationBackup, cluster *model.Cluster) (int64, error)
+	CleanupBackup(backup *model.InstallationBackup, cluster *model.Cluster) error
+}
+
+// BackupSupervisor finds backup pending work and effects the required changes.
+//
+// The degree of parallelism is controlled by a weighted semaphore, intended to be shared with
+// other clients needing to coordinate background jobs.
+type BackupSupervisor struct {
+	store      installationBackupStore
+	aws        aws.AWS
+	instanceID string
+	logger     log.FieldLogger
+
+	backupOperator BackupOperator
+}
+
+// NewBackupSupervisor creates a new BackupSupervisor.
+func NewBackupSupervisor(
+	store installationBackupStore,
+	backupOperator BackupOperator,
+	aws aws.AWS,
+	instanceID string,
+	logger log.FieldLogger) *BackupSupervisor {
+	return &BackupSupervisor{
+		store:          store,
+		backupOperator: backupOperator,
+		aws:            aws,
+		instanceID:     instanceID,
+		logger:         logger,
+	}
+}
+
+// Shutdown performs graceful shutdown tasks for the backup supervisor.
+func (s *BackupSupervisor) Shutdown() {
+	s.logger.Debug("Shutting down backup supervisor")
+}
+
+// Do looks for work to be done on any pending backups and attempts to schedule the required work.
+func (s *BackupSupervisor) Do() error {
+	installations, err := s.store.GetUnlockedInstallationBackupPendingWork()
+	if err != nil {
+		s.logger.WithError(err).Warn("Failed to query for backup pending work")
+		return nil
+	}
+
+	for _, installation := range installations {
+		s.Supervise(installation)
+	}
+
+	return nil
+}
+
+// Supervise schedules the required work on the given backup.
+func (s *BackupSupervisor) Supervise(backup *model.InstallationBackup) {
+	logger := s.logger.WithFields(log.Fields{
+		"backup": backup.ID,
+	})
+
+	lock := newBackupLock(backup.ID, s.instanceID, s.store, logger)
+	if !lock.TryLock() {
+		return
+	}
+	defer lock.Unlock()
+
+	// Before working on the backup, it is crucial that we ensure that it
+	// was not updated to a new state by another provisioning server.
+	originalState := backup.State
+	backup, err := s.store.GetInstallationBackup(backup.ID)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to get refreshed backup")
+		return
+	}
+	if backup.State != originalState {
+		logger.WithField("oldBackupState", originalState).
+			WithField("newBackupState", backup.State).
+			Warn("Another provisioner has worked on this backup; skipping...")
+		return
+	}
+
+	logger.Debugf("Supervising backup in state %s", backup.State)
+
+	newState := s.transitionBackup(backup, s.instanceID, logger)
+
+	backup, err = s.store.GetInstallationBackup(backup.ID)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to get backup and thus persist state %s", newState)
+		return
+	}
+
+	if backup.State == newState {
+		return
+	}
+
+	oldState := backup.State
+	backup.State = newState
+
+	err = s.store.UpdateInstallationBackupState(backup)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to set backup state to %s", newState)
+		return
+	}
+
+	webhookPayload := &model.WebhookPayload{
+		Type:      model.TypeInstallation,
+		ID:        backup.ID,
+		NewState:  string(backup.State),
+		OldState:  string(oldState),
+		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"Environment": s.aws.GetCloudEnvironmentName()},
+	}
+	err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
+	if err != nil {
+		logger.WithError(err).Error("Unable to process and send webhooks")
+	}
+
+	logger.Debugf("Transitioned backup from %s to %s", oldState, backup.State)
+}
+
+// transitionBackup works with the given backup to transition it to a final state.
+func (s *BackupSupervisor) transitionBackup(backupMetadata *model.InstallationBackup, instanceID string, logger log.FieldLogger) model.InstallationBackupState {
+	switch backupMetadata.State {
+	case model.InstallationBackupStateBackupRequested:
+		return s.triggerBackup(backupMetadata, instanceID, logger)
+
+	case model.InstallationBackupStateBackupInProgress:
+		return s.monitorBackup(backupMetadata, instanceID, logger)
+
+	default:
+		logger.Warnf("Found backup pending work in unexpected state %s", backupMetadata.State)
+		return backupMetadata.State
+	}
+}
+
+func (s *BackupSupervisor) triggerBackup(backup *model.InstallationBackup, instanceID string, logger log.FieldLogger) model.InstallationBackupState {
+	installation, err := s.store.GetInstallation(backup.InstallationID, false, false)
+	if err != nil {
+		logger.WithError(err).Error("Failed to get installation")
+		return backup.State
+	}
+	if installation == nil {
+		logger.Errorf("Installation, with id %q not found, setting backup as failed", backup.InstallationID)
+		return model.InstallationBackupStateBackupFailed
+	}
+
+	installationLock := newInstallationLock(installation.ID, instanceID, s.store, logger)
+	if !installationLock.TryLock() {
+		logger.Errorf("Failed to lock installation %s", installation.ID)
+		return backup.State
+	}
+	defer installationLock.Unlock()
+
+	err = model.EnsureBackupCompatible(installation)
+	if err != nil {
+		logger.WithError(err).Errorf("Installation is not backup compatible %s", installation.ID)
+		return backup.State
+	}
+
+	clusterInstallationFilter := &model.ClusterInstallationFilter{
+		InstallationID: installation.ID,
+		PerPage:        model.AllPerPage,
+	}
+	clusterInstallations, err := s.store.GetClusterInstallations(clusterInstallationFilter)
+	if err != nil {
+		logger.WithError(err).Error("Failed to get cluster installations")
+		return backup.State
+	}
+
+	if len(clusterInstallations) == 0 {
+		logger.WithError(err).Error("Expected at least one cluster installation to run backup but found none")
+		return backup.State
+	}
+
+	backupCI := clusterInstallations[0]
+	ciLock := newClusterInstallationLock(backupCI.ID, instanceID, s.store, logger)
+	if !ciLock.TryLock() {
+		logger.Errorf("Failed to lock cluster installation %s", backupCI.ID)
+		return backup.State
+	}
+	defer ciLock.Unlock()
+
+	cluster, err := s.store.GetCluster(backupCI.ClusterID)
+	if err != nil {
+		logger.WithError(err).Error("Failed to get cluster")
+		return backup.State
+	}
+
+	dataRes, err := s.backupOperator.TriggerBackup(backup, cluster, installation)
+	if err != nil {
+		logger.WithError(err).Error("Failed to trigger backup")
+		return backup.State
+	}
+
+	backup.DataResidence = dataRes
+	backup.ClusterInstallationID = backupCI.ID
+
+	err = s.store.UpdateInstallationBackupSchedulingData(backup)
+	if err != nil {
+		logger.Error("Failed to update backup data residency")
+		return backup.State
+	}
+
+	return model.InstallationBackupStateBackupInProgress
+}
+
+func (s *BackupSupervisor) monitorBackup(backup *model.InstallationBackup, instanceID string, logger log.FieldLogger) model.InstallationBackupState {
+	backupCI, err := s.store.GetClusterInstallation(backup.ClusterInstallationID)
+	if err != nil {
+		logger.WithError(err).Error("Failed to get cluster installations")
+		return backup.State
+	}
+
+	cluster, err := s.store.GetCluster(backupCI.ClusterID)
+	if err != nil {
+		logger.WithError(err).Error("Failed to get cluster")
+		return backup.State
+	}
+
+	startTime, err := s.backupOperator.CheckBackupStatus(backup, cluster)
+	if err != nil {
+		if err == provisioner.ErrJobBackoffLimitReached {
+			logger.WithError(err).Error("Backup job backoff limit reached, backup failed")
+			return model.InstallationBackupStateBackupFailed
+		}
+		logger.WithError(err).Error("Failed to check backup state")
+		return backup.State
+	}
+
+	if startTime <= 0 {
+		logger.Debugf("Backup in progress")
+		return backup.State
+	}
+
+	backup.StartAt = startTime
+
+	err = s.store.UpdateInstallationBackupStartTime(backup)
+	if err != nil {
+		logger.Error("Failed to update backup data start time")
+		return backup.State
+	}
+
+	return model.InstallationBackupStateBackupSucceeded
+}

--- a/internal/supervisor/backup_lock.go
+++ b/internal/supervisor/backup_lock.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package supervisor
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+type backupLockStore interface {
+	LockInstallationBackup(backupID, lockerID string) (bool, error)
+	UnlockInstallationBackup(backupID, lockerID string, force bool) (bool, error)
+}
+
+type backupLock struct {
+	backupID string
+	lockerID string
+	store    backupLockStore
+	logger   log.FieldLogger
+}
+
+func newBackupLock(backupID, lockerID string, store backupLockStore, logger log.FieldLogger) *backupLock {
+	return &backupLock{
+		backupID: backupID,
+		lockerID: lockerID,
+		store:    store,
+		logger:   logger,
+	}
+}
+
+func (l *backupLock) TryLock() bool {
+	locked, err := l.store.LockInstallationBackup(l.backupID, l.lockerID)
+	if err != nil {
+		l.logger.WithError(err).Error("failed to lock backup")
+		return false
+	}
+
+	return locked
+}
+
+func (l *backupLock) Unlock() {
+	unlocked, err := l.store.UnlockInstallationBackup(l.backupID, l.lockerID, false)
+	if err != nil {
+		l.logger.WithError(err).Error("failed to unlock backup")
+	} else if unlocked != true {
+		l.logger.Error("failed to release lock for backup")
+	}
+}

--- a/internal/supervisor/backup_test.go
+++ b/internal/supervisor/backup_test.go
@@ -1,0 +1,308 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package supervisor_test
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/internal/provisioner"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/supervisor"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockBackupStore struct {
+	BackupMetadata        *model.InstallationBackup
+	BackupMetadataPending []*model.InstallationBackup
+	Cluster               *model.Cluster
+	Installation          *model.Installation
+	ClusterInstallations  []*model.ClusterInstallation
+	UnlockChan            chan interface{}
+
+	UpdateBackupMetadataCalls int
+}
+
+func (s mockBackupStore) GetUnlockedInstallationBackupPendingWork() ([]*model.InstallationBackup, error) {
+	return s.BackupMetadataPending, nil
+}
+
+func (s mockBackupStore) GetInstallationBackup(id string) (*model.InstallationBackup, error) {
+	return s.BackupMetadataPending[0], nil
+}
+
+func (s *mockBackupStore) UpdateInstallationBackupState(backupMeta *model.InstallationBackup) error {
+	s.UpdateBackupMetadataCalls++
+	return nil
+}
+
+func (s *mockBackupStore) UpdateInstallationBackupSchedulingData(backupMeta *model.InstallationBackup) error {
+	s.UpdateBackupMetadataCalls++
+	return nil
+}
+
+func (s mockBackupStore) UpdateInstallationBackupStartTime(backupMeta *model.InstallationBackup) error {
+	panic("implement me")
+}
+
+func (s mockBackupStore) LockInstallationBackup(installationID, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (s *mockBackupStore) UnlockInstallationBackup(installationID, lockerID string, force bool) (bool, error) {
+	if s.UnlockChan != nil {
+		close(s.UnlockChan)
+	}
+	return true, nil
+}
+
+func (s mockBackupStore) GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error) {
+	return s.Installation, nil
+}
+
+func (s mockBackupStore) LockInstallation(installationID, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (s mockBackupStore) UnlockInstallation(installationID, lockerID string, force bool) (bool, error) {
+	return true, nil
+}
+
+func (s mockBackupStore) GetClusterInstallations(filter *model.ClusterInstallationFilter) ([]*model.ClusterInstallation, error) {
+	return s.ClusterInstallations, nil
+}
+
+func (s mockBackupStore) GetClusterInstallation(clusterInstallationID string) (*model.ClusterInstallation, error) {
+	return s.ClusterInstallations[0], nil
+}
+
+func (s mockBackupStore) LockClusterInstallations(clusterInstallationID []string, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (s mockBackupStore) UnlockClusterInstallations(clusterInstallationID []string, lockerID string, force bool) (bool, error) {
+	return true, nil
+}
+
+func (s mockBackupStore) GetCluster(id string) (*model.Cluster, error) {
+	return s.Cluster, nil
+}
+
+func (s mockBackupStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error) {
+	return nil, nil
+}
+
+type mockBackupOperator struct {
+	BackupStartTime int64
+	err             error
+}
+
+func (b *mockBackupOperator) TriggerBackup(backup *model.InstallationBackup, cluster *model.Cluster, installation *model.Installation) (*model.S3DataResidence, error) {
+	return &model.S3DataResidence{URL: "file-store.com"}, b.err
+}
+
+func (b *mockBackupOperator) CheckBackupStatus(backup *model.InstallationBackup, cluster *model.Cluster) (int64, error) {
+	return b.BackupStartTime, b.err
+}
+
+func (b *mockBackupOperator) CleanupBackup(backup *model.InstallationBackup, cluster *model.Cluster) error {
+	return nil
+}
+
+func TestBackupSupervisorDo(t *testing.T) {
+	t.Run("no backup pending work", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		mockStore := &mockBackupStore{}
+		mockBackupOp := &mockBackupOperator{}
+
+		backupSupervisor := supervisor.NewBackupSupervisor(mockStore, mockBackupOp, &mockAWS{}, "instanceID", logger)
+		err := backupSupervisor.Do()
+		require.NoError(t, err)
+
+		require.Equal(t, 0, mockStore.UpdateBackupMetadataCalls)
+	})
+
+	t.Run("mock backup trigger", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+
+		cluster := &model.Cluster{ID: model.NewID()}
+		installation := &model.Installation{
+			ID:        model.NewID(),
+			State:     model.InstallationStateHibernating,
+			Database:  model.InstallationDatabaseMultiTenantRDSPostgres,
+			Filestore: model.InstallationFilestoreBifrost,
+		}
+		mockStore := &mockBackupStore{
+			Cluster:      cluster,
+			Installation: installation,
+			BackupMetadataPending: []*model.InstallationBackup{
+				{ID: model.NewID(), InstallationID: installation.ID, State: model.InstallationBackupStateBackupRequested},
+			},
+			ClusterInstallations: []*model.ClusterInstallation{{
+				ID:             model.NewID(),
+				ClusterID:      cluster.ID,
+				InstallationID: installation.ID,
+				State:          model.ClusterInstallationStateStable,
+			}},
+			UnlockChan: make(chan interface{}),
+		}
+
+		backupSupervisor := supervisor.NewBackupSupervisor(mockStore, &mockBackupOperator{}, &mockAWS{}, "instanceID", logger)
+		err := backupSupervisor.Do()
+		require.NoError(t, err)
+
+		<-mockStore.UnlockChan
+		require.Equal(t, 2, mockStore.UpdateBackupMetadataCalls)
+	})
+}
+
+func TestBackupMetadataSupervisorSupervise(t *testing.T) {
+
+	t.Run("trigger backup", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		mockBackupOp := &mockBackupOperator{}
+
+		installation, clusterInstallation := setupBackupRequiredResources(t, sqlStore)
+
+		backupMeta := &model.InstallationBackup{
+			InstallationID: installation.ID,
+			State:          model.InstallationBackupStateBackupRequested,
+		}
+		err := sqlStore.CreateInstallationBackup(backupMeta)
+		require.NoError(t, err)
+
+		backupSupervisor := supervisor.NewBackupSupervisor(sqlStore, mockBackupOp, &mockAWS{}, "instanceID", logger)
+		backupSupervisor.Supervise(backupMeta)
+
+		// Assert
+		backupMeta, err = sqlStore.GetInstallationBackup(backupMeta.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationBackupStateBackupInProgress, backupMeta.State)
+		assert.Equal(t, clusterInstallation.ID, backupMeta.ClusterInstallationID)
+		assert.Equal(t, "file-store.com", backupMeta.DataResidence.URL)
+	})
+
+	t.Run("do not trigger backup if installation not hibernated", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		mockBackupOp := &mockBackupOperator{}
+
+		installation, _ := setupBackupRequiredResources(t, sqlStore)
+		installation.State = model.InstallationStateStable
+		err := sqlStore.UpdateInstallationState(installation)
+		require.NoError(t, err)
+
+		backupMeta := &model.InstallationBackup{
+			InstallationID: installation.ID,
+			State:          model.InstallationBackupStateBackupRequested,
+		}
+		err = sqlStore.CreateInstallationBackup(backupMeta)
+		require.NoError(t, err)
+
+		backupSupervisor := supervisor.NewBackupSupervisor(sqlStore, mockBackupOp, &mockAWS{}, "instanceID", logger)
+		backupSupervisor.Supervise(backupMeta)
+
+		// Assert
+		backupMeta, err = sqlStore.GetInstallationBackup(backupMeta.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationBackupStateBackupRequested, backupMeta.State)
+	})
+
+	t.Run("set backup as failed if installation deleted", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		mockBackupOp := &mockBackupOperator{}
+
+		backupMeta := &model.InstallationBackup{
+			InstallationID: "deleted-installation-id",
+			State:          model.InstallationBackupStateBackupRequested,
+		}
+		err := sqlStore.CreateInstallationBackup(backupMeta)
+		require.NoError(t, err)
+
+		backupSupervisor := supervisor.NewBackupSupervisor(sqlStore, mockBackupOp, &mockAWS{}, "instanceID", logger)
+		backupSupervisor.Supervise(backupMeta)
+
+		// Assert
+		backupMeta, err = sqlStore.GetInstallationBackup(backupMeta.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationBackupStateBackupFailed, backupMeta.State)
+	})
+
+	t.Run("check backup status", func(t *testing.T) {
+		for _, testCase := range []struct {
+			description   string
+			mockBackupOp  *mockBackupOperator
+			expectedState model.InstallationBackupState
+		}{
+			{
+				description:   "when backup finished",
+				mockBackupOp:  &mockBackupOperator{BackupStartTime: 100},
+				expectedState: model.InstallationBackupStateBackupSucceeded,
+			},
+			{
+				description:   "when still in progress",
+				mockBackupOp:  &mockBackupOperator{BackupStartTime: -1},
+				expectedState: model.InstallationBackupStateBackupInProgress,
+			},
+			{
+				description:   "when non terminal error",
+				mockBackupOp:  &mockBackupOperator{BackupStartTime: -1, err: errors.New("some error")},
+				expectedState: model.InstallationBackupStateBackupInProgress,
+			},
+			{
+				description:   "when terminal error",
+				mockBackupOp:  &mockBackupOperator{BackupStartTime: -1, err: provisioner.ErrJobBackoffLimitReached},
+				expectedState: model.InstallationBackupStateBackupFailed,
+			},
+		} {
+			t.Run(testCase.description, func(t *testing.T) {
+				logger := testlib.MakeLogger(t)
+				sqlStore := store.MakeTestSQLStore(t, logger)
+
+				installation, clusterInstallation := setupBackupRequiredResources(t, sqlStore)
+
+				backupMeta := &model.InstallationBackup{
+					InstallationID:        installation.ID,
+					ClusterInstallationID: clusterInstallation.ID,
+					State:                 model.InstallationBackupStateBackupInProgress,
+				}
+				err := sqlStore.CreateInstallationBackup(backupMeta)
+				require.NoError(t, err)
+
+				backupSupervisor := supervisor.NewBackupSupervisor(sqlStore, testCase.mockBackupOp, &mockAWS{}, "instanceID", logger)
+				backupSupervisor.Supervise(backupMeta)
+
+				// Assert
+				backupMeta, err = sqlStore.GetInstallationBackup(backupMeta.ID)
+				require.NoError(t, err)
+				assert.Equal(t, testCase.expectedState, backupMeta.State)
+
+				if testCase.mockBackupOp.BackupStartTime > 0 {
+					assert.Equal(t, testCase.mockBackupOp.BackupStartTime, backupMeta.StartAt)
+				}
+			})
+		}
+	})
+}
+
+func setupBackupRequiredResources(t *testing.T, sqlStore *store.SQLStore) (*model.Installation, *model.ClusterInstallation) {
+	installation := testutil.CreateBackupCompatibleInstallation(t, sqlStore)
+
+	cluster := &model.Cluster{}
+	err := sqlStore.CreateCluster(cluster, nil)
+	require.NoError(t, err)
+
+	clusterInstallation := &model.ClusterInstallation{InstallationID: installation.ID, ClusterID: cluster.ID}
+	err = sqlStore.CreateClusterInstallation(clusterInstallation)
+	require.NoError(t, err)
+
+	return installation, clusterInstallation
+}

--- a/internal/supervisor/backup_test.go
+++ b/internal/supervisor/backup_test.go
@@ -111,7 +111,7 @@ func (b *mockBackupProvisioner) CheckBackupStatus(backup *model.InstallationBack
 	return b.BackupStartTime, b.err
 }
 
-func (b *mockBackupProvisioner) CleanupBackup(backup *model.InstallationBackup, cluster *model.Cluster) error {
+func (b *mockBackupProvisioner) CleanupBackupJob(backup *model.InstallationBackup, cluster *model.Cluster) error {
 	return nil
 }
 

--- a/internal/testutil/backup.go
+++ b/internal/testutil/backup.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package testutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pborman/uuid"
+
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/require"
+)
+
+// CreateBackupCompatibleInstallation is a helper function for tests which creates Installation compatible with backup.
+func CreateBackupCompatibleInstallation(t *testing.T, sqlStore *store.SQLStore) *model.Installation {
+	installation := &model.Installation{
+		Database:  model.InstallationDatabaseMultiTenantRDSPostgres,
+		Filestore: model.InstallationFilestoreBifrost,
+		State:     model.InstallationStateHibernating,
+		DNS:       fmt.Sprintf("dns-%s", uuid.NewRandom().String()[:6]),
+	}
+	err := sqlStore.CreateInstallation(installation, nil)
+	require.NoError(t, err)
+	return installation
+}

--- a/manifests/bifrost/bifrost.yaml
+++ b/manifests/bifrost/bifrost.yaml
@@ -93,7 +93,7 @@ spec:
         podSelector:
           matchLabels:
             app: mattermost-update-check
-      - namespaceSelector: { }
+      - namespaceSelector: {}
         podSelector:
           matchLabels:
             app: backup-restore

--- a/manifests/bifrost/bifrost.yaml
+++ b/manifests/bifrost/bifrost.yaml
@@ -88,3 +88,7 @@ spec:
         podSelector:
           matchLabels:
             app: mattermost-update-check
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            app: backup-restore

--- a/model/installation_backup.go
+++ b/model/installation_backup.go
@@ -32,10 +32,11 @@ type InstallationBackup struct {
 
 // S3DataResidence contains information about backup location.
 type S3DataResidence struct {
-	Region    string
-	URL       string
-	Bucket    string
-	ObjectKey string
+	Region     string
+	URL        string
+	Bucket     string
+	PathPrefix string
+	ObjectKey  string
 }
 
 // InstallationBackupState represents the state of backup.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR introduces Backup Supervisor, which performs backup operations for installations.
PR bullet points:
- Backup is run as Kubernetes job deployed on Cluster on which one of the Cluster Installations run, in this Installation's namespace.
- The Installation needs to be in `hibernating` state to trigger backup (will also be checked on API level).
- After backup is triggered `InstallationBackup.ClusterInstallationID` is set to the id  of Cluster Installation next to which it is running.
- The Installation state can change after backup started running.
- Backup is marked as `failed` if the job fails and as `succeeded` if it completed.

Besides locking mechanism in this PR, to ensure that backup does not end in unpredictable state upcoming PRs will introduce following constraints:
- Cluster Installation cannot be deleted if Backup is running "on it".
- Installation cannot be deleted if Backup is requested or in progress for it.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-33398

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Introduce Backup supervisor
```
