### PR TITLE
Handle case when migration not started yet

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster_installation_beta.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation_beta.go
@@ -461,6 +461,10 @@ func (provisioner *kopsCIBeta) migrateFromClusterInstallation(clusterInstallatio
 	}
 
 	if cr.Spec.Migrate {
+		if cr.Status.Migration == nil {
+			logger.Warn("Installation migration waiting to start")
+			return false, nil
+		}
 		if cr.Status.Migration.Error != "" {
 			return false, errors.Errorf("error while migrating ClusterInstallation: %s", cr.Status.Migration.Error)
 		}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
If the Mattermost Operator is lagging behind the Provisioner migration might not start between Provisioner runs.
This PR provides a way to handle this case.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Handle case when migration not started yet
```
