### PR TITLE
Add DB migration rollback mechanism and cleanup for restorations and migrations

### DIFF
--- a/internal/store/installation_db_migration.go
+++ b/internal/store/installation_db_migration.go
@@ -121,6 +121,35 @@ func (sqlStore *SQLStore) TriggerInstallationDBMigration(dbMigrationOp *model.In
 	return dbMigrationOp, nil
 }
 
+// TriggerInstallationDBMigrationRollback triggers rollback of DB migration in single transaction.
+func (sqlStore *SQLStore) TriggerInstallationDBMigrationRollback(dbMigrationOp *model.InstallationDBMigrationOperation, installation *model.Installation) error {
+	dbMigrationOp.State = model.InstallationDBMigrationStateRollbackRequested
+	installation.State = model.InstallationStateDBMigrationRollbackInProgress
+
+	tx, err := sqlStore.beginTransaction(sqlStore.db)
+	if err != nil {
+		return errors.Wrap(err, "failed to start transaction")
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	err = sqlStore.updateInstallationDBMigration(tx, dbMigrationOp)
+	if err != nil {
+		return errors.Wrap(err, "failed to update installation db migration")
+	}
+
+	err = sqlStore.updateInstallation(tx, installation)
+	if err != nil {
+		return errors.Wrap(err, "failed to update installation")
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return errors.Wrap(err, "failed to commit transaction")
+	}
+
+	return nil
+}
+
 // CreateInstallationDBMigrationOperation records installation db migration to the database, assigning it a unique ID.
 func (sqlStore *SQLStore) CreateInstallationDBMigrationOperation(dbMigration *model.InstallationDBMigrationOperation) error {
 	return sqlStore.createInstallationDBMigration(sqlStore.db, dbMigration)
@@ -261,6 +290,21 @@ func (sqlStore *SQLStore) updateInstallationDBMigrationFields(db execer, id stri
 		Where("ID = ?", id))
 	if err != nil {
 		return errors.Wrapf(err, "failed to update installation db migration fields: %s", getMapKeys(fields))
+	}
+
+	return nil
+}
+
+// DeleteInstallationDBMigrationOperation marks the given migration operation as deleted,
+// but does not remove the record from the database.
+func (sqlStore *SQLStore) DeleteInstallationDBMigrationOperation(id string) error {
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Update(installationDBMigrationTable).
+		Set("DeleteAt", GetMillis()).
+		Where("ID = ?", id).
+		Where("DeleteAt = ?", 0))
+	if err != nil {
+		return errors.Wrapf(err, "failed to to mark migration as deleted")
 	}
 
 	return nil

--- a/internal/store/installation_db_migration.go
+++ b/internal/store/installation_db_migration.go
@@ -304,7 +304,7 @@ func (sqlStore *SQLStore) DeleteInstallationDBMigrationOperation(id string) erro
 		Where("ID = ?", id).
 		Where("DeleteAt = ?", 0))
 	if err != nil {
-		return errors.Wrapf(err, "failed to to mark migration as deleted")
+		return errors.Wrap(err, "failed to to mark migration as deleted")
 	}
 
 	return nil

--- a/internal/store/installation_db_restoration_operation.go
+++ b/internal/store/installation_db_restoration_operation.go
@@ -196,6 +196,21 @@ func (sqlStore *SQLStore) updateInstallationDBRestorationFields(db execer, id st
 	return nil
 }
 
+// DeleteInstallationDBRestorationOperation marks the given restoration operation as deleted,
+// but does not remove the record from the database.
+func (sqlStore *SQLStore) DeleteInstallationDBRestorationOperation(id string) error {
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Update(installationDBRestorationTable).
+		Set("DeleteAt", GetMillis()).
+		Where("ID = ?", id).
+		Where("DeleteAt = ?", 0))
+	if err != nil {
+		return errors.Wrapf(err, "failed to to mark restoration as deleted")
+	}
+
+	return nil
+}
+
 // LockInstallationDBRestorationOperation marks the InstallationDBRestoration as locked for exclusive use by the caller.
 func (sqlStore *SQLStore) LockInstallationDBRestorationOperation(id, lockerID string) (bool, error) {
 	return sqlStore.lockRows(installationDBRestorationTable, []string{id}, lockerID)

--- a/internal/store/installation_db_restoration_operation_test.go
+++ b/internal/store/installation_db_restoration_operation_test.go
@@ -224,3 +224,25 @@ func TestUpdateInstallationDBRestoration(t *testing.T) {
 		assert.Equal(t, int64(100), fetched.CompleteAt)
 	})
 }
