### PR TITLE
Add installation restoration supervisor

### DIFF
--- a/internal/supervisor/backup_lock.go
+++ b/internal/supervisor/backup_lock.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type backupLockStore interface {
+type installationBackupLockStore interface {
 	LockInstallationBackups(backupsID []string, lockerID string) (bool, error)
 	UnlockInstallationBackups(backupsID []string, lockerID string, force bool) (bool, error)
 }
@@ -16,11 +16,11 @@ type backupLockStore interface {
 type backupLock struct {
 	backupsID []string
 	lockerID  string
-	store     backupLockStore
+	store     installationBackupLockStore
 	logger    log.FieldLogger
 }
 
-func newBackupLock(backupID, lockerID string, store backupLockStore, logger log.FieldLogger) *backupLock {
+func newBackupLock(backupID, lockerID string, store installationBackupLockStore, logger log.FieldLogger) *backupLock {
 	return &backupLock{
 		backupsID: []string{backupID},
 		lockerID:  lockerID,
@@ -29,7 +29,7 @@ func newBackupLock(backupID, lockerID string, store backupLockStore, logger log.
 	}
 }
 
-func newBackupsLock(backupsID []string, lockerID string, store backupLockStore, logger log.FieldLogger) *backupLock {
+func newBackupsLock(backupsID []string, lockerID string, store installationBackupLockStore, logger log.FieldLogger) *backupLock {
 	return &backupLock{
 		backupsID: backupsID,
 		lockerID:  lockerID,

--- a/internal/supervisor/common.go
+++ b/internal/supervisor/common.go
@@ -22,11 +22,11 @@ func claimClusterInstallation(store clusterInstallationClaimStore, installation 
 	}
 	clusterInstallations, err := store.GetClusterInstallations(clusterInstallationFilter)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "Failed to get cluster installations")
+		return nil, nil, errors.Wrap(err, "failed to get cluster installations")
 	}
 
 	if len(clusterInstallations) == 0 {
-		return nil, nil, errors.Wrap(err, "Expected at least one cluster installation for the installation but found none")
+		return nil, nil, errors.Wrap(err, "expected at least one cluster installation for the installation but found none")
 	}
 
 	claimedCI := clusterInstallations[0]
@@ -49,7 +49,7 @@ func getAndLockInstallation(store getAndLockInstallationStore, installationID, i
 		return nil, nil, errors.Wrap(err, "failed to get installation")
 	}
 	if installation == nil {
-		return nil, nil, errors.New("could not found the installation")
+		return nil, nil, errors.New("could not find the installation")
 	}
 
 	lock := newInstallationLock(installation.ID, instanceID, store, logger)
@@ -67,12 +67,12 @@ type getClusterForClusterInstallationStore interface {
 func getClusterForClusterInstallation(store getClusterForClusterInstallationStore, clusterInstallationID string) (*model.Cluster, error) {
 	clusterInstallation, err := store.GetClusterInstallation(clusterInstallationID)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get cluster installations")
+		return nil, errors.Wrap(err, "failed to get cluster installations")
 	}
 
 	cluster, err := store.GetCluster(clusterInstallation.ClusterID)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get cluster")
+		return nil, errors.Wrap(err, "failed to get cluster")
 	}
 
 	if cluster == nil {

--- a/internal/supervisor/common.go
+++ b/internal/supervisor/common.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package supervisor
+
+import (
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type clusterInstallationClaimStore interface {
+	GetClusterInstallations(*model.ClusterInstallationFilter) ([]*model.ClusterInstallation, error)
+	clusterInstallationLockStore
+}
+
+func claimClusterInstallation(store clusterInstallationClaimStore, installation *model.Installation, instanceID string, logger log.FieldLogger) (*model.ClusterInstallation, *clusterInstallationLock, error) {
+	clusterInstallationFilter := &model.ClusterInstallationFilter{
+		InstallationID: installation.ID,
+		Paging:         model.AllPagesNotDeleted(),
+	}
+	clusterInstallations, err := store.GetClusterInstallations(clusterInstallationFilter)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Failed to get cluster installations")
+	}
+
+	if len(clusterInstallations) == 0 {
+		return nil, nil, errors.Wrap(err, "Expected at least one cluster installation for the installation but found none")
+	}
+
+	claimedCI := clusterInstallations[0]
+	ciLock := newClusterInstallationLock(claimedCI.ID, instanceID, store, logger)
+	if !ciLock.TryLock() {
+		return nil, nil, errors.Errorf("failed to lock cluster installation %s", claimedCI.ID)
+	}
+
+	return claimedCI, ciLock, nil
+}
+
+type getAndLockInstallationStore interface {
+	GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error)
+	installationLockStore
+}
+
+func getAndLockInstallation(store getAndLockInstallationStore, installationID, instanceID string, logger log.FieldLogger) (*model.Installation, *installationLock, error) {
+	installation, err := store.GetInstallation(installationID, false, false)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get installation")
+	}
+	if installation == nil {
+		return nil, nil, errors.New("could not found the installation")
+	}
+
+	lock := newInstallationLock(installation.ID, instanceID, store, logger)
+	if !lock.TryLock() {
+		return nil, nil, errors.Errorf("failed to lock installation %s", installationID)
+	}
+	return installation, lock, nil
+}
+
+type getClusterForClusterInstallationStore interface {
+	GetClusterInstallation(string) (*model.ClusterInstallation, error)
+	GetCluster(string) (*model.Cluster, error)
+}
+
+func getClusterForClusterInstallation(store getClusterForClusterInstallationStore, clusterInstallationID string) (*model.Cluster, error) {
+	clusterInstallation, err := store.GetClusterInstallation(clusterInstallationID)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get cluster installations")
+	}
+
+	cluster, err := store.GetCluster(clusterInstallation.ClusterID)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get cluster")
+	}
+
+	if cluster == nil {
+		return nil, errors.New("cluster not found for cluster installation")
+	}
+
+	return cluster, nil
+}

--- a/internal/supervisor/installation_db_restoration.go
+++ b/internal/supervisor/installation_db_restoration.go
@@ -113,7 +113,7 @@ func (s *InstallationDBRestorationSupervisor) Supervise(restoration *model.Insta
 	originalState := restoration.State
 	restoration, err := s.store.GetInstallationDBRestorationOperation(restoration.ID)
 	if err != nil {
-		logger.WithError(err).Errorf("Failed to get refreshed restoration")
+		logger.WithError(err).Error("Failed to get refreshed restoration")
 		return
 	}
 	if restoration.State != originalState {
@@ -186,14 +186,14 @@ func (s *InstallationDBRestorationSupervisor) transitionRestoration(restoration 
 func (s *InstallationDBRestorationSupervisor) triggerRestoration(restoration *model.InstallationDBRestorationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBRestorationState {
 	installation, lock, err := getAndLockInstallation(s.store, restoration.InstallationID, instanceID, logger)
 	if err != nil {
-		logger.WithError(err).Error("failed to get and lock installation")
+		logger.WithError(err).Error("Failed to get and lock installation")
 		return restoration.State
 	}
 	defer lock.Unlock()
 
 	backup, err := s.store.GetInstallationBackup(restoration.BackupID)
 	if err != nil {
-		logger.WithError(err).Error("failed to get backup")
+		logger.WithError(err).Error("Failed to get backup")
 		return restoration.State
 	}
 
@@ -207,7 +207,7 @@ func (s *InstallationDBRestorationSupervisor) triggerRestoration(restoration *mo
 		restoration.ClusterInstallationID = restoreCI.ID
 		err = s.store.UpdateInstallationDBRestorationOperation(restoration)
 		if err != nil {
-			logger.WithError(err).Errorf("Failed to assign cluster installation to restoration")
+			logger.WithError(err).Error("Failed to assign cluster installation to restoration")
 			return restoration.State
 		}
 	}
@@ -230,7 +230,7 @@ func (s *InstallationDBRestorationSupervisor) triggerRestoration(restoration *mo
 func (s *InstallationDBRestorationSupervisor) checkRestorationStatus(restoration *model.InstallationDBRestorationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBRestorationState {
 	backup, err := s.store.GetInstallationBackup(restoration.BackupID)
 	if err != nil {
-		logger.WithError(err).Error("failed to get backup")
+		logger.WithError(err).Error("Failed to get backup")
 		return restoration.State
 	}
 
@@ -243,7 +243,7 @@ func (s *InstallationDBRestorationSupervisor) checkRestorationStatus(restoration
 	completeAt, err := s.restoreOperator.CheckRestoreStatus(backup, cluster)
 	if err != nil {
 		if err == provisioner.ErrJobBackoffLimitReached {
-			logger.WithError(err).Errorf("installation db restoration failed")
+			logger.WithError(err).Error("Installation db restoration failed")
 			return model.InstallationDBRestorationStateFailing
 		}
 		logger.WithError(err).Error("Failed to check restoration status")
@@ -267,7 +267,7 @@ func (s *InstallationDBRestorationSupervisor) checkRestorationStatus(restoration
 func (s *InstallationDBRestorationSupervisor) finalizeRestoration(restoration *model.InstallationDBRestorationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBRestorationState {
 	installation, lock, err := getAndLockInstallation(s.store, restoration.InstallationID, instanceID, logger)
 	if err != nil {
-		logger.WithError(err).Error("failed to get and lock installation")
+		logger.WithError(err).Error("Failed to get and lock installation")
 		return restoration.State
 	}
 	defer lock.Unlock()
@@ -276,7 +276,7 @@ func (s *InstallationDBRestorationSupervisor) finalizeRestoration(restoration *m
 	installation.State = restoration.TargetInstallationState
 	err = s.store.UpdateInstallation(installation)
 	if err != nil {
-		logger.WithError(err).Error("failed to set installation to target state after restore")
+		logger.WithError(err).Error("Failed to set installation to target state after restore")
 		return restoration.State
 	}
 
@@ -300,7 +300,7 @@ func (s *InstallationDBRestorationSupervisor) finalizeRestoration(restoration *m
 func (s *InstallationDBRestorationSupervisor) failRestoration(restoration *model.InstallationDBRestorationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBRestorationState {
 	installation, lock, err := getAndLockInstallation(s.store, restoration.InstallationID, instanceID, logger)
 	if err != nil {
-		logger.WithError(err).Error("failed to get and lock installation")
+		logger.WithError(err).Error("Failed to get and lock installation")
 		return restoration.State
 	}
 	defer lock.Unlock()
@@ -309,7 +309,7 @@ func (s *InstallationDBRestorationSupervisor) failRestoration(restoration *model
 	installation.State = model.InstallationStateDBRestorationFailed
 	err = s.store.UpdateInstallation(installation)
 	if err != nil {
-		logger.WithError(err).Errorf("Failed to set installation to failed DB restoration state")
+		logger.WithError(err).Error("Failed to set installation to failed DB restoration state")
 		return restoration.State
 	}
 

--- a/internal/supervisor/installation_db_restoration.go
+++ b/internal/supervisor/installation_db_restoration.go
@@ -1,0 +1,299 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package supervisor
+
+import (
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/provisioner"
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/internal/webhook"
+	"github.com/mattermost/mattermost-cloud/model"
+	log "github.com/sirupsen/logrus"
+)
+
+// installationDBRestorationStore abstracts the database operations required by the supervisor.
+type installationDBRestorationStore interface {
+	GetUnlockedInstallationDBRestorationOperationsPendingWork() ([]*model.InstallationDBRestorationOperation, error)
+	GetInstallationDBRestorationOperation(id string) (*model.InstallationDBRestorationOperation, error)
+	UpdateInstallationDBRestorationOperationState(dbRestoration *model.InstallationDBRestorationOperation) error
+	UpdateInstallationDBRestorationOperation(dbRestoration *model.InstallationDBRestorationOperation) error
+	installationDBRestorationLockStore
+
+	GetInstallationBackup(id string) (*model.InstallationBackup, error)
+	installationBackupLockStore
+
+	GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error)
+	UpdateInstallation(installation *model.Installation) error
+	installationLockStore
+
+	GetClusterInstallations(*model.ClusterInstallationFilter) ([]*model.ClusterInstallation, error)
+	GetClusterInstallation(clusterInstallationID string) (*model.ClusterInstallation, error)
+	clusterInstallationLockStore
+
+	GetCluster(id string) (*model.Cluster, error)
+
+	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
+}
+
+// restoreOperator abstracts different restoration operations required by the installation db restoration supervisor.
+type restoreOperator interface {
+	TriggerRestore(installation *model.Installation, backup *model.InstallationBackup, cluster *model.Cluster) error
+	CheckRestoreStatus(backupMeta *model.InstallationBackup, cluster *model.Cluster) (int64, error)
+	CleanupRestoreJob(backup *model.InstallationBackup, cluster *model.Cluster) error
+}
+
+// InstallationDBRestorationSupervisor finds pending work and effects the required changes.
+//
+// The degree of parallelism is controlled by a weighted semaphore, intended to be shared with
+// other clients needing to coordinate background jobs.
+type InstallationDBRestorationSupervisor struct {
+	store      installationDBRestorationStore
+	aws        aws.AWS
+	instanceID string
+	logger     log.FieldLogger
+
+	restoreOperator restoreOperator
+}
+
+// NewInstallationDBRestorationSupervisor creates a new InstallationDBRestorationSupervisor.
+func NewInstallationDBRestorationSupervisor(
+	store installationDBRestorationStore,
+	aws aws.AWS,
+	restoreOperator restoreOperator,
+	instanceID string,
+	logger log.FieldLogger) *InstallationDBRestorationSupervisor {
+	return &InstallationDBRestorationSupervisor{
+		store:           store,
+		aws:             aws,
+		restoreOperator: restoreOperator,
+		instanceID:      instanceID,
+		logger:          logger,
+	}
+}
+
+// Shutdown performs graceful shutdown tasks for the supervisor.
+func (s *InstallationDBRestorationSupervisor) Shutdown() {
+	s.logger.Debug("Shutting down installation db restoration supervisor")
+}
+
+// Do looks for work to be done on any pending restoration operations and attempts to schedule the required work.
+func (s *InstallationDBRestorationSupervisor) Do() error {
+	installationDBRestorations, err := s.store.GetUnlockedInstallationDBRestorationOperationsPendingWork()
+	if err != nil {
+		s.logger.WithError(err).Warn("Failed to query for pending work")
+		return nil
+	}
+
+	for _, restoration := range installationDBRestorations {
+		s.Supervise(restoration)
+	}
+
+	return nil
+}
+
+// Supervise schedules the required work on the given restoration.
+func (s *InstallationDBRestorationSupervisor) Supervise(restoration *model.InstallationDBRestorationOperation) {
+	logger := s.logger.WithFields(log.Fields{
+		"restorationOperation": restoration.ID,
+	})
+
+	lock := newInstallationDBRestorationLock(restoration.ID, s.instanceID, s.store, logger)
+	if !lock.TryLock() {
+		return
+	}
+	defer lock.Unlock()
+
+	// Before working on the restoration, it is crucial that we ensure that it
+	// was not updated to a new state by another provisioning server.
+	originalState := restoration.State
+	restoration, err := s.store.GetInstallationDBRestorationOperation(restoration.ID)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to get refreshed restoration")
+		return
+	}
+	if restoration.State != originalState {
+		logger.WithField("oldRestorationState", originalState).
+			WithField("newRestorationState", restoration.State).
+			Warn("Another provisioner has worked on this restoration; skipping...")
+		return
+	}
+
+	logger.Debugf("Supervising restoration in state %s", restoration.State)
+
+	newState := s.transitionRestoration(restoration, s.instanceID, logger)
+
+	restoration, err = s.store.GetInstallationDBRestorationOperation(restoration.ID)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to get restoration and thus persist state %s", newState)
+		return
+	}
+
+	if restoration.State == newState {
+		return
+	}
+
+	oldState := restoration.State
+	restoration.State = newState
+
+	err = s.store.UpdateInstallationDBRestorationOperationState(restoration)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to set restoration state to %s", newState)
+		return
+	}
+
+	webhookPayload := &model.WebhookPayload{
+		Type:      model.TypeInstallationDBRestoration,
+		ID:        restoration.ID,
+		NewState:  string(restoration.State),
+		OldState:  string(oldState),
+		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"Environment": s.aws.GetCloudEnvironmentName()},
+	}
+	err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
+	if err != nil {
+		logger.WithError(err).Error("Unable to process and send webhooks")
+	}
+
+	logger.Debugf("Transitioned restoration from %s to %s", oldState, restoration.State)
+}
+
+// transitionRestoration works with the given restoration to transition it to a final state.
+func (s *InstallationDBRestorationSupervisor) transitionRestoration(restoration *model.InstallationDBRestorationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBRestorationState {
+	switch restoration.State {
+	case model.InstallationDBRestorationStateRequested:
+		return s.triggerRestoration(restoration, instanceID, logger)
+
+	case model.InstallationDBRestorationStateInProgress:
+		return s.checkRestorationStatus(restoration, instanceID, logger)
+
+	case model.InstallationDBRestorationStateFinalizing:
+		return s.finalizeRestoration(restoration, instanceID, logger)
+
+	case model.InstallationDBRestorationStateFailing:
+		return s.failRestoration(restoration, instanceID, logger)
+
+	default:
+		logger.Warnf("Found restoration pending work in unexpected state %s", restoration.State)
+		return restoration.State
+	}
+}
+
+func (s *InstallationDBRestorationSupervisor) triggerRestoration(restoration *model.InstallationDBRestorationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBRestorationState {
+	installation, lock, err := getAndLockInstallation(s.store, restoration.InstallationID, instanceID, logger)
+	if err != nil {
+		logger.WithError(err).Error("failed to get and lock installation")
+		return restoration.State
+	}
+	defer lock.Unlock()
+
+	backup, err := s.store.GetInstallationBackup(restoration.BackupID)
+	if err != nil {
+		logger.WithError(err).Error("failed to get backup")
+		return restoration.State
+	}
+
+	if restoration.ClusterInstallationID == "" {
+		restoreCI, ciLock, err := claimClusterInstallation(s.store, installation, instanceID, logger)
+		if err != nil {
+			logger.WithError(err).Error("Failed to claim Cluster Installation for restoration")
+			return restoration.State
+		}
+		defer ciLock.Unlock()
+		restoration.ClusterInstallationID = restoreCI.ID
+		err = s.store.UpdateInstallationDBRestorationOperation(restoration)
+		if err != nil {
+			logger.WithError(err).Errorf("Failed to assign cluster installation to restoration")
+			return restoration.State
+		}
+	}
+
+	cluster, err := getClusterForClusterInstallation(s.store, restoration.ClusterInstallationID)
+	if err != nil {
+		logger.WithError(err).Error("Failed to get cluster for restoration")
+		return restoration.State
+	}
+
+	err = s.restoreOperator.TriggerRestore(installation, backup, cluster)
+	if err != nil {
+		logger.WithError(err).Error("Failed to trigger restoration job")
+		return restoration.State
+	}
+
+	return model.InstallationDBRestorationStateInProgress
+}
+
+func (s *InstallationDBRestorationSupervisor) checkRestorationStatus(restoration *model.InstallationDBRestorationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBRestorationState {
+	backup, err := s.store.GetInstallationBackup(restoration.BackupID)
+	if err != nil {
+		logger.WithError(err).Error("failed to get backup")
+		return restoration.State
+	}
+
+	cluster, err := getClusterForClusterInstallation(s.store, restoration.ClusterInstallationID)
+	if err != nil {
+		logger.WithError(err).Error("Failed to get cluster for restoration")
+		return restoration.State
+	}
+
+	completeAt, err := s.restoreOperator.CheckRestoreStatus(backup, cluster)
+	if err != nil {
+		if err == provisioner.ErrJobBackoffLimitReached {
+			logger.WithError(err).Errorf("installation db restoration failed")
+			return model.InstallationDBRestorationStateFailing
+		}
+		logger.WithError(err).Error("Failed to check restoration status")
+		return restoration.State
+	}
+	if completeAt <= 0 {
+		logger.Info("Database restoration still in progress")
+		return restoration.State
+	}
+
+	restoration.CompleteAt = completeAt
+	err = s.store.UpdateInstallationDBRestorationOperation(restoration)
+	if err != nil {
+		logger.WithError(err).Error("Failed to update restoration")
+		return restoration.State
+	}
+
+	return model.InstallationDBRestorationStateFinalizing
+}
+
+func (s *InstallationDBRestorationSupervisor) finalizeRestoration(restoration *model.InstallationDBRestorationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBRestorationState {
+	installation, lock, err := getAndLockInstallation(s.store, restoration.InstallationID, instanceID, logger)
+	if err != nil {
+		logger.WithError(err).Error("failed to get and lock installation")
+		return restoration.State
+	}
+	defer lock.Unlock()
+
+	installation.State = restoration.TargetInstallationState
+	err = s.store.UpdateInstallation(installation)
+	if err != nil {
+		logger.WithError(err).Error("failed to set installation to target state after restore")
+		return restoration.State
+	}
+
+	return model.InstallationDBRestorationStateSucceeded
+}
+
+func (s *InstallationDBRestorationSupervisor) failRestoration(restoration *model.InstallationDBRestorationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBRestorationState {
+	installation, lock, err := getAndLockInstallation(s.store, restoration.InstallationID, instanceID, logger)
+	if err != nil {
+		logger.WithError(err).Error("failed to get and lock installation")
+		return restoration.State
+	}
+	defer lock.Unlock()
+
+	installation.State = model.InstallationStateDBRestorationFailed
+	err = s.store.UpdateInstallation(installation)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to set installation to failed DB restoration state")
+		return restoration.State
+	}
+
+	return model.InstallationDBRestorationStateFailed
+}

--- a/internal/supervisor/installation_db_restoration_lock.go
+++ b/internal/supervisor/installation_db_restoration_lock.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package supervisor
+
+import log "github.com/sirupsen/logrus"
+
+type installationDBRestorationLockStore interface {
+	LockInstallationDBRestorationOperations(id []string, lockerID string) (bool, error)
+	UnlockInstallationDBRestorationOperations(id []string, lockerID string, force bool) (bool, error)
+}
+
+type installationDBRestorationLock struct {
+	ids      []string
+	lockerID string
+	store    installationDBRestorationLockStore
+	logger   log.FieldLogger
+}
+
+func newInstallationDBRestorationLock(id, lockerID string, store installationDBRestorationLockStore, logger log.FieldLogger) *installationDBRestorationLock {
+	return &installationDBRestorationLock{
+		ids:      []string{id},
+		lockerID: lockerID,
+		store:    store,
+		logger:   logger,
+	}
+}
+
+func newInstallationDBRestorationLocks(ids []string, lockerID string, store installationDBRestorationLockStore, logger log.FieldLogger) *installationDBRestorationLock {
+	return &installationDBRestorationLock{
+		ids:      ids,
+		lockerID: lockerID,
+		store:    store,
+		logger:   logger,
+	}
+}
+
+func (l *installationDBRestorationLock) TryLock() bool {
+	locked, err := l.store.LockInstallationDBRestorationOperations(l.ids, l.lockerID)
+	if err != nil {
+		l.logger.WithError(err).Error("failed to lock installationDBRestorations")
+		return false
+	}
+
+	return locked
+}
+
+func (l *installationDBRestorationLock) Unlock() {
+	unlocked, err := l.store.UnlockInstallationDBRestorationOperations(l.ids, l.lockerID, false)
+	if err != nil {
+		l.logger.WithError(err).Error("failed to unlock installationDBRestorations")
+	} else if unlocked != true {
+		l.logger.Error("failed to release lock for installationDBRestorations")
+	}
+}

--- a/internal/supervisor/installation_db_restoration_test.go
+++ b/internal/supervisor/installation_db_restoration_test.go
@@ -1,0 +1,348 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package supervisor_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/internal/provisioner"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/supervisor"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pborman/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRestorationStore struct {
+	InstallationRestorationOperation *model.InstallationDBRestorationOperation
+	RestorationPending               []*model.InstallationDBRestorationOperation
+	Installation                     *model.Installation
+	UnlockChan                       chan interface{}
+
+	UpdateRestorationOperationCalls int
+}
+
+func (m *mockRestorationStore) GetUnlockedInstallationDBRestorationOperationsPendingWork() ([]*model.InstallationDBRestorationOperation, error) {
+	return m.RestorationPending, nil
+}
+
+func (m *mockRestorationStore) GetInstallationDBRestorationOperation(id string) (*model.InstallationDBRestorationOperation, error) {
+	return m.InstallationRestorationOperation, nil
+}
+
+func (m *mockRestorationStore) UpdateInstallationDBRestorationOperationState(dbRestoration *model.InstallationDBRestorationOperation) error {
+	m.UpdateRestorationOperationCalls++
+	return nil
+}
+
+func (m *mockRestorationStore) UpdateInstallationDBRestorationOperation(dbRestoration *model.InstallationDBRestorationOperation) error {
+	m.UpdateRestorationOperationCalls++
+	return nil
+}
+
+func (m *mockRestorationStore) LockInstallationDBRestorationOperations(id []string, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (m *mockRestorationStore) UnlockInstallationDBRestorationOperations(id []string, lockerID string, force bool) (bool, error) {
+	if m.UnlockChan != nil {
+		close(m.UnlockChan)
+	}
+	return true, nil
+}
+
+func (m *mockRestorationStore) GetInstallationBackup(id string) (*model.InstallationBackup, error) {
+	return &model.InstallationBackup{ID: id}, nil
+}
+
+func (m *mockRestorationStore) LockInstallationBackups(backupsID []string, lockerID string) (bool, error) {
+	panic("implement me")
+}
+
+func (m *mockRestorationStore) UnlockInstallationBackups(backupsID []string, lockerID string, force bool) (bool, error) {
+	panic("implement me")
+}
+
+func (m *mockRestorationStore) GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error) {
+	return m.Installation, nil
+}
+
+func (m *mockRestorationStore) UpdateInstallation(installation *model.Installation) error {
+	panic("implement me")
+}
+
+func (m *mockRestorationStore) LockInstallation(installationID, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (m *mockRestorationStore) UnlockInstallation(installationID, lockerID string, force bool) (bool, error) {
+	return true, nil
+}
+
+func (m *mockRestorationStore) GetClusterInstallations(filter *model.ClusterInstallationFilter) ([]*model.ClusterInstallation, error) {
+	return []*model.ClusterInstallation{{ID: "id"}}, nil
+}
+
+func (m *mockRestorationStore) GetClusterInstallation(clusterInstallationID string) (*model.ClusterInstallation, error) {
+	return &model.ClusterInstallation{ID: "id"}, nil
+}
+
+func (m *mockRestorationStore) LockClusterInstallations(clusterInstallationID []string, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (m *mockRestorationStore) UnlockClusterInstallations(clusterInstallationID []string, lockerID string, force bool) (bool, error) {
+	return true, nil
+}
+
+func (m *mockRestorationStore) GetCluster(id string) (*model.Cluster, error) {
+	return &model.Cluster{ID: id}, nil
+}
+
+func (m *mockRestorationStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error) {
+	return nil, nil
+}
+
+type mockRestoreProvisioner struct {
+	RestoreCompleteTime int64
+	err                 error
+}
+
+func (p *mockRestoreProvisioner) TriggerRestore(installation *model.Installation, backup *model.InstallationBackup, cluster *model.Cluster) error {
+	return p.err
+}
+
+func (p *mockRestoreProvisioner) CheckRestoreStatus(backupMeta *model.InstallationBackup, cluster *model.Cluster) (int64, error) {
+	return p.RestoreCompleteTime, p.err
+}
+
+func (p *mockRestoreProvisioner) CleanupRestoreJob(backup *model.InstallationBackup, cluster *model.Cluster) error {
+	return p.err
+}
+
+func TestInstallationDBRestorationSupervisor_Do(t *testing.T) {
+	t.Run("no installation restoration operations pending work", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		mockStore := &mockRestorationStore{}
+
+		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(mockStore, &mockAWS{}, &mockRestoreProvisioner{}, "instanceID", logger)
+		err := restorationSupervisor.Do()
+		require.NoError(t, err)
+
+		require.Equal(t, 0, mockStore.UpdateRestorationOperationCalls)
+	})
+
+	t.Run("mock restoration trigger", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+
+		installation := &model.Installation{
+			ID:        model.NewID(),
+			State:     model.InstallationStateHibernating,
+			Database:  model.InstallationDatabaseMultiTenantRDSPostgres,
+			Filestore: model.InstallationFilestoreBifrost,
+		}
+		mockStore := &mockRestorationStore{
+			Installation: installation,
+			RestorationPending: []*model.InstallationDBRestorationOperation{
+				{ID: model.NewID(), InstallationID: installation.ID, State: model.InstallationDBRestorationStateRequested},
+			},
+			InstallationRestorationOperation: &model.InstallationDBRestorationOperation{ID: model.NewID(), InstallationID: installation.ID, State: model.InstallationDBRestorationStateRequested},
+			UnlockChan:                       make(chan interface{}),
+		}
+
+		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(mockStore, &mockAWS{}, &mockRestoreProvisioner{}, "instanceID", logger)
+		err := restorationSupervisor.Do()
+		require.NoError(t, err)
+
+		<-mockStore.UnlockChan
+		require.Equal(t, 2, mockStore.UpdateRestorationOperationCalls)
+	})
+}
+
+func TestInstallationDBRestorationSupervisor_Supervise(t *testing.T) {
+
+	t.Run("transition to restoration", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
+		mockRestoreOp := &mockRestoreProvisioner{}
+
+		installation, clusterInstallation, backup := setupRestoreRequiredResources(t, sqlStore)
+
+		restorationOp := &model.InstallationDBRestorationOperation{
+			InstallationID:          installation.ID,
+			BackupID:                backup.ID,
+			State:                   model.InstallationDBRestorationStateRequested,
+			TargetInstallationState: model.InstallationStateHibernating,
+		}
+		err := sqlStore.CreateInstallationDBRestorationOperation(restorationOp)
+		require.NoError(t, err)
+
+		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(sqlStore, &mockAWS{}, mockRestoreOp, "instanceID", logger)
+		restorationSupervisor.Supervise(restorationOp)
+
+		// Assert
+		restorationOp, err = sqlStore.GetInstallationDBRestorationOperation(restorationOp.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationDBRestorationStateInProgress, restorationOp.State)
+		assert.Equal(t, clusterInstallation.ID, restorationOp.ClusterInstallationID)
+
+		installation, err = sqlStore.GetInstallation(installation.ID, false, false)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationStateDBRestorationInProgress, installation.State)
+	})
+
+	t.Run("check restoration status", func(t *testing.T) {
+		for _, testCase := range []struct {
+			description   string
+			mockRestoreOp *mockRestoreProvisioner
+			expectedState model.InstallationDBRestorationState
+		}{
+			{
+				description:   "when restore finished",
+				mockRestoreOp: &mockRestoreProvisioner{RestoreCompleteTime: 100},
+				expectedState: model.InstallationDBRestorationStateFinalizing,
+			},
+			{
+				description:   "when still in progress",
+				mockRestoreOp: &mockRestoreProvisioner{RestoreCompleteTime: -1},
+				expectedState: model.InstallationDBRestorationStateInProgress,
+			},
+			{
+				description:   "when non terminal error",
+				mockRestoreOp: &mockRestoreProvisioner{RestoreCompleteTime: -1, err: errors.New("some error")},
+				expectedState: model.InstallationDBRestorationStateInProgress,
+			},
+			{
+				description:   "when terminal error",
+				mockRestoreOp: &mockRestoreProvisioner{RestoreCompleteTime: -1, err: provisioner.ErrJobBackoffLimitReached},
+				expectedState: model.InstallationDBRestorationStateFailing,
+			},
+		} {
+			t.Run(testCase.description, func(t *testing.T) {
+				logger := testlib.MakeLogger(t)
+				sqlStore := store.MakeTestSQLStore(t, logger)
+				defer store.CloseConnection(t, sqlStore)
+
+				installation, clusterInstallation, backup := setupRestoreRequiredResources(t, sqlStore)
+
+				restorationOp := &model.InstallationDBRestorationOperation{
+					InstallationID:        installation.ID,
+					BackupID:              backup.ID,
+					State:                 model.InstallationDBRestorationStateInProgress,
+					ClusterInstallationID: clusterInstallation.ID,
+				}
+				err := sqlStore.CreateInstallationDBRestorationOperation(restorationOp)
+				require.NoError(t, err)
+
+				restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(sqlStore, &mockAWS{}, testCase.mockRestoreOp, "instanceID", logger)
+				restorationSupervisor.Supervise(restorationOp)
+
+				// Assert
+				restorationOp, err = sqlStore.GetInstallationDBRestorationOperation(restorationOp.ID)
+				require.NoError(t, err)
+				assert.Equal(t, testCase.expectedState, restorationOp.State)
+				assert.Equal(t, clusterInstallation.ID, restorationOp.ClusterInstallationID)
+			})
+		}
+	})
+
+	t.Run("finalizing restoration", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
+		mockRestoreOp := &mockRestoreProvisioner{}
+
+		installation, clusterInstallation, backup := setupRestoreRequiredResources(t, sqlStore)
+
+		restorationOp := &model.InstallationDBRestorationOperation{
+			InstallationID:          installation.ID,
+			BackupID:                backup.ID,
+			State:                   model.InstallationDBRestorationStateFinalizing,
+			ClusterInstallationID:   clusterInstallation.ID,
+			TargetInstallationState: model.InstallationStateHibernating,
+		}
+		err := sqlStore.CreateInstallationDBRestorationOperation(restorationOp)
+		require.NoError(t, err)
+
+		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(sqlStore, &mockAWS{}, mockRestoreOp, "instanceID", logger)
+		restorationSupervisor.Supervise(restorationOp)
+
+		// Assert
+		restorationOp, err = sqlStore.GetInstallationDBRestorationOperation(restorationOp.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationDBRestorationStateSucceeded, restorationOp.State)
+
+		installation, err = sqlStore.GetInstallation(installation.ID, false, false)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationStateHibernating, installation.State)
+	})
+
+	t.Run("failing restoration", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
+		mockRestoreOp := &mockRestoreProvisioner{}
+
+		installation, clusterInstallation, backup := setupRestoreRequiredResources(t, sqlStore)
+
+		restorationOp := &model.InstallationDBRestorationOperation{
+			InstallationID:          installation.ID,
+			BackupID:                backup.ID,
+			State:                   model.InstallationDBRestorationStateFailing,
+			ClusterInstallationID:   clusterInstallation.ID,
+			TargetInstallationState: model.InstallationStateHibernating,
+		}
+		err := sqlStore.CreateInstallationDBRestorationOperation(restorationOp)
+		require.NoError(t, err)
+
+		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(sqlStore, &mockAWS{}, mockRestoreOp, "instanceID", logger)
+		restorationSupervisor.Supervise(restorationOp)
+
+		// Assert
+		restorationOp, err = sqlStore.GetInstallationDBRestorationOperation(restorationOp.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationDBRestorationStateFailed, restorationOp.State)
+
+		installation, err = sqlStore.GetInstallation(installation.ID, false, false)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationStateDBRestorationFailed, installation.State)
+	})
+}
+
+func setupRestoreRequiredResources(t *testing.T, sqlStore *store.SQLStore) (*model.Installation, *model.ClusterInstallation, *model.InstallationBackup) {
+	installation := &model.Installation{
+		Database:  model.InstallationDatabaseMultiTenantRDSPostgres,
+		Filestore: model.InstallationFilestoreBifrost,
+		State:     model.InstallationStateDBRestorationInProgress,
+		DNS:       fmt.Sprintf("dns-%s", uuid.NewRandom().String()[:6]),
+	}
+	err := sqlStore.CreateInstallation(installation, nil)
+	require.NoError(t, err)
+
+	cluster := &model.Cluster{}
+	err = sqlStore.CreateCluster(cluster, nil)
+	require.NoError(t, err)
+
+	clusterInstallation := &model.ClusterInstallation{InstallationID: installation.ID, ClusterID: cluster.ID}
+	err = sqlStore.CreateClusterInstallation(clusterInstallation)
+	require.NoError(t, err)
+
+	backup := &model.InstallationBackup{
+		InstallationID: installation.ID,
+		State:          model.InstallationBackupStateBackupSucceeded,
+	}
+	err = sqlStore.CreateInstallationBackup(backup)
+	require.NoError(t, err)
+
+	return installation, clusterInstallation, backup
+}

--- a/model/webhook.go
+++ b/model/webhook.go
@@ -19,6 +19,10 @@ const (
 	TypeClusterInstallation = "cluster_installaton"
 	// TypeInstallationBackup is the string value that represents an installation backup.
 	TypeInstallationBackup = "installation_backup"
+	// TypeInstallationDBRestoration is the string value that represents an installation db restoration operation.
+	TypeInstallationDBRestoration = "installation_db_restoration_operation"
+	// TypeInstallationDBMigration is the string value that represents an installation db migration operation.
+	TypeInstallationDBMigration = "installation_db_migration_operation"
 )
 
 // Webhook is


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Another PR for Installation database migration and restoration story, this PR introduces:
- New installation restoration supervisor which operates based on `InstallationDBRestorationOperation`.
- Some refactoring for backup supervisor - extracting common functionalities to helper functions.
- New flag enabling the supervisor. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add installation restoration supervisor
```
