### PR TITLE
Add installation database migration model and store

### DIFF
--- a/internal/store/installation_db_migration.go
+++ b/internal/store/installation_db_migration.go
@@ -87,7 +87,7 @@ func (r *rawDBMigrationOperations) toDBMigrationOperations() ([]*model.Installat
 }
 
 // TODO: we should probably create some intermediary layer to not keep this logic in store.
-// For now tho transactions are not accessible outside the store, therefore it is implemented this way.
+// For now though transactions are not accessible outside the store, therefore it is implemented this way.
 
 // TriggerInstallationDBMigration creates new InstallationDBMigrationOperation in Requested state
 // and changes installation state to InstallationStateDBMigrationInProgress.

--- a/internal/store/installation_db_migration.go
+++ b/internal/store/installation_db_migration.go
@@ -1,0 +1,305 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+const (
+	installationDBMigrationTable = "InstallationDBMigrationOperation"
+)
+
+var installationDBMigrationSelect sq.SelectBuilder
+
+func init() {
+	installationDBMigrationSelect = sq.
+		Select("ID",
+			"InstallationID",
+			"RequestAt",
+			"State",
+			"SourceDatabase",
+			"DestinationDatabase",
+			"SourceMultiTenantRaw",
+			"DestinationMultiTenantRaw",
+			"BackupID",
+			"InstallationDBRestorationOperationID",
+			"CompleteAt",
+			"DeleteAt",
+			"LockAcquiredBy",
+			"LockAcquiredAt",
+		).
+		From(installationDBMigrationTable)
+}
+
+type rawDBMigrationOperation struct {
+	*model.InstallationDBMigrationOperation
+	SourceMultiTenantRaw      []byte
+	DestinationMultiTenantRaw []byte
+}
+
+type rawDBMigrationOperations []*rawDBMigrationOperation
+
+func (r *rawDBMigrationOperation) toDBMigrationOperation() (*model.InstallationDBMigrationOperation, error) {
+	// We only need to set values that are converted from a raw database format.
+	var err error
+	if len(r.SourceMultiTenantRaw) > 0 {
+		data := model.MultiTenantDBMigrationData{}
+		err = json.Unmarshal(r.SourceMultiTenantRaw, &data)
+		if err != nil {
+			return nil, err
+		}
+		r.InstallationDBMigrationOperation.SourceMultiTenant = &data
+	}
+	if len(r.DestinationMultiTenantRaw) > 0 {
+		data := model.MultiTenantDBMigrationData{}
+		err = json.Unmarshal(r.DestinationMultiTenantRaw, &data)
+		if err != nil {
+			return nil, err
+		}
+		r.InstallationDBMigrationOperation.DestinationMultiTenant = &data
+	}
+
+	return r.InstallationDBMigrationOperation, nil
+}
+
+func (r *rawDBMigrationOperations) toDBMigrationOperations() ([]*model.InstallationDBMigrationOperation, error) {
+	if r == nil {
+		return []*model.InstallationDBMigrationOperation{}, nil
+	}
+	migrationOperations := make([]*model.InstallationDBMigrationOperation, 0, len(*r))
+
+	for _, raw := range *r {
+		operation, err := raw.toDBMigrationOperation()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create migration operation from raw")
+		}
+		migrationOperations = append(migrationOperations, operation)
+	}
+	return migrationOperations, nil
+}
+
+// TODO: we should probably create some intermediary layer to not keep this logic in store.
+// For now tho transactions are not accessible outside the store, therefore it is implemented this way.
+
+// TriggerInstallationDBMigration creates new InstallationDBMigrationOperation in Requested state
+// and changes installation state to InstallationStateDBMigrationInProgress.
+func (sqlStore *SQLStore) TriggerInstallationDBMigration(dbMigrationOp *model.InstallationDBMigrationOperation, installation *model.Installation) (*model.InstallationDBMigrationOperation, error) {
+	dbMigrationOp.InstallationID = installation.ID
+	dbMigrationOp.State = model.InstallationDBMigrationStateRequested
+	dbMigrationOp.InstallationDBRestorationOperationID = ""
+
+	tx, err := sqlStore.beginTransaction(sqlStore.db)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to start transaction")
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	err = sqlStore.createInstallationDBMigration(tx, dbMigrationOp)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create installation db migration")
+	}
+
+	installation.State = model.InstallationStateDBMigrationInProgress
+	err = sqlStore.updateInstallation(tx, installation)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update installation")
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to commit transaction")
+	}
+
+	return dbMigrationOp, nil
+}
+
+// CreateInstallationDBMigrationOperation records installation db migration to the database, assigning it a unique ID.
+func (sqlStore *SQLStore) CreateInstallationDBMigrationOperation(dbMigration *model.InstallationDBMigrationOperation) error {
+	return sqlStore.createInstallationDBMigration(sqlStore.db, dbMigration)
+}
+
+// createInstallationDBMigration records installation db migration to the database, assigning it a unique ID.
+func (sqlStore *SQLStore) createInstallationDBMigration(db execer, dbMigration *model.InstallationDBMigrationOperation) error {
+	dbMigration.ID = model.NewID()
+	dbMigration.RequestAt = GetMillis()
+
+	insertMap := map[string]interface{}{
+		"ID":                                   dbMigration.ID,
+		"InstallationID":                       dbMigration.InstallationID,
+		"RequestAt":                            dbMigration.RequestAt,
+		"State":                                dbMigration.State,
+		"SourceDatabase":                       dbMigration.SourceDatabase,
+		"DestinationDatabase":                  dbMigration.DestinationDatabase,
+		"BackupID":                             dbMigration.BackupID,
+		"InstallationDBRestorationOperationID": dbMigration.InstallationDBRestorationOperationID,
+		"CompleteAt":                           dbMigration.CompleteAt,
+		"DeleteAt":                             0,
+		"LockAcquiredBy":                       dbMigration.LockAcquiredBy,
+		"LockAcquiredAt":                       dbMigration.LockAcquiredAt,
+	}
+
+	if dbMigration.SourceMultiTenant != nil {
+		multiTenantSourceRaw, err := json.Marshal(dbMigration.SourceMultiTenant)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal source multi tenant db")
+		}
+		insertMap["SourceMultiTenantRaw"] = multiTenantSourceRaw
+	}
+	if dbMigration.DestinationMultiTenant != nil {
+		multiTenantDestinationRaw, err := json.Marshal(dbMigration.DestinationMultiTenant)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal destination multi tenant db")
+		}
+		insertMap["DestinationMultiTenantRaw"] = multiTenantDestinationRaw
+	}
+
+	_, err := sqlStore.execBuilder(db, sq.
+		Insert(installationDBMigrationTable).
+		SetMap(insertMap),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to create installation db migration operation")
+	}
+
+	return nil
+}
+
+// GetInstallationDBMigrationOperation fetches the given installation db migration.
+func (sqlStore *SQLStore) GetInstallationDBMigrationOperation(id string) (*model.InstallationDBMigrationOperation, error) {
+	builder := installationDBMigrationSelect.
+		Where("ID = ?", id)
+
+	var migrationOpRaw rawDBMigrationOperation
+	err := sqlStore.getBuilder(sqlStore.db, &migrationOpRaw, builder)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Wrap(err, "failed to query for installation db migration")
+	}
+
+	migrationOp, err := migrationOpRaw.toDBMigrationOperation()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create migration operation from raw")
+	}
+
+	return migrationOp, nil
+}
+
+// GetInstallationDBMigrationOperations fetches the given page of created installation db migration. The first page is 0.
+func (sqlStore *SQLStore) GetInstallationDBMigrationOperations(filter *model.InstallationDBMigrationFilter) ([]*model.InstallationDBMigrationOperation, error) {
+	builder := installationDBMigrationSelect.
+		OrderBy("RequestAt DESC")
+	builder = sqlStore.applyInstallationDBMigrationFilter(builder, filter)
+
+	return sqlStore.getInstallationDBMigrationOperations(builder)
+}
+
+// GetUnlockedInstallationDBMigrationOperationsPendingWork returns unlocked installation db migrations in a pending state.
+func (sqlStore *SQLStore) GetUnlockedInstallationDBMigrationOperationsPendingWork() ([]*model.InstallationDBMigrationOperation, error) {
+	builder := installationDBMigrationSelect.
+		Where(sq.Eq{
+			"State": model.AllInstallationDBMigrationOperationsStatesPendingWork,
+		}).
+		Where("LockAcquiredAt = 0").
+		OrderBy("RequestAt ASC")
+
+	return sqlStore.getInstallationDBMigrationOperations(builder)
+}
+
+func (sqlStore *SQLStore) getInstallationDBMigrationOperations(builder builder) ([]*model.InstallationDBMigrationOperation, error) {
+	var rawMigrationOps rawDBMigrationOperations
+	err := sqlStore.selectBuilder(sqlStore.db, &rawMigrationOps, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query for installation db migrations")
+	}
+
+	migrationOps, err := rawMigrationOps.toDBMigrationOperations()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create migration operations from raw")
+	}
+
+	return migrationOps, nil
+}
+
+// UpdateInstallationDBMigrationOperationState updates the given installation db migration state.
+func (sqlStore *SQLStore) UpdateInstallationDBMigrationOperationState(dbMigration *model.InstallationDBMigrationOperation) error {
+	return sqlStore.updateInstallationDBMigrationFields(
+		sqlStore.db,
+		dbMigration.ID, map[string]interface{}{
+			"State": dbMigration.State,
+		})
+}
+
+// UpdateInstallationDBMigrationOperation updates the given installation db migration.
+func (sqlStore *SQLStore) UpdateInstallationDBMigrationOperation(dbMigration *model.InstallationDBMigrationOperation) error {
+	return sqlStore.updateInstallationDBMigration(sqlStore.db, dbMigration)
+}
+
+func (sqlStore *SQLStore) updateInstallationDBMigration(db execer, dbMigration *model.InstallationDBMigrationOperation) error {
+	return sqlStore.updateInstallationDBMigrationFields(
+		db,
+		dbMigration.ID, map[string]interface{}{
+			"State":                                dbMigration.State,
+			"BackupID":                             dbMigration.BackupID,
+			"InstallationDBRestorationOperationID": dbMigration.InstallationDBRestorationOperationID,
+			"CompleteAt":                           dbMigration.CompleteAt,
+		})
+}
+
+func (sqlStore *SQLStore) updateInstallationDBMigrationFields(db execer, id string, fields map[string]interface{}) error {
+	_, err := sqlStore.execBuilder(db, sq.
+		Update(installationDBMigrationTable).
+		SetMap(fields).
+		Where("ID = ?", id))
+	if err != nil {
+		return errors.Wrapf(err, "failed to update installation db migration fields: %s", getMapKeys(fields))
+	}
+
+	return nil
+}
+
+// LockInstallationDBMigrationOperation marks the InstallationDBMigrationOperation as locked for exclusive use by the caller.
+func (sqlStore *SQLStore) LockInstallationDBMigrationOperation(id, lockerID string) (bool, error) {
+	return sqlStore.lockRows(installationDBMigrationTable, []string{id}, lockerID)
+}
+
+// LockInstallationDBMigrationOperations marks InstallationDBMigrationOperation as locked for exclusive use by the caller.
+func (sqlStore *SQLStore) LockInstallationDBMigrationOperations(ids []string, lockerID string) (bool, error) {
+	return sqlStore.lockRows(installationDBMigrationTable, ids, lockerID)
+}
+
+// UnlockInstallationDBMigrationOperation releases a lock previously acquired against a caller.
+func (sqlStore *SQLStore) UnlockInstallationDBMigrationOperation(id, lockerID string, force bool) (bool, error) {
+	return sqlStore.unlockRows(installationDBMigrationTable, []string{id}, lockerID, force)
+}
+
+// UnlockInstallationDBMigrationOperations releases a locks previously acquired against a caller.
+func (sqlStore *SQLStore) UnlockInstallationDBMigrationOperations(ids []string, lockerID string, force bool) (bool, error) {
+	return sqlStore.unlockRows(installationDBMigrationTable, ids, lockerID, force)
+}
+
+func (sqlStore *SQLStore) applyInstallationDBMigrationFilter(builder sq.SelectBuilder, filter *model.InstallationDBMigrationFilter) sq.SelectBuilder {
+	builder = applyPagingFilter(builder, filter.Paging)
+
+	if len(filter.IDs) > 0 {
+		builder = builder.Where(sq.Eq{"ID": filter.IDs})
+	}
+	if filter.InstallationID != "" {
+		builder = builder.Where("InstallationID = ?", filter.InstallationID)
+	}
+	if len(filter.States) > 0 {
+		builder = builder.Where(sq.Eq{
+			"State": filter.States,
+		})
+	}
+
+	return builder
+}

