### PR TITLE
MM 34873 shared vpc feature for kops clusters

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -45,6 +45,7 @@ func init() {
 	clusterCreateCmd.Flags().String("nginx-internal-values", model.NginxInternalDefaultVersion.Values(), "The branch name of the desired chart value file's version for NGINX Internal")
 	clusterCreateCmd.Flags().String("teleport-values", model.TeleportDefaultVersion.Values(), "The branch name of the desired chart value file's version for Teleport")
 	clusterCreateCmd.Flags().String("networking", "amazon-vpc-routed-eni", "Networking mode to use, for example: weave, calico, canal, amazon-vpc-routed-eni")
+	clusterCreateCmd.Flags().String("vpc", "", "Set to use a shared VPC")
 
 	clusterCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the cluster. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 
@@ -141,6 +142,7 @@ var clusterCreateCmd = &cobra.Command{
 		allowInstallations, _ := command.Flags().GetBool("allow-installations")
 		annotations, _ := command.Flags().GetStringArray("annotation")
 		networking, _ := command.Flags().GetString("networking")
+		vpc, _ := command.Flags().GetString("vpc")
 
 		request := &model.CreateClusterRequest{
 			Provider:               provider,
@@ -151,6 +153,7 @@ var clusterCreateCmd = &cobra.Command{
 			DesiredUtilityVersions: processUtilityFlags(command),
 			Annotations:            annotations,
 			Networking:             networking,
+			VPC:                    vpc,
 		}
 
 		size, _ := command.Flags().GetString("size")
@@ -463,7 +466,7 @@ var clusterListCmd = &cobra.Command{
 		if outputToTable {
 			table := tablewriter.NewWriter(os.Stdout)
 			table.SetAlignment(tablewriter.ALIGN_LEFT)
-			table.SetHeader([]string{"ID", "STATE", "VERSION", "MASTER NODES", "WORKER NODES", "NETWORKING"})
+			table.SetHeader([]string{"ID", "STATE", "VERSION", "MASTER NODES", "WORKER NODES", "NETWORKING", "VPC"})
 
 			for _, cluster := range clusters {
 				table.Append([]string{
@@ -473,6 +476,7 @@ var clusterListCmd = &cobra.Command{
 					fmt.Sprintf("%d x %s", cluster.ProvisionerMetadataKops.MasterCount, cluster.ProvisionerMetadataKops.MasterInstanceType),
 					fmt.Sprintf("%d x %s (max %d)", cluster.ProvisionerMetadataKops.NodeMinCount, cluster.ProvisionerMetadataKops.NodeInstanceType, cluster.ProvisionerMetadataKops.NodeMaxCount),
 					cluster.ProvisionerMetadataKops.Networking,
+					cluster.ProvisionerMetadataKops.VPC,
 				})
 			}
 			table.Render()

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -131,8 +131,6 @@ func handleCreateCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 		AllowInstallations: createClusterRequest.AllowInstallations,
 		APISecurityLock:    createClusterRequest.APISecurityLock,
 		State:              model.ClusterStateCreationRequested,
-		Networking:         createClusterRequest.Networking,
-		VPC:                createClusterRequest.VPC,
 	}
 
 	err = cluster.SetUtilityDesiredVersions(createClusterRequest.DesiredUtilityVersions)

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -125,11 +125,14 @@ func handleCreateCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 				NodeMinCount:       createClusterRequest.NodeMinCount,
 				NodeMaxCount:       createClusterRequest.NodeMaxCount,
 				Networking:         createClusterRequest.Networking,
+				VPC:                createClusterRequest.VPC,
 			},
 		},
 		AllowInstallations: createClusterRequest.AllowInstallations,
 		APISecurityLock:    createClusterRequest.APISecurityLock,
 		State:              model.ClusterStateCreationRequested,
+		Networking:         createClusterRequest.Networking,
+		VPC:                createClusterRequest.VPC,
 	}
 
 	err = cluster.SetUtilityDesiredVersions(createClusterRequest.DesiredUtilityVersions)

--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -354,9 +354,9 @@ func (mr *MockAWSMockRecorder) S3EnsureObjectDeleted(bucketName, path interface{
 }
 
 // GenerateBifrostUtilitySecret mocks base method
-func (m *MockAWS) GenerateBifrostUtilitySecret(clusterID string, logger logrus.FieldLogger) (*v1.Secret, error) {
+func (m *MockAWS) GenerateBifrostUtilitySecret(clusterID string, vpc string, logger logrus.FieldLogger) (*v1.Secret, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateBifrostUtilitySecret", clusterID, logger)
+	ret := m.ctrl.Call(m, "GenerateBifrostUtilitySecret", clusterID, vpc, logger)
 	ret0, _ := ret[0].(*v1.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -381,4 +381,21 @@ func (m *MockAWS) GetCIDRByVPCTag(vpcTagName string, logger logrus.FieldLogger) 
 func (mr *MockAWSMockRecorder) GetCIDRByVPCTag(vpcTagName, logger interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCIDRByVPCTag", reflect.TypeOf((*MockAWS)(nil).GetCIDRByVPCTag), vpcTagName, logger)
+}
+
+// GetVpcResourcesByVpcID mock GetVpcResourcesByVpcID method
+func (m *MockAWS) GetVpcResourcesByVpcID(vpcID string, logger logrus.FieldLogger) (aws.ClusterResources, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVpcResourcesByVpcID", vpcID, logger)
+	ret0, _ := ret[0].(aws.ClusterResources)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TagResourcesByCluster mock TagResourcesByCluster method
+func (m *MockAWS) TagResourcesByCluster(clusterResources aws.ClusterResources, clusterID string, owner string, logger logrus.FieldLogger) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TagResourcesByCluster", clusterResources, logger)
+	ret0, _ := ret[0].(error)
+	return ret0
 }

--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -354,7 +354,7 @@ func (mr *MockAWSMockRecorder) S3EnsureObjectDeleted(bucketName, path interface{
 }
 
 // GenerateBifrostUtilitySecret mocks base method
-func (m *MockAWS) GenerateBifrostUtilitySecret(clusterID string, vpc string, logger logrus.FieldLogger) (*v1.Secret, error) {
+func (m *MockAWS) GenerateBifrostUtilitySecret(clusterID, vpc string, logger logrus.FieldLogger) (*v1.Secret, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateBifrostUtilitySecret", clusterID, vpc, logger)
 	ret0, _ := ret[0].(*v1.Secret)
@@ -363,9 +363,9 @@ func (m *MockAWS) GenerateBifrostUtilitySecret(clusterID string, vpc string, log
 }
 
 // GenerateBifrostUtilitySecret indicates an expected call of GenerateBifrostUtilitySecret
-func (mr *MockAWSMockRecorder) GenerateBifrostUtilitySecret(clusterID, logger interface{}) *gomock.Call {
+func (mr *MockAWSMockRecorder) GenerateBifrostUtilitySecret(clusterID, vpc, logger interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateBifrostUtilitySecret", reflect.TypeOf((*MockAWS)(nil).GenerateBifrostUtilitySecret), clusterID, logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateBifrostUtilitySecret", reflect.TypeOf((*MockAWS)(nil).GenerateBifrostUtilitySecret), clusterID, vpc, logger)
 }
 
 // GetCIDRByVPCTag mocks base method
@@ -383,7 +383,7 @@ func (mr *MockAWSMockRecorder) GetCIDRByVPCTag(vpcTagName, logger interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCIDRByVPCTag", reflect.TypeOf((*MockAWS)(nil).GetCIDRByVPCTag), vpcTagName, logger)
 }
 
-// GetVpcResourcesByVpcID mock GetVpcResourcesByVpcID method
+// GetVpcResourcesByVpcID mocks base method
 func (m *MockAWS) GetVpcResourcesByVpcID(vpcID string, logger logrus.FieldLogger) (aws.ClusterResources, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVpcResourcesByVpcID", vpcID, logger)
@@ -392,10 +392,22 @@ func (m *MockAWS) GetVpcResourcesByVpcID(vpcID string, logger logrus.FieldLogger
 	return ret0, ret1
 }
 
-// TagResourcesByCluster mock TagResourcesByCluster method
-func (m *MockAWS) TagResourcesByCluster(clusterResources aws.ClusterResources, clusterID string, owner string, logger logrus.FieldLogger) error {
+// GetVpcResourcesByVpcID indicates an expected call of GetVpcResourcesByVpcID
+func (mr *MockAWSMockRecorder) GetVpcResourcesByVpcID(vpcID, logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVpcResourcesByVpcID", reflect.TypeOf((*MockAWS)(nil).GetVpcResourcesByVpcID), vpcID, logger)
+}
+
+// TagResourcesByCluster mocks base method
+func (m *MockAWS) TagResourcesByCluster(clusterResources aws.ClusterResources, clusterID, owner string, logger logrus.FieldLogger) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TagResourcesByCluster", clusterResources, logger)
+	ret := m.ctrl.Call(m, "TagResourcesByCluster", clusterResources, clusterID, owner, logger)
 	ret0, _ := ret[0].(error)
 	return ret0
+}
+
+// TagResourcesByCluster indicates an expected call of TagResourcesByCluster
+func (mr *MockAWSMockRecorder) TagResourcesByCluster(clusterResources, clusterID, owner, logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourcesByCluster", reflect.TypeOf((*MockAWS)(nil).TagResourcesByCluster), clusterResources, clusterID, owner, logger)
 }

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -107,8 +107,8 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 		clusterResources.WorkerSecurityGroupIDs,
 		allowSSHCIDRS,
 	)
-	// Only release VPC resources, if create cluster request was for the primary cluster.
-	if err != nil && kopsMetadata.ChangeRequest.VPC == "" {
+	// release VPC resources
+	if err != nil {
 		releaseErr := awsClient.ReleaseVpc(cluster.ID, logger)
 		if releaseErr != nil {
 			logger.WithError(releaseErr).Error("Unable to release VPC")
@@ -116,8 +116,8 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 
 		return errors.Wrap(err, "unable to create kops cluster")
 	}
-	// Tag Public subnets & respective VPC for the secondary cluster.
-	if err == nil && kopsMetadata.ChangeRequest.VPC != "" {
+	// Tag Public subnets & respective VPC for the secondary cluster if there is no error.
+	if kopsMetadata.ChangeRequest.VPC != "" {
 		err = awsClient.TagResourcesByCluster(clusterResources, cluster.ID, provisioner.params.Owner, logger)
 		if err != nil {
 			return err

--- a/internal/provisioner/nginx.go
+++ b/internal/provisioner/nginx.go
@@ -118,11 +118,16 @@ func (n *nginx) NewHelmDeployment() (*helmDeployment, error) {
 		return nil, errors.Wrap(err, "failed to retrive the AWS ACM")
 	}
 
-	clusterResources, err := n.awsClient.GetVpcResources(n.cluster.ID, n.logger)
+	var clusterResources aws.ClusterResources
+	if n.cluster.ProvisionerMetadataKops.ChangeRequest.VPC != "" {
+		clusterResources, err = n.awsClient.GetVpcResourcesByVpcID(n.cluster.ProvisionerMetadataKops.ChangeRequest.VPC, n.logger)
+	} else {
+		clusterResources, err = n.awsClient.GetVpcResources(n.cluster.ID, n.logger)
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to retrive the VPC information")
 	}
-
+	
 	return &helmDeployment{
 		chartDeploymentName: "nginx",
 		chartName:           "ingress-nginx/ingress-nginx",

--- a/internal/provisioner/nginx.go
+++ b/internal/provisioner/nginx.go
@@ -127,7 +127,6 @@ func (n *nginx) NewHelmDeployment() (*helmDeployment, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to retrive the VPC information")
 	}
-	
 	return &helmDeployment{
 		chartDeploymentName: "nginx",
 		chartName:           "ingress-nginx/ingress-nginx",

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -74,12 +74,7 @@ func (r *rawCluster) toCluster() (*model.Cluster, error) {
 		return nil, err
 	}
 	if r.Cluster.ProvisionerMetadataKops != nil && r.Cluster.ProvisionerMetadataKops.Networking != "" {
-
 		r.Cluster.Networking = r.Cluster.ProvisionerMetadataKops.Networking
-	}
-	if r.Cluster.ProvisionerMetadataKops != nil && r.Cluster.ProvisionerMetadataKops.VPC != "" {
-
-		r.Cluster.VPC = r.Cluster.ProvisionerMetadataKops.VPC
 	}
 
 	return r.Cluster, nil

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -73,11 +73,11 @@ func (r *rawCluster) toCluster() (*model.Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	if r.Cluster.ProvisionerMetadataKops.Networking != "" {
+	if r.Cluster.ProvisionerMetadataKops != nil && r.Cluster.ProvisionerMetadataKops.Networking != "" {
 
 		r.Cluster.Networking = r.Cluster.ProvisionerMetadataKops.Networking
 	}
-	if r.Cluster.ProvisionerMetadataKops.VPC != "" {
+	if r.Cluster.ProvisionerMetadataKops != nil && r.Cluster.ProvisionerMetadataKops.VPC != "" {
 
 		r.Cluster.VPC = r.Cluster.ProvisionerMetadataKops.VPC
 	}

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -73,6 +73,14 @@ func (r *rawCluster) toCluster() (*model.Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
+	if r.Cluster.ProvisionerMetadataKops.Networking != "" {
+
+		r.Cluster.Networking = r.Cluster.ProvisionerMetadataKops.Networking
+	}
+	if r.Cluster.ProvisionerMetadataKops.VPC != "" {
+
+		r.Cluster.VPC = r.Cluster.ProvisionerMetadataKops.VPC
+	}
 
 	return r.Cluster, nil
 }
@@ -192,7 +200,6 @@ func (sqlStore *SQLStore) createCluster(execer execer, cluster *model.Cluster) e
 	if err != nil {
 		return errors.Wrap(err, "unable to build raw cluster metadata")
 	}
-
 	_, err = sqlStore.execBuilder(execer, sq.
 		Insert("Cluster").
 		SetMap(map[string]interface{}{
@@ -224,7 +231,6 @@ func (sqlStore *SQLStore) UpdateCluster(cluster *model.Cluster) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to build raw cluster metadata")
 	}
-
 	_, err = sqlStore.execBuilder(sqlStore.db, sq.
 		Update("Cluster").
 		SetMap(map[string]interface{}{

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -359,14 +359,19 @@ func (a *mockAWS) SecretsManagerGetIAMAccessKey(installationID string, logger lo
 	return nil, nil
 }
 
-func (a *mockAWS) GenerateBifrostUtilitySecret(clusterID string, logger log.FieldLogger) (*corev1.Secret, error) {
+func (a *mockAWS) GenerateBifrostUtilitySecret(clusterID string, vpc string, logger log.FieldLogger) (*corev1.Secret, error) {
 	return nil, nil
 }
 
 func (a *mockAWS) GetCIDRByVPCTag(vpcTagName string, logger log.FieldLogger) (string, error) {
 	return "", nil
 }
-
+func (a *mockAWS) GetVpcResourcesByVpcID(vpcID string, logger log.FieldLogger) (aws.ClusterResources, error) {
+	return aws.ClusterResources{}, nil
+}
+func (a *mockAWS) TagResourcesByCluster(clusterResources aws.ClusterResources, clusterID string, owner string, logger log.FieldLogger) error {
+	return nil
+}
 func TestInstallationSupervisorDo(t *testing.T) {
 	standardSchedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(false, 80, 0)
 

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -72,8 +72,11 @@ type AWS interface {
 	S3EnsureBucketDeleted(bucketName string, logger log.FieldLogger) error
 	S3EnsureObjectDeleted(bucketName, path string) error
 
-	GenerateBifrostUtilitySecret(clusterID string, logger log.FieldLogger) (*corev1.Secret, error)
+	GenerateBifrostUtilitySecret(clusterID string, vpc string, logger log.FieldLogger) (*corev1.Secret, error)
 	GetCIDRByVPCTag(vpcTagName string, logger log.FieldLogger) (string, error)
+
+	GetVpcResourcesByVpcID(vpcID string, logger log.FieldLogger) (ClusterResources, error)
+	TagResourcesByCluster(clusterResources ClusterResources, clusterID string, owner string, logger log.FieldLogger) error
 }
 
 // Client is a client for interacting with AWS resources in a single AWS account.

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -317,7 +317,6 @@ func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
 	if len(vpcs) != 0 {
 		//untag keys for secondary cluster
 		isSecondaryCluster = true
-
 	}
 	if !isSecondaryCluster {
 		vpcFilters := []*ec2.Filter{

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -413,7 +413,7 @@ func (a *Client) GetVpcResourcesByVpcID(vpcID string, logger log.FieldLogger) (C
 	return a.getClusterResourcesForVPC(vpcID, *vpcCidr.Vpcs[0].CidrBlock, logger)
 }
 
-// TagPublicSubnets for secondary cluster.
+// TagResourcesByCluster for secondary cluster.
 func (a *Client) TagResourcesByCluster(clusterResources ClusterResources, clusterID string, owner string, logger log.FieldLogger) error {
 
 	for _, subnet := range clusterResources.PublicSubnetsIDs {

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -299,22 +299,43 @@ func (a *Client) claimVpc(clusterResources ClusterResources, clusterID string, o
 }
 
 func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
-	vpcFilters := []*ec2.Filter{
+	var isSecondaryCluster bool = false
+	secondaryVpcFilters := []*ec2.Filter{
 		{
 			Name:   aws.String(VpcAvailableTagKey),
 			Values: []*string{aws.String(VpcAvailableTagValueFalse)},
 		},
 		{
-			Name:   aws.String(VpcClusterIDTagKey),
+			Name:   aws.String(VpcSecondaryClusterIDTagKey),
 			Values: []*string{aws.String(clusterID)},
 		},
 	}
-
-	vpcs, err := a.GetVpcsWithFilters(vpcFilters)
+	vpcs, err := a.GetVpcsWithFilters(secondaryVpcFilters)
 	if err != nil {
 		return err
 	}
+	if len(vpcs) != 0 {
+		//untag keys for secondary cluster
+		isSecondaryCluster = true
 
+	}
+	if !isSecondaryCluster {
+		vpcFilters := []*ec2.Filter{
+			{
+				Name:   aws.String(VpcAvailableTagKey),
+				Values: []*string{aws.String(VpcAvailableTagValueFalse)},
+			},
+			{
+				Name:   aws.String(VpcClusterIDTagKey),
+				Values: []*string{aws.String(clusterID)},
+			},
+		}
+
+		vpcs, err = a.GetVpcsWithFilters(vpcFilters)
+		if err != nil {
+			return err
+		}
+	}
 	numVPCs := len(vpcs)
 	if numVPCs == 0 {
 		logger.Warnf("No VPCs are currently claimed by cluster %s, assuming already released", clusterID)
@@ -350,7 +371,14 @@ func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
 			return errors.Wrap(err, "failed to untag subnet")
 		}
 	}
-
+	if isSecondaryCluster {
+		err = a.TagResource(*vpcs[0].VpcId, trimTagPrefix(VpcSecondaryClusterIDTagKey), VpcClusterIDTagValueNone, logger)
+		if err != nil {
+			return errors.Wrapf(err, "unable to update %s", VpcSecondaryClusterIDTagKey)
+		}
+		logger.Debugf("Secondary cluster %s related tags has been unset from VPC %s", clusterID, *vpcs[0].VpcId)
+		return nil
+	}
 	err = a.TagResource(*vpcs[0].VpcId, trimTagPrefix(VpcClusterIDTagKey), VpcClusterIDTagValueNone, logger)
 	if err != nil {
 		return errors.Wrapf(err, "unable to update %s", VpcClusterIDTagKey)
@@ -368,5 +396,36 @@ func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
 
 	logger.Debugf("Released VPC %s", *vpcs[0].VpcId)
 
+	return nil
+}
+
+// GetVpcResourcesByVpcID retrieve the VPC information for a particulary cluster.
+func (a *Client) GetVpcResourcesByVpcID(vpcID string, logger log.FieldLogger) (ClusterResources, error) {
+	input := &ec2.DescribeVpcsInput{
+		VpcIds: []*string{
+			aws.String(vpcID),
+		},
+	}
+	vpcCidr, err := a.Service().ec2.DescribeVpcs(input)
+	if err != nil {
+		return ClusterResources{}, errors.Wrapf(err, "failed to fetch the VPC information using VPC ID %s", vpcID)
+	}
+	return a.getClusterResourcesForVPC(vpcID, *vpcCidr.Vpcs[0].CidrBlock, logger)
+}
+
+// TagPublicSubnets for secondary cluster.
+func (a *Client) TagResourcesByCluster(clusterResources ClusterResources, clusterID string, owner string, logger log.FieldLogger) error {
+
+	for _, subnet := range clusterResources.PublicSubnetsIDs {
+		err := a.TagResource(subnet, fmt.Sprintf("kubernetes.io/cluster/%s", fmt.Sprintf("%s-kops.k8s.local", clusterID)), "shared", logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to tag subnet")
+		}
+	}
+
+	err := a.TagResource(clusterResources.VpcID, trimTagPrefix(VpcSecondaryClusterIDTagKey), clusterID, logger)
+	if err != nil {
+		return errors.Wrapf(err, "unable to update %s", VpcSecondaryClusterIDTagKey)
+	}
 	return nil
 }

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -310,4 +310,8 @@ const (
 	// Warning:
 	// changing this value will break the connection to AWS resources for existing installations.
 	DefaultAWSTerraformProvisionedValueTrue = "true"
+
+	// VpcSecondaryClusterIDTagKey is the tag key used to store the secondary cluster ID of the
+	// cluster running in that VPC.
+	VpcSecondaryClusterIDTagKey = "tag:CloudSecondaryClusterID"
 )

--- a/internal/tools/aws/filestore_bifrost.go
+++ b/internal/tools/aws/filestore_bifrost.go
@@ -155,8 +155,8 @@ func (f *BifrostFilestore) s3FilestoreProvision(store model.InstallationDatabase
 
 // GenerateBifrostUtilitySecret creates the secret needed by the bifrost service
 // to access the shared S3 bucket for a given cluster.
-func (a *Client) GenerateBifrostUtilitySecret(clusterID string, logger log.FieldLogger) (*corev1.Secret, error) {
-	bucketName, err := getMultitenantBucketNameForCluster(clusterID, a)
+func (a *Client) GenerateBifrostUtilitySecret(clusterID string, vpc string, logger log.FieldLogger) (*corev1.Secret, error) {
+	bucketName, err := getMultitenantBucketNameForCluster(clusterID, vpc, a)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get multitenant bucket name")
 	}

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -250,6 +250,19 @@ func getVPCForCluster(clusterID string, client *Client) (*ec2.Vpc, error) {
 			Values: []*string{aws.String(VpcAvailableTagValueFalse)},
 		},
 	})
+	// checking if cluster is secondary
+	if len(vpcs) == 0 {
+		vpcs, err = client.GetVpcsWithFilters([]*ec2.Filter{
+			{
+				Name:   aws.String(VpcAvailableTagKey),
+				Values: []*string{aws.String(VpcAvailableTagValueFalse)},
+			},
+			{
+				Name:   aws.String(VpcSecondaryClusterIDTagKey),
+				Values: []*string{aws.String(clusterID)},
+			},
+		})
+	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to lookup VPC for cluster %s", clusterID)
 	}

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -170,16 +170,16 @@ func getMultitenantBucketNameForInstallation(installationID string, store model.
 	return bucketName, nil
 }
 
-func getMultitenantBucketNameForCluster(clusterID string, VpcId string, client *Client) (string, error) {
+func getMultitenantBucketNameForCluster(clusterID string, VpcID string, client *Client) (string, error) {
 
-	if VpcId == "" {
+	if VpcID == "" {
 		vpc, err := getVPCForCluster(clusterID, client)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to find cluster VPC")
 		}
-		VpcId = *vpc.VpcId
+		VpcID = *vpc.VpcId
 	}
-	bucketName, err := getMultitenantBucketNameForVPC(VpcId, client)
+	bucketName, err := getMultitenantBucketNameForVPC(VpcID, client)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get multitenant bucket name for VPC")
 	}

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -170,17 +170,19 @@ func getMultitenantBucketNameForInstallation(installationID string, store model.
 	return bucketName, nil
 }
 
-func getMultitenantBucketNameForCluster(clusterID string, client *Client) (string, error) {
-	vpc, err := getVPCForCluster(clusterID, client)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to find cluster VPC")
-	}
+func getMultitenantBucketNameForCluster(clusterID string, VpcId string, client *Client) (string, error) {
 
-	bucketName, err := getMultitenantBucketNameForVPC(*vpc.VpcId, client)
+	if VpcId == "" {
+		vpc, err := getVPCForCluster(clusterID, client)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to find cluster VPC")
+		}
+		VpcId = *vpc.VpcId
+	}
+	bucketName, err := getMultitenantBucketNameForVPC(VpcId, client)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get multitenant bucket name for VPC")
 	}
-
 	return bucketName, nil
 }
 

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -225,7 +225,7 @@ func (c *Cmd) GetClusterSpecInfoFromJSON(name string, subData string) (string, e
 	return string(data), nil
 }
 
-// GetCurrentCni, it get the current CNI value for the cluster
+// GetCurrentCni it get the current CNI value for the cluster
 func GetCurrentCni(network string) string {
 	for _, CNI := range model.GetSupportedCniList() {
 		if strings.Contains(network, CNI) {

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -47,7 +47,9 @@ func (c *Cmd) CreateCluster(name, cloud string, kopsRequest *model.KopsMetadataR
 	if kopsRequest.Networking != "" {
 		args = append(args, arg("networking", kopsRequest.Networking))
 	}
-
+	if kopsRequest.VPC != "" {
+		args = append(args, arg("vpc", kopsRequest.VPC))
+	}
 	if len(privateSubnetIds) != 0 {
 		args = append(args,
 			commaArg("subnets", privateSubnetIds),
@@ -215,15 +217,16 @@ func (c *Cmd) GetClusterSpecInfoFromJSON(name string, subData string) (string, e
 	if err != nil {
 		return "", errors.Wrap(err, "failed to unmarshal JSON output from kops get cluster")
 	}
+
 	data, err := json.Marshal(clusterdata["spec"].(map[string]interface{})[subData])
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to marshal cluster specification value for %s", subData)
 	}
-	return getCurrentCni(string(data)), nil
+	return string(data), nil
 }
 
-// getCurrentCni, it get the current CNI value for the cluster
-func getCurrentCni(network string) string {
+// GetCurrentCni, it get the current CNI value for the cluster
+func GetCurrentCni(network string) string {
 	for _, CNI := range model.GetSupportedCniList() {
 		if strings.Contains(network, CNI) {
 			return CNI

--- a/internal/tools/kops/instance_groups.go
+++ b/internal/tools/kops/instance_groups.go
@@ -129,13 +129,17 @@ func (c *Cmd) UpdateMetadata(metadata *model.KopsMetadata) error {
 	if err != nil {
 		return err
 	}
-
+	vpc, err := c.GetClusterSpecInfoFromJSON(metadata.Name, "networkID")
+	if err != nil {
+		return err
+	}
 	metadata.AMI = AMI
 	metadata.MasterInstanceType = masterMachineType
 	metadata.MasterCount = masterIGCount
 	metadata.NodeMinCount = nodeMinCount
 	metadata.NodeMaxCount = nodeMaxCount
-	metadata.Networking = networking
+	metadata.Networking = GetCurrentCni(networking)
+	metadata.VPC = strings.Trim(vpc, "\"")
 
 	return nil
 }

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -26,7 +26,6 @@ type Cluster struct {
 	LockAcquiredBy          *string
 	LockAcquiredAt          int64
 	Networking              string
-	VPC                     string
 }
 
 // Clone returns a deep copy the cluster.

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -26,6 +26,7 @@ type Cluster struct {
 	LockAcquiredBy          *string
 	LockAcquiredAt          int64
 	Networking              string
+	VPC                     string
 }
 
 // Clone returns a deep copy the cluster.

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -28,6 +28,7 @@ type CreateClusterRequest struct {
 	DesiredUtilityVersions map[string]*HelmUtilityVersion `json:"utility-versions,omitempty"`
 	Annotations            []string                       `json:"annotations,omitempty"`
 	Networking             string                         `json:"networking,omitempty"`
+	VPC                    string                         `json:"vpc,omitempty"`
 }
 
 // SetDefaults sets the default values for a cluster create request.

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -29,6 +29,7 @@ type KopsMetadata struct {
 	RotatorRequest       *RotatorMetadata            `json:"RotatorRequest,omitempty"`
 	Warnings             []string                    `json:"Warnings,omitempty"`
 	Networking           string                      `json:"Networking,omitempty"`
+	VPC                  string                      `json:"VPC,omitempty"`
 }
 
 // KopsInstanceGroupsMetadata is a map of instance group names to their metadata.
@@ -51,6 +52,7 @@ type KopsMetadataRequestedState struct {
 	NodeMinCount       int64  `json:"NodeMinCount,omitempty"`
 	NodeMaxCount       int64  `json:"NodeMaxCount,omitempty"`
 	Networking         string `json:"Networking,omitempty"`
+	VPC                string `json:"VPC,omitempty"`
 }
 
 // RotatorMetadata is the metadata for the Rotator tool


### PR DESCRIPTION
Summary

Shared VPC feature for KOPS clusters. Introduce changes:

- Creating a secondary kops cluster inside the same VPC used by the Primary / existing cluster.
- Deleting a secondary cluster & untagging resources where required.
- Represent VPC information with cloud cluster list command.

Ticket Link

https://mattermost.atlassian.net/browse/MM-34077

Release Note

`Introducing Shared VPC feature in provisioner for KOPS clusters creation.`

Test cases:

`[Testing Shared VPC feature -Dev.pdf](https://github.com/mattermost/mattermost-cloud/files/6355460/Testing.Shared.VPC.feature.-Dev.pdf)
`