+
+func TestDeleteInstallationDBRestoration(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	dbRestoration := &model.InstallationDBRestorationOperation{
+		InstallationID: "installation",
+		State:          model.InstallationDBRestorationStateRequested,
+	}
+
+	err := sqlStore.CreateInstallationDBRestorationOperation(dbRestoration)
+	require.NoError(t, err)
+	assert.NotEmpty(t, dbRestoration.ID)
+
+	err = sqlStore.DeleteInstallationDBRestorationOperation(dbRestoration.ID)
+	require.NoError(t, err)
+
+	operation, err := sqlStore.GetInstallationDBRestorationOperation(dbRestoration.ID)
+	require.NoError(t, err)
+	assert.True(t, operation.DeleteAt > 0)
+}

--- a/internal/supervisor/db_migration.go
+++ b/internal/supervisor/db_migration.go
@@ -500,7 +500,7 @@ func (s *DBMigrationSupervisor) rollbackMigration(dbMigration *model.Installatio
 	installation.Database = dbMigration.SourceDatabase
 	err = s.store.UpdateInstallation(installation)
 	if err != nil {
-		logger.WithError(err).Errorf("Failed to switch database for installation")
+		logger.WithError(err).Error("Failed to switch database for installation")
 		return dbMigration.State
 	}
 
@@ -514,7 +514,7 @@ func (s *DBMigrationSupervisor) rollbackMigration(dbMigration *model.Installatio
 	installation.State = model.InstallationStateHibernating
 	err = s.store.UpdateInstallation(installation)
 	if err != nil {
-		logger.WithError(err).Errorf("Failed to set installation back to hibernating state")
+		logger.WithError(err).Error("Failed to set installation back to hibernating state")
 		return dbMigration.State
 	}
 
@@ -559,13 +559,13 @@ func (s *DBMigrationSupervisor) refreshSecrets(installation *model.Installation)
 func (s *DBMigrationSupervisor) cleanupMigration(dbMigration *model.InstallationDBMigrationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBMigrationOperationState {
 	err := s.cleanupMigratedDBs(dbMigration, logger)
 	if err != nil {
-		logger.WithError(err).Errorf("Failed to cleanup source database")
+		logger.WithError(err).Error("Failed to cleanup source database")
 		return dbMigration.State
 	}
 
 	err = s.store.DeleteInstallationDBMigrationOperation(dbMigration.ID)
 	if err != nil {
-		logger.WithError(err).Errorf("Failed to mark migration operation as deleted")
+		logger.WithError(err).Error("Failed to mark migration operation as deleted")
 		return dbMigration.State
 	}
 

--- a/internal/supervisor/db_migration.go
+++ b/internal/supervisor/db_migration.go
@@ -26,6 +26,7 @@ type installationDBMigrationStore interface {
 	GetInstallationDBMigrationOperation(id string) (*model.InstallationDBMigrationOperation, error)
 	UpdateInstallationDBMigrationOperationState(dbMigration *model.InstallationDBMigrationOperation) error
 	UpdateInstallationDBMigrationOperation(dbMigration *model.InstallationDBMigrationOperation) error
+	DeleteInstallationDBMigrationOperation(id string) error
 	installationDBMigrationOperationLockStore
 
 	TriggerInstallationRestoration(installation *model.Installation, backup *model.InstallationBackup) (*model.InstallationDBRestorationOperation, error)
@@ -203,6 +204,10 @@ func (s *DBMigrationSupervisor) transitionMigration(dbMigration *model.Installat
 		return s.finalizeMigration(dbMigration, instanceID, logger)
 	case model.InstallationDBMigrationStateFailing:
 		return s.failMigration(dbMigration, instanceID, logger)
+	case model.InstallationDBMigrationStateRollbackRequested:
+		return s.rollbackMigration(dbMigration, instanceID, logger)
+	case model.InstallationDBMigrationStateDeletionRequested:
+		return s.cleanupMigration(dbMigration, instanceID, logger)
 	default:
 		logger.Warnf("Found migration pending work in unexpected state %s", dbMigration.State)
 		return dbMigration.State
@@ -475,6 +480,61 @@ func (s *DBMigrationSupervisor) failMigration(dbMigration *model.InstallationDBM
 	return model.InstallationDBMigrationStateFailed
 }
 
+func (s *DBMigrationSupervisor) rollbackMigration(dbMigration *model.InstallationDBMigrationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBMigrationOperationState {
+	installation, lock, err := getAndLockInstallation(s.store, dbMigration.InstallationID, instanceID, logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed to get and lock installation")
+		return dbMigration.State
+	}
+	defer lock.Unlock()
+
+	// TODO: this approach is slightly simplified and will need to be split to 2 methods
+	// when we want to support different database types.
+	destinationDB := s.dbProvider.GetDatabase(installation.ID, dbMigration.DestinationDatabase)
+	err = destinationDB.RollbackMigration(s.store, dbMigration, logger)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to migrate installation to database")
+		return dbMigration.State
+	}
+
+	installation.Database = dbMigration.SourceDatabase
+	err = s.store.UpdateInstallation(installation)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to switch database for installation")
+		return dbMigration.State
+	}
+
+	err = s.refreshSecrets(installation)
+	if err != nil {
+		logger.WithError(err).Error("Failed to refresh secrets on cluster installations during rollback")
+		return dbMigration.State
+	}
+
+	oldState := installation.State
+	installation.State = model.InstallationStateHibernating
+	err = s.store.UpdateInstallation(installation)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to set installation back to hibernating state")
+		return dbMigration.State
+	}
+
+	webhookPayload := &model.WebhookPayload{
+		Type:      model.TypeInstallation,
+		ID:        installation.ID,
+		NewState:  installation.State,
+		OldState:  oldState,
+		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"DNS": installation.DNS, "Environment": s.environment},
+	}
+
+	err = webhook.SendToAllWebhooks(s.store, webhookPayload, logger.WithField("webhookEvent", webhookPayload.NewState))
+	if err != nil {
+		logger.WithError(err).Error("Unable to process and send webhooks")
+	}
+
+	return model.InstallationDBMigrationStateRollbackFinished
+}
+
 func (s *DBMigrationSupervisor) refreshSecrets(installation *model.Installation) error {
 	cis, err := s.store.GetClusterInstallations(&model.ClusterInstallationFilter{InstallationID: installation.ID, Paging: model.AllPagesNotDeleted()})
 	if err != nil {
@@ -496,3 +556,29 @@ func (s *DBMigrationSupervisor) refreshSecrets(installation *model.Installation)
 	return nil
 }
 
+func (s *DBMigrationSupervisor) cleanupMigration(dbMigration *model.InstallationDBMigrationOperation, instanceID string, logger log.FieldLogger) model.InstallationDBMigrationOperationState {
+	err := s.cleanupMigratedDBs(dbMigration, logger)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to cleanup source database")
+		return dbMigration.State
+	}
+
+	err = s.store.DeleteInstallationDBMigrationOperation(dbMigration.ID)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to mark migration operation as deleted")
+		return dbMigration.State
+	}
+
+	return model.InstallationDBMigrationStateDeleted
+}
+
+func (s *DBMigrationSupervisor) cleanupMigratedDBs(dbMigration *model.InstallationDBMigrationOperation, logger log.FieldLogger) error {
+	sourceDB := s.dbProvider.GetDatabase(dbMigration.InstallationID, dbMigration.SourceDatabase)
+
+	err := sourceDB.TeardownMigrated(s.store, dbMigration, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to tear down migrated database")
+	}
+
+	return nil
+}

--- a/internal/supervisor/db_migration_test.go
+++ b/internal/supervisor/db_migration_test.go
@@ -604,6 +604,59 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, model.InstallationStateDBMigrationFailed, installation.State)
 	})
