### PR TITLE
Fix nil VPC ID value references

### DIFF
--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -384,18 +384,18 @@ func (mr *MockAWSMockRecorder) GetMultitenantBucketNameForInstallation(installat
 }
 
 // GenerateBifrostUtilitySecret mocks base method
-func (m *MockAWS) GenerateBifrostUtilitySecret(clusterID, vpc string, logger logrus.FieldLogger) (*v1.Secret, error) {
+func (m *MockAWS) GenerateBifrostUtilitySecret(clusterID string, logger logrus.FieldLogger) (*v1.Secret, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateBifrostUtilitySecret", clusterID, vpc, logger)
+	ret := m.ctrl.Call(m, "GenerateBifrostUtilitySecret", clusterID, logger)
 	ret0, _ := ret[0].(*v1.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateBifrostUtilitySecret indicates an expected call of GenerateBifrostUtilitySecret
-func (mr *MockAWSMockRecorder) GenerateBifrostUtilitySecret(clusterID, vpc, logger interface{}) *gomock.Call {
+func (mr *MockAWSMockRecorder) GenerateBifrostUtilitySecret(clusterID, logger interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateBifrostUtilitySecret", reflect.TypeOf((*MockAWS)(nil).GenerateBifrostUtilitySecret), clusterID, vpc, logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateBifrostUtilitySecret", reflect.TypeOf((*MockAWS)(nil).GenerateBifrostUtilitySecret), clusterID, logger)
 }
 
 // GetCIDRByVPCTag mocks base method

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -222,7 +222,7 @@ func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster, aws
 
 	// Start by gathering resources that will be needed later. If any of this
 	// fails then no cluster changes have been made which reduces risk.
-	bifrostSecret, err := awsClient.GenerateBifrostUtilitySecret(cluster.ID, cluster.ProvisionerMetadataKops.ChangeRequest.VPC, logger)
+	bifrostSecret, err := awsClient.GenerateBifrostUtilitySecret(cluster.ID, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate bifrost secret")
 	}

--- a/internal/provisioner/nginx.go
+++ b/internal/provisioner/nginx.go
@@ -118,15 +118,11 @@ func (n *nginx) NewHelmDeployment() (*helmDeployment, error) {
 		return nil, errors.Wrap(err, "failed to retrive the AWS ACM")
 	}
 
-	var clusterResources aws.ClusterResources
-	if n.cluster.ProvisionerMetadataKops.ChangeRequest.VPC != "" {
-		clusterResources, err = n.awsClient.GetVpcResourcesByVpcID(n.cluster.ProvisionerMetadataKops.ChangeRequest.VPC, n.logger)
-	} else {
-		clusterResources, err = n.awsClient.GetVpcResources(n.cluster.ID, n.logger)
-	}
+	clusterResources, err := n.awsClient.GetVpcResources(n.cluster.ID, n.logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to retrive the VPC information")
 	}
+
 	return &helmDeployment{
 		chartDeploymentName: "nginx",
 		chartName:           "ingress-nginx/ingress-nginx",

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -369,7 +369,7 @@ func (a *mockAWS) SecretsManagerGetIAMAccessKey(installationID string, logger lo
 	return nil, nil
 }
 
-func (a *mockAWS) GenerateBifrostUtilitySecret(clusterID string, vpc string, logger log.FieldLogger) (*corev1.Secret, error) {
+func (a *mockAWS) GenerateBifrostUtilitySecret(clusterID string, logger log.FieldLogger) (*corev1.Secret, error) {
 	return nil, nil
 }
 

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -74,7 +74,7 @@ type AWS interface {
 	S3LargeCopy(srcBucketName, srcKey, destBucketName, destKey *string) error
 	GetMultitenantBucketNameForInstallation(installationID string, store model.InstallationDatabaseStoreInterface) (string, error)
 
-	GenerateBifrostUtilitySecret(clusterID string, vpc string, logger log.FieldLogger) (*corev1.Secret, error)
+	GenerateBifrostUtilitySecret(clusterID string, logger log.FieldLogger) (*corev1.Secret, error)
 	GetCIDRByVPCTag(vpcTagName string, logger log.FieldLogger) (string, error)
 
 	GetVpcResourcesByVpcID(vpcID string, logger log.FieldLogger) (ClusterResources, error)

--- a/internal/tools/aws/filestore_bifrost.go
+++ b/internal/tools/aws/filestore_bifrost.go
@@ -155,8 +155,8 @@ func (f *BifrostFilestore) s3FilestoreProvision(store model.InstallationDatabase
 
 // GenerateBifrostUtilitySecret creates the secret needed by the bifrost service
 // to access the shared S3 bucket for a given cluster.
-func (a *Client) GenerateBifrostUtilitySecret(clusterID string, vpc string, logger log.FieldLogger) (*corev1.Secret, error) {
-	bucketName, err := getMultitenantBucketNameForCluster(clusterID, vpc, a)
+func (a *Client) GenerateBifrostUtilitySecret(clusterID string, logger log.FieldLogger) (*corev1.Secret, error) {
+	bucketName, err := getMultitenantBucketNameForCluster(clusterID, a)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get multitenant bucket name")
 	}

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -174,16 +174,13 @@ func (client *Client) GetMultitenantBucketNameForInstallation(installationID str
 	return bucketName, nil
 }
 
-func getMultitenantBucketNameForCluster(clusterID string, VpcID string, client *Client) (string, error) {
-
-	if VpcID == "" {
-		vpc, err := getVPCForCluster(clusterID, client)
-		if err != nil {
-			return "", errors.Wrap(err, "failed to find cluster VPC")
-		}
-		VpcID = *vpc.VpcId
+func getMultitenantBucketNameForCluster(clusterID string, client *Client) (string, error) {
+	vpc, err := getVPCForCluster(clusterID, client)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to find cluster VPC")
 	}
-	bucketName, err := getMultitenantBucketNameForVPC(VpcID, client)
+
+	bucketName, err := getMultitenantBucketNameForVPC(*vpc.VpcId, client)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get multitenant bucket name for VPC")
 	}
@@ -254,21 +251,26 @@ func getVPCForCluster(clusterID string, client *Client) (*ec2.Vpc, error) {
 			Values: []*string{aws.String(VpcAvailableTagValueFalse)},
 		},
 	})
-	// checking if cluster is secondary
-	if len(vpcs) == 0 {
-		vpcs, err = client.GetVpcsWithFilters([]*ec2.Filter{
-			{
-				Name:   aws.String(VpcAvailableTagKey),
-				Values: []*string{aws.String(VpcAvailableTagValueFalse)},
-			},
-			{
-				Name:   aws.String(VpcSecondaryClusterIDTagKey),
-				Values: []*string{aws.String(clusterID)},
-			},
-		})
-	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to lookup VPC for cluster %s", clusterID)
+		return nil, errors.Wrapf(err, "failed to perform VPC lookup for cluster %s", clusterID)
+	}
+	if len(vpcs) == 1 {
+		return vpcs[0], nil
+	}
+
+	// Proceed to check if this is a secondary cluster.
+	vpcs, err = client.GetVpcsWithFilters([]*ec2.Filter{
+		{
+			Name:   aws.String(VpcSecondaryClusterIDTagKey),
+			Values: []*string{aws.String(clusterID)},
+		},
+		{
+			Name:   aws.String(VpcAvailableTagKey),
+			Values: []*string{aws.String(VpcAvailableTagValueFalse)},
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to perform VPC lookup for secondary cluster %s", clusterID)
 	}
 	if len(vpcs) != 1 {
 		return nil, errors.Errorf("expected 1 VPC for cluster %s, but found %d", clusterID, len(vpcs))


### PR DESCRIPTION
This simplifies the cluster VPC logic a bit and corrects an issue
where a nil value could be referenced during provisioning.

Fixes https://mattermost.atlassian.net/browse/MM-35547

```release-note
Fix nil VPC ID value references
```
