### PR TITLE
Adds variables to handle spot-instances notifications

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -48,6 +48,8 @@ func init() {
 	clusterCreateCmd.Flags().String("pgbouncer-values", model.PgbouncerDefaultVersion.Values(), "The branch name of the desired chart value file's version for Pgbouncer")
 	clusterCreateCmd.Flags().String("networking", "amazon-vpc-routed-eni", "Networking mode to use, for example: weave, calico, canal, amazon-vpc-routed-eni")
 	clusterCreateCmd.Flags().String("vpc", "", "Set to use a shared VPC")
+	clusterCreateCmd.Flags().String("mattermost-webhook", "", "Set to use a Mattermost webhook for spot instances termination notifications")
+	clusterCreateCmd.Flags().String("mattermost-channel", "", "Set a mattermost channel for spot instances termination notifications")
 
 	clusterCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the cluster. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 
@@ -67,6 +69,8 @@ func init() {
 	clusterProvisionCmd.Flags().String("nginx-internal-values", "", "The branch name of the desired chart value file's version for NGINX Internal")
 	clusterProvisionCmd.Flags().String("teleport-values", "", "The branch name of the desired chart value file's version for Teleport")
 	clusterProvisionCmd.Flags().String("pgbouncer-values", "", "The branch name of the desired chart value file's version for Pgbouncer")
+	clusterProvisionCmd.Flags().String("mattermost-webhook", "", "Set to use a Mattermost webhook for spot instances termination notifications")
+	clusterProvisionCmd.Flags().String("mattermost-channel", "", "Set a mattermost channel for spot instances termination notifications")
 
 	clusterProvisionCmd.MarkFlagRequired("cluster")
 
@@ -184,6 +188,14 @@ var clusterCreateCmd = &cobra.Command{
 			request.NodeMinCount = nodeCount
 			request.NodeMaxCount = nodeCount
 		}
+		spotNotificationsWebhook, _ := command.Flags().GetString("mattermost-webhook")
+		if len(spotNotificationsWebhook) != 0 {
+			request.MattermostWebhook = spotNotificationsWebhook
+		}
+		spotNotificationsChannel, _ := command.Flags().GetString("mattermost-channel")
+		if len(spotNotificationsChannel) != 0 {
+			request.MattermostChannel = spotNotificationsChannel
+		}
 
 		dryRun, _ := command.Flags().GetBool("dry-run")
 		if dryRun {
@@ -211,7 +223,7 @@ var clusterCreateCmd = &cobra.Command{
 
 var clusterProvisionCmd = &cobra.Command{
 	Use:   "provision",
-	Short: "Provision/Reprovision a cluster's k8s resources.",
+	Short: "Provision/Re-provision a cluster's k8s resources.",
 	RunE: func(command *cobra.Command, args []string) error {
 		command.SilenceUsage = true
 
@@ -224,6 +236,14 @@ var clusterProvisionCmd = &cobra.Command{
 			request = &model.ProvisionClusterRequest{
 				DesiredUtilityVersions: desiredUtilityVersions,
 			}
+		}
+		spotNotificationsWebhook, _ := command.Flags().GetString("mattermost-webhook")
+		if len(spotNotificationsWebhook) != 0 {
+			request.MattermostWebhook = spotNotificationsWebhook
+		}
+		spotNotificationsChannel, _ := command.Flags().GetString("mattermost-channel")
+		if len(spotNotificationsChannel) != 0 {
+			request.MattermostChannel = spotNotificationsChannel
 		}
 
 		dryRun, _ := command.Flags().GetBool("dry-run")

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -48,8 +48,6 @@ func init() {
 	clusterCreateCmd.Flags().String("pgbouncer-values", model.PgbouncerDefaultVersion.Values(), "The branch name of the desired chart value file's version for Pgbouncer")
 	clusterCreateCmd.Flags().String("networking", "amazon-vpc-routed-eni", "Networking mode to use, for example: weave, calico, canal, amazon-vpc-routed-eni")
 	clusterCreateCmd.Flags().String("vpc", "", "Set to use a shared VPC")
-	clusterCreateCmd.Flags().String("mattermost-webhook", "", "Set to use a Mattermost webhook for spot instances termination notifications")
-	clusterCreateCmd.Flags().String("mattermost-channel", "", "Set a mattermost channel for spot instances termination notifications")
 
 	clusterCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the cluster. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 
@@ -69,8 +67,6 @@ func init() {
 	clusterProvisionCmd.Flags().String("nginx-internal-values", "", "The branch name of the desired chart value file's version for NGINX Internal")
 	clusterProvisionCmd.Flags().String("teleport-values", "", "The branch name of the desired chart value file's version for Teleport")
 	clusterProvisionCmd.Flags().String("pgbouncer-values", "", "The branch name of the desired chart value file's version for Pgbouncer")
-	clusterProvisionCmd.Flags().String("mattermost-webhook", "", "Set to use a Mattermost webhook for spot instances termination notifications")
-	clusterProvisionCmd.Flags().String("mattermost-channel", "", "Set a mattermost channel for spot instances termination notifications")
 
 	clusterProvisionCmd.MarkFlagRequired("cluster")
 
@@ -188,14 +184,6 @@ var clusterCreateCmd = &cobra.Command{
 			request.NodeMinCount = nodeCount
 			request.NodeMaxCount = nodeCount
 		}
-		spotNotificationsWebhook, _ := command.Flags().GetString("mattermost-webhook")
-		if len(spotNotificationsWebhook) != 0 {
-			request.MattermostWebhook = spotNotificationsWebhook
-		}
-		spotNotificationsChannel, _ := command.Flags().GetString("mattermost-channel")
-		if len(spotNotificationsChannel) != 0 {
-			request.MattermostChannel = spotNotificationsChannel
-		}
 
 		dryRun, _ := command.Flags().GetBool("dry-run")
 		if dryRun {
@@ -236,14 +224,6 @@ var clusterProvisionCmd = &cobra.Command{
 			request = &model.ProvisionClusterRequest{
 				DesiredUtilityVersions: desiredUtilityVersions,
 			}
-		}
-		spotNotificationsWebhook, _ := command.Flags().GetString("mattermost-webhook")
-		if len(spotNotificationsWebhook) != 0 {
-			request.MattermostWebhook = spotNotificationsWebhook
-		}
-		spotNotificationsChannel, _ := command.Flags().GetString("mattermost-channel")
-		if len(spotNotificationsChannel) != 0 {
-			request.MattermostChannel = spotNotificationsChannel
 		}
 
 		dryRun, _ := command.Flags().GetBool("dry-run")

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -77,6 +77,8 @@ func init() {
 	serverCmd.PersistentFlags().Bool("require-annotated-installations", false, "Require new installations to have at least one annotation.")
 	serverCmd.PersistentFlags().String("gitlab-oauth", "", "If Helm charts are stored in a Gitlab instance that requires authentication, provide the token here and it will be automatically set in the environment.")
 	serverCmd.PersistentFlags().Bool("force-cr-upgrade", false, "If specified installation CRVersions will be updated to the latest version when supervised.")
+	serverCmd.PersistentFlags().String("mattermost-webhook", "", "Set to use a Mattermost webhook for spot instances termination notifications")
+	serverCmd.PersistentFlags().String("mattermost-channel", "", "Set a mattermost channel for spot instances termination notifications")
 }
 
 var serverCmd = &cobra.Command{
@@ -119,6 +121,16 @@ var serverCmd = &cobra.Command{
 		vpnListCIDR, _ := command.Flags().GetStringSlice("vpn-list-cidr")
 		if len(vpnListCIDR) == 0 {
 			return errors.New("vpn-list-cidr must have at least one value")
+		}
+
+		mattermostWebHook, _ := command.Flags().GetString("mattermost-webhook")
+		if mattermostWebHook != "" {
+			os.Setenv(model.MattermostWebhook, mattermostWebHook)
+		}
+
+		mattermostChannel, _ := command.Flags().GetString("mattermost-channel")
+		if mattermostChannel != "" {
+			os.Setenv(model.MattermostChannel, mattermostChannel)
 		}
 
 		logger := logger.WithField("instance", instanceID)

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -127,8 +127,6 @@ func handleCreateCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 				Networking:         createClusterRequest.Networking,
 				VPC:                createClusterRequest.VPC,
 			},
-			MattermostWebhook:  createClusterRequest.MattermostWebhook,
-			MattermostChannel:  createClusterRequest.MattermostChannel,
 		},
 
 		AllowInstallations: createClusterRequest.AllowInstallations,
@@ -256,8 +254,6 @@ func handleProvisionCluster(c *Context, w http.ResponseWriter, r *http.Request) 
 	}
 
 	provisionClusterRequest, err := model.NewProvisionClusterRequestFromReader(r.Body)
-	clusterDTO.Cluster.ProvisionerMetadataKops.MattermostChannel = provisionClusterRequest.MattermostChannel
-	clusterDTO.Cluster.ProvisionerMetadataKops.MattermostWebhook = provisionClusterRequest.MattermostWebhook
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to deserialize cluster provision request body")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -127,7 +127,10 @@ func handleCreateCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 				Networking:         createClusterRequest.Networking,
 				VPC:                createClusterRequest.VPC,
 			},
+			MattermostWebhook:  createClusterRequest.MattermostWebhook,
+			MattermostChannel:  createClusterRequest.MattermostChannel,
 		},
+
 		AllowInstallations: createClusterRequest.AllowInstallations,
 		APISecurityLock:    createClusterRequest.APISecurityLock,
 		State:              model.ClusterStateCreationRequested,
@@ -253,12 +256,13 @@ func handleProvisionCluster(c *Context, w http.ResponseWriter, r *http.Request) 
 	}
 
 	provisionClusterRequest, err := model.NewProvisionClusterRequestFromReader(r.Body)
+	clusterDTO.Cluster.ProvisionerMetadataKops.MattermostChannel = provisionClusterRequest.MattermostChannel
+	clusterDTO.Cluster.ProvisionerMetadataKops.MattermostWebhook = provisionClusterRequest.MattermostWebhook
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to deserialize cluster provision request body")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-
 	err = clusterDTO.SetUtilityDesiredVersions(provisionClusterRequest.DesiredUtilityVersions)
 	if err != nil {
 		c.Logger.WithError(err).Error("provided utility metadata could not be applied without error")
@@ -283,7 +287,6 @@ func handleProvisionCluster(c *Context, w http.ResponseWriter, r *http.Request) 
 			ExtraData: map[string]string{"Environment": c.Environment},
 		}
 		clusterDTO.State = newState
-
 		err := c.Store.UpdateCluster(clusterDTO.Cluster)
 		if err != nil {
 			c.Logger.WithError(err).Errorf("failed to mark cluster provisioning state")

--- a/internal/tools/aws/iam.go
+++ b/internal/tools/aws/iam.go
@@ -265,7 +265,7 @@ func (a *Client) GetAccountAliases() (*iam.ListAccountAliasesOutput, error) {
 	return accountAliases, nil
 }
 
-// AttachPolicyToRole attaches a precreated IAM policy to an IAM role.
+// AttachPolicyToRole attaches a pre-created IAM policy to an IAM role.
 func (a *Client) AttachPolicyToRole(roleName, policyName string, logger log.FieldLogger) error {
 	accountID, err := a.GetAccountID()
 	if err != nil {

--- a/k8s/helpers.go
+++ b/k8s/helpers.go
@@ -103,6 +103,7 @@ func (kc *KubeClient) PatchPodsDaemonSet(namespace, daemonSetName string, payloa
 	payloadBytes, _ := json.Marshal(payload)
 	_, err := daemonSet.Patch(ctx, daemonSetName, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
 	if err != nil {
+		errors.Wrapf(err, "failed to patch daemonSet %s", daemonSetName)
 		return err
 	}
 	return nil

--- a/k8s/helpers.go
+++ b/k8s/helpers.go
@@ -7,7 +7,9 @@ package k8s
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
+	"k8s.io/apimachinery/pkg/types"
 	"net/url"
 	"time"
 
@@ -20,6 +22,13 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	utilexec "k8s.io/client-go/util/exec"
 )
+
+// PatchStringValue is a helper struct for patch operations
+type PatchStringValue struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}
 
 // WaitForPodRunning will poll a given kubernetes pod at a regular interval for
 // it to enter the 'Running' state. If the pod fails to become ready before
@@ -85,6 +94,18 @@ func (kc *KubeClient) GetPodsFromDaemonSet(namespace, daemonSetName string) (*co
 	listOptions := metav1.ListOptions{LabelSelector: set.AsSelector().String()}
 
 	return kc.Clientset.CoreV1().Pods(namespace).List(ctx, listOptions)
+}
+
+// PatchPodsDaemonSet patches the pods that belong to a given daemonset with a given payload.
+func (kc *KubeClient) PatchPodsDaemonSet(namespace, daemonSetName string, payload []PatchStringValue) error {
+	ctx := context.TODO()
+	daemonSet := kc.Clientset.AppsV1().DaemonSets(namespace)
+	payloadBytes, _ := json.Marshal(payload)
+	_, err := daemonSet.Patch(ctx, daemonSetName, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // RemoteCommand executes a kubernetes command against a remote cluster.

--- a/manifests/k8s-spot-termination-handler/k8s-spot-termination-handler.yaml
+++ b/manifests/k8s-spot-termination-handler/k8s-spot-termination-handler.yaml
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: k8s-spot-termination-handler
       containers:
         - name: k8s-spot-termination-handler
-          image: kubeaws/kube-spot-termination-notice-handler:1.13.7-1
+          image: stafot/kube-spot-termination-notice-handler:1.21.0_628d3aef
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_NAME
@@ -76,6 +76,16 @@ spec:
             # Parameters to drain command can be adjusted
             - name: DRAIN_PARAMETERS
               value: '--grace-period=120 --force --ignore-daemonsets --delete-local-data'
+            - name: CLUSTER
+              value: ""
+            - name: MATTERMOST_WEBHOOK
+              value: ""
+            - name: MATTERMOST_USERNAME
+              value: "spot-monitor-bot"
+            - name: MATTERMOST_CHANNEL
+              value: ""
+            - name: DETACH_ASG
+              value: "true"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -10,6 +10,14 @@ import (
 	"regexp"
 )
 
+const (
+	// MattermostWebhook is the name of the Environment Variable which
+	// may contain a Mattermost webhook to send notifications to a Mattermost installation
+	MattermostWebhook = "mattermost-webhook"
+	// MattermostChannel is the name of the Environment Variable which
+	// may contain a Mattermost channel in which notifications are going to be sent
+	MattermostChannel = "mattermost-channel"
+)
 // Cluster represents a Kubernetes cluster.
 type Cluster struct {
 	ID                      string

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -29,6 +29,8 @@ type CreateClusterRequest struct {
 	Annotations            []string                       `json:"annotations,omitempty"`
 	Networking             string                         `json:"networking,omitempty"`
 	VPC                    string                         `json:"vpc,omitempty"`
+	MattermostWebhook      string                         `json:"mattermost-webhook,omitempty"`
+	MattermostChannel      string                         `json:"mattermost-channel,omitempty"`
 }
 
 // SetDefaults sets the default values for a cluster create request.
@@ -59,6 +61,12 @@ func (request *CreateClusterRequest) SetDefaults() {
 	}
 	if len(request.Networking) == 0 {
 		request.Networking = "amazon-vpc-routed-eni"
+	}
+	if len(request.MattermostChannel) == 0 {
+		request.MattermostChannel = ""
+	}
+	if len(request.MattermostWebhook) == 0 {
+		request.MattermostWebhook = ""
 	}
 	if request.DesiredUtilityVersions == nil {
 		request.DesiredUtilityVersions = make(map[string]*HelmUtilityVersion)
@@ -321,6 +329,8 @@ func NewResizeClusterRequestFromReader(reader io.Reader) (*PatchClusterSizeReque
 // ProvisionClusterRequest contains metadata related to changing the installed cluster state.
 type ProvisionClusterRequest struct {
 	DesiredUtilityVersions map[string]*HelmUtilityVersion `json:"utility-versions,omitempty"`
+	MattermostWebhook      string                         `json:"mattermost-webhook,omitempty"`
+	MattermostChannel      string                         `json:"mattermost-channel,omitempty"`
 }
 
 // NewProvisionClusterRequestFromReader will create an UpdateClusterRequest from an io.Reader with JSON data.

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -29,8 +29,6 @@ type CreateClusterRequest struct {
 	Annotations            []string                       `json:"annotations,omitempty"`
 	Networking             string                         `json:"networking,omitempty"`
 	VPC                    string                         `json:"vpc,omitempty"`
-	MattermostWebhook      string                         `json:"mattermost-webhook,omitempty"`
-	MattermostChannel      string                         `json:"mattermost-channel,omitempty"`
 }
 
 // SetDefaults sets the default values for a cluster create request.
@@ -61,12 +59,6 @@ func (request *CreateClusterRequest) SetDefaults() {
 	}
 	if len(request.Networking) == 0 {
 		request.Networking = "amazon-vpc-routed-eni"
-	}
-	if len(request.MattermostChannel) == 0 {
-		request.MattermostChannel = ""
-	}
-	if len(request.MattermostWebhook) == 0 {
-		request.MattermostWebhook = ""
 	}
 	if request.DesiredUtilityVersions == nil {
 		request.DesiredUtilityVersions = make(map[string]*HelmUtilityVersion)
@@ -329,8 +321,6 @@ func NewResizeClusterRequestFromReader(reader io.Reader) (*PatchClusterSizeReque
 // ProvisionClusterRequest contains metadata related to changing the installed cluster state.
 type ProvisionClusterRequest struct {
 	DesiredUtilityVersions map[string]*HelmUtilityVersion `json:"utility-versions,omitempty"`
-	MattermostWebhook      string                         `json:"mattermost-webhook,omitempty"`
-	MattermostChannel      string                         `json:"mattermost-channel,omitempty"`
 }
 
 // NewProvisionClusterRequestFromReader will create an UpdateClusterRequest from an io.Reader with JSON data.

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -30,8 +30,6 @@ type KopsMetadata struct {
 	Warnings             []string                    `json:"Warnings,omitempty"`
 	Networking           string                      `json:"Networking,omitempty"`
 	VPC                  string                      `json:"VPC,omitempty"`
-	MattermostWebhook    string                      `json:"MattermostWebhook,omitempty"`
-	MattermostChannel    string                      `json:"MattermostChannel,omitempty"`
 }
 
 // KopsInstanceGroupsMetadata is a map of instance group names to their metadata.

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -30,6 +30,8 @@ type KopsMetadata struct {
 	Warnings             []string                    `json:"Warnings,omitempty"`
 	Networking           string                      `json:"Networking,omitempty"`
 	VPC                  string                      `json:"VPC,omitempty"`
+	MattermostWebhook    string                      `json:"MattermostWebhook,omitempty"`
+	MattermostChannel    string                      `json:"MattermostChannel,omitempty"`
 }
 
 // KopsInstanceGroupsMetadata is a map of instance group names to their metadata.
@@ -92,7 +94,7 @@ func (km *KopsMetadata) ValidateChangeRequest() error {
 }
 
 // GetWorkerNodesResizeChanges calculates instance group resizing based on the
-// curent ChangeRequest.
+// current ChangeRequest.
 func (km *KopsMetadata) GetWorkerNodesResizeChanges() KopsInstanceGroupsMetadata {
 	difference := km.ChangeRequest.NodeMinCount - km.NodeMinCount
 


### PR DESCRIPTION
Issue: MM-34990

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
If this commit applied clusters will be able to send notifications to mattermost to the chosen channel when a spot instance substituted.
When spot-instances are used and is needed to have notifications in place is mandatory to pass the following arguments on server.
--mattemost-webhook "some url" --mattermost-channel "channel-name"

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34990

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Adds server flags to handle spot-instances notifications
```
