### PR TITLE
[MM-34083] Fix CLRF vulnerability in wakeup redirect

### DIFF
--- a/helm-charts/nginx_values.yaml
+++ b/helm-charts/nginx_values.yaml
@@ -51,7 +51,7 @@ controller:
     force-ssl-redirect: "true"
     server-snippet: |
       proxy_intercept_errors on;
-      error_page 410 "http://127.0.0.1:8076/api/v1/installation/wakeup?dns=$host&uri=$uri";
+      error_page 410 "http://127.0.0.1:8076/api/v1/installation/wakeup?dns=$host&uri=$request_uri";
 
   resources:
    limits:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

More explanation [here](https://book.hacktricks.xyz/pentesting/pentesting-web/nginx#usage-of-usduri-can-lead-to-crlf-injection)

Signed-off-by: Mario de Frutos <mario@defrutos.org>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-34083

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fix for a CLRF injection attack in the wakeup process due to nginx
```