+
+	t.Run("rollback migration", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
+		installation, _ := setupMigrationRequiredResources(t, sqlStore)
+
+		migrationOp := &model.InstallationDBMigrationOperation{
+			InstallationID: installation.ID,
+			State:          model.InstallationDBMigrationStateRollbackRequested,
+		}
+
+		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
+		require.NoError(t, err)
+
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &mockResourceUtil{}, "instanceID", &mockMigrationProvisioner{}, logger)
+		dbMigrationSupervisor.Supervise(migrationOp)
+
+		// Assert
+		migrationOp, err = sqlStore.GetInstallationDBMigrationOperation(migrationOp.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationDBMigrationStateRollbackFinished, migrationOp.State)
+
+		installation, err = sqlStore.GetInstallation(installation.ID, false, false)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationStateHibernating, installation.State)
+	})
+
+	t.Run("cleanup migration", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
+		installation, _ := setupMigrationRequiredResources(t, sqlStore)
+
+		migrationOp := &model.InstallationDBMigrationOperation{
+			InstallationID: installation.ID,
+			State:          model.InstallationDBMigrationStateDeletionRequested,
+		}
+
+		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
+		require.NoError(t, err)
+
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &mockResourceUtil{}, "instanceID", &mockMigrationProvisioner{}, logger)
+		dbMigrationSupervisor.Supervise(migrationOp)
+
+		// Assert
+		migrationOp, err = sqlStore.GetInstallationDBMigrationOperation(migrationOp.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationDBMigrationStateDeleted, migrationOp.State)
+		assert.True(t, migrationOp.DeleteAt > 0)
+	})
 }
 
 func setupMigrationRequiredResources(t *testing.T, sqlStore *store.SQLStore) (*model.Installation, *model.ClusterInstallation) {

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -58,6 +58,14 @@ type installationStore interface {
 	UpdateInstallationBackupState(backup *model.InstallationBackup) error
 	installationBackupLockStore
 
+	GetInstallationDBMigrationOperations(filter *model.InstallationDBMigrationFilter) ([]*model.InstallationDBMigrationOperation, error)
+	UpdateInstallationDBMigrationOperationState(operation *model.InstallationDBMigrationOperation) error
+	installationDBMigrationOperationLockStore
+
+	GetInstallationDBRestorationOperations(filter *model.InstallationDBRestorationFilter) ([]*model.InstallationDBRestorationOperation, error)
+	UpdateInstallationDBRestorationOperationState(operation *model.InstallationDBRestorationOperation) error
+	installationDBRestorationLockStore
+
 	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
 
 	model.InstallationDatabaseStoreInterface
@@ -1082,6 +1090,21 @@ func (s *InstallationSupervisor) finalDeletionCleanup(installation *model.Instal
 		}
 	}
 
+	migrationDeletionFinished, err := s.deleteMigrationOperations(installation, instanceID, logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed to delete db migration operations")
+		return model.InstallationStateDeletionFinalCleanup
+	}
+	restorationDeletionFinished, err := s.deleteRestorationOperations(installation, instanceID, logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed to delete db restoration operations")
+		return model.InstallationStateDeletionFinalCleanup
+	}
+	if !migrationDeletionFinished || !restorationDeletionFinished {
+		logger.Info("Installation db restoration and migration deletion in progress")
+		return model.InstallationStateDeletionFinalCleanup
+	}
+
 	err = s.resourceUtil.GetDatabaseForInstallation(installation).Teardown(s.store, s.keepDatabaseData, logger)
 	if err != nil {
 		logger.WithError(err).Error("Failed to delete database")
@@ -1188,6 +1211,144 @@ func (s *InstallationSupervisor) deleteBackups(installation *model.Installation,
 	return true, nil
 }
 
+func (s *InstallationSupervisor) deleteRestorationOperations(installation *model.Installation, instanceID string, logger log.FieldLogger) (bool, error) {
+	logger.Info("Deleting installation db restoration operations")
+
+	restorationOperations, err := s.store.GetInstallationDBRestorationOperations(&model.InstallationDBRestorationFilter{
+		InstallationID: installation.ID,
+		Paging:         model.AllPagesNotDeleted(),
+	})
+	if err != nil {
+		return false, errors.Wrap(err, "failed to list db restoration operations")
+	}
+
+	if len(restorationOperations) == 0 {
+		logger.Info("No existing db restoration operations found for installation")
+		return true, nil
+	}
+
+	operationIDs := getInstallationDBRestorationOperationIDs(restorationOperations)
+	installationBackupsLocks := newInstallationDBRestorationLocks(operationIDs, instanceID, s.store, logger)
+
+	if !installationBackupsLocks.TryLock() {
+		return false, errors.Errorf("Failed to lock %d installation db restorations", len(restorationOperations))
+	}
+	defer installationBackupsLocks.Unlock()
+
+	// Fetch the same elements again, now that we have the locks.
+	restorationOperations, err = s.store.GetInstallationDBRestorationOperations(&model.InstallationDBRestorationFilter{
+		IDs:    operationIDs,
+		Paging: model.AllPagesNotDeleted(),
+	})
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to fetch %d installation db restoration operations by ids", len(restorationOperations))
+	}
+
+	if len(restorationOperations) != len(operationIDs) {
+		logger.Warnf("Found only %d installation db restoration operations after locking, expected %d", len(restorationOperations), len(operationIDs))
+	}
+
+	deleted := 0
+	deleting := 0
+
+	for _, operation := range restorationOperations {
+		switch operation.State {
+		case model.InstallationDBRestorationStateDeleted:
+			deleted++
+			continue
+		case model.InstallationDBRestorationStateDeletionRequested:
+			deleting++
+			continue
+		}
+
+		logger.Debugf("Deleting installation db restoration operation %q in state %q", operation.ID, operation.State)
+		operation.State = model.InstallationDBRestorationStateDeletionRequested
+		err = s.store.UpdateInstallationDBRestorationOperationState(operation)
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to mark istallation db restoration %s for deletion", operation.ID)
+		}
+		deleting++
+	}
+
+	logger.Debugf("Found %d installation db restorations, %d deleting, %d deleted", len(restorationOperations), deleting, deleted)
+
+	if deleting > 0 {
+		logger.Infof("Installation db restorations deletion in progress, deleting operations %d", deleting)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (s *InstallationSupervisor) deleteMigrationOperations(installation *model.Installation, instanceID string, logger log.FieldLogger) (bool, error) {
+	logger.Info("Deleting installation db migration operations")
+
+	migrationOperations, err := s.store.GetInstallationDBMigrationOperations(&model.InstallationDBMigrationFilter{
+		InstallationID: installation.ID,
+		Paging:         model.AllPagesNotDeleted(),
+	})
+	if err != nil {
+		return false, errors.Wrap(err, "failed to list db migration operations")
+	}
+
+	if len(migrationOperations) == 0 {
+		logger.Info("No existing db migration operations found for installation")
+		return true, nil
+	}
+
+	operationIDs := getInstallationDBMigrationOperationIDs(migrationOperations)
+	installationBackupsLocks := newInstallationDBMigrationOperationLocks(operationIDs, instanceID, s.store, logger)
+
+	if !installationBackupsLocks.TryLock() {
+		return false, errors.Errorf("Failed to lock %d installation db migrations", len(migrationOperations))
+	}
+	defer installationBackupsLocks.Unlock()
+
+	// Fetch the same elements again, now that we have the locks.
+	migrationOperations, err = s.store.GetInstallationDBMigrationOperations(&model.InstallationDBMigrationFilter{
+		IDs:    operationIDs,
+		Paging: model.AllPagesNotDeleted(),
+	})
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to fetch %d installation db migration operations by ids", len(migrationOperations))
+	}
+
+	if len(migrationOperations) != len(operationIDs) {
+		logger.Warnf("Found only %d installation db migration operations after locking, expected %d", len(migrationOperations), len(operationIDs))
+	}
+
+	deleted := 0
+	deleting := 0
+
+	for _, operation := range migrationOperations {
+		switch operation.State {
+		case model.InstallationDBMigrationStateDeleted:
+			deleted++
+			continue
+		case model.InstallationDBMigrationStateDeletionRequested:
+			deleting++
+			continue
+		}
+
+		logger.Debugf("Deleting installation db migration operation %q in state %q", operation.ID, operation.State)
+		operation.State = model.InstallationDBMigrationStateDeletionRequested
+		err = s.store.UpdateInstallationDBMigrationOperationState(operation)
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to mark istallation db migration %s for deletion", operation.ID)
+		}
+		deleting++
+	}
+
+	logger.Debugf("Found %d installation db migrations, %d deleting, %d deleted", len(migrationOperations), deleting, deleted)
+
+	if deleting > 0 {
+		logger.Infof("Installation db migrations deletion in progress, deleting operations %d", deleting)
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func (s *InstallationSupervisor) finalCreationTasks(installation *model.Installation, logger log.FieldLogger) string {
 	logger.Info("Finished final creation tasks")
 	s.metrics.InstallationCreationDurationHist.Observe(elapsedTimeInSeconds(installation.CreateAt))
@@ -1251,6 +1412,22 @@ func getInstallationBackupsIDs(backups []*model.InstallationBackup) []string {
 		backupIDs = append(backupIDs, backup.ID)
 	}
 	return backupIDs
+}
+
+func getInstallationDBRestorationOperationIDs(operations []*model.InstallationDBRestorationOperation) []string {
+	ids := make([]string, 0, len(operations))
+	for _, op := range operations {
+		ids = append(ids, op.ID)
+	}
+	return ids
+}
+
+func getInstallationDBMigrationOperationIDs(operations []*model.InstallationDBMigrationOperation) []string {
+	ids := make([]string, 0, len(operations))
+	for _, op := range operations {
+		ids = append(ids, op.ID)
+	}
+	return ids
 }
 
 func getAnnotationsIDs(annotations []*model.Annotation) []string {

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -1182,7 +1182,7 @@ func (s *InstallationSupervisor) deleteBackups(installation *model.Installation,
 			continue
 		}
 
-		logger.Debugf("Deleting installation backup %q in state %q", backup.ID, backup.State)
+		logger.Debugf("Deleting installation backup %s in state %s", backup.ID, backup.State)
 		backup.State = model.InstallationBackupStateDeletionRequested
 		err = s.store.UpdateInstallationBackupState(backup)
 		if err != nil {
@@ -1261,7 +1261,7 @@ func (s *InstallationSupervisor) deleteRestorationOperations(installation *model
 			continue
 		}
 
-		logger.Debugf("Deleting installation db restoration operation %q in state %q", operation.ID, operation.State)
+		logger.Debugf("Deleting installation db restoration operation %s in state %s", operation.ID, operation.State)
 		operation.State = model.InstallationDBRestorationStateDeletionRequested
 		err = s.store.UpdateInstallationDBRestorationOperationState(operation)
 		if err != nil {
@@ -1330,7 +1330,7 @@ func (s *InstallationSupervisor) deleteMigrationOperations(installation *model.I
 			continue
 		}
 
-		logger.Debugf("Deleting installation db migration operation %q in state %q", operation.ID, operation.State)
+		logger.Debugf("Deleting installation db migration operation %s in state %s", operation.ID, operation.State)
 		operation.State = model.InstallationDBMigrationStateDeletionRequested
 		err = s.store.UpdateInstallationDBMigrationOperationState(operation)
 		if err != nil {

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -166,15 +166,15 @@ func (s *mockInstallationStore) UpdateInstallationBackupState(backup *model.Inst
 	return nil
 }
 
-func (m *mockInstallationStore) LockInstallationBackups(backupIDs []string, lockerID string) (bool, error) {
+func (s *mockInstallationStore) LockInstallationBackups(backupIDs []string, lockerID string) (bool, error) {
 	return true, nil
 }
 
-func (m *mockInstallationStore) UnlockInstallationBackups(backupIDs []string, lockerID string, force bool) (bool, error) {
+func (s *mockInstallationStore) UnlockInstallationBackups(backupIDs []string, lockerID string, force bool) (bool, error) {
 	return true, nil
 }
 
-func (m *mockInstallationStore) GetInstallationDBMigrationOperations(filter *model.InstallationDBMigrationFilter) ([]*model.InstallationDBMigrationOperation, error) {
+func (s *mockInstallationStore) GetInstallationDBMigrationOperations(filter *model.InstallationDBMigrationFilter) ([]*model.InstallationDBMigrationOperation, error) {
 	return nil, nil
 }
 
@@ -182,7 +182,7 @@ func (s *mockInstallationStore) UpdateInstallationDBMigrationOperationState(oper
 	return nil
 }
 
-func (m *mockInstallationStore) LockInstallationDBMigrationOperations(backupIDs []string, lockerID string) (bool, error) {
+func (s *mockInstallationStore) LockInstallationDBMigrationOperations(backupIDs []string, lockerID string) (bool, error) {
 	return true, nil
 }
 

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -166,11 +166,42 @@ func (s *mockInstallationStore) UpdateInstallationBackupState(backup *model.Inst
 	return nil
 }
 
-func (s *mockInstallationStore) LockInstallationBackups(backupIDs []string, lockerID string) (bool, error) {
+func (m *mockInstallationStore) LockInstallationBackups(backupIDs []string, lockerID string) (bool, error) {
 	return true, nil
 }
 
-func (s *mockInstallationStore) UnlockInstallationBackups(backupIDs []string, lockerID string, force bool) (bool, error) {
+func (m *mockInstallationStore) UnlockInstallationBackups(backupIDs []string, lockerID string, force bool) (bool, error) {
+	return true, nil
+}
+
+func (m *mockInstallationStore) GetInstallationDBMigrationOperations(filter *model.InstallationDBMigrationFilter) ([]*model.InstallationDBMigrationOperation, error) {
+	return nil, nil
+}
+
+func (s *mockInstallationStore) UpdateInstallationDBMigrationOperationState(operation *model.InstallationDBMigrationOperation) error {
+	return nil
+}
+
+func (m *mockInstallationStore) LockInstallationDBMigrationOperations(backupIDs []string, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (s *mockInstallationStore) UnlockInstallationDBMigrationOperations(backupIDs []string, lockerID string, force bool) (bool, error) {
+	return true, nil
+}
+
+func (s *mockInstallationStore) GetInstallationDBRestorationOperations(filter *model.InstallationDBRestorationFilter) ([]*model.InstallationDBRestorationOperation, error) {
+	return nil, nil
+}
+func (s *mockInstallationStore) UpdateInstallationDBRestorationOperationState(operation *model.InstallationDBRestorationOperation) error {
+	return nil
+}
+
+func (s *mockInstallationStore) LockInstallationDBRestorationOperations(backupIDs []string, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (s *mockInstallationStore) UnlockInstallationDBRestorationOperations(backupIDs []string, lockerID string, force bool) (bool, error) {
 	return true, nil
 }
 
@@ -1862,6 +1893,64 @@ func TestInstallationSupervisor(t *testing.T) {
 		fetchedBackup, err := sqlStore.GetInstallationBackup(backup.ID)
 		require.NoError(t, err)
 		assert.Equal(t, model.InstallationBackupStateDeletionRequested, fetchedBackup.State)
+	})
+
+	t.Run("deletion requested, delete migrations and restorations", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		supervisor := supervisor.NewInstallationSupervisor(sqlStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, false)
+
+		cluster := standardStableTestCluster()
+		err := sqlStore.CreateCluster(cluster, nil)
+		require.NoError(t, err)
+
+		owner := model.NewID()
+		groupID := model.NewID()
+		installation := &model.Installation{
+			OwnerID:  owner,
+			Version:  "version",
+			DNS:      "dns.example.com",
+			Size:     mmv1alpha1.Size100String,
+			Affinity: model.InstallationAffinityIsolated,
+			GroupID:  &groupID,
+			State:    model.InstallationStateDeletionRequested,
+		}
+		err = sqlStore.CreateInstallation(installation, nil)
+		require.NoError(t, err)
+
+		clusterInstallation := &model.ClusterInstallation{
+			ClusterID:      cluster.ID,
+			InstallationID: installation.ID,
+			Namespace:      "namespace",
+			State:          model.ClusterInstallationStateDeleted,
+		}
+		err = sqlStore.CreateClusterInstallation(clusterInstallation)
+		require.NoError(t, err)
+
+		restorationOP := &model.InstallationDBRestorationOperation{
+			InstallationID:        installation.ID,
+			ClusterInstallationID: clusterInstallation.ID,
+			State:                 model.InstallationDBRestorationStateSucceeded,
+		}
+		err = sqlStore.CreateInstallationDBRestorationOperation(restorationOP)
+		require.NoError(t, err)
+
+		migrationOP := &model.InstallationDBMigrationOperation{
+			InstallationID: installation.ID,
+			State:          model.InstallationDBMigrationStateSucceeded,
+		}
+		err = sqlStore.CreateInstallationDBMigrationOperation(migrationOP)
+		require.NoError(t, err)
+
+		supervisor.Supervise(installation)
+		expectInstallationState(t, sqlStore, installation, model.InstallationStateDeletionFinalCleanup)
+		expectClusterInstallations(t, sqlStore, installation, 1, model.ClusterInstallationStateDeleted)
+		fetchedRestoration, err := sqlStore.GetInstallationDBRestorationOperation(restorationOP.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationDBRestorationStateDeletionRequested, fetchedRestoration.State)
+		fetchedMigration, err := sqlStore.GetInstallationDBMigrationOperation(migrationOP.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.InstallationDBMigrationStateDeletionRequested, fetchedMigration.State)
 	})
 
 	t.Run("creation requested, cluster installations deleted", func(t *testing.T) {

--- a/model/installation_db_migration_operation_test.go
+++ b/model/installation_db_migration_operation_test.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,4 +84,31 @@ func TestNewDBMigrationOperationsFromReader(t *testing.T) {
 			},
 		}, dBMigrationOperations)
 	})
+}
+
+func TestInstallationDBMigrationOperation_ValidTransitionState(t *testing.T) {
+	// Couple of tests to verify mechanism is working - we can add more for specific cases
+	for _, testCase := range []struct {
+		oldState InstallationDBMigrationOperationState
+		newState InstallationDBMigrationOperationState
+		isValid  bool
+	}{
+		{
+			oldState: InstallationDBMigrationStateSucceeded,
+			newState: InstallationDBMigrationStateRollbackRequested,
+			isValid:  true,
+		},
+		{
+			oldState: InstallationDBMigrationStateRefreshSecrets,
+			newState: InstallationDBMigrationStateRollbackRequested,
+			isValid:  false,
+		},
+	} {
+		t.Run(string(testCase.oldState)+" to "+string(testCase.newState), func(t *testing.T) {
+			dbMigration := &InstallationDBMigrationOperation{State: testCase.oldState}
+
+			isValid := dbMigration.ValidTransitionState(testCase.newState)
+			assert.Equal(t, testCase.isValid, isValid)
+		})
+	}
 }

--- a/model/installation_db_restoration_operation.go
+++ b/model/installation_db_restoration_operation.go
@@ -46,6 +46,10 @@ const (
 	InstallationDBRestorationStateFailed InstallationDBRestorationState = "installation-db-restoration-failed"
 	// InstallationDBRestorationStateInvalid is an installation db restoration that is invalid.
 	InstallationDBRestorationStateInvalid InstallationDBRestorationState = "installation-db-restoration-invalid"
+	// InstallationDBRestorationStateDeletionRequested is an installation db restoration scheduled for deletion.
+	InstallationDBRestorationStateDeletionRequested InstallationDBRestorationState = "installation-db-restoration-deletion-requested"
+	// InstallationDBRestorationStateDeleted is an installation db restoration that is deleted.
+	InstallationDBRestorationStateDeleted InstallationDBRestorationState = "installation-db-restoration-deleted"
 )
 
 // AllInstallationDBRestorationStatesPendingWork is a list of all installation restoration operation
@@ -55,6 +59,7 @@ var AllInstallationDBRestorationStatesPendingWork = []InstallationDBRestorationS
 	InstallationDBRestorationStateInProgress,
 	InstallationDBRestorationStateFinalizing,
 	InstallationDBRestorationStateFailing,
+	InstallationDBRestorationStateDeletionRequested,
 }
 
 // InstallationDBRestorationFilter describes the parameters used to constrain a set of installation-db-restoration.

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -61,6 +61,8 @@ const (
 	InstallationStateDBRestorationInProgress = "db-restoration-in-progress"
 	// InstallationStateDBMigrationInProgress is an installation that is being migrated to different database.
 	InstallationStateDBMigrationInProgress = "db-migration-in-progress"
+	// InstallationStateDBMigrationRollbackInProgress is an installation that is being migrated back to original database.
+	InstallationStateDBMigrationRollbackInProgress = "db-migration-rollback-in-progress"
 	// InstallationStateDBRestorationFailed is an installation for which database restoration failed.
 	InstallationStateDBRestorationFailed = "db-restoration-failed"
 	// InstallationStateDBMigrationFailed is an installation for which database migration failed.
@@ -99,6 +101,7 @@ var AllInstallationStates = []string{
 	InstallationStateDeleted,
 	InstallationStateDBRestorationInProgress,
 	InstallationStateDBMigrationInProgress,
+	InstallationStateDBMigrationRollbackInProgress,
 	InstallationStateDBRestorationFailed,
 	InstallationStateDBMigrationFailed,
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR add the folowing:
- DB migration rollback mechanism.
- Cleanup mechanism for DB Restoration operations.
- Cleanup mechanism for DB Migration operations.
- Cleanup of all operations when the Installation is deleted.

DB Migration rollback switches the Installation to use database used before the migration. Any changes made to the new database after the migration will be lost.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add DB migration rollback mechanism and cleanup for restorations and migrations
```
