### PR TITLE
Correct the type of the JSON line number returned by Mattermost while checking Import Jobs

### DIFF
--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -81,7 +81,7 @@ type jobResponse struct {
 
 type jobResponseData struct {
 	Error      string `json:"error"`
-	LineNumber int    `json:"line_number"`
+	LineNumber string `json:"line_number"`
 	ImportFile string `json:"import_file"`
 }
 
@@ -374,8 +374,8 @@ func (s *ImportSupervisor) waitForImportToComplete(mmctl *mmctl, mattermostJobID
 		}
 		if resp.Status == "error" {
 			errorString := fmt.Sprintf("import job failed with error %s", resp.Error)
-			if resp.LineNumber != 0 {
-				errorString = fmt.Sprintf("%s on line %d", errorString, resp.LineNumber)
+			if resp.LineNumber != "" {
+				errorString = fmt.Sprintf("%s on line %s", errorString, resp.LineNumber)
 			}
 			if resp.ImportFile != "" {
 				errorString = fmt.Sprintf("%s in JSONL file from %s", errorString, resp.ImportFile)

--- a/internal/supervisor/import_test.go
+++ b/internal/supervisor/import_test.go
@@ -244,7 +244,7 @@ func (m *mockImportProvisioner) ExecClusterInstallationCLI(cluster *model.Cluste
 								"progress": 0,
 								"data": {
 										"error": "FUBAR",
-										"line_number": 70,
+										"line_number": "70",
 										"import_file": "some-import-file.zip"
 								}
 						}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
I missed this in testing PR #439 , I apologize. I should've caught this before merging. Mattermost returns a Job object that sometimes contains a LineNumber field and I encoded the incorrect type (an int, when it should be a string) into the struct it's unmarshalled into, and into the test.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

No ticket, just caught this while doing some testing that I probably should've done before merging PR #439 :/

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