--- a/internal/store/installation_db_migration_test.go
+++ b/internal/store/installation_db_migration_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTriggerInstallationDBMigration(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation := setupHibernatingInstallation(t, sqlStore)
+
+	dbMigrationOp := &model.InstallationDBMigrationOperation{
+		SourceDatabase:      "source",
+		DestinationDatabase: "destination",
+	}
+
+	migrationOp, err := sqlStore.TriggerInstallationDBMigration(dbMigrationOp, installation)
+	require.NoError(t, err)
+	assert.Equal(t, installation.ID, migrationOp.InstallationID)
+	assert.Equal(t, model.InstallationDBMigrationStateRequested, migrationOp.State)
+
+	fetchOp, err := sqlStore.GetInstallationDBMigrationOperation(migrationOp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, migrationOp, fetchOp)
+
+	installation, err = sqlStore.GetInstallation(installation.ID, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, model.InstallationStateDBMigrationInProgress, installation.State)
+}
+
+func TestInstallationDBMigrationOperation(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation := setupHibernatingInstallation(t, sqlStore)
+
+	dbMigrationOp := &model.InstallationDBMigrationOperation{
+		InstallationID:         installation.ID,
+		SourceMultiTenant:      &model.MultiTenantDBMigrationData{DatabaseID: "abcd"},
+		DestinationMultiTenant: &model.MultiTenantDBMigrationData{DatabaseID: "efgh"},
+		SourceDatabase:         model.InstallationDatabaseMultiTenantRDSPostgres,
+		DestinationDatabase:    model.InstallationDatabaseMultiTenantRDSPostgres,
+		BackupID:               "",
+		RequestAt:              0,
+		State:                  model.InstallationDBMigrationStateRequested,
+	}
+
+	err := sqlStore.CreateInstallationDBMigrationOperation(dbMigrationOp)
+	require.NoError(t, err)
+	assert.NotEmpty(t, dbMigrationOp.ID)
+
+	fetchedRestoration, err := sqlStore.GetInstallationDBMigrationOperation(dbMigrationOp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, dbMigrationOp, fetchedRestoration)
+
+	t.Run("unknown restoration", func(t *testing.T) {
+		fetchedRestoration, err = sqlStore.GetInstallationDBMigrationOperation("unknown")
+		require.NoError(t, err)
+		assert.Nil(t, fetchedRestoration)
+	})
+}
+
+func TestGetInstallationDBMigrations(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation1 := setupHibernatingInstallation(t, sqlStore)
+	installation2 := setupHibernatingInstallation(t, sqlStore)
+
+	dbMigrations := []*model.InstallationDBMigrationOperation{
+		{InstallationID: installation1.ID, State: model.InstallationDBMigrationStateRequested},
+		{InstallationID: installation1.ID, State: model.InstallationDBMigrationStateBackupInProgress},
+		{InstallationID: installation1.ID, State: model.InstallationDBMigrationStateFailed},
+		{InstallationID: installation2.ID, State: model.InstallationDBMigrationStateRequested},
+		{InstallationID: installation2.ID, State: model.InstallationDBMigrationStateBackupInProgress},
+	}
+
+	for i := range dbMigrations {
+		err := sqlStore.CreateInstallationDBMigrationOperation(dbMigrations[i])
+		require.NoError(t, err)
+		time.Sleep(1 * time.Millisecond) // Ensure RequestAt is different for all installations.
+	}
+
+	for _, testCase := range []struct {
+		description string
+		filter      *model.InstallationDBMigrationFilter
+		fetchedIds  []string
+	}{
+		{
+			description: "fetch all",
+			filter:      &model.InstallationDBMigrationFilter{Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{dbMigrations[4].ID, dbMigrations[3].ID, dbMigrations[2].ID, dbMigrations[1].ID, dbMigrations[0].ID},
+		},
+		{
+			description: "fetch all for installation 1",
+			filter:      &model.InstallationDBMigrationFilter{InstallationID: installation1.ID, Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{dbMigrations[2].ID, dbMigrations[1].ID, dbMigrations[0].ID},
+		},
+		{
+			description: "fetch requested operations",
+			filter:      &model.InstallationDBMigrationFilter{States: []model.InstallationDBMigrationOperationState{model.InstallationDBMigrationStateRequested}, Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{dbMigrations[3].ID, dbMigrations[0].ID},
+		},
+		{
+			description: "fetch with IDs",
+			filter:      &model.InstallationDBMigrationFilter{IDs: []string{dbMigrations[0].ID, dbMigrations[3].ID, dbMigrations[4].ID}, Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{dbMigrations[4].ID, dbMigrations[3].ID, dbMigrations[0].ID},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			fetchedBackups, err := sqlStore.GetInstallationDBMigrationOperations(testCase.filter)
+			require.NoError(t, err)
+			assert.Equal(t, len(testCase.fetchedIds), len(fetchedBackups))
+
+			for i, b := range fetchedBackups {
+				assert.Equal(t, testCase.fetchedIds[i], b.ID)
+			}
+		})
+	}
+}
+
+func TestGetUnlockedInstallationDBRMigrationsPendingWork(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation := setupHibernatingInstallation(t, sqlStore)
+
+	dbMigration1 := &model.InstallationDBMigrationOperation{
+		InstallationID: installation.ID,
+		State:          model.InstallationDBMigrationStateRequested,
+	}
+
+	err := sqlStore.CreateInstallationDBMigrationOperation(dbMigration1)
+	require.NoError(t, err)
+	assert.NotEmpty(t, dbMigration1.ID)
+
+	dbMigration2 := &model.InstallationDBMigrationOperation{
+		InstallationID: installation.ID,
+		State:          model.InstallationDBMigrationStateSucceeded,
+	}
+
+	err = sqlStore.CreateInstallationDBMigrationOperation(dbMigration2)
+	require.NoError(t, err)
+	assert.NotEmpty(t, dbMigration1.ID)
+
+	backupsMeta, err := sqlStore.GetUnlockedInstallationDBMigrationOperationsPendingWork()
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(backupsMeta))
+	assert.Equal(t, dbMigration1.ID, backupsMeta[0].ID)
+
+	locaked, err := sqlStore.LockInstallationDBMigrationOperation(dbMigration1.ID, "abc")
+	require.NoError(t, err)
+	assert.True(t, locaked)
+
+	backupsMeta, err = sqlStore.GetUnlockedInstallationDBMigrationOperationsPendingWork()
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(backupsMeta))
+}
+
+func TestUpdateInstallationDBMigration(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	installation := setupHibernatingInstallation(t, sqlStore)
+
+	dbMigration := &model.InstallationDBMigrationOperation{
+		InstallationID: installation.ID,
+		State:          model.InstallationDBMigrationStateRequested,
+	}
+
+	err := sqlStore.CreateInstallationDBMigrationOperation(dbMigration)
+	require.NoError(t, err)
+	assert.NotEmpty(t, dbMigration.ID)
+
+	t.Run("update state only", func(t *testing.T) {
+		dbMigration.State = model.InstallationDBMigrationStateSucceeded
+		dbMigration.CompleteAt = -1
+		dbMigration.InstallationDBRestorationOperationID = "test"
+
+		err = sqlStore.UpdateInstallationDBMigrationOperationState(dbMigration)
+		require.NoError(t, err)
+
+		fetched, err := sqlStore.GetInstallationDBMigrationOperation(dbMigration.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationDBMigrationStateSucceeded, fetched.State)
+		assert.Equal(t, int64(0), fetched.CompleteAt)                     // Assert complete time not updated
+		assert.Equal(t, "", fetched.InstallationDBRestorationOperationID) // Assert ID not updated
+	})
+
+	t.Run("full update", func(t *testing.T) {
+		dbMigration.InstallationDBRestorationOperationID = "test"
+		dbMigration.CompleteAt = 100
+		dbMigration.State = model.InstallationDBMigrationStateFailed
+		err = sqlStore.UpdateInstallationDBMigrationOperation(dbMigration)
+		require.NoError(t, err)
+
+		fetched, err := sqlStore.GetInstallationDBMigrationOperation(dbMigration.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationDBMigrationStateFailed, fetched.State)
+		assert.Equal(t, "test", fetched.InstallationDBRestorationOperationID)
+		assert.Equal(t, int64(100), fetched.CompleteAt)
+	})
+}

--- a/internal/store/multitenant_database_test.go
+++ b/internal/store/multitenant_database_test.go
@@ -72,6 +72,8 @@ func (s *TestMultitenantDatabaseSuite) SetupTest() {
 	s.database1.Installations = model.MultitenantDatabaseInstallations{s.installationID0, s.installationID1}
 	s.database2.Installations = model.MultitenantDatabaseInstallations{s.installationID2, s.installationID3, s.installationID4}
 
+	s.database1.MigratedInstallations = model.MultitenantDatabaseInstallations{s.installationID4}
+
 	err := s.sqlStore.CreateMultitenantDatabase(s.database1)
 	s.Assert().NoError(err)
 
@@ -201,6 +203,17 @@ func (s *TestMultitenantDatabaseSuite) TestGetMultitenantDatabase() {
 	})
 	s.Assert().NoError(err)
 	s.Assert().Equal(0, len(databases))
+}
+
+func (s *TestMultitenantDatabaseSuite) TestGetMultitenantDatabaseForMigratedInstallationID() {
+	database, err := s.sqlStore.GetMultitenantDatabases(&model.MultitenantDatabaseFilter{
+		Paging:                 model.AllPagesNotDeleted(),
+		MigratedInstallationID: s.installationID4,
+		MaxInstallationsLimit:  model.NoInstallationsLimit,
+	})
+	s.Assert().NoError(err)
+	s.Assert().Len(database, 1)
+	s.Assert().Equal(s.database1.ID, database[0].ID)
 }
 
 func (s *TestMultitenantDatabaseSuite) TestUpdate() {

--- a/internal/store/util.go
+++ b/internal/store/util.go
@@ -5,9 +5,10 @@
 package store
 
 import (
+	"time"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-cloud/model"
-	"time"
 )
 
 // GetMillis is a convenience method to get milliseconds since epoch.

--- a/model/installation_db_migration_operation.go
+++ b/model/installation_db_migration_operation.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// InstallationDBMigrationOperation contains information about installation's database migration operation.
+type InstallationDBMigrationOperation struct {
+	ID             string
+	InstallationID string
+	RequestAt      int64
+	State          InstallationDBMigrationOperationState
+	// SourceDatabase is current Installation database.
+	SourceDatabase string
+	// DestinationDatabase is database type to which migration will be performed.
+	DestinationDatabase string
+	// For now only supported migration is from multi-tenant DB to multi-tenant DB.
+	SourceMultiTenant                    *MultiTenantDBMigrationData `json:"SourceMultiTenant,omitempty"`
+	DestinationMultiTenant               *MultiTenantDBMigrationData `json:"DestinationMultiTenant,omitempty"`
+	BackupID                             string
+	InstallationDBRestorationOperationID string
+	CompleteAt                           int64
+	DeleteAt                             int64
+	LockAcquiredBy                       *string
+	LockAcquiredAt                       int64
+}
+
+// MultiTenantDBMigrationData represents migration data for Multi-tenant database.
+type MultiTenantDBMigrationData struct {
+	DatabaseID string
+}
+
+// InstallationDBMigrationOperationState represents the state of db migration operation.
+type InstallationDBMigrationOperationState string
+
+const (
+	// InstallationDBMigrationStateRequested is requested DB migration operation.
+	InstallationDBMigrationStateRequested InstallationDBMigrationOperationState = "installation-db-migration-requested"
+	// InstallationDBMigrationStateBackupInProgress is DB migration operation waiting for backup to complete.
+	InstallationDBMigrationStateBackupInProgress InstallationDBMigrationOperationState = "installation-db-migration-installation-backup-in-progress"
+	// InstallationDBMigrationStateDatabaseSwitch is DB migration operation that is switching to new database.
+	InstallationDBMigrationStateDatabaseSwitch InstallationDBMigrationOperationState = "installation-db-migration-database switch"
+	// InstallationDBMigrationStateRefreshSecrets is DB migration operation that is refreshing secrets.
+	InstallationDBMigrationStateRefreshSecrets InstallationDBMigrationOperationState = "installation-db-migration-refresh-secrets"
+	// InstallationDBMigrationStateTriggerRestoration is DB migration operation that is triggering database restoration.
+	InstallationDBMigrationStateTriggerRestoration InstallationDBMigrationOperationState = "installation-db-migration-trigger-restoration"
+	// InstallationDBMigrationStateRestorationInProgress is DB migration operation that is waiting for restoration to complete.
+	InstallationDBMigrationStateRestorationInProgress InstallationDBMigrationOperationState = "installation-db-migration-restoration-in-progress"
+	// InstallationDBMigrationStateUpdatingInstallationConfig is DB migration operation that is updating Installation configuration.
+	InstallationDBMigrationStateUpdatingInstallationConfig InstallationDBMigrationOperationState = "installation-db-migration-updating-installation-config"
+	// InstallationDBMigrationStateFinalizing is DB migration operation that is finalizing the migration.
+	InstallationDBMigrationStateFinalizing InstallationDBMigrationOperationState = "installation-db-migration-finalizing"
+	// InstallationDBMigrationStateFailing is DB migration operation that is failing.
+	InstallationDBMigrationStateFailing InstallationDBMigrationOperationState = "installation-db-migration-failing"
+	// InstallationDBMigrationStateSucceeded is DB migration operation that finished with success.
+	InstallationDBMigrationStateSucceeded InstallationDBMigrationOperationState = "installation-db-migration-succeeded"
+	// InstallationDBMigrationStateFailed is DB migration operation that failed.
+	InstallationDBMigrationStateFailed InstallationDBMigrationOperationState = "installation-db-migration-failed"
+)
+
+// AllInstallationDBMigrationOperationsStatesPendingWork is a list of all db migration operations states
+// that the supervisor will attempt to transition towards stable on the next "tick".
+var AllInstallationDBMigrationOperationsStatesPendingWork = []InstallationDBMigrationOperationState{
+	InstallationDBMigrationStateRequested,
+	InstallationDBMigrationStateBackupInProgress,
+	InstallationDBMigrationStateDatabaseSwitch,
+	InstallationDBMigrationStateRefreshSecrets,
+	InstallationDBMigrationStateTriggerRestoration,
+	InstallationDBMigrationStateRestorationInProgress,
+	InstallationDBMigrationStateUpdatingInstallationConfig,
+	InstallationDBMigrationStateFinalizing,
+	InstallationDBMigrationStateFailing,
+}
+
+// InstallationDBMigrationFilter describes the parameters used to constrain a set of installation db migration operations.
+type InstallationDBMigrationFilter struct {
+	Paging
+	IDs            []string
+	InstallationID string
+	States         []InstallationDBMigrationOperationState
+}
+
+// NewDBMigrationOperationFromReader will create a InstallationDBMigrationOperation from an
+// io.Reader with JSON data.
+func NewDBMigrationOperationFromReader(reader io.Reader) (*InstallationDBMigrationOperation, error) {
+	var dBMigrationOperation InstallationDBMigrationOperation
+	err := json.NewDecoder(reader).Decode(&dBMigrationOperation)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode InstallationDBMigrationOperation")
+	}
+
+	return &dBMigrationOperation, nil
+}
+
+// NewDBMigrationOperationsFromReader will create a slice of DBMigrationOperations from an
+// io.Reader with JSON data.
+func NewDBMigrationOperationsFromReader(reader io.Reader) ([]*InstallationDBMigrationOperation, error) {
+	dBMigrationOperations := []*InstallationDBMigrationOperation{}
+	err := json.NewDecoder(reader).Decode(&dBMigrationOperations)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode DBMigrationOperations")
+	}
+
+	return dBMigrationOperations, nil
+}

