### PR TITLE
Update kOps and other tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   default:
     docker:
-    - image: circleci/golang:1.15.8
+    - image: circleci/golang:1.16.2
 
 aliases:
 - &restore_cache
@@ -60,7 +60,7 @@ jobs:
 
   test-postgres:
     docker:
-    - image: circleci/golang:1.14.6
+    - image: circleci/golang:1.16.2
       environment:
         CLOUD_DATABASE=postgres://cloud_test@localhost:5432/cloud_test?sslmode=disable
     - image: circleci/postgres:11.2-alpine

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@
 ################################################################################
 
 ## Docker Build Versions
-DOCKER_BUILD_IMAGE = golang:1.14.6
-DOCKER_BASE_IMAGE = alpine:3.12
+DOCKER_BUILD_IMAGE = golang:1.16.2
+DOCKER_BASE_IMAGE = alpine:3.13.2
 
 ## Tool Versions
 TERRAFORM_VERSION=0.12.29
-KOPS_VERSION=v1.18.3
-HELM_VERSION=v3.4.1
-KUBECTL_VERSION=v1.18.15
+KOPS_VERSION=v1.19.1
+HELM_VERSION=v3.5.3
+KUBECTL_VERSION=v1.19.8
 
 ################################################################################
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The following is required to properly run the cloud server.
 1. Install [Go](https://golang.org/doc/install)
 2. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) version v0.12.29
    1. Try using [tfswitch](https://warrensbox.github.io/terraform-switcher/) for switching easily between versions
-3. Install [kops](https://github.com/kubernetes/kops/blob/master/docs/install.md) version 1.18.X
-4. Install [Helm](https://helm.sh/docs/intro/install/) version 3.4.X
+3. Install [kops](https://github.com/kubernetes/kops/blob/master/docs/install.md) version 1.19.X
+4. Install [Helm](https://helm.sh/docs/intro/install/) version 3.5.X
 5. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 6. Install [golang/mock](https://github.com/golang/mock#installation) version 1.4.x
 

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -115,6 +115,7 @@ func (c *Cmd) UpdateCluster(name, dir string) error {
 		"--yes",
 		arg("target", "terraform"),
 		arg("out", dir),
+		arg("admin", "87600h"),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to invoke kops update cluster")

--- a/internal/tools/kops/export.go
+++ b/internal/tools/kops/export.go
@@ -13,6 +13,7 @@ func (c *Cmd) ExportKubecfg(name string) error {
 		"kubecfg",
 		arg("name", name),
 		arg("state", "s3://", c.s3StateStore),
+		arg("admin", "87600h"),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to invoke kops export kubecfg")

--- a/model/kops_metadata_test.go
+++ b/model/kops_metadata_test.go
@@ -47,3 +47,329 @@ func TestValidateChangeRequest(t *testing.T) {
 		require.NoError(t, km.ValidateChangeRequest())
 	})
 }
+
+func TestGetWorkerNodesResizeChanges(t *testing.T) {
+	var testCases = []struct {
+		testName string
+		metadata model.KopsMetadata
+		expected model.KopsInstanceGroupsMetadata
+	}{
+		{
+			"no change",
+			model.KopsMetadata{
+				NodeMinCount: 1,
+				NodeInstanceGroups: model.KopsInstanceGroupsMetadata{
+					"node-ig1": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 1,
+						NodeMaxCount: 1,
+					},
+				},
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					NodeMinCount: 1,
+				},
+			},
+			model.KopsInstanceGroupsMetadata{
+				"node-ig1": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 1,
+					NodeMaxCount: 1,
+				},
+			},
+		},
+		{
+			"add one, one node group",
+			model.KopsMetadata{
+				NodeMinCount: 1,
+				NodeInstanceGroups: model.KopsInstanceGroupsMetadata{
+					"node-ig1": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 1,
+						NodeMaxCount: 1,
+					},
+				},
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					NodeMinCount: 2,
+				},
+			},
+			model.KopsInstanceGroupsMetadata{
+				"node-ig1": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 2,
+					NodeMaxCount: 2,
+				},
+			},
+		},
+		{
+			"add ten, one node group",
+			model.KopsMetadata{
+				NodeMinCount: 1,
+				NodeInstanceGroups: model.KopsInstanceGroupsMetadata{
+					"node-ig1": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 1,
+						NodeMaxCount: 1,
+					},
+				},
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					NodeMinCount: 11,
+				},
+			},
+			model.KopsInstanceGroupsMetadata{
+				"node-ig1": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 11,
+					NodeMaxCount: 11,
+				},
+			},
+		},
+		{
+			"add one, two node groups",
+			model.KopsMetadata{
+				NodeMinCount: 1,
+				NodeInstanceGroups: model.KopsInstanceGroupsMetadata{
+					"node-ig1": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 1,
+						NodeMaxCount: 1,
+					},
+					"node-ig2": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 0,
+						NodeMaxCount: 0,
+					},
+				},
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					NodeMinCount: 2,
+				},
+			},
+			model.KopsInstanceGroupsMetadata{
+				"node-ig1": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 1,
+					NodeMaxCount: 1,
+				},
+				"node-ig2": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 1,
+					NodeMaxCount: 1,
+				},
+			},
+		},
+		{
+			"add ten, two node groups",
+			model.KopsMetadata{
+				NodeMinCount: 1,
+				NodeInstanceGroups: model.KopsInstanceGroupsMetadata{
+					"node-ig1": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 1,
+						NodeMaxCount: 1,
+					},
+					"node-ig2": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 0,
+						NodeMaxCount: 0,
+					},
+				},
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					NodeMinCount: 11,
+				},
+			},
+			model.KopsInstanceGroupsMetadata{
+				"node-ig1": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 6,
+					NodeMaxCount: 6,
+				},
+				"node-ig2": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 5,
+					NodeMaxCount: 5,
+				},
+			},
+		},
+		{
+			"add ten, four node groups",
+			model.KopsMetadata{
+				NodeMinCount: 3,
+				NodeInstanceGroups: model.KopsInstanceGroupsMetadata{
+					"node-ig1": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 1,
+						NodeMaxCount: 1,
+					},
+					"node-ig2": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 1,
+						NodeMaxCount: 1,
+					},
+					"node-ig3": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 1,
+						NodeMaxCount: 1,
+					},
+					"node-ig4": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 0,
+						NodeMaxCount: 0,
+					},
+				},
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					NodeMinCount: 11,
+				},
+			},
+			model.KopsInstanceGroupsMetadata{
+				"node-ig1": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 3,
+					NodeMaxCount: 3,
+				},
+				"node-ig2": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 3,
+					NodeMaxCount: 3,
+				},
+				"node-ig3": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 3,
+					NodeMaxCount: 3,
+				},
+				"node-ig4": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 2,
+					NodeMaxCount: 2,
+				},
+			},
+		},
+		{
+			"remove one, one node group",
+			model.KopsMetadata{
+				NodeMinCount: 2,
+				NodeInstanceGroups: model.KopsInstanceGroupsMetadata{
+					"node-ig1": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 2,
+						NodeMaxCount: 2,
+					},
+				},
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					NodeMinCount: 1,
+				},
+			},
+			model.KopsInstanceGroupsMetadata{
+				"node-ig1": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 1,
+					NodeMaxCount: 1,
+				},
+			},
+		},
+		{
+			"remove ten, one node group",
+			model.KopsMetadata{
+				NodeMinCount: 11,
+				NodeInstanceGroups: model.KopsInstanceGroupsMetadata{
+					"node-ig1": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 11,
+						NodeMaxCount: 11,
+					},
+				},
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					NodeMinCount: 1,
+				},
+			},
+			model.KopsInstanceGroupsMetadata{
+				"node-ig1": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 1,
+					NodeMaxCount: 1,
+				},
+			},
+		},
+		{
+			"remove one, two node groups",
+			model.KopsMetadata{
+				NodeMinCount: 2,
+				NodeInstanceGroups: model.KopsInstanceGroupsMetadata{
+					"node-ig1": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 1,
+						NodeMaxCount: 1,
+					},
+					"node-ig2": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 1,
+						NodeMaxCount: 1,
+					},
+				},
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					NodeMinCount: 1,
+				},
+			},
+			model.KopsInstanceGroupsMetadata{
+				"node-ig1": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 1,
+					NodeMaxCount: 1,
+				},
+				"node-ig2": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 0,
+					NodeMaxCount: 0,
+				},
+			},
+		},
+		{
+			"remove ten, two node groups",
+			model.KopsMetadata{
+				NodeMinCount: 21,
+				NodeInstanceGroups: model.KopsInstanceGroupsMetadata{
+					"node-ig1": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 11,
+						NodeMaxCount: 11,
+					},
+					"node-ig2": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 10,
+						NodeMaxCount: 10,
+					},
+				},
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					NodeMinCount: 11,
+				},
+			},
+			model.KopsInstanceGroupsMetadata{
+				"node-ig1": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 6,
+					NodeMaxCount: 6,
+				},
+				"node-ig2": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 5,
+					NodeMaxCount: 5,
+				},
+			},
+		},
+		{
+			"remove ten, four node groups",
+			model.KopsMetadata{
+				NodeMinCount: 21,
+				NodeInstanceGroups: model.KopsInstanceGroupsMetadata{
+					"node-ig1": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 6,
+						NodeMaxCount: 6,
+					},
+					"node-ig2": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 5,
+						NodeMaxCount: 5,
+					},
+					"node-ig3": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 5,
+						NodeMaxCount: 5,
+					},
+					"node-ig4": model.KopsInstanceGroupMetadata{
+						NodeMinCount: 5,
+						NodeMaxCount: 5,
+					},
+				},
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					NodeMinCount: 11,
+				},
+			},
+			model.KopsInstanceGroupsMetadata{
+				"node-ig1": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 3,
+					NodeMaxCount: 3,
+				},
+				"node-ig2": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 3,
+					NodeMaxCount: 3,
+				},
+				"node-ig3": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 3,
+					NodeMaxCount: 3,
+				},
+				"node-ig4": model.KopsInstanceGroupMetadata{
+					NodeMinCount: 2,
+					NodeMaxCount: 2,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.metadata.GetWorkerNodesResizeChanges())
+		})
+	}
+}


### PR DESCRIPTION
This change includes:
 - Update kOps to 1.19.1
 - Update builds to use Go 1.16.2 and Alpine 3.13.2
 - Update helm to 3.5.3
 - Update kubectl to 1.19.8
 - Add provisioner logic to handle kOps clusters with multiple
   instance groups.

Fixes https://mattermost.atlassian.net/browse/MM-33906 and https://mattermost.atlassian.net/browse/MM-32329

```release-note
Update kOps and other tooling
```
