### PR TITLE
Add k8s-spot-termination-handler Daemonset

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -337,6 +337,9 @@ func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster, aws
 		}, {
 			Path:            "manifests/metric-server/metric-server.yaml",
 			DeployNamespace: "kube-system",
+		}, {
+			Path:            "manifests/k8s-spot-termination-handler/k8s-spot-termination-handler.yaml",
+			DeployNamespace: "kube-system",
 		},
 	}
 	err = k8sClient.CreateFromFiles(files)

--- a/manifests/k8s-spot-termination-handler/k8s-spot-termination-handler.yaml
+++ b/manifests/k8s-spot-termination-handler/k8s-spot-termination-handler.yaml
@@ -1,0 +1,104 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: k8s-spot-termination-handler
+rules:
+  # For draining nodes
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - extensions
+    resources:
+      - replicasets
+      - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-spot-termination-handler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-spot-termination-handler
+subjects:
+  - kind: ServiceAccount
+    name: k8s-spot-termination-handler
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: k8s-spot-termination-handler
+  namespace: kube-system
+  labels:
+    app: k8s-spot-termination-handler
+spec:
+  selector:
+    matchLabels:
+      app: k8s-spot-termination-handler
+  template:
+    metadata:
+      name: k8s-spot-termination-handler
+      labels:
+        app: k8s-spot-termination-handler
+    spec:
+      serviceAccountName: k8s-spot-termination-handler
+      containers:
+        - name: k8s-spot-termination-handler
+          image: kubeaws/kube-spot-termination-notice-handler:1.13.7-1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Parameters to drain command can be adjusted
+            - name: DRAIN_PARAMETERS
+              value: '--grace-period=120 --force --ignore-daemonsets --delete-local-data'
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 5m
+              memory: 20Mi
+            limits:
+              cpu: 100m
+              memory: 100Mi
+      nodeSelector:
+        "node-role.kubernetes.io/spot-worker": "true"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: k8s-spot-termination-handler
+  name: k8s-spot-termination-handler
+  namespace: kube-system
+


### PR DESCRIPTION
Purpose:  To be able to gracefully drain spot instances that get
termination notice.

#### Summary
` k8s-spot-termination-handler` Daemonset addition

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31295

#### Release Note
```release-note
Adds ` k8s-spot-termination-handler` Daemonset to handle spot instances termination notices.
```