--- a/model/installation_db_migration_operation_test.go
+++ b/model/installation_db_migration_operation_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDBMigrationOperationFromReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		dBMigrationOperation, err := NewDBMigrationOperationFromReader(bytes.NewReader([]byte(
+			"",
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &InstallationDBMigrationOperation{}, dBMigrationOperation)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		dBMigrationOperation, err := NewDBMigrationOperationFromReader(bytes.NewReader([]byte(
+			"{test",
+		)))
+		require.Error(t, err)
+		require.Nil(t, dBMigrationOperation)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		dBMigrationOperation, err := NewDBMigrationOperationFromReader(bytes.NewReader([]byte(
+			`{"ID":"id", "InstallationID": "installation", "RequestAt": 10, "State": "installation-db-migration-requested"}`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &InstallationDBMigrationOperation{
+			ID:             "id",
+			InstallationID: "installation",
+			RequestAt:      10,
+			State:          InstallationDBMigrationStateRequested,
+		}, dBMigrationOperation)
+	})
+}
+
+func TestNewDBMigrationOperationsFromReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		dBMigrationOperations, err := NewDBMigrationOperationsFromReader(bytes.NewReader([]byte(
+			"",
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*InstallationDBMigrationOperation{}, dBMigrationOperations)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		dBMigrationOperations, err := NewDBMigrationOperationsFromReader(bytes.NewReader([]byte(
+			"{test",
+		)))
+		require.Error(t, err)
+		require.Nil(t, dBMigrationOperations)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		dBMigrationOperations, err := NewDBMigrationOperationsFromReader(bytes.NewReader([]byte(
+			`[
+	{"ID":"id", "InstallationID": "installation", "RequestAt": 10, "State": "installation-db-migration-requested"},
+	{"ID":"id2", "InstallationID": "installation2", "RequestAt": 20, "State": "installation-db-migration-requested"}
+]`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*InstallationDBMigrationOperation{
+			{
+				ID:             "id",
+				InstallationID: "installation",
+				RequestAt:      10,
+				State:          InstallationDBMigrationStateRequested,
+			},
+			{
+				ID:             "id2",
+				InstallationID: "installation2",
+				RequestAt:      20,
+				State:          InstallationDBMigrationStateRequested,
+			},
+		}, dBMigrationOperations)
+	})
+}

--- a/model/installation_db_migration_request.go
+++ b/model/installation_db_migration_request.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+// InstallationDBMigrationRequest represent request for installation database migration.
+type InstallationDBMigrationRequest struct {
+	InstallationID string
+
+	DestinationDatabase string
+
+	DestinationMultiTenant *MultiTenantDBMigrationData `json:"DestinationMultiTenant,omitempty"`
+}
+
+// NewInstallationDBMigrationRequestFromReader will create a InstallationDBMigrationRequest from an
+// io.Reader with JSON data.
+func NewInstallationDBMigrationRequestFromReader(reader io.Reader) (*InstallationDBMigrationRequest, error) {
+	var installationDBMigrationRequest InstallationDBMigrationRequest
+	err := json.NewDecoder(reader).Decode(&installationDBMigrationRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode InstallationDBMigrationRequest")
+	}
+
+	return &installationDBMigrationRequest, nil
+}
+
+// GetInstallationDBMigrationOperationsRequest describes the parameters to request
+// a list of installation db migration operations.
+type GetInstallationDBMigrationOperationsRequest struct {
+	Paging
+	InstallationID        string
+	ClusterInstallationID string
+	State                 string
+}
+
+// ApplyToURL modifies the given url to include query string parameters for the request.
+func (request *GetInstallationDBMigrationOperationsRequest) ApplyToURL(u *url.URL) {
+	q := u.Query()
+	q.Add("installation", request.InstallationID)
+	q.Add("cluster_installation", request.ClusterInstallationID)
+	q.Add("state", request.State)
+	request.Paging.AddToQuery(q)
+
+	u.RawQuery = q.Encode()
+}

--- a/model/installation_db_migration_request_test.go
+++ b/model/installation_db_migration_request_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInstallationDBMigrationRequestFromReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		installationDBMigrationRequest, err := NewInstallationDBMigrationRequestFromReader(bytes.NewReader([]byte(
+			"",
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &InstallationDBMigrationRequest{}, installationDBMigrationRequest)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		installationDBMigrationRequest, err := NewInstallationDBMigrationRequestFromReader(bytes.NewReader([]byte(
+			"{test",
+		)))
+		require.Error(t, err)
+		require.Nil(t, installationDBMigrationRequest)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		installationDBMigrationRequest, err := NewInstallationDBMigrationRequestFromReader(bytes.NewReader([]byte(
+			`{"InstallationID": "installation", "DestinationDatabase":"pg", "DestinationMultiTenant": {"DatabaseID":"db"}}`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &InstallationDBMigrationRequest{
+			InstallationID:         "installation",
+			DestinationDatabase:    "pg",
+			DestinationMultiTenant: &MultiTenantDBMigrationData{DatabaseID: "db"},
+		}, installationDBMigrationRequest)
+	})
+}

--- a/model/installation_db_restoration_operation.go
+++ b/model/installation_db_restoration_operation.go
@@ -28,7 +28,7 @@ type InstallationDBRestorationOperation struct {
 	LockAcquiredAt          int64
 }
 
-// InstallationDBRestorationState represents the state of backup.
+// InstallationDBRestorationState represents the state of db restoration operation.
 type InstallationDBRestorationState string
 
 const (

--- a/model/multitenant_database.go
+++ b/model/multitenant_database.go
@@ -12,14 +12,15 @@ import (
 // MultitenantDatabase represents database infrastructure that contains multiple
 // installation databases.
 type MultitenantDatabase struct {
-	ID             string
-	VpcID          string
-	DatabaseType   string
-	Installations  MultitenantDatabaseInstallations
-	CreateAt       int64
-	DeleteAt       int64
-	LockAcquiredBy *string
-	LockAcquiredAt int64
+	ID                    string
+	VpcID                 string
+	DatabaseType          string
+	Installations         MultitenantDatabaseInstallations
+	MigratedInstallations MultitenantDatabaseInstallations
+	CreateAt              int64
+	DeleteAt              int64
+	LockAcquiredBy        *string
+	LockAcquiredAt        int64
 }
 
 // MultitenantDatabaseInstallations is the list of installation IDs that belong
@@ -60,11 +61,12 @@ func (i *MultitenantDatabaseInstallations) Remove(installationID string) {
 // installation's limit.
 type MultitenantDatabaseFilter struct {
 	Paging
-	LockerID              string
-	InstallationID        string
-	VpcID                 string
-	DatabaseType          string
-	MaxInstallationsLimit int
+	LockerID               string
+	InstallationID         string
+	MigratedInstallationID string
+	VpcID                  string
+	DatabaseType           string
+	MaxInstallationsLimit  int
 }
 
 // MultitenantDatabasesFromReader decodes a json-encoded list of multitenant databases from the given io.Reader.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Another PR for Installation restoration and migration story. This PR introduces:
- Model for `InstallationDBMigrationOperation`.
- Store methods for new model.
- Adds `MigratedInstallations` to `MultitenantDatabase` - The new field will store installations migrated from this database until the logical database still exists on this DB cluster.
- Adds store method to `InstallationBackup` verifying if backup is used by any operation.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add installation database migration model and store
```
