### PR TITLE
Implement Installation DB restoration API

### DIFF
--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -98,11 +98,6 @@ type Provisioner interface {
 	GetClusterResources(*model.Cluster, bool) (*k8s.ClusterResources, error)
 }
 
-// DBProvider describes the interface required to get database for specific installation and specified type.
-type DBProvider interface {
-	GetDatabase(installationID, dbType string) model.Database
-}
-
 // Context provides the API with all necessary data and interfaces for responding to requests.
 //
 // It is cloned before each request, allowing per-request changes such as logger annotations.
@@ -110,7 +105,6 @@ type Context struct {
 	Store       Store
 	Supervisor  Supervisor
 	Provisioner Provisioner
-	DBProvider  DBProvider
 	RequestID   string
 	Environment string
 	Logger      logrus.FieldLogger
@@ -122,7 +116,6 @@ func (c *Context) Clone() *Context {
 		Store:       c.Store,
 		Supervisor:  c.Supervisor,
 		Provisioner: c.Provisioner,
-		DBProvider:  c.DBProvider,
 		Logger:      c.Logger,
 	}
 }

--- a/internal/api/installation_db_restoration_operation.go
+++ b/internal/api/installation_db_restoration_operation.go
@@ -60,7 +60,7 @@ func handleTriggerInstallationDBRestoration(c *Context, w http.ResponseWriter, r
 	}
 	if backup == nil {
 		c.Logger.Error("Backup not found")
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 

--- a/internal/api/installation_db_restoration_operation.go
+++ b/internal/api/installation_db_restoration_operation.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/common"
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+// initInstallationRestoration registers installation restoration operation endpoints on the given router.
+func initInstallationRestoration(apiRouter *mux.Router, context *Context) {
+	addContext := func(handler contextHandlerFunc) *contextHandler {
+		return newContextHandler(context, handler)
+	}
+
+	restorationsRouter := apiRouter.PathPrefix("/operations/database/restorations").Subrouter()
+
+	restorationsRouter.Handle("", addContext(handleTriggerInstallationDBRestoration)).Methods("POST")
+	restorationsRouter.Handle("", addContext(handleGetInstallationDBRestorationOperations)).Methods("GET")
+
+	restorationRouter := apiRouter.PathPrefix("/operations/database/restoration/{restoration:[A-Za-z0-9]{26}}").Subrouter()
+	restorationRouter.Handle("", addContext(handleGetInstallationDBRestorationOperation)).Methods("GET")
+}
+
+// handleTriggerInstallationDBRestoration responds to POST /api/installations/operations/database/restorations,
+// requests restoration of Installation's data.
+func handleTriggerInstallationDBRestoration(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.Logger = c.Logger.
+		WithField("action", "restore-installation-database")
+
+	restoreRequest, err := model.NewInstallationDBRestorationRequestFromReader(r.Body)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to decode request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	c.Logger = c.Logger.
+		WithField("installation", restoreRequest.InstallationID).
+		WithField("backup", restoreRequest.BackupID)
+
+	newState := model.InstallationStateDBRestorationInProgress
+
+	installationDTO, status, unlockOnce := getInstallationForTransition(c, restoreRequest.InstallationID, newState)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	backup, err := c.Store.GetInstallationBackup(restoreRequest.BackupID)
+	if err != nil {
+		c.Logger.WithError(err).Errorf("failed to get backup")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if backup == nil {
+		c.Logger.Error("Backup not found")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	dbRestoration, err := common.TriggerInstallationDBRestoration(c.Store, installationDTO.Installation, backup, c.Environment, c.Logger)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to trigger installation db restoration")
+		w.WriteHeader(common.ErrToStatus(err))
+		return
+	}
+
+	unlockOnce()
+	c.Supervisor.Do()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	outputJSON(c, w, dbRestoration)
+}
+
+// handleGetInstallationDBRestorationOperations responds to GET /api/installations/operations/database/restorations,
+// returns list of installation restoration operation.
+func handleGetInstallationDBRestorationOperations(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.Logger = c.Logger.
+		WithField("action", "list-installation-db-restorations")
+
+	paging, err := parsePaging(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse paging parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	installationID := r.URL.Query().Get("installation")
+	clusterInstallationID := r.URL.Query().Get("cluster_installation")
+	state := r.URL.Query().Get("state")
+	var states []model.InstallationDBRestorationState
+	if state != "" {
+		states = append(states, model.InstallationDBRestorationState(state))
+	}
+
+	dbRestorations, err := c.Store.GetInstallationDBRestorationOperations(&model.InstallationDBRestorationFilter{
+		Paging:                paging,
+		InstallationID:        installationID,
+		ClusterInstallationID: clusterInstallationID,
+		States:                states,
+	})
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to list installation restorations")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, dbRestorations)
+}
+
+// handleGetInstallationDBRestorationOperation responds to GET /api/installations/operations/database/restoration/{restoration},
+// returns specified installation restoration operation.
+func handleGetInstallationDBRestorationOperation(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	restorationID := vars["restoration"]
+
+	c.Logger = c.Logger.
+		WithField("action", "get-installation-db-restoration").
+		WithField("restoration-operation", restorationID)
+
+	dbRestorationOp, err := c.Store.GetInstallationDBRestorationOperation(restorationID)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to get installation restoration")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if dbRestorationOp == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, dbRestorationOp)
+}

--- a/internal/api/installation_db_restoration_operation_test.go
+++ b/internal/api/installation_db_restoration_operation_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTriggerInstallationDBRestoration(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+	installation1, err := client.CreateInstallation(
+		&model.CreateInstallationRequest{
+			OwnerID:   "owner",
+			DNS:       "dns1.example.com",
+			Database:  model.InstallationDatabaseMultiTenantRDSPostgres,
+			Filestore: model.InstallationFilestoreBifrost,
+		})
+	require.NoError(t, err)
+	backup1 := &model.InstallationBackup{InstallationID: installation1.ID, State: model.InstallationBackupStateBackupSucceeded}
+	err = sqlStore.CreateInstallationBackup(backup1)
+	require.NoError(t, err)
+
+	t.Run("fail for not hibernated installation1", func(t *testing.T) {
+		_, err = client.RestoreInstallationDatabase(installation1.ID, backup1.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+	t.Run("fail for restoring installation1", func(t *testing.T) {
+		installation1.State = model.InstallationStateDBRestorationInProgress
+		err = sqlStore.UpdateInstallation(installation1.Installation)
+		require.NoError(t, err)
+
+		_, err = client.RestoreInstallationDatabase(installation1.ID, backup1.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+
+	installation1.State = model.InstallationStateHibernating
+	err = sqlStore.UpdateInstallation(installation1.Installation)
+	require.NoError(t, err)
+
+	restorationOp, err := client.RestoreInstallationDatabase(installation1.ID, backup1.ID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, restorationOp.ID)
+
+	assert.Equal(t, model.InstallationDBRestorationStateRequested, restorationOp.State)
+	assert.Equal(t, installation1.ID, restorationOp.InstallationID)
+
+	fetchedInstallation, err := sqlStore.GetInstallation(installation1.ID, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, model.InstallationStateDBRestorationInProgress, fetchedInstallation.State)
+}
+
+func TestGetInstallationDBRestorationOperations(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	installation1 := testutil.CreateBackupCompatibleInstallation(t, sqlStore)
+	installation2 := testutil.CreateBackupCompatibleInstallation(t, sqlStore)
+
+	restorationOperations := []*model.InstallationDBRestorationOperation{
+		{
+			InstallationID: installation1.ID,
+			State:          model.InstallationDBRestorationStateRequested,
+		},
+		{
+			InstallationID: installation1.ID,
+			State:          model.InstallationDBRestorationStateFailed,
+		},
+		{
+			InstallationID: installation2.ID,
+			State:          model.InstallationDBRestorationStateRequested,
+		},
+		{
+			InstallationID:        installation2.ID,
+			State:                 model.InstallationDBRestorationStateRequested,
+			ClusterInstallationID: "ci1",
+		},
+		{
+			InstallationID:        installation2.ID,
+			State:                 model.InstallationDBRestorationStateSucceeded,
+			ClusterInstallationID: "ci1",
+		},
+	}
+
+	for i := range restorationOperations {
+		err := sqlStore.CreateInstallationDBRestorationOperation(restorationOperations[i])
+		require.NoError(t, err)
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	for _, testCase := range []struct {
+		description string
+		filter      model.GetInstallationDBRestorationOperationsRequest
+		found       []*model.InstallationDBRestorationOperation
+	}{
+		{
+			description: "all not deleted",
+			filter:      model.GetInstallationDBRestorationOperationsRequest{Paging: model.AllPagesNotDeleted()},
+			found:       restorationOperations,
+		},
+		{
+			description: "1 per page",
+			filter:      model.GetInstallationDBRestorationOperationsRequest{Paging: model.Paging{PerPage: 1}},
+			found:       []*model.InstallationDBRestorationOperation{restorationOperations[4]},
+		},
+		{
+			description: "2nd page",
+			filter:      model.GetInstallationDBRestorationOperationsRequest{Paging: model.Paging{PerPage: 1, Page: 1}},
+			found:       []*model.InstallationDBRestorationOperation{restorationOperations[3]},
+		},
+		{
+			description: "filter by installation ID",
+			filter:      model.GetInstallationDBRestorationOperationsRequest{Paging: model.AllPagesNotDeleted(), InstallationID: installation1.ID},
+			found:       []*model.InstallationDBRestorationOperation{restorationOperations[0], restorationOperations[1]},
+		},
+		{
+			description: "filter by cluster installation ID",
+			filter:      model.GetInstallationDBRestorationOperationsRequest{Paging: model.AllPagesNotDeleted(), ClusterInstallationID: "ci1"},
+			found:       []*model.InstallationDBRestorationOperation{restorationOperations[3], restorationOperations[4]},
+		},
+		{
+			description: "filter by state",
+			filter:      model.GetInstallationDBRestorationOperationsRequest{Paging: model.AllPagesNotDeleted(), State: string(model.InstallationDBRestorationStateRequested)},
+			found:       []*model.InstallationDBRestorationOperation{restorationOperations[0], restorationOperations[2], restorationOperations[3]},
+		},
+		{
+			description: "no results",
+			filter:      model.GetInstallationDBRestorationOperationsRequest{Paging: model.AllPagesNotDeleted(), InstallationID: "no-existent"},
+			found:       []*model.InstallationDBRestorationOperation{},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+
+			backups, err := client.GetInstallationDBRestorationOperations(&testCase.filter)
+			require.NoError(t, err)
+			require.Equal(t, len(testCase.found), len(backups))
+
+			for i := 0; i < len(testCase.found); i++ {
+				assert.Equal(t, testCase.found[i], backups[len(testCase.found)-1-i])
+			}
+		})
+	}
+}
+
+func TestGetInstallationDBRestorationOperation(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	restorationOp := &model.InstallationDBRestorationOperation{
+		BackupID:       "backup",
+		InstallationID: "installation",
+		State:          model.InstallationDBRestorationStateInProgress,
+	}
+	err := sqlStore.CreateInstallationDBRestorationOperation(restorationOp)
+	require.NoError(t, err)
+
+	fetchedOp, err := client.GetInstallationDBRestoration(restorationOp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, restorationOp, fetchedOp)
+
+	t.Run("return 404 if operation not found", func(t *testing.T) {
+		_, err = client.GetInstallationDBRestoration("not-real")
+		require.EqualError(t, err, "failed with status code 404")
+	})
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR introduces:
- Installation DB restoration API handlers.
- Some refactoring of common functionality across handlers transitioning Installation state and updating it:
  - Use `getInstallationForTransition` in places where Installation is being transitioned to new state.
  - Use `updateInstallationState` where installation state changes.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Implement Installation DB restoration API 
```
