### PR TITLE
MM-33398 - Installation backup API

### DIFF
--- a/cmd/cloud/backup.go
+++ b/cmd/cloud/backup.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
+	"os"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	backupCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
+
+	backupCreateCmd.Flags().String("installation", "", "The installation id to be backed up.")
+	backupCreateCmd.MarkFlagRequired("installation")
+
+	backupListCmd.Flags().String("installation", "", "The installation id for which the backups should be listed.")
+	backupListCmd.Flags().String("state", "", "The state to filter backups by.")
+	backupListCmd.Flags().Int("page", 0, "The page of backups to fetch, starting at 0.")
+	backupListCmd.Flags().Int("per-page", 100, "The number of backups to fetch per page.")
+	backupListCmd.Flags().Bool("include-deleted", false, "Whether to include deleted backups.")
+	backupListCmd.Flags().Bool("table", false, "Whether to display the returned backup list in a table or not.")
+
+	backupGetCmd.Flags().String("backup", "", "The id of the backup to get.")
+	backupGetCmd.MarkFlagRequired("backup")
+
+	backupDeleteCmd.Flags().String("backup", "", "The id of the backup to delete.")
+	backupDeleteCmd.MarkFlagRequired("backup")
+
+	backupCmd.AddCommand(backupCreateCmd)
+	backupCmd.AddCommand(backupListCmd)
+	backupCmd.AddCommand(backupGetCmd)
+	backupCmd.AddCommand(backupDeleteCmd)
+}
+
+var backupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "Manipulate installation backups managed by the provisioning server.",
+}
+
+var backupCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Request an installation backup.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		installationID, _ := command.Flags().GetString("installation")
+
+		backup, err := client.CreateInstallationBackup(installationID)
+		if err != nil {
+			return errors.Wrap(err, "failed to request installation backup")
+		}
+
+		return printJSON(backup)
+	},
+}
+
+var backupListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List installation backups.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		installationID, _ := command.Flags().GetString("installation")
+		clusterInstallationID, _ := command.Flags().GetString("cluster-installation")
+		state, _ := command.Flags().GetString("state")
+		page, _ := command.Flags().GetInt("page")
+		perPage, _ := command.Flags().GetInt("per-page")
+		includeDeleted, _ := command.Flags().GetBool("include-deleted")
+
+		request := &model.GetInstallationBackupsRequest{
+			InstallationID:        installationID,
+			ClusterInstallationID: clusterInstallationID,
+			State:                 state,
+			Page:                  page,
+			PerPage:               perPage,
+			IncludeDeleted:        includeDeleted,
+		}
+
+		backups, err := client.GetInstallationBackups(request)
+		if err != nil {
+			return errors.Wrap(err, "failed to get backup")
+		}
+
+		outputToTable, _ := command.Flags().GetBool("table")
+		if outputToTable {
+			table := tablewriter.NewWriter(os.Stdout)
+			table.SetAlignment(tablewriter.ALIGN_LEFT)
+			table.SetHeader([]string{"ID", "INSTALLATION ID", "STATE", "CLUSTER INSTALLATION ID", "REQUEST AT"})
+
+			for _, backup := range backups {
+				table.Append([]string{
+					backup.ID,
+					backup.InstallationID,
+					string(backup.State),
+					backup.ClusterInstallationID,
+					utils.TimeFromMillis(backup.RequestAt).Format("2006-01-02 15:04:05 -0700 MST"),
+				})
+			}
+			table.Render()
+
+			return nil
+		}
+
+		err = printJSON(backups)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var backupGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get installation backup.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		backupID, _ := command.Flags().GetString("backup")
+
+		backup, err := client.GetInstallationBackup(backupID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get backup")
+		}
+
+		err = printJSON(backup)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var backupDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete installation backup.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		backupID, _ := command.Flags().GetString("backup")
+
+		err := client.DeleteInstallationBackup(backupID)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete backup")
+		}
+
+		return nil
+	},
+}

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -84,6 +84,7 @@ func init() {
 	installationCmd.AddCommand(installationShowStateReport)
 	installationCmd.AddCommand(installationAnnotationCmd)
 	installationCmd.AddCommand(installationsGetStatuses)
+	installationCmd.AddCommand(backupCmd)
 }
 
 var installationCmd = &cobra.Command{

--- a/cmd/cloud/security.go
+++ b/cmd/cloud/security.go
@@ -25,6 +25,9 @@ func init() {
 	securityGroupCmd.PersistentFlags().String("group", "", "The id of the group.")
 	securityGroupCmd.MarkPersistentFlagRequired("group")
 
+	securityBackupCmd.PersistentFlags().String("backup", "", "The id of the backup.")
+	securityBackupCmd.MarkPersistentFlagRequired("backup")
+
 	securityCmd.AddCommand(securityClusterCmd)
 	securityClusterCmd.AddCommand(securityClusterLockAPICmd)
 	securityClusterCmd.AddCommand(securityClusterUnlockAPICmd)
@@ -40,6 +43,10 @@ func init() {
 	securityCmd.AddCommand(securityGroupCmd)
 	securityGroupCmd.AddCommand(securityGroupLockAPICmd)
 	securityGroupCmd.AddCommand(securityGroupUnlockAPICmd)
+
+	securityCmd.AddCommand(securityBackupCmd)
+	securityBackupCmd.AddCommand(securityBackupLockAPICmd)
+	securityBackupCmd.AddCommand(securityBackupUnlockAPICmd)
 }
 
 var securityCmd = &cobra.Command{
@@ -213,6 +220,49 @@ var securityGroupUnlockAPICmd = &cobra.Command{
 		err := client.UnlockAPIForGroup(groupID)
 		if err != nil {
 			return errors.Wrap(err, "failed to unlock group API")
+		}
+
+		return nil
+	},
+}
+
+var securityBackupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "Manage security locks for backup resources.",
+}
+
+var securityBackupLockAPICmd = &cobra.Command{
+	Use:   "api-lock",
+	Short: "Lock API changes on a given backup",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		backupID, _ := command.Flags().GetString("backup")
+		err := client.LockAPIForBackup(backupID)
+		if err != nil {
+			return errors.Wrap(err, "failed to lock backup API")
+		}
+
+		return nil
+	},
+}
+
+var securityBackupUnlockAPICmd = &cobra.Command{
+	Use:   "api-unlock",
+	Short: "Unlock API changes on a given backup",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		backupID, _ := command.Flags().GetString("backup")
+		err := client.UnlockAPIForBackup(backupID)
+		if err != nil {
+			return errors.Wrap(err, "failed to unlock backup API")
 		}
 
 		return nil

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -73,6 +73,16 @@ type Store interface {
 
 	CreateInstallationAnnotations(installationID string, annotations []*model.Annotation) ([]*model.Annotation, error)
 	DeleteInstallationAnnotation(installationID string, annotationName string) error
+
+	IsInstallationBackupRunning(installationID string) (bool, error)
+	CreateInstallationBackup(backupMeta *model.InstallationBackup) error
+	UpdateInstallationBackupState(backupMeta *model.InstallationBackup) error
+	GetInstallationBackup(id string) (*model.InstallationBackup, error)
+	GetInstallationBackups(filter *model.InstallationBackupFilter) ([]*model.InstallationBackup, error)
+	LockInstallationBackup(backupMetadataID, lockerID string) (bool, error)
+	UnlockInstallationBackup(backupMetadataID, lockerID string, force bool) (bool, error)
+	LockInstallationBackupAPI(backupID string) error
+	UnlockInstallationBackupAPI(backupID string) error
 }
 
 // Provisioner describes the interface required to communicate with the Kubernetes cluster.

--- a/internal/api/installation_backup.go
+++ b/internal/api/installation_backup.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/webhook"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+// initInstallationBackup registers installation backups endpoints on the given router.
+func initInstallationBackup(apiRouter *mux.Router, context *Context) {
+	addContext := func(handler contextHandlerFunc) *contextHandler {
+		return newContextHandler(context, handler)
+	}
+
+	backupsRouter := apiRouter.PathPrefix("/backups").Subrouter()
+
+	backupsRouter.Handle("", addContext(handleRequestInstallationBackup)).Methods("POST")
+	backupsRouter.Handle("", addContext(handleGetInstallationBackups)).Methods("GET")
+
+	backupRouter := apiRouter.PathPrefix("/backup/{backup:[A-Za-z0-9]{26}}").Subrouter()
+	backupRouter.Handle("", addContext(handleGetInstallationBackup)).Methods("GET")
+	backupRouter.Handle("", addContext(handleDeleteInstallationBackup)).Methods("DELETE")
+}
+
+// handleRequestInstallationBackup responds to POST /api/installations/backups,
+// requests backup of Installation's data.
+func handleRequestInstallationBackup(c *Context, w http.ResponseWriter, r *http.Request) {
+	backupRequest, err := model.NewInstallationBackupRequestFromReader(r.Body)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to decode request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	c.Logger = c.Logger.
+		WithField("installation", backupRequest.InstallationID).
+		WithField("action", "request-backup")
+
+	installationDTO, status, unlockOnce := lockInstallation(c, backupRequest.InstallationID)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	if err := model.EnsureBackupCompatible(installationDTO.Installation); err != nil {
+		c.Logger.WithError(err).Error("installation cannot be backed up")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	backupRunning, err := c.Store.IsInstallationBackupRunning(installationDTO.ID)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to check if backup is running for Installation")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if backupRunning {
+		c.Logger.Error("Backup for the installation is already requested or in progress")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	backup := &model.InstallationBackup{
+		InstallationID: installationDTO.ID,
+		State:          model.InstallationBackupStateBackupRequested,
+	}
+
+	err = c.Store.CreateInstallationBackup(backup)
+	if err != nil {
+		c.Logger.Error("Failed to create backup metadata")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	sendInstallationBackupWebhook(c, backup, "n/a")
+
+	c.Supervisor.Do()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, backup)
+}
+
+// handleGetInstallationBackups responds to GET /api/installations/backups,
+// returns backups metadata.
+func handleGetInstallationBackups(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.Logger = c.Logger.
+		WithField("action", "list-installation-backups")
+
+	page, perPage, includeDeleted, err := parsePaging(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse paging parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	installationID := r.URL.Query().Get("installation")
+	clusterInstallationID := r.URL.Query().Get("cluster_installation")
+	state := r.URL.Query().Get("state")
+	var states []model.InstallationBackupState
+	if state != "" {
+		states = append(states, model.InstallationBackupState(state))
+	}
+
+	filter := &model.InstallationBackupFilter{
+		InstallationID:        installationID,
+		ClusterInstallationID: clusterInstallationID,
+		States:                states,
+		Page:                  page,
+		PerPage:               perPage,
+		IncludeDeleted:        includeDeleted,
+	}
+
+	backupsMeta, err := c.Store.GetInstallationBackups(filter)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to list installation backups")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, backupsMeta)
+}
+
+// handleGetInstallationBackup responds to GET /api/installations/backup/{backup},
+// returns metadata of specified backup.
+func handleGetInstallationBackup(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	installationID := vars["installation"]
+	backupID := vars["backup"]
+	c.Logger = c.Logger.
+		WithField("installation", installationID).
+		WithField("backup", backupID).
+		WithField("action", "get-installation-backup")
+
+	backupMetadata, err := c.Store.GetInstallationBackup(backupID)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to get backup")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if backupMetadata == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, backupMetadata)
+}
+
+// handleDeleteInstallationBackup responds to DELETE /api/installations/backup/{backup},
+// returns metadata of specified backup.
+func handleDeleteInstallationBackup(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	backupID := vars["backup"]
+	c.Logger = c.Logger.
+		WithField("backup", backupID).
+		WithField("action", "delete-installation-backup")
+
+	backup, status, unlockOnce := lockInstallationBackup(c, backupID)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	if backup.APISecurityLock {
+		logSecurityLockConflict("backup", c.Logger)
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	newState := model.InstallationBackupStateDeletionRequested
+
+	if !backup.ValidTransitionState(newState) {
+		c.Logger.Warnf("unable to delete backup installation while in state %s", backup.State)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if backup.State != newState {
+		oldState := backup.State
+		backup.State = newState
+		err := c.Store.UpdateInstallationBackupState(backup)
+		if err != nil {
+			c.Logger.WithError(err).Error("Failed to delete installation backup")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		sendInstallationBackupWebhook(c, backup, string(oldState))
+	}
+
+	unlockOnce()
+	c.Supervisor.Do()
+
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func sendInstallationBackupWebhook(c *Context, backup *model.InstallationBackup, oldState string) {
+	webhookPayload := &model.WebhookPayload{
+		Type:      model.TypeInstallationBackup,
+		ID:        backup.ID,
+		NewState:  string(backup.State),
+		OldState:  oldState,
+		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"Installation": backup.InstallationID, "Environment": c.Environment},
+	}
+	err := webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
+	if err != nil {
+		c.Logger.WithError(err).Error("Unable to process and send webhooks")
+	}
+}

--- a/internal/api/installation_backup_test.go
+++ b/internal/api/installation_backup_test.go
@@ -1,0 +1,334 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestInstallationBackup(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+	installation1, err := client.CreateInstallation(
+		&model.CreateInstallationRequest{
+			OwnerID:   "owner",
+			Version:   "version",
+			DNS:       "dns1.example.com",
+			Affinity:  model.InstallationAffinityMultiTenant,
+			Database:  model.InstallationDatabaseMultiTenantRDSPostgres,
+			Filestore: model.InstallationFilestoreBifrost,
+		})
+	require.NoError(t, err)
+
+	t.Run("fail for not hibernated installation1", func(t *testing.T) {
+		_, err = client.CreateInstallationBackup(installation1.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+
+	installation1.State = model.InstallationStateHibernating
+	err = sqlStore.UpdateInstallation(installation1.Installation)
+	require.NoError(t, err)
+
+	backup, err := client.CreateInstallationBackup(installation1.ID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, backup.ID)
+
+	t.Run("fail to request multiple backups for same installation1", func(t *testing.T) {
+		_, err = client.CreateInstallationBackup(installation1.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+
+	t.Run("can request backup for different installation", func(t *testing.T) {
+		installation2, err := client.CreateInstallation(
+			&model.CreateInstallationRequest{
+				OwnerID:   "owner",
+				Version:   "version",
+				DNS:       "dns2.example.com",
+				Affinity:  model.InstallationAffinityMultiTenant,
+				Database:  model.InstallationDatabaseMultiTenantRDSPostgres,
+				Filestore: model.InstallationFilestoreBifrost,
+			})
+		require.NoError(t, err)
+
+		installation2.State = model.InstallationStateHibernating
+		err = sqlStore.UpdateInstallation(installation2.Installation)
+		require.NoError(t, err)
+
+		backup2, err := client.CreateInstallationBackup(installation2.ID)
+		require.NoError(t, err)
+		assert.NotEmpty(t, backup2.ID)
+	})
+}
+
+func TestGetInstallationBackups(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	installation1 := testutil.CreateBackupCompatibleInstallation(t, sqlStore)
+	installation2 := testutil.CreateBackupCompatibleInstallation(t, sqlStore)
+
+	backup := []*model.InstallationBackup{
+		{
+			InstallationID: installation1.ID,
+			State:          model.InstallationBackupStateBackupRequested,
+		},
+		{
+			InstallationID: installation1.ID,
+			State:          model.InstallationBackupStateBackupFailed,
+		},
+		{
+			InstallationID: installation2.ID,
+			State:          model.InstallationBackupStateBackupRequested,
+		},
+		{
+			InstallationID:        installation2.ID,
+			State:                 model.InstallationBackupStateBackupRequested,
+			ClusterInstallationID: "ci1",
+		},
+		{
+			InstallationID:        installation2.ID,
+			State:                 model.InstallationBackupStateBackupSucceeded,
+			ClusterInstallationID: "ci1",
+		},
+	}
+
+	for i := range backup {
+		err := sqlStore.CreateInstallationBackup(backup[i])
+		require.NoError(t, err)
+		time.Sleep(1 * time.Millisecond)
+	}
+	deletedMeta := &model.InstallationBackup{InstallationID: "deleted"}
+	err := sqlStore.CreateInstallationBackup(deletedMeta)
+	require.NoError(t, err)
+	err = sqlStore.DeleteInstallationBackup(deletedMeta.ID)
+	require.NoError(t, err)
+	deletedMeta, err = sqlStore.GetInstallationBackup(deletedMeta.ID)
+
+	for _, testCase := range []struct {
+		description string
+		filter      model.GetInstallationBackupsRequest
+		found       []*model.InstallationBackup
+	}{
+		{
+			description: "all",
+			filter:      model.GetInstallationBackupsRequest{PerPage: model.AllPerPage, IncludeDeleted: true},
+			found:       append(backup, deletedMeta),
+		},
+		{
+			description: "all not deleted",
+			filter:      model.GetInstallationBackupsRequest{PerPage: model.AllPerPage, IncludeDeleted: false},
+			found:       backup,
+		},
+		{
+			description: "1 per page",
+			filter:      model.GetInstallationBackupsRequest{PerPage: 1},
+			found:       []*model.InstallationBackup{backup[4]},
+		},
+		{
+			description: "2nd page",
+			filter:      model.GetInstallationBackupsRequest{PerPage: 1, Page: 1},
+			found:       []*model.InstallationBackup{backup[3]},
+		},
+		{
+			description: "filter by installation ID",
+			filter:      model.GetInstallationBackupsRequest{PerPage: model.AllPerPage, InstallationID: installation1.ID},
+			found:       []*model.InstallationBackup{backup[0], backup[1]},
+		},
+		{
+			description: "filter by cluster installation ID",
+			filter:      model.GetInstallationBackupsRequest{PerPage: model.AllPerPage, ClusterInstallationID: "ci1"},
+			found:       []*model.InstallationBackup{backup[3], backup[4]},
+		},
+		{
+			description: "filter by state",
+			filter:      model.GetInstallationBackupsRequest{PerPage: model.AllPerPage, State: string(model.InstallationBackupStateBackupRequested)},
+			found:       []*model.InstallationBackup{backup[0], backup[2], backup[3]},
+		},
+		{
+			description: "no results",
+			filter:      model.GetInstallationBackupsRequest{PerPage: model.AllPerPage, InstallationID: "no-existent"},
+			found:       []*model.InstallationBackup{},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+
+			backups, err := client.GetInstallationBackups(&testCase.filter)
+			require.NoError(t, err)
+			require.Equal(t, len(testCase.found), len(backups))
+
+			for i := 0; i < len(testCase.found); i++ {
+				assert.Equal(t, testCase.found[i], backups[len(testCase.found)-1-i])
+			}
+
+		})
+	}
+}
+
+func TestGetInstallationBackup(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	installation1 := testutil.CreateBackupCompatibleInstallation(t, sqlStore)
+
+	backup, err := client.CreateInstallationBackup(installation1.ID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, backup.ID)
+
+	fetchedMeta, err := client.GetInstallationBackup(backup.ID)
+	require.NoError(t, err)
+	assert.Equal(t, backup, fetchedMeta)
+
+	t.Run("return 404 if backup not found", func(t *testing.T) {
+		_, err = client.GetInstallationBackup("not-real")
+		require.EqualError(t, err, "failed with status code 404")
+	})
+}
+
+func TestDeleteInstallationBackup(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	installation1 := testutil.CreateBackupCompatibleInstallation(t, sqlStore)
+
+	backup, err := client.CreateInstallationBackup(installation1.ID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, backup.ID)
+
+	t.Run("unknown backup", func(t *testing.T) {
+		err = client.DeleteInstallationBackup(model.NewID())
+		require.EqualError(t, err, "failed with status code 404")
+	})
+
+	t.Run("while locked", func(t *testing.T) {
+		_, err = sqlStore.LockInstallationBackup(backup.ID, "locker")
+		require.NoError(t, err)
+		defer func() {
+			_, err = sqlStore.UnlockInstallationBackup(backup.ID, "locker", true)
+			require.NoError(t, err)
+		}()
+
+		err = client.DeleteInstallationBackup(backup.ID)
+		require.EqualError(t, err, "failed with status code 409")
+	})
+
+	t.Run("while api-security-locked", func(t *testing.T) {
+		err = sqlStore.LockInstallationBackupAPI(backup.ID)
+		require.NoError(t, err)
+		defer func() {
+			err = sqlStore.UnlockInstallationBackupAPI(backup.ID)
+			require.NoError(t, err)
+		}()
+
+		err = client.DeleteInstallationBackup(backup.ID)
+		require.EqualError(t, err, "failed with status code 403")
+	})
+
+	err = client.DeleteInstallationBackup(backup.ID)
+	require.NoError(t, err)
+
+	fetchedBackup, err := client.GetInstallationBackup(backup.ID)
+	require.NoError(t, err)
+	assert.Equal(t, model.InstallationBackupStateDeletionRequested, fetchedBackup.State)
+
+	t.Run("cannot deleted already deleted", func(t *testing.T) {
+		backup.State = model.InstallationBackupStateDeleted
+		err = sqlStore.UpdateInstallationBackupState(backup)
+		require.NoError(t, err)
+
+		err = client.DeleteInstallationBackup(backup.ID)
+		require.EqualError(t, err, "failed with status code 400")
+	})
+}
+
+func TestBackupAPILock(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	installation1 := testutil.CreateBackupCompatibleInstallation(t, sqlStore)
+
+	backup, err := client.CreateInstallationBackup(installation1.ID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, backup.ID)
+
+	err = client.LockAPIForBackup(backup.ID)
+	require.NoError(t, err)
+	fetchedMeta, err := client.GetInstallationBackup(backup.ID)
+	require.NoError(t, err)
+	assert.True(t, fetchedMeta.APISecurityLock)
+
+	err = client.UnlockAPIForBackup(backup.ID)
+	require.NoError(t, err)
+	fetchedMeta, err = client.GetInstallationBackup(backup.ID)
+	require.NoError(t, err)
+	assert.False(t, fetchedMeta.APISecurityLock)
+}

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -1255,6 +1255,21 @@ func TestDeleteInstallation(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("while backup is running", func(t *testing.T) {
+		backup1 := &model.InstallationBackup{InstallationID: installation1.ID, State: model.InstallationBackupStateBackupRequested}
+		backup2 := &model.InstallationBackup{InstallationID: installation1.ID, State: model.InstallationBackupStateBackupSucceeded}
+		err = sqlStore.CreateInstallationBackup(backup1)
+		require.NoError(t, err)
+		err = sqlStore.CreateInstallationBackup(backup2)
+		require.NoError(t, err)
+
+		err = client.DeleteInstallation(installation1.ID)
+		require.EqualError(t, err, "failed with status code 400")
+
+		err = sqlStore.DeleteInstallationBackup(backup1.ID)
+		require.NoError(t, err)
+	})
+
 	t.Run("while", func(t *testing.T) {
 		validDeletingStates := []string{
 			model.InstallationStateStable,

--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -339,6 +339,20 @@ func (mr *MockAWSMockRecorder) S3EnsureBucketDeleted(bucketName, logger interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "S3EnsureBucketDeleted", reflect.TypeOf((*MockAWS)(nil).S3EnsureBucketDeleted), bucketName, logger)
 }
 
+// S3EnsureObjectDeleted mocks base method
+func (m *MockAWS) S3EnsureObjectDeleted(bucketName, path string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "S3EnsureObjectDeleted", bucketName, path)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// S3EnsureObjectDeleted indicates an expected call of S3EnsureObjectDeleted
+func (mr *MockAWSMockRecorder) S3EnsureObjectDeleted(bucketName, path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "S3EnsureObjectDeleted", reflect.TypeOf((*MockAWS)(nil).S3EnsureObjectDeleted), bucketName, path)
+}
+
 // GenerateBifrostUtilitySecret mocks base method
 func (m *MockAWS) GenerateBifrostUtilitySecret(clusterID string, logger logrus.FieldLogger) (*v1.Secret, error) {
 	m.ctrl.T.Helper()

--- a/internal/provisioner/backup_restore.go
+++ b/internal/provisioner/backup_restore.go
@@ -156,8 +156,9 @@ func (o BackupOperator) CheckBackupStatus(jobsClient v1.JobInterface, backup *mo
 func (o BackupOperator) CleanupBackupJob(jobsClient v1.JobInterface, backup *model.InstallationBackup, logger log.FieldLogger) error {
 	backupJobName := jobName(backupAction, backup.ID)
 
+	deletePropagation := metav1.DeletePropagationBackground
 	ctx := context.Background()
-	err := jobsClient.Delete(ctx, backupJobName, metav1.DeleteOptions{})
+	err := jobsClient.Delete(ctx, backupJobName, metav1.DeleteOptions{PropagationPolicy: &deletePropagation})
 	if k8sErrors.IsNotFound(err) {
 		logger.Warnf("backup job %q does not exist, assuming already deleted", backupJobName)
 		return nil

--- a/internal/store/installation_backup.go
+++ b/internal/store/installation_backup.go
@@ -81,7 +81,7 @@ func (sqlStore *SQLStore) IsInstallationBackupRunning(installationID string) (bo
 		Select("Count (*)").
 		From(backupTable).
 		Where("InstallationID = ?", installationID).
-		Where(sq.Eq{"State": model.AllInstallationBackupStatesPendingWork}).
+		Where(sq.Eq{"State": model.AllInstallationBackupsStatesRunning}).
 		Where("DeleteAt = 0")
 	err := sqlStore.selectBuilder(sqlStore.db, &totalResult, builder)
 	if err != nil {
@@ -217,9 +217,9 @@ func (sqlStore *SQLStore) UpdateInstallationBackupState(backup *model.Installati
 		})
 }
 
-// DeleteBackup marks the given backup as deleted, but does not remove
+// DeleteInstallationBackup marks the given backup as deleted, but does not remove
 // the record from the database.
-func (sqlStore *SQLStore) DeleteBackup(id string) error {
+func (sqlStore *SQLStore) DeleteInstallationBackup(id string) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Update(backupTable).
 		Set("DeleteAt", GetMillis()).
@@ -249,9 +249,19 @@ func (sqlStore *SQLStore) LockInstallationBackup(backupID, lockerID string) (boo
 	return sqlStore.lockRows(backupTable, []string{backupID}, lockerID)
 }
 
+// LockInstallationBackups marks backups as locked for exclusive use by the caller.
+func (sqlStore *SQLStore) LockInstallationBackups(backupIDs []string, lockerID string) (bool, error) {
+	return sqlStore.lockRows(backupTable, backupIDs, lockerID)
+}
+
 // UnlockInstallationBackup releases a lock previously acquired against a caller.
 func (sqlStore *SQLStore) UnlockInstallationBackup(backupID, lockerID string, force bool) (bool, error) {
 	return sqlStore.unlockRows(backupTable, []string{backupID}, lockerID, force)
+}
+
+// UnlockInstallationBackups releases a locks previously acquired against a caller.
+func (sqlStore *SQLStore) UnlockInstallationBackups(backupIDs []string, lockerID string, force bool) (bool, error) {
+	return sqlStore.unlockRows(backupTable, backupIDs, lockerID, force)
 }
 
 func (sqlStore *SQLStore) applyInstallationBackupFilter(builder sq.SelectBuilder, filter *model.InstallationBackupFilter) sq.SelectBuilder {
@@ -261,14 +271,19 @@ func (sqlStore *SQLStore) applyInstallationBackupFilter(builder sq.SelectBuilder
 			Offset(uint64(filter.Page * filter.PerPage))
 	}
 
+	if len(filter.IDs) > 0 {
+		builder = builder.Where(sq.Eq{"ID": filter.IDs})
+	}
 	if filter.InstallationID != "" {
 		builder = builder.Where("InstallationID = ?", filter.InstallationID)
 	}
 	if filter.ClusterInstallationID != "" {
 		builder = builder.Where("ClusterInstallationID = ?", filter.ClusterInstallationID)
 	}
-	if filter.State != "" {
-		builder = builder.Where("State = ?", filter.State)
+	if len(filter.States) > 0 {
+		builder = builder.Where(sq.Eq{
+			"State": filter.States,
+		})
 	}
 	if !filter.IncludeDeleted {
 		builder = builder.Where("DeleteAt = 0")

--- a/internal/store/installation_backup_test.go
+++ b/internal/store/installation_backup_test.go
@@ -118,7 +118,7 @@ func TestGetInstallationBackupsMetadata(t *testing.T) {
 		time.Sleep(1 * time.Millisecond) // Ensure RequestAt is different for all installations.
 	}
 
-	err = sqlStore.DeleteBackup(backupsMeta[2].ID)
+	err = sqlStore.DeleteInstallationBackup(backupsMeta[2].ID)
 	require.NoError(t, err)
 
 	for _, testCase := range []struct {
@@ -148,8 +148,13 @@ func TestGetInstallationBackupsMetadata(t *testing.T) {
 		},
 		{
 			description: "fetch requested installations",
-			filter:      &model.InstallationBackupFilter{State: model.InstallationBackupStateBackupRequested, PerPage: model.AllPerPage},
+			filter:      &model.InstallationBackupFilter{States: []model.InstallationBackupState{model.InstallationBackupStateBackupRequested}, PerPage: model.AllPerPage},
 			fetchedIds:  []string{backupsMeta[3].ID, backupsMeta[0].ID},
+		},
+		{
+			description: "fetch with IDs",
+			filter:      &model.InstallationBackupFilter{IDs: []string{backupsMeta[0].ID, backupsMeta[3].ID, backupsMeta[4].ID}, PerPage: model.AllPerPage},
+			fetchedIds:  []string{backupsMeta[4].ID, backupsMeta[3].ID, backupsMeta[0].ID},
 		},
 	} {
 		t.Run(testCase.description, func(t *testing.T) {

--- a/internal/supervisor/cluster_installation.go
+++ b/internal/supervisor/cluster_installation.go
@@ -29,6 +29,8 @@ type clusterInstallationStore interface {
 	UpdateClusterInstallation(clusterInstallation *model.ClusterInstallation) error
 	DeleteClusterInstallation(clusterInstallationID string) error
 
+	GetInstallationBackups(filter *model.InstallationBackupFilter) ([]*model.InstallationBackup, error)
+
 	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
 }
 
@@ -211,7 +213,21 @@ func (s *ClusterInstallationSupervisor) createClusterInstallation(clusterInstall
 }
 
 func (s *ClusterInstallationSupervisor) deleteClusterInstallation(clusterInstallation *model.ClusterInstallation, logger log.FieldLogger, installation *model.Installation, cluster *model.Cluster) string {
-	err := s.provisioner.ClusterInstallationProvisioner(installation.CRVersion).
+	backups, err := s.store.GetInstallationBackups(&model.InstallationBackupFilter{
+		ClusterInstallationID: clusterInstallation.ID,
+		States:                model.AllInstallationBackupsStatesRunning,
+		PerPage:               model.AllPerPage,
+	})
+	if err != nil {
+		logger.WithError(err).Error("Failed to get installation backups running in cluster installation namespace")
+		return clusterInstallation.State
+	}
+	if len(backups) > 0 {
+		logger.Warn("Cannot delete cluster installation while backups are running in its namespace")
+		return clusterInstallation.State
+	}
+
+	err = s.provisioner.ClusterInstallationProvisioner(installation.CRVersion).
 		DeleteClusterInstallation(cluster, installation, clusterInstallation)
 	if err != nil {
 		logger.WithError(err).Error("Failed to delete cluster installation")

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -66,6 +66,11 @@ type installationStore interface {
 
 	GetAnnotationsForInstallation(installationID string) ([]*model.Annotation, error)
 
+	GetInstallationBackups(filter *model.InstallationBackupFilter) ([]*model.InstallationBackup, error)
+	UpdateInstallationBackupState(backup *model.InstallationBackup) error
+	LockInstallationBackups(backupIDs []string, lockerID string) (bool, error)
+	UnlockInstallationBackups(backupIDs []string, lockerID string, force bool) (bool, error)
+
 	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
 }
 
@@ -285,7 +290,7 @@ func (s *InstallationSupervisor) transitionInstallation(installation *model.Inst
 		return s.deleteInstallation(installation, instanceID, logger)
 
 	case model.InstallationStateDeletionFinalCleanup:
-		return s.finalDeletionCleanup(installation, logger)
+		return s.finalDeletionCleanup(installation, instanceID, logger)
 
 	default:
 		logger.Warnf("Found installation pending work in unexpected state %s", installation.State)
@@ -336,7 +341,7 @@ func (s *InstallationSupervisor) createInstallation(installation *model.Installa
 		return model.InstallationStateCreationRequested
 	}
 	if len(annotations) > 0 {
-		clusterFilter.Annotations = &model.AnnotationsFilter{MatchAllIDs: annotationsToIDs(annotations)}
+		clusterFilter.Annotations = &model.AnnotationsFilter{MatchAllIDs: getAnnotationsIDs(annotations)}
 	}
 
 	// Proceed to requesting cluster installation creation on any available clusters.
@@ -713,12 +718,8 @@ func (s *InstallationSupervisor) updateInstallation(installation *model.Installa
 		return installation.State
 	}
 
-	var clusterInstallationIDs []string
+	clusterInstallationIDs := getClusterInstallationIDs(clusterInstallations)
 	if len(clusterInstallations) > 0 {
-		for _, clusterInstallation := range clusterInstallations {
-			clusterInstallationIDs = append(clusterInstallationIDs, clusterInstallation.ID)
-		}
-
 		clusterInstallationLocks := newClusterInstallationLocks(clusterInstallationIDs, instanceID, s.store, logger)
 		if !clusterInstallationLocks.TryLock() {
 			logger.Debugf("Failed to lock %d cluster installations", len(clusterInstallations))
@@ -892,10 +893,7 @@ func (s *InstallationSupervisor) hibernateInstallation(installation *model.Insta
 		return installation.State
 	}
 
-	var clusterInstallationIDs []string
-	for _, clusterInstallation := range clusterInstallations {
-		clusterInstallationIDs = append(clusterInstallationIDs, clusterInstallation.ID)
-	}
+	clusterInstallationIDs := getClusterInstallationIDs(clusterInstallations)
 
 	clusterInstallationLocks := newClusterInstallationLocks(clusterInstallationIDs, instanceID, s.store, logger)
 	if !clusterInstallationLocks.TryLock() {
@@ -987,12 +985,8 @@ func (s *InstallationSupervisor) deleteInstallation(installation *model.Installa
 		return installation.State
 	}
 
-	var clusterInstallationIDs []string
+	clusterInstallationIDs := getClusterInstallationIDs(clusterInstallations)
 	if len(clusterInstallations) > 0 {
-		for _, clusterInstallation := range clusterInstallations {
-			clusterInstallationIDs = append(clusterInstallationIDs, clusterInstallation.ID)
-		}
-
 		clusterInstallationLocks := newClusterInstallationLocks(clusterInstallationIDs, instanceID, s.store, logger)
 		if !clusterInstallationLocks.TryLock() {
 			logger.Debugf("Failed to lock %d cluster installations", len(clusterInstallations))
@@ -1078,14 +1072,28 @@ func (s *InstallationSupervisor) deleteInstallation(installation *model.Installa
 		return model.InstallationStateDeletionInProgress
 	}
 
-	return s.finalDeletionCleanup(installation, logger)
+	return s.finalDeletionCleanup(installation, instanceID, logger)
 }
 
-func (s *InstallationSupervisor) finalDeletionCleanup(installation *model.Installation, logger log.FieldLogger) string {
+func (s *InstallationSupervisor) finalDeletionCleanup(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
 	err := s.aws.DeletePublicCNAME(installation.DNS, logger)
 	if err != nil {
 		logger.WithError(err).Error("Failed to delete installation DNS")
 		return model.InstallationStateDeletionFinalCleanup
+	}
+
+	// Backups are stored in Installations file store, therefore if file store is deleted
+	// the backups will be deleted also.
+	if !s.keepFilestoreData {
+		finished, err := s.deleteBackups(installation, instanceID, logger)
+		if err != nil {
+			logger.WithError(err).Error("Failed to delete backups")
+			return model.InstallationStateDeletionFinalCleanup
+		}
+		if !finished {
+			logger.Info("Installation backups deletion in progress")
+			return model.InstallationStateDeletionFinalCleanup
+		}
 	}
 
 	err = s.resourceUtil.GetDatabase(installation).Teardown(s.store, s.keepDatabaseData, logger)
@@ -1109,6 +1117,89 @@ func (s *InstallationSupervisor) finalDeletionCleanup(installation *model.Instal
 	logger.Info("Finished deleting installation")
 
 	return model.InstallationStateDeleted
+}
+
+func (s *InstallationSupervisor) deleteBackups(installation *model.Installation, instanceID string, logger log.FieldLogger) (bool, error) {
+	logger.Info("Deleting installation backups")
+
+	backups, err := s.store.GetInstallationBackups(&model.InstallationBackupFilter{
+		InstallationID: installation.ID,
+		PerPage:        model.AllPerPage,
+	})
+	if err != nil {
+		return false, errors.Wrap(err, "failed to list backup")
+	}
+
+	if len(backups) == 0 {
+		logger.Info("No existing backups found for installation")
+		return true, nil
+	}
+
+	backupIDs := getInstallationBackupsIDs(backups)
+
+	installationBackupsLocks := newBackupsLock(backupIDs, instanceID, s.store, logger)
+	if !installationBackupsLocks.TryLock() {
+		return false, errors.Errorf("Failed to lock %d installation backups", len(backups))
+	}
+	defer installationBackupsLocks.Unlock()
+
+	// Fetch the same backups again, now that we have the locks.
+	backups, err = s.store.GetInstallationBackups(&model.InstallationBackupFilter{
+		PerPage: model.AllPerPage,
+		IDs:     backupIDs,
+	})
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to fetch %d installation backups by ids", len(backups))
+	}
+
+	if len(backups) != len(backupIDs) {
+		logger.Warnf("Found only %d installation backups after locking, expected %d", len(backups), len(backupIDs))
+	}
+
+	deletedBackups := 0
+	deletingBackups := 0
+	deletionFailedBackups := 0
+
+	for _, backup := range backups {
+		switch backup.State {
+		case model.InstallationBackupStateDeleted:
+			deletedBackups++
+			continue
+		case model.InstallationBackupStateDeletionRequested:
+			deletingBackups++
+			continue
+		case model.InstallationBackupStateDeletionFailed:
+			deletionFailedBackups++
+			continue
+		}
+
+		logger.Debugf("Deleting installation backup %q in state %q", backup.ID, backup.State)
+		backup.State = model.InstallationBackupStateDeletionRequested
+		err = s.store.UpdateInstallationBackupState(backup)
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to mark istallation backup %s for deletion", backup.ID)
+		}
+		deletingBackups++
+	}
+
+	logger.Debugf(
+		"Found %d installation backups, %d deleting, %d deleted, %d failed",
+		len(backups),
+		deletingBackups,
+		deletedBackups,
+		deletionFailedBackups,
+	)
+
+	if deletionFailedBackups > 0 {
+		return false, errors.Errorf("Failed to delete %d installation backups", deletionFailedBackups)
+	}
+
+	if deletingBackups > 0 {
+		logger.Infof("Installation backups deletion in progress, deleting backups %d", deletingBackups)
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (s *InstallationSupervisor) finalCreationTasks(installation *model.Installation, logger log.FieldLogger) string {
@@ -1160,8 +1251,23 @@ func (s *InstallationSupervisor) checkIfClusterInstallationsAreStable(installati
 	return false, nil
 }
 
-// annotationsToIDs parses slice of annotations to slice of strings containing annotations IDs.
-func annotationsToIDs(annotations []*model.Annotation) []string {
+func getClusterInstallationIDs(clusterInstallations []*model.ClusterInstallation) []string {
+	clusterInstallationIDs := make([]string, 0, len(clusterInstallations))
+	for _, clusterInstallation := range clusterInstallations {
+		clusterInstallationIDs = append(clusterInstallationIDs, clusterInstallation.ID)
+	}
+	return clusterInstallationIDs
+}
+
+func getInstallationBackupsIDs(backups []*model.InstallationBackup) []string {
+	backupIDs := make([]string, 0, len(backups))
+	for _, backup := range backups {
+		backupIDs = append(backupIDs, backup.ID)
+	}
+	return backupIDs
+}
+
+func getAnnotationsIDs(annotations []*model.Annotation) []string {
 	ids := make([]string, 0, len(annotations))
 	for _, ann := range annotations {
 		ids = append(ids, ann.ID)

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -70,6 +70,7 @@ type AWS interface {
 
 	DynamoDBEnsureTableDeleted(tableName string, logger log.FieldLogger) error
 	S3EnsureBucketDeleted(bucketName string, logger log.FieldLogger) error
+	S3EnsureObjectDeleted(bucketName, path string) error
 
 	GenerateBifrostUtilitySecret(clusterID string, logger log.FieldLogger) (*corev1.Secret, error)
 	GetCIDRByVPCTag(vpcTagName string, logger log.FieldLogger) (string, error)

--- a/internal/tools/aws/s3.go
+++ b/internal/tools/aws/s3.go
@@ -103,3 +103,16 @@ func (a *Client) S3EnsureBucketDirectoryDeleted(bucketName, directory string, lo
 
 	return nil
 }
+
+// S3EnsureObjectDeleted is used to ensure that the file is deleted.
+func (a *Client) S3EnsureObjectDeleted(bucketName, path string) error {
+	_, err := a.Service().s3.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(path),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to delete object")
+	}
+
+	return nil
+}

--- a/internal/tools/utils/time.go
+++ b/internal/tools/utils/time.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package utils
+
+import "time"
+
+// TimeFromMillis converts time in milliseconds to time.Time.
+func TimeFromMillis(millis int64) time.Time {
+	return time.Unix(0, millis*int64(time.Millisecond))
+}

--- a/model/installation_backup.go
+++ b/model/installation_backup.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -39,6 +40,11 @@ type S3DataResidence struct {
 	ObjectKey  string
 }
 
+// FullPath returns joined path of object in the file store.
+func (dr S3DataResidence) FullPath() string {
+	return filepath.Join(dr.PathPrefix, dr.ObjectKey)
+}
+
 // InstallationBackupState represents the state of backup.
 type InstallationBackupState string
 
@@ -51,6 +57,12 @@ const (
 	InstallationBackupStateBackupSucceeded InstallationBackupState = "backup-succeeded"
 	// InstallationBackupStateBackupFailed if a backup that have failed.
 	InstallationBackupStateBackupFailed InstallationBackupState = "backup-failed"
+	// InstallationBackupStateDeletionRequested is a backup marked for deletion.
+	InstallationBackupStateDeletionRequested InstallationBackupState = "deletion-requested"
+	// InstallationBackupStateDeleted is a deleted backup.
+	InstallationBackupStateDeleted InstallationBackupState = "deleted"
+	// InstallationBackupStateDeletionFailed is a backup which deletion failed.
+	InstallationBackupStateDeletionFailed InstallationBackupState = "deletion-failed"
 )
 
 // AllInstallationBackupStatesPendingWork is a list of all backup states that
@@ -58,13 +70,22 @@ const (
 var AllInstallationBackupStatesPendingWork = []InstallationBackupState{
 	InstallationBackupStateBackupRequested,
 	InstallationBackupStateBackupInProgress,
+	InstallationBackupStateDeletionRequested,
+}
+
+// AllInstallationBackupsStatesRunning is a list of all backup states that are
+// currently running.
+var AllInstallationBackupsStatesRunning = []InstallationBackupState{
+	InstallationBackupStateBackupRequested,
+	InstallationBackupStateBackupInProgress,
 }
 
 // InstallationBackupFilter describes the parameters used to constrain a set of backup.
 type InstallationBackupFilter struct {
+	IDs                   []string
 	InstallationID        string
 	ClusterInstallationID string
-	State                 InstallationBackupState
+	States                []InstallationBackupState
 	Page                  int
 	PerPage               int
 	IncludeDeleted        bool
@@ -116,4 +137,38 @@ func EnsureBackupCompatible(installation *Installation) error {
 	}
 
 	return nil
+}
+
+// ValidTransitionState returns whether an installation backup can be transitioned into
+// the new state or not based on its current state.
+func (b *InstallationBackup) ValidTransitionState(newState InstallationBackupState) bool {
+	validStates, found := validInstallationBackupTransitions[newState]
+	if !found {
+		// If not found assume all states are valid
+		return true
+	}
+
+	return stateIn(b.State, validStates)
+}
+
+var (
+	validInstallationBackupTransitions = map[InstallationBackupState][]InstallationBackupState{
+		InstallationBackupStateDeletionRequested: {
+			InstallationBackupStateBackupRequested,
+			InstallationBackupStateBackupInProgress,
+			InstallationBackupStateBackupSucceeded,
+			InstallationBackupStateBackupFailed,
+			InstallationBackupStateDeletionRequested,
+			InstallationBackupStateDeletionFailed,
+		},
+	}
+)
+
+func stateIn(state InstallationBackupState, states []InstallationBackupState) bool {
+	for _, s := range states {
+		if s == state {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The last part of backup functionality for Installations. This PR contains:
- API to manage backup operations
- CLI methods
- Delete functionality for Backup Supervisor
- Minor improvements of other parts

Some notes on deleting backup:
- When backup deletion is requested the backuped data is removed from the file store.
- When deleting installation, deletion of backups will be dependant on `keepFilestoreData` flag, if it is set to `true` backups will be preserved, otherwise they will be deleted.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-33398

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Installation backup API
```
