### PR TITLE
Respect installation weights when querying multi tenant databases

### DIFF
--- a/internal/store/multitenant_database_test.go
+++ b/internal/store/multitenant_database_test.go
@@ -39,11 +39,23 @@ type TestMultitenantDatabaseSuite struct {
 func (s *TestMultitenantDatabaseSuite) SetupTest() {
 	s.sqlStore = MakeTestSQLStore(s.t, testlib.MakeLogger(s.t))
 
-	s.installationID0 = "intalllation_id0"
-	s.installationID1 = "intalllation_id1"
-	s.installationID2 = "intalllation_id2"
-	s.installationID3 = "intalllation_id3"
-	s.installationID4 = "intalllation_id4"
+	installations := []*model.Installation{
+		{DNS: "dns0.com"},
+		{DNS: "dns1.com"},
+		{DNS: "dns2.com"},
+		{DNS: "dns3.com"},
+		{DNS: "dns4.com"},
+	}
+	for i := range installations {
+		err := s.sqlStore.CreateInstallation(installations[i], nil)
+		require.NoError(s.t, err)
+	}
+
+	s.installationID0 = installations[0].ID
+	s.installationID1 = installations[1].ID
+	s.installationID2 = installations[2].ID
+	s.installationID3 = installations[3].ID
+	s.installationID4 = installations[4].ID
 
 	s.lockerID = s.installationID0
 
@@ -258,6 +270,7 @@ func (s *TestMultitenantDatabaseSuite) TestGetDatabasesWithVpcIDFilter() {
 
 func TestGetMultitenantDatabases_WeightCalculation(t *testing.T) {
 	sqlStore := MakeTestSQLStore(t, testlib.MakeLogger(t))
+	defer CloseConnection(t, sqlStore)
 
 	// 2 + 6.75 = 8.75
 	installations := []*model.Installation{


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Get installation weights when querying for multitenant databases. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Respect installation weights when querying multi tenant databases
```
