### PR TITLE
Add bifrost metric monitoring

### DIFF
--- a/helm-charts/prometheus_operator_values.yaml
+++ b/helm-charts/prometheus_operator_values.yaml
@@ -2044,6 +2044,18 @@ prometheus:
         interval: 30s
         path: /metrics
         scheme: http
+  - name: bifrost
+    selector:
+      matchLabels:
+        kubernetes.io/name: "bifrost"
+    namespaceSelector:
+      matchNames:
+      - bifrost
+    endpoints:
+      - port: service
+        interval: 30s
+        path: /metrics
+        scheme: http
 
   additionalPodMonitors: []
   ## Name of the PodMonitor to create

--- a/manifests/bifrost/bifrost.yaml
+++ b/manifests/bifrost/bifrost.yaml
@@ -17,12 +17,12 @@ spec:
       - name: bifrost
         command:
         - /bifrost
-        image: mattermost/bifrost:cloud-1
+        image: mattermost/bifrost:v1.0.1
         imagePullPolicy: IfNotPresent
         env:
         - name: BIFROST_SERVICESETTINGS_HOST
           value: "0.0.0.0:8087"
-        - name: BIFROST_SERVICESETTINGS_HEALTHHOST
+        - name: BIFROST_SERVICESETTINGS_SERVICEHOST
           value: "0.0.0.0:8099"
         - name: BIFROST_LOGSETTINGS_CONSOLEJSON
           value: "true"
@@ -65,8 +65,13 @@ spec:
     name: bifrost
   ports:
   - port: 80
+    name: bifrost
     protocol: TCP
     targetPort: 8087
+  - port: 8099
+    name: service
+    protocol: TCP
+    targetPort: 8099
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -88,3 +93,19 @@ spec:
         podSelector:
           matchLabels:
             app: mattermost-update-check
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-metrics
+  namespace: bifrost
+spec:
+  podSelector: {}
+  ingress:
+  - ports:
+    - port: 8099
+      protocol: TCP
+    from:
+      - namespaceSelector:
+          matchLabels:
+            name: prometheus


### PR DESCRIPTION
This update exposes bifrost metrics for prometheus to scrape and
export for monitoring purposes.

Fixes https://mattermost.atlassian.net/browse/MM-32149

```release-note
Add bifrost metric monitoring
```
