### PR TITLE
Implement Installation DB restoration model

### DIFF
--- a/internal/api/installation_backup.go
+++ b/internal/api/installation_backup.go
@@ -51,7 +51,7 @@ func handleRequestInstallationBackup(c *Context, w http.ResponseWriter, r *http.
 	}
 	defer unlockOnce()
 
-	if err := model.EnsureBackupCompatible(installationDTO.Installation); err != nil {
+	if err := model.EnsureInstallationReadyForBackup(installationDTO.Installation); err != nil {
 		c.Logger.WithError(err).Error("installation cannot be backed up")
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -378,6 +378,10 @@ func (sqlStore *SQLStore) createInstallation(db execer, installation *model.Inst
 
 // UpdateInstallation updates the given installation in the database.
 func (sqlStore *SQLStore) UpdateInstallation(installation *model.Installation) error {
+	return sqlStore.updateInstallation(sqlStore.db, installation)
+}
+
+func (sqlStore *SQLStore) updateInstallation(db execer, installation *model.Installation) error {
 	if installation.ConfigMergedWithGroup() {
 		return errors.New("unable to save installations that have merged group config")
 	}
@@ -386,7 +390,7 @@ func (sqlStore *SQLStore) UpdateInstallation(installation *model.Installation) e
 		return errors.Wrap(err, "unable to marshal MattermostEnv")
 	}
 
-	_, err = sqlStore.execBuilder(sqlStore.db, sq.
+	_, err = sqlStore.execBuilder(db, sq.
 		Update("Installation").
 		SetMap(map[string]interface{}{
 			"OwnerID":          installation.OwnerID,

--- a/internal/store/installation_db_restoration_operation.go
+++ b/internal/store/installation_db_restoration_operation.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"database/sql"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+const (
+	installationDBRestorationTable = "InstallationDBRestorationOperation"
+)
+
+var installationDBRestorationSelect sq.SelectBuilder
+
+func init() {
+	installationDBRestorationSelect = sq.
+		Select("ID",
+			"InstallationID",
+			"BackupID",
+			"RequestAt",
+			"State",
+			"TargetInstallationState",
+			"ClusterInstallationID",
+			"CompleteAt",
+			"DeleteAt",
+			"LockAcquiredBy",
+			"LockAcquiredAt",
+		).
+		From(installationDBRestorationTable)
+}
+
+// TODO: we should probably create some intermediary layer to not keep this logic in store.
+// For now tho transactions are not accessible outside the store, therefore it is implemented this way.
+
+// TriggerInstallationRestoration creates new InstallationDBRestorationOperation in Requested state
+// and changes installation state to InstallationStateDBRestorationInProgress.
+func (sqlStore *SQLStore) TriggerInstallationRestoration(installation *model.Installation, backup *model.InstallationBackup) (*model.InstallationDBRestorationOperation, error) {
+	targetInstallationState, err := model.DetermineAfterRestorationState(installation)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to determine target installation state")
+	}
+
+	dbRestorationOp := &model.InstallationDBRestorationOperation{
+		InstallationID:          installation.ID,
+		BackupID:                backup.ID,
+		State:                   model.InstallationDBRestorationStateRequested,
+		TargetInstallationState: targetInstallationState,
+	}
+
+	tx, err := sqlStore.beginTransaction(sqlStore.db)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to start transaction")
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	err = sqlStore.createInstallationDBRestoration(tx, dbRestorationOp)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create installation db restoration")
+	}
+
+	installation.State = model.InstallationStateDBRestorationInProgress
+	err = sqlStore.updateInstallation(tx, installation)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update installation")
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to commit transaction")
+	}
+
+	return dbRestorationOp, nil
+}
+
+// CreateInstallationDBRestorationOperation records installation db restoration to the database, assigning it a unique ID.
+func (sqlStore *SQLStore) CreateInstallationDBRestorationOperation(dbRestoration *model.InstallationDBRestorationOperation) error {
+	return sqlStore.createInstallationDBRestoration(sqlStore.db, dbRestoration)
+}
+
+func (sqlStore *SQLStore) createInstallationDBRestoration(db execer, dbRestoration *model.InstallationDBRestorationOperation) error {
+	dbRestoration.ID = model.NewID()
+	dbRestoration.RequestAt = GetMillis()
+
+	_, err := sqlStore.execBuilder(db, sq.
+		Insert(installationDBRestorationTable).
+		SetMap(map[string]interface{}{
+			"ID":                      dbRestoration.ID,
+			"InstallationID":          dbRestoration.InstallationID,
+			"BackupID":                dbRestoration.BackupID,
+			"State":                   dbRestoration.State,
+			"RequestAt":               dbRestoration.RequestAt,
+			"TargetInstallationState": dbRestoration.TargetInstallationState,
+			"ClusterInstallationID":   dbRestoration.ClusterInstallationID,
+			"CompleteAt":              dbRestoration.CompleteAt,
+			"DeleteAt":                0,
+			"LockAcquiredBy":          dbRestoration.LockAcquiredBy,
+			"LockAcquiredAt":          dbRestoration.LockAcquiredAt,
+		}),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to create installation db restoration operation")
+	}
+
+	return nil
+}
+
+// GetInstallationDBRestorationOperation fetches the given installation db restoration.
+func (sqlStore *SQLStore) GetInstallationDBRestorationOperation(id string) (*model.InstallationDBRestorationOperation, error) {
+	builder := installationDBRestorationSelect.
+		Where("ID = ?", id)
+
+	var restorationOp model.InstallationDBRestorationOperation
+	err := sqlStore.getBuilder(sqlStore.db, &restorationOp, builder)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Wrap(err, "failed to query for installation db restoration")
+	}
+
+	return &restorationOp, nil
+}
+
+// GetInstallationDBRestorationOperations fetches the given page of created installation db restoration. The first page is 0.
+func (sqlStore *SQLStore) GetInstallationDBRestorationOperations(filter *model.InstallationDBRestorationFilter) ([]*model.InstallationDBRestorationOperation, error) {
+	builder := installationDBRestorationSelect.
+		OrderBy("RequestAt DESC")
+	builder = sqlStore.applyInstallationDBRestorationFilter(builder, filter)
+
+	var restorationOps []*model.InstallationDBRestorationOperation
+	err := sqlStore.selectBuilder(sqlStore.db, &restorationOps, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query for installation db restorations")
+	}
+
+	return restorationOps, nil
+}
+
+// GetUnlockedInstallationDBRestorationOperationsPendingWork returns unlocked installation db restorations in a pending state.
+func (sqlStore *SQLStore) GetUnlockedInstallationDBRestorationOperationsPendingWork() ([]*model.InstallationDBRestorationOperation, error) {
+	builder := installationDBRestorationSelect.
+		Where(sq.Eq{
+			"State": model.AllInstallationDBRestorationStatesPendingWork,
+		}).
+		Where("LockAcquiredAt = 0").
+		OrderBy("RequestAt ASC")
+
+	var restorationOps []*model.InstallationDBRestorationOperation
+	err := sqlStore.selectBuilder(sqlStore.db, &restorationOps, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query for installation db restorations")
+	}
+
+	return restorationOps, nil
+}
+
+// UpdateInstallationDBRestorationOperationState updates the given installation db restoration state.
+func (sqlStore *SQLStore) UpdateInstallationDBRestorationOperationState(dbRestoration *model.InstallationDBRestorationOperation) error {
+	return sqlStore.updateInstallationDBRestorationFields(
+		sqlStore.db,
+		dbRestoration.ID, map[string]interface{}{
+			"State": dbRestoration.State,
+		})
+}
+
+// UpdateInstallationDBRestorationOperation updates the given installation db restoration.
+func (sqlStore *SQLStore) UpdateInstallationDBRestorationOperation(dbRestoration *model.InstallationDBRestorationOperation) error {
+	return sqlStore.updateInstallationDBRestoration(sqlStore.db, dbRestoration)
+}
+
+func (sqlStore *SQLStore) updateInstallationDBRestoration(db execer, dbRestoration *model.InstallationDBRestorationOperation) error {
+	return sqlStore.updateInstallationDBRestorationFields(
+		db,
+		dbRestoration.ID, map[string]interface{}{
+			"State":                   dbRestoration.State,
+			"TargetInstallationState": dbRestoration.TargetInstallationState,
+			"ClusterInstallationID":   dbRestoration.ClusterInstallationID,
+			"CompleteAt":              dbRestoration.CompleteAt,
+		})
+}
+
+func (sqlStore *SQLStore) updateInstallationDBRestorationFields(db execer, id string, fields map[string]interface{}) error {
+	_, err := sqlStore.execBuilder(db, sq.
+		Update(installationDBRestorationTable).
+		SetMap(fields).
+		Where("ID = ?", id))
+	if err != nil {
+		return errors.Wrapf(err, "failed to update installation db restoration fields: %s", getMapKeys(fields))
+	}
+
+	return nil
+}
+
+// LockInstallationDBRestorationOperation marks the InstallationDBRestoration as locked for exclusive use by the caller.
+func (sqlStore *SQLStore) LockInstallationDBRestorationOperation(id, lockerID string) (bool, error) {
+	return sqlStore.lockRows(installationDBRestorationTable, []string{id}, lockerID)
+}
+
+// LockInstallationDBRestorationOperations marks InstallationDBRestorations as locked for exclusive use by the caller.
+func (sqlStore *SQLStore) LockInstallationDBRestorationOperations(ids []string, lockerID string) (bool, error) {
+	return sqlStore.lockRows(installationDBRestorationTable, ids, lockerID)
+}
+
+// UnlockInstallationDBRestorationOperation releases a lock previously acquired against a caller.
+func (sqlStore *SQLStore) UnlockInstallationDBRestorationOperation(id, lockerID string, force bool) (bool, error) {
+	return sqlStore.unlockRows(installationDBRestorationTable, []string{id}, lockerID, force)
+}
+
+// UnlockInstallationDBRestorationOperations releases a locks previously acquired against a caller.
+func (sqlStore *SQLStore) UnlockInstallationDBRestorationOperations(ids []string, lockerID string, force bool) (bool, error) {
+	return sqlStore.unlockRows(installationDBRestorationTable, ids, lockerID, force)
+}
+
+func (sqlStore *SQLStore) applyInstallationDBRestorationFilter(builder sq.SelectBuilder, filter *model.InstallationDBRestorationFilter) sq.SelectBuilder {
+	builder = applyPagingFilter(builder, filter.Paging)
+
+	if len(filter.IDs) > 0 {
+		builder = builder.Where(sq.Eq{"ID": filter.IDs})
+	}
+	if filter.InstallationID != "" {
+		builder = builder.Where("InstallationID = ?", filter.InstallationID)
+	}
+	if filter.ClusterInstallationID != "" {
+		builder = builder.Where("ClusterInstallationID = ?", filter.ClusterInstallationID)
+	}
+	if len(filter.States) > 0 {
+		builder = builder.Where(sq.Eq{
+			"State": filter.States,
+		})
+	}
+
+	return builder
+}

--- a/internal/store/installation_db_restoration_operation_test.go
+++ b/internal/store/installation_db_restoration_operation_test.go
@@ -1,0 +1,225 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTriggerInstallationRestoration(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation := &model.Installation{
+		State: model.InstallationStateHibernating,
+		DNS:   fmt.Sprintf("dns-%s", uuid.NewRandom().String()[:6]),
+	}
+	err := sqlStore.CreateInstallation(installation, nil)
+	require.NoError(t, err)
+
+	backup := &model.InstallationBackup{
+		InstallationID: installation.ID,
+	}
+	err = sqlStore.CreateInstallationBackup(backup)
+	require.NoError(t, err)
+
+	restorationOp, err := sqlStore.TriggerInstallationRestoration(installation, backup)
+	require.NoError(t, err)
+	assert.Equal(t, installation.ID, restorationOp.InstallationID)
+	assert.Equal(t, backup.ID, restorationOp.BackupID)
+
+	fetchOp, err := sqlStore.GetInstallationDBRestorationOperation(restorationOp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, restorationOp, fetchOp)
+}
+
+func TestInstallationDBRestoration(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation := setupBasicInstallation(t, sqlStore)
+
+	dbRestoration := &model.InstallationDBRestorationOperation{
+		InstallationID:        installation.ID,
+		BackupID:              "test",
+		State:                 model.InstallationDBRestorationStateRequested,
+		ClusterInstallationID: "",
+		CompleteAt:            0,
+	}
+
+	err := sqlStore.CreateInstallationDBRestorationOperation(dbRestoration)
+	require.NoError(t, err)
+	assert.NotEmpty(t, dbRestoration.ID)
+
+	fetchedRestoration, err := sqlStore.GetInstallationDBRestorationOperation(dbRestoration.ID)
+	require.NoError(t, err)
+	assert.Equal(t, dbRestoration, fetchedRestoration)
+
+	t.Run("unknown restoration", func(t *testing.T) {
+		fetchedRestoration, err = sqlStore.GetInstallationDBRestorationOperation("unknown")
+		require.NoError(t, err)
+		assert.Nil(t, fetchedRestoration)
+	})
+}
+
+func TestGetInstallationDBRestorations(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation1 := setupBasicInstallation(t, sqlStore)
+	installation2 := setupBasicInstallation(t, sqlStore)
+	clusterInstallation := &model.ClusterInstallation{
+		InstallationID: installation1.ID,
+	}
+	err := sqlStore.CreateClusterInstallation(clusterInstallation)
+	require.NoError(t, err)
+
+	dbRestorations := []*model.InstallationDBRestorationOperation{
+		{InstallationID: installation1.ID, State: model.InstallationDBRestorationStateRequested, ClusterInstallationID: clusterInstallation.ID},
+		{InstallationID: installation1.ID, State: model.InstallationDBRestorationStateInProgress, ClusterInstallationID: clusterInstallation.ID},
+		{InstallationID: installation1.ID, State: model.InstallationDBRestorationStateFailed},
+		{InstallationID: installation2.ID, State: model.InstallationDBRestorationStateRequested},
+		{InstallationID: installation2.ID, State: model.InstallationDBRestorationStateInProgress},
+	}
+
+	for i := range dbRestorations {
+		err := sqlStore.CreateInstallationDBRestorationOperation(dbRestorations[i])
+		require.NoError(t, err)
+		time.Sleep(1 * time.Millisecond) // Ensure RequestAt is different for all installations.
+	}
+
+	for _, testCase := range []struct {
+		description string
+		filter      *model.InstallationDBRestorationFilter
+		fetchedIds  []string
+	}{
+		{
+			description: "fetch all",
+			filter:      &model.InstallationDBRestorationFilter{Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{dbRestorations[4].ID, dbRestorations[3].ID, dbRestorations[2].ID, dbRestorations[1].ID, dbRestorations[0].ID},
+		},
+		{
+			description: "fetch all for installation 1",
+			filter:      &model.InstallationDBRestorationFilter{InstallationID: installation1.ID, Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{dbRestorations[2].ID, dbRestorations[1].ID, dbRestorations[0].ID},
+		},
+		{
+			description: "fetch all for cluster installation ",
+			filter:      &model.InstallationDBRestorationFilter{ClusterInstallationID: clusterInstallation.ID, Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{dbRestorations[1].ID, dbRestorations[0].ID},
+		},
+		{
+			description: "fetch requested installations",
+			filter:      &model.InstallationDBRestorationFilter{States: []model.InstallationDBRestorationState{model.InstallationDBRestorationStateRequested}, Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{dbRestorations[3].ID, dbRestorations[0].ID},
+		},
+		{
+			description: "fetch with IDs",
+			filter:      &model.InstallationDBRestorationFilter{IDs: []string{dbRestorations[0].ID, dbRestorations[3].ID, dbRestorations[4].ID}, Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{dbRestorations[4].ID, dbRestorations[3].ID, dbRestorations[0].ID},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			fetchedBackups, err := sqlStore.GetInstallationDBRestorationOperations(testCase.filter)
+			require.NoError(t, err)
+			assert.Equal(t, len(testCase.fetchedIds), len(fetchedBackups))
+
+			for i, b := range fetchedBackups {
+				assert.Equal(t, testCase.fetchedIds[i], b.ID)
+			}
+		})
+	}
+}
+
+func TestGetUnlockedInstallationDBRestorationsPendingWork(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation := setupBasicInstallation(t, sqlStore)
+
+	dbRestoration1 := &model.InstallationDBRestorationOperation{
+		InstallationID: installation.ID,
+		State:          model.InstallationDBRestorationStateRequested,
+	}
+
+	err := sqlStore.CreateInstallationDBRestorationOperation(dbRestoration1)
+	require.NoError(t, err)
+	assert.NotEmpty(t, dbRestoration1.ID)
+
+	dbRestoration2 := &model.InstallationDBRestorationOperation{
+		InstallationID: installation.ID,
+		State:          model.InstallationDBRestorationStateSucceeded,
+	}
+
+	err = sqlStore.CreateInstallationDBRestorationOperation(dbRestoration2)
+	require.NoError(t, err)
+	assert.NotEmpty(t, dbRestoration1.ID)
+
+	backupsMeta, err := sqlStore.GetUnlockedInstallationDBRestorationOperationsPendingWork()
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(backupsMeta))
+	assert.Equal(t, dbRestoration1.ID, backupsMeta[0].ID)
+
+	locaked, err := sqlStore.LockInstallationDBRestorationOperation(dbRestoration1.ID, "abc")
+	require.NoError(t, err)
+	assert.True(t, locaked)
+
+	backupsMeta, err = sqlStore.GetUnlockedInstallationDBRestorationOperationsPendingWork()
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(backupsMeta))
+}
+
+func TestUpdateInstallationDBRestoration(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation := setupBasicInstallation(t, sqlStore)
+
+	dbRestoration := &model.InstallationDBRestorationOperation{
+		InstallationID: installation.ID,
+		State:          model.InstallationDBRestorationStateRequested,
+	}
+
+	err := sqlStore.CreateInstallationDBRestorationOperation(dbRestoration)
+	require.NoError(t, err)
+	assert.NotEmpty(t, dbRestoration.ID)
+
+	t.Run("update state only", func(t *testing.T) {
+		dbRestoration.State = model.InstallationDBRestorationStateSucceeded
+		dbRestoration.CompleteAt = -1
+
+		err = sqlStore.UpdateInstallationDBRestorationOperationState(dbRestoration)
+		require.NoError(t, err)
+
+		fetched, err := sqlStore.GetInstallationDBRestorationOperation(dbRestoration.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationDBRestorationStateSucceeded, fetched.State)
+		assert.Equal(t, int64(0), fetched.CompleteAt)      // Assert complete time not updated
+		assert.Equal(t, "", fetched.ClusterInstallationID) // Assert CI ID not updated
+	})
+
+	t.Run("full update", func(t *testing.T) {
+		dbRestoration.ClusterInstallationID = "test"
+		dbRestoration.CompleteAt = 100
+		dbRestoration.State = model.InstallationDBRestorationStateFailed
+		err = sqlStore.UpdateInstallationDBRestorationOperation(dbRestoration)
+		require.NoError(t, err)
+
+		fetched, err := sqlStore.GetInstallationDBRestorationOperation(dbRestoration.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationDBRestorationStateFailed, fetched.State)
+		assert.Equal(t, "test", fetched.ClusterInstallationID)
+		assert.Equal(t, int64(100), fetched.CompleteAt)
+	})
+}

--- a/internal/store/installation_db_restoration_operation_test.go
+++ b/internal/store/installation_db_restoration_operation_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
 package store
 
 import (

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1217,4 +1217,27 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.25.0"), semver.MustParse("0.26.0"), func(e execer) error {
+		// Add InstallationDBRestorationOperation table.
+		_, err := e.Exec(`
+			CREATE TABLE InstallationDBRestorationOperation (
+				ID TEXT PRIMARY KEY,
+				InstallationID TEXT NOT NULL,
+				BackupID TEXT NOT NULL,
+				RequestAt BIGINT NOT NULL,
+				State TEXT NOT NULL,
+				TargetInstallationState TEXT NOT NULL,
+				ClusterInstallationID TEXT NOT NULL,
+				CompleteAt BIGINT NOT NULL,
+				DeleteAt BIGINT NOT NULL,
+				LockAcquiredBy TEXT NULL,
+				LockAcquiredAt BIGINT NOT NULL
+			);
+		`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/internal/supervisor/backup.go
+++ b/internal/supervisor/backup.go
@@ -200,7 +200,7 @@ func (s *BackupSupervisor) triggerBackup(backup *model.InstallationBackup, insta
 	}
 	defer installationLock.Unlock()
 
-	err = model.EnsureBackupCompatible(installation)
+	err = model.EnsureInstallationReadyForBackup(installation)
 	if err != nil {
 		logger.WithError(err).Errorf("Installation is not backup compatible %s", installation.ID)
 		return backup.State

--- a/model/installation_db_restoration_operation.go
+++ b/model/installation_db_restoration_operation.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
 package model
 
 import (

--- a/model/installation_db_restoration_operation.go
+++ b/model/installation_db_restoration_operation.go
@@ -1,0 +1,117 @@
+package model
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// InstallationDBRestorationOperation contains information about installation's database restoration operation.
+type InstallationDBRestorationOperation struct {
+	ID             string
+	InstallationID string
+	BackupID       string
+	RequestAt      int64
+	State          InstallationDBRestorationState
+	// TargetInstallationState is an installation State to which installation
+	// will be transitioned when the restoration finishes successfully.
+	TargetInstallationState string
+	ClusterInstallationID   string
+	CompleteAt              int64
+	DeleteAt                int64
+	LockAcquiredBy          *string
+	LockAcquiredAt          int64
+}
+
+// InstallationDBRestorationState represents the state of backup.
+type InstallationDBRestorationState string
+
+const (
+	// InstallationDBRestorationStateRequested is a requested installation db restoration that was not yet started.
+	InstallationDBRestorationStateRequested InstallationDBRestorationState = "installation-db-restoration-requested"
+	// InstallationDBRestorationStateInProgress is an installation db restoration that is currently running.
+	InstallationDBRestorationStateInProgress InstallationDBRestorationState = "installation-db-restoration-in-progress"
+	// InstallationDBRestorationStateFinalizing is an installation db restoration that is finalizing restoration.
+	InstallationDBRestorationStateFinalizing InstallationDBRestorationState = "installation-db-restoration-finishing"
+	// InstallationDBRestorationStateSucceeded is an installation db restoration that have finished with success.
+	InstallationDBRestorationStateSucceeded InstallationDBRestorationState = "installation-db-restoration-succeeded"
+	// InstallationDBRestorationStateFailing is an installation db restoration that is failing.
+	InstallationDBRestorationStateFailing InstallationDBRestorationState = "installation-db-restoration-failing"
+	// InstallationDBRestorationStateFailed is an installation db restoration that have failed.
+	InstallationDBRestorationStateFailed InstallationDBRestorationState = "installation-db-restoration-failed"
+	// InstallationDBRestorationStateInvalid is an installation db restoration that is invalid.
+	InstallationDBRestorationStateInvalid InstallationDBRestorationState = "installation-db-restoration-invalid"
+)
+
+// AllInstallationDBRestorationStatesPendingWork is a list of all installation restoration operation
+// states that the supervisor will attempt to transition towards succeeded on the next "tick".
+var AllInstallationDBRestorationStatesPendingWork = []InstallationDBRestorationState{
+	InstallationDBRestorationStateRequested,
+	InstallationDBRestorationStateInProgress,
+	InstallationDBRestorationStateFinalizing,
+	InstallationDBRestorationStateFailing,
+}
+
+// InstallationDBRestorationFilter describes the parameters used to constrain a set of installation-db-restoration.
+type InstallationDBRestorationFilter struct {
+	Paging
+	IDs                   []string
+	InstallationID        string
+	ClusterInstallationID string
+	States                []InstallationDBRestorationState
+}
+
+// EnsureInstallationReadyForDBRestoration ensures that installation can be restored.
+func EnsureInstallationReadyForDBRestoration(installation *Installation, backup *InstallationBackup) error {
+	if installation.ID != backup.InstallationID {
+		return errors.New("Backup belongs to different installation")
+	}
+	if backup.State != InstallationBackupStateBackupSucceeded {
+		return errors.Errorf("Only backups in succeeded state can be restored, the state is %q", backup.State)
+	}
+	if backup.DeleteAt > 0 {
+		return errors.New("Backup files are deleted")
+	}
+
+	if installation.State != InstallationStateHibernating && installation.State != InstallationStateDBMigrationInProgress {
+		return errors.Errorf("invalid installation state, only hibernated installations can be restored, state is %q", installation.State)
+	}
+
+	return EnsureBackupRestoreCompatible(installation)
+}
+
+// DetermineAfterRestorationState returns installation state that should be set after successful restoration.
+func DetermineAfterRestorationState(installation *Installation) (string, error) {
+	switch installation.State {
+	case InstallationStateHibernating:
+		return InstallationStateHibernating, nil
+	case InstallationStateDBMigrationInProgress:
+		return InstallationStateDBMigrationInProgress, nil
+	}
+	return "", errors.Errorf("restoration is not supported for installation in state %s", installation.State)
+}
+
+// NewInstallationDBRestorationOperationFromReader will create a InstallationDBRestorationOperation from an
+// io.Reader with JSON data.
+func NewInstallationDBRestorationOperationFromReader(reader io.Reader) (*InstallationDBRestorationOperation, error) {
+	var installationDBRestorationOperation InstallationDBRestorationOperation
+	err := json.NewDecoder(reader).Decode(&installationDBRestorationOperation)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode InstallationDBRestorationOperation")
+	}
+
+	return &installationDBRestorationOperation, nil
+}
+
+// NewInstallationDBRestorationOperationsFromReader will create a slice of InstallationDBRestorationOperations from an
+// io.Reader with JSON data.
+func NewInstallationDBRestorationOperationsFromReader(reader io.Reader) ([]*InstallationDBRestorationOperation, error) {
+	installationDBRestorationOperations := []*InstallationDBRestorationOperation{}
+	err := json.NewDecoder(reader).Decode(&installationDBRestorationOperations)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode InstallationDBRestorationOperations")
+	}
+
+	return installationDBRestorationOperations, nil
+}

--- a/model/installation_db_restoration_operation_test.go
+++ b/model/installation_db_restoration_operation_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
 package model
 
 import (

--- a/model/installation_db_restoration_operation_test.go
+++ b/model/installation_db_restoration_operation_test.go
@@ -1,0 +1,215 @@
+package model
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInstallationDBRestorationOperationFromReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		installationDBRestorationOperation, err := NewInstallationDBRestorationOperationFromReader(bytes.NewReader([]byte(
+			"",
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &InstallationDBRestorationOperation{}, installationDBRestorationOperation)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		installationDBRestorationOperation, err := NewInstallationDBRestorationOperationFromReader(bytes.NewReader([]byte(
+			"{test",
+		)))
+		require.Error(t, err)
+		require.Nil(t, installationDBRestorationOperation)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		installationDBRestorationOperation, err := NewInstallationDBRestorationOperationFromReader(bytes.NewReader([]byte(
+			`{"ID":"id", "InstallationID":"Installation", "BackupID": "backup", "RequestAt": 10}`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &InstallationDBRestorationOperation{
+			ID:             "id",
+			InstallationID: "Installation",
+			BackupID:       "backup",
+			RequestAt:      10,
+		}, installationDBRestorationOperation)
+	})
+}
+
+func TestNewInstallationDBRestorationOperationsFromReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		installationDBRestorationOperations, err := NewInstallationDBRestorationOperationsFromReader(bytes.NewReader([]byte(
+			"",
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*InstallationDBRestorationOperation{}, installationDBRestorationOperations)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		installationDBRestorationOperations, err := NewInstallationDBRestorationOperationsFromReader(bytes.NewReader([]byte(
+			"{test",
+		)))
+		require.Error(t, err)
+		require.Nil(t, installationDBRestorationOperations)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		installationDBRestorationOperations, err := NewInstallationDBRestorationOperationsFromReader(bytes.NewReader([]byte(
+			`[
+	{"ID":"id", "InstallationID":"Installation", "BackupID": "backup", "RequestAt": 10},
+	{"ID":"id2", "InstallationID":"Installation2", "BackupID": "backup2", "RequestAt": 20}
+]`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*InstallationDBRestorationOperation{
+			{
+				ID:             "id",
+				InstallationID: "Installation",
+				BackupID:       "backup",
+				RequestAt:      10,
+			},
+			{
+				ID:             "id2",
+				InstallationID: "Installation2",
+				BackupID:       "backup2",
+				RequestAt:      20,
+			},
+		}, installationDBRestorationOperations)
+	})
+}
+
+func TestEnsureInstallationReadyForDBRestoration(t *testing.T) {
+
+	for _, testCase := range []struct {
+		description   string
+		installation  *Installation
+		backup        *InstallationBackup
+		errorContains string
+	}{
+		{
+			description: "valid installation and backup",
+			installation: &Installation{
+				ID:        "abcd",
+				State:     InstallationStateHibernating,
+				Database:  InstallationDatabaseMultiTenantRDSPostgres,
+				Filestore: InstallationFilestoreBifrost,
+			},
+			backup: &InstallationBackup{
+				InstallationID: "abcd",
+				State:          InstallationBackupStateBackupSucceeded,
+			},
+		},
+		{
+			description: "backup failed",
+			installation: &Installation{
+				ID:        "abcd",
+				State:     InstallationStateHibernating,
+				Database:  InstallationDatabaseMultiTenantRDSPostgres,
+				Filestore: InstallationFilestoreBifrost,
+			},
+			backup: &InstallationBackup{
+				InstallationID: "abcd",
+				State:          InstallationBackupStateBackupFailed,
+			},
+			errorContains: "Only backups in succeeded state can be restored",
+		},
+		{
+			description: "backup not matching installation",
+			installation: &Installation{
+				ID:        "abcd",
+				State:     InstallationStateHibernating,
+				Database:  InstallationDatabaseMultiTenantRDSPostgres,
+				Filestore: InstallationFilestoreBifrost,
+			},
+			backup: &InstallationBackup{
+				InstallationID: "efgh",
+				State:          InstallationBackupStateBackupSucceeded,
+			},
+			errorContains: "Backup belongs to different installation",
+		},
+		{
+			description: "backup deleted",
+			installation: &Installation{
+				ID:        "abcd",
+				State:     InstallationStateHibernating,
+				Database:  InstallationDatabaseMultiTenantRDSPostgres,
+				Filestore: InstallationFilestoreBifrost,
+			},
+			backup: &InstallationBackup{
+				InstallationID: "abcd",
+				State:          InstallationBackupStateBackupSucceeded,
+				DeleteAt:       1,
+			},
+			errorContains: "Backup files are deleted",
+		},
+		{
+			description: "installation invalid state",
+			installation: &Installation{
+				ID:        "abcd",
+				State:     InstallationStateStable,
+				Database:  InstallationDatabaseMultiTenantRDSPostgres,
+				Filestore: InstallationFilestoreBifrost,
+			},
+			backup: &InstallationBackup{
+				InstallationID: "abcd",
+				State:          InstallationBackupStateBackupSucceeded,
+			},
+			errorContains: "invalid installation state",
+		},
+		{
+			description: "invalid db",
+			installation: &Installation{
+				ID:        "abcd",
+				State:     InstallationStateHibernating,
+				Database:  InstallationDatabaseMultiTenantRDSMySQL,
+				Filestore: InstallationFilestoreBifrost,
+			},
+			backup: &InstallationBackup{
+				InstallationID: "abcd",
+				State:          InstallationBackupStateBackupSucceeded,
+			},
+			errorContains: "invalid installation database",
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			err := EnsureInstallationReadyForDBRestoration(testCase.installation, testCase.backup)
+			if testCase.errorContains == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), testCase.errorContains)
+			}
+		})
+	}
+}
+
+func TestDetermineAfterRestorationState(t *testing.T) {
+
+	for _, testCase := range []struct {
+		description string
+		state       string
+		expected    string
+	}{
+		{
+			description: "hibernating",
+			state:       InstallationStateHibernating,
+			expected:    InstallationStateHibernating,
+		},
+		{
+			description: "db-migration",
+			state:       InstallationStateDBMigrationInProgress,
+			expected:    InstallationStateDBMigrationInProgress,
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			installation := &Installation{State: testCase.state}
+			targetState, err := DetermineAfterRestorationState(installation)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expected, targetState)
+		})
+	}
+
+}

--- a/model/installation_db_restoration_request.go
+++ b/model/installation_db_restoration_request.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
 package model
 
 import (

--- a/model/installation_db_restoration_request.go
+++ b/model/installation_db_restoration_request.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"encoding/json"
+	"io"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+// InstallationDBRestorationRequest represents request for installation restoration.
+type InstallationDBRestorationRequest struct {
+	InstallationID string
+	BackupID       string
+}
+
+// NewInstallationDBRestorationRequestFromReader will create a InstallationDBRestorationRequest from an
+// io.Reader with JSON data.
+func NewInstallationDBRestorationRequestFromReader(reader io.Reader) (*InstallationDBRestorationRequest, error) {
+	var restoreRequest InstallationDBRestorationRequest
+	err := json.NewDecoder(reader).Decode(&restoreRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode installation db restore request")
+	}
+
+	return &restoreRequest, nil
+}
+
+// GetInstallationDBRestorationOperationsRequest describes the parameters to request
+// a list of installation restoration operations.
+type GetInstallationDBRestorationOperationsRequest struct {
+	Paging
+	InstallationID        string
+	ClusterInstallationID string
+	State                 string
+}
+
+// ApplyToURL modifies the given url to include query string parameters for the request.
+func (request *GetInstallationDBRestorationOperationsRequest) ApplyToURL(u *url.URL) {
+	q := u.Query()
+	q.Add("installation", request.InstallationID)
+	q.Add("cluster_installation", request.ClusterInstallationID)
+	q.Add("state", request.State)
+	request.Paging.AddToQuery(q)
+
+	u.RawQuery = q.Encode()
+}

--- a/model/installation_db_restoration_request_test.go
+++ b/model/installation_db_restoration_request_test.go
@@ -1,0 +1,61 @@
+package model
+
+import (
+	"bytes"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInstallationDBRestorationRequestFromReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		installationDBRestorationRequest, err := NewInstallationDBRestorationRequestFromReader(bytes.NewReader([]byte(
+			"",
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &InstallationDBRestorationRequest{}, installationDBRestorationRequest)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		installationDBRestorationRequest, err := NewInstallationDBRestorationRequestFromReader(bytes.NewReader([]byte(
+			"{test",
+		)))
+		require.Error(t, err)
+		require.Nil(t, installationDBRestorationRequest)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		installationDBRestorationRequest, err := NewInstallationDBRestorationRequestFromReader(bytes.NewReader([]byte(
+			`{"InstallationID": "installation", "BackupID": "backup"}`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &InstallationDBRestorationRequest{InstallationID: "installation", BackupID: "backup"}, installationDBRestorationRequest)
+	})
+}
+
+func TestGetInstallationDBRestorationOperationsRequest_ApplyToURL(t *testing.T) {
+	req := &GetInstallationDBRestorationOperationsRequest{
+		InstallationID:        "my-installation",
+		ClusterInstallationID: "my-ci",
+		State:                 "failed",
+		Paging: Paging{
+			Page:           1,
+			PerPage:        5,
+			IncludeDeleted: true,
+		},
+	}
+
+	u, err := url.Parse("https://provisioner/backups")
+	require.NoError(t, err)
+
+	req.ApplyToURL(u)
+
+	assert.Equal(t, req.InstallationID, u.Query().Get("installation"))
+	assert.Equal(t, req.ClusterInstallationID, u.Query().Get("cluster_installation"))
+	assert.Equal(t, req.State, u.Query().Get("state"))
+	assert.Equal(t, "1", u.Query().Get("page"))
+	assert.Equal(t, "5", u.Query().Get("per_page"))
+	assert.Equal(t, "true", u.Query().Get("include_deleted"))
+}

--- a/model/installation_db_restoration_request_test.go
+++ b/model/installation_db_restoration_request_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
 package model
 
 import (

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -118,7 +118,6 @@ var AllInstallationStatesPendingWork = []string{
 	InstallationStateDeletionRequested,
 	InstallationStateDeletionInProgress,
 	InstallationStateDeletionFinalCleanup,
-	InstallationStateDBRestorationInProgress,
 }
 
 // AllInstallationRequestStates is a list of all states that an installation can

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -53,6 +53,14 @@ const (
 	InstallationStateDeletionFailed = "deletion-failed"
 	// InstallationStateDeleted is an installation that has been deleted
 	InstallationStateDeleted = "deleted"
+	// InstallationStateDBRestorationInProgress is an installation that is being restored from backup.
+	InstallationStateDBRestorationInProgress = "db-restoration-in-progress"
+	// InstallationStateDBMigrationInProgress is an installation that is being migrated to different database.
+	InstallationStateDBMigrationInProgress = "db-migration-in-progress"
+	// InstallationStateDBRestorationFailed is an installation for which database restoration failed.
+	InstallationStateDBRestorationFailed = "db-restoration-failed"
+	// InstallationStateDBMigrationFailed is an installation for which database migration failed.
+	InstallationStateDBMigrationFailed = "db-migration-failed"
 )
 
 const (
@@ -84,6 +92,10 @@ var AllInstallationStates = []string{
 	InstallationStateDeletionFinalCleanup,
 	InstallationStateDeletionFailed,
 	InstallationStateDeleted,
+	InstallationStateDBRestorationInProgress,
+	InstallationStateDBMigrationInProgress,
+	InstallationStateDBRestorationFailed,
+	InstallationStateDBMigrationFailed,
 }
 
 // AllInstallationStatesPendingWork is a list of all installation states that
@@ -106,6 +118,7 @@ var AllInstallationStatesPendingWork = []string{
 	InstallationStateDeletionRequested,
 	InstallationStateDeletionInProgress,
 	InstallationStateDeletionFinalCleanup,
+	InstallationStateDBRestorationInProgress,
 }
 
 // AllInstallationRequestStates is a list of all states that an installation can
@@ -169,6 +182,12 @@ var (
 			InstallationStateDeletionInProgress,
 			InstallationStateDeletionFinalCleanup,
 			InstallationStateDeletionFailed,
+		},
+		InstallationStateDBRestorationInProgress: {
+			InstallationStateHibernating,
+		},
+		InstallationStateDBMigrationInProgress: {
+			InstallationStateHibernating,
 		},
 	}
 )


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
First PR of Installation Restoration story. Introduced changes:
- Add `InstallationDBRestorationOperation` model.
- Add store methods for new model.
- Add new Installation states, that will be used for restoration and migration.
- Refactor some backup parts to reuse logic.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://focalboard-community.octo.mattermost.com/workspace/168joqfacb8jjc9h1ww4897qxe?id=c753202e-848d-4e2f-81c0-99a31013616c&v=dda14aa7-9993-470a-8e3f-eaf02af6fb0e&c=47dcaaf3-9739-43c4-8020-ffbbb451d8a7

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add Installation DB restoration model.
```
