### PR TITLE
Create k8s license secrets with unique names

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -614,13 +614,13 @@ func prepareCILicenseSecret(installation *model.Installation, clusterInstallatio
 	return licenseSecretName, nil
 }
 
+// generateCILicenseName generates a unique license secret name by using a short
+// sha256 hash.
 func generateCILicenseName(installation *model.Installation, clusterInstallation *model.ClusterInstallation) string {
-	sum := fmt.Sprintf("%x", sha256.Sum256([]byte(installation.License)))
-	if len(sum) > 7 {
-		sum = sum[0:6]
-	}
-
-	return fmt.Sprintf("%s-%s-license", makeClusterInstallationName(clusterInstallation), sum)
+	return fmt.Sprintf("%s-%s-license",
+		makeClusterInstallationName(clusterInstallation),
+		fmt.Sprintf("%x", sha256.Sum256([]byte(installation.License))),
+	)
 }
 
 // cleanupOldLicenseSecrets removes an secrets matching the license naming

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -619,7 +619,7 @@ func prepareCILicenseSecret(installation *model.Installation, clusterInstallatio
 func generateCILicenseName(installation *model.Installation, clusterInstallation *model.ClusterInstallation) string {
 	return fmt.Sprintf("%s-%s-license",
 		makeClusterInstallationName(clusterInstallation),
-		fmt.Sprintf("%x", sha256.Sum256([]byte(installation.License))),
+		fmt.Sprintf("%x", sha256.Sum256([]byte(installation.License)))[0:6],
 	)
 }
 

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -237,6 +237,10 @@ func (p *mockInstallationProvisioner) HibernateClusterInstallation(cluster *mode
 	return nil
 }
 
+func (p *mockInstallationProvisioner) DeleteOldClusterInstallationLicenseSecrets(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) error {
+	return nil
+}
+
 func (p *mockInstallationProvisioner) DeleteClusterInstallation(cluster *model.Cluster, installation *model.Installation, clusterInstallation *model.ClusterInstallation) error {
 	return nil
 }


### PR DESCRIPTION
This change results in the provisioner creating license secrets
with unique names based on the installation license secret value.
This allows the operator to know that the mattermost app pods
should be rolled to obtain this new value. This also ensures that
external systems can properly wait for license updates to occur
via provisioner webhooks.

Fixes https://mattermost.atlassian.net/browse/MM-35808

```release-note
Create k8s license secrets with unique names
```
