### PR TITLE
MM-35892 - Add API for DB migrations

### DIFF
--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -65,7 +65,7 @@ type Store interface {
 	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
 	DeleteWebhook(webhookID string) error
 
-	GetMultitenantDatabases(filter *model.MultitenantDatabaseFilter) ([]*model.MultitenantDatabase, error)
+	model.InstallationDatabaseStoreInterface
 
 	GetOrCreateAnnotations(annotations []*model.Annotation) ([]*model.Annotation, error)
 
@@ -89,6 +89,14 @@ type Store interface {
 	TriggerInstallationRestoration(installation *model.Installation, backup *model.InstallationBackup) (*model.InstallationDBRestorationOperation, error)
 	GetInstallationDBRestorationOperation(id string) (*model.InstallationDBRestorationOperation, error)
 	GetInstallationDBRestorationOperations(filter *model.InstallationDBRestorationFilter) ([]*model.InstallationDBRestorationOperation, error)
+
+	TriggerInstallationDBMigration(dbMigrationOp *model.InstallationDBMigrationOperation, installation *model.Installation) (*model.InstallationDBMigrationOperation, error)
+	TriggerInstallationDBMigrationRollback(dbMigrationOp *model.InstallationDBMigrationOperation, installation *model.Installation) error
+	GetInstallationDBMigrationOperations(filter *model.InstallationDBMigrationFilter) ([]*model.InstallationDBMigrationOperation, error)
+	GetInstallationDBMigrationOperation(id string) (*model.InstallationDBMigrationOperation, error)
+	UpdateInstallationDBMigrationOperationState(dbMigration *model.InstallationDBMigrationOperation) error
+	LockInstallationDBMigrationOperation(id, lockerID string) (bool, error)
+	UnlockInstallationDBMigrationOperation(id, lockerID string, force bool) (bool, error)
 }
 
 // Provisioner describes the interface required to communicate with the Kubernetes cluster.
@@ -98,6 +106,11 @@ type Provisioner interface {
 	GetClusterResources(*model.Cluster, bool) (*k8s.ClusterResources, error)
 }
 
+// DBProvider describes the interface required to get database for specific installation and specified type.
+type DBProvider interface {
+	GetDatabase(installationID, dbType string) model.Database
+}
+
 // Context provides the API with all necessary data and interfaces for responding to requests.
 //
 // It is cloned before each request, allowing per-request changes such as logger annotations.
@@ -105,6 +118,7 @@ type Context struct {
 	Store       Store
 	Supervisor  Supervisor
 	Provisioner Provisioner
+	DBProvider  DBProvider
 	RequestID   string
 	Environment string
 	Logger      logrus.FieldLogger
@@ -116,6 +130,7 @@ func (c *Context) Clone() *Context {
 		Store:       c.Store,
 		Supervisor:  c.Supervisor,
 		Provisioner: c.Provisioner,
+		DBProvider:  c.DBProvider,
 		Logger:      c.Logger,
 	}
 }

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -17,6 +17,8 @@ type Supervisor interface {
 
 // Store describes the interface required to persist changes made via API requests.
 type Store interface {
+	model.InstallationDatabaseStoreInterface
+
 	CreateCluster(cluster *model.Cluster, annotations []*model.Annotation) error
 	GetCluster(clusterID string) (*model.Cluster, error)
 	GetClusterDTO(clusterID string) (*model.ClusterDTO, error)
@@ -64,8 +66,6 @@ type Store interface {
 	GetWebhook(webhookID string) (*model.Webhook, error)
 	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
 	DeleteWebhook(webhookID string) error
-
-	model.InstallationDatabaseStoreInterface
 
 	GetOrCreateAnnotations(annotations []*model.Annotation) ([]*model.Annotation, error)
 

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -5,9 +5,10 @@
 package api
 
 import (
-	"github.com/mattermost/mattermost-cloud/model"
 	"net/url"
 	"strconv"
+
+	"github.com/mattermost/mattermost-cloud/model"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -26,6 +26,7 @@ func initInstallation(apiRouter *mux.Router, context *Context) {
 	installationsRouter := apiRouter.PathPrefix("/installations").Subrouter()
 	initInstallationBackup(installationsRouter, context)
 	initInstallationRestoration(installationsRouter, context)
+	initInstallationMigration(installationsRouter, context)
 
 	installationsRouter.Handle("", addContext(handleGetInstallations)).Methods("GET")
 	installationsRouter.Handle("", addContext(handleCreateInstallation)).Methods("POST")

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -26,7 +26,7 @@ func initInstallation(apiRouter *mux.Router, context *Context) {
 	installationsRouter := apiRouter.PathPrefix("/installations").Subrouter()
 	initInstallationBackup(installationsRouter, context)
 	initInstallationRestoration(installationsRouter, context)
-	initInstallationMigration(installationsRouter, context)
+	initInstallationDBMigration(installationsRouter, context)
 
 	installationsRouter.Handle("", addContext(handleGetInstallations)).Methods("GET")
 	installationsRouter.Handle("", addContext(handleCreateInstallation)).Methods("POST")

--- a/internal/api/installation_db_migration.go
+++ b/internal/api/installation_db_migration.go
@@ -213,7 +213,7 @@ func handleCommitInstallationDatabaseMigration(c *Context, w http.ResponseWriter
 	defer unlockOnce()
 
 	if dbMigrationOperation.State != model.InstallationDBMigrationStateSucceeded {
-		c.Logger.Warn("Cannot commit not succeeded DB migration")
+		c.Logger.Warn("Cannot commit DB migration that hasn't succeeded")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -293,7 +293,7 @@ func handleRollbackInstallationDatabaseMigration(c *Context, w http.ResponseWrit
 func validateDBMigration(c *Context, installation *model.Installation, migrationRequest *model.InstallationDBMigrationRequest, currentDB *model.MultitenantDatabase) error {
 	if migrationRequest.DestinationDatabase != model.InstallationDatabaseMultiTenantRDSPostgres ||
 		installation.Database != model.InstallationDatabaseMultiTenantRDSPostgres {
-		return errors.Errorf("db migration is supported when both source and destination are %q database", model.InstallationDatabaseMultiTenantRDSPostgres)
+		return errors.Errorf("db migration is supported only when both source and destination are %q database types", model.InstallationDatabaseMultiTenantRDSPostgres)
 	}
 
 	if migrationRequest.DestinationMultiTenant == nil {

--- a/internal/api/installation_db_migration.go
+++ b/internal/api/installation_db_migration.go
@@ -1,0 +1,328 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/common"
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/internal/webhook"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+// initInstallationMigration registers installation migration operation endpoints on the given router.
+func initInstallationMigration(apiRouter *mux.Router, context *Context) {
+	addContext := func(handler contextHandlerFunc) *contextHandler {
+		return newContextHandler(context, handler)
+	}
+
+	migrationsRouter := apiRouter.PathPrefix("/operations/database/migrations").Subrouter()
+
+	migrationsRouter.Handle("", addContext(handleTriggerInstallationDatabaseMigration)).Methods("POST")
+	migrationsRouter.Handle("", addContext(handleGetInstallationDBMigrationOperations)).Methods("GET")
+
+	migrationRouter := apiRouter.PathPrefix("/operations/database/migration/{migration:[A-Za-z0-9]{26}}").Subrouter()
+	migrationRouter.Handle("", addContext(handleGetInstallationDBMigrationOperation)).Methods("GET")
+	migrationRouter.Handle("/commit", addContext(handleCommitInstallationDatabaseMigration)).Methods("POST")
+	migrationRouter.Handle("/rollback", addContext(handleRollbackInstallationDatabaseMigration)).Methods("POST")
+}
+
+// handleTriggerInstallationDatabaseMigration responds to POST /api/installations/operations/database/migrations,
+// requests migration of Installation's data to different DB cluster.
+func handleTriggerInstallationDatabaseMigration(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.Logger = c.Logger.WithField("action", "migrate-installation-database")
+
+	migrationRequest, err := model.NewInstallationDBMigrationRequestFromReader(r.Body)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to decode request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	c.Logger = c.Logger.WithField("installation", migrationRequest.InstallationID)
+
+	newState := model.InstallationStateDBMigrationInProgress
+
+	installationDTO, status, unlockOnce := getInstallationForTransition(c, migrationRequest.InstallationID, newState)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	dbMigrations, err := c.Store.GetInstallationDBMigrationOperations(&model.InstallationDBMigrationFilter{
+		Paging:         model.AllPagesNotDeleted(),
+		InstallationID: installationDTO.ID,
+		States:         []model.InstallationDBMigrationOperationState{model.InstallationDBMigrationStateSucceeded},
+	})
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to query succeeded installation DB migrations")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if len(dbMigrations) > 0 {
+		c.Logger.Error("DB migration cannot be started if other successful migration is not committed")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	currentDB, err := c.Store.GetMultitenantDatabaseForInstallationID(installationDTO.ID)
+	if err != nil {
+		c.Logger.WithError(err).Errorf("failed to get current multi-tenant database for installation")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	err = validateDBMigration(c, installationDTO.Installation, migrationRequest, currentDB)
+	if err != nil {
+		c.Logger.WithError(err).Errorf("Cannot migrate installation database")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	dbMigrationOperation := &model.InstallationDBMigrationOperation{
+		InstallationID:         migrationRequest.InstallationID,
+		SourceDatabase:         installationDTO.Database,
+		DestinationDatabase:    migrationRequest.DestinationDatabase,
+		SourceMultiTenant:      &model.MultiTenantDBMigrationData{DatabaseID: currentDB.ID},
+		DestinationMultiTenant: migrationRequest.DestinationMultiTenant,
+	}
+
+	oldInstallationState := installationDTO.State
+
+	dbMigrationOperation, err = c.Store.TriggerInstallationDBMigration(dbMigrationOperation, installationDTO.Installation)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to trigger DB migration operation")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	webhookPayload := &model.WebhookPayload{
+		Type:      model.TypeInstallationDBMigration,
+		ID:        dbMigrationOperation.ID,
+		NewState:  string(dbMigrationOperation.State),
+		OldState:  "n/a",
+		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"Installation": dbMigrationOperation.InstallationID, "Environment": c.Environment},
+	}
+	err = webhook.SendToAllWebhooks(c.Store, webhookPayload, c.Logger.WithField("webhookEvent", webhookPayload.NewState))
+	if err != nil {
+		c.Logger.WithError(err).Error("Unable to process and send webhooks")
+	}
+
+	installationWebhookPayload := &model.WebhookPayload{
+		Type:      model.TypeInstallation,
+		ID:        installationDTO.ID,
+		NewState:  installationDTO.State,
+		OldState:  oldInstallationState,
+		Timestamp: time.Now().UnixNano(),
+		ExtraData: map[string]string{"DNS": installationDTO.DNS, "Environment": c.Environment},
+	}
+	err = webhook.SendToAllWebhooks(c.Store, installationWebhookPayload, c.Logger.WithField("webhookEvent", installationWebhookPayload.NewState))
+	if err != nil {
+		c.Logger.WithError(err).Error("Unable to process and send webhooks")
+	}
+
+	unlockOnce()
+	c.Supervisor.Do()
+
+	w.WriteHeader(http.StatusAccepted)
+	outputJSON(c, w, dbMigrationOperation)
+}
+
+// handleGetInstallationDBMigrationOperations responds to GET /api/installations/operations/database/migrations,
+// returns list of installation migration operation.
+func handleGetInstallationDBMigrationOperations(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.Logger = c.Logger.
+		WithField("action", "list-installation-db-migrations")
+
+	paging, err := parsePaging(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse paging parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	installationID := r.URL.Query().Get("installation")
+	state := r.URL.Query().Get("state")
+	var states []model.InstallationDBMigrationOperationState
+	if state != "" {
+		states = append(states, model.InstallationDBMigrationOperationState(state))
+	}
+
+	dbMigrations, err := c.Store.GetInstallationDBMigrationOperations(&model.InstallationDBMigrationFilter{
+		Paging:         paging,
+		InstallationID: installationID,
+		States:         states,
+	})
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to list installation migrations")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, dbMigrations)
+}
+
+// handleGetInstallationDBMigrationOperation responds to GET /api/installations/operations/database/migration/{migration},
+// returns specified installation db migration operation.
+func handleGetInstallationDBMigrationOperation(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	migrationID := vars["migration"]
+
+	c.Logger = c.Logger.
+		WithField("action", "get-installation-db-migration").
+		WithField("migration-operation", migrationID)
+
+	dbRestorationOp, err := c.Store.GetInstallationDBMigrationOperation(migrationID)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to get installation db migration")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if dbRestorationOp == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, dbRestorationOp)
+}
+
+// handleCommitInstallationDatabaseMigration responds to POST /api/installations/operations/database/migration/{migration}/commit,
+// commits database migration.
+func handleCommitInstallationDatabaseMigration(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	migrationID := vars["migration"]
+
+	c.Logger = c.Logger.WithField("action", "commit-installation-database-migration").
+		WithField("migration-operation", migrationID)
+
+	dbMigrationOperation, status, unlockOnce := lockInstallationDBMigrationOperation(c, migrationID)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	if dbMigrationOperation.State != model.InstallationDBMigrationStateSucceeded {
+		c.Logger.Warn("Cannot commit not succeeded DB migration")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	sourceDB := c.DBProvider.GetDatabase(dbMigrationOperation.InstallationID, dbMigrationOperation.SourceDatabase)
+
+	err := sourceDB.TeardownMigrated(c.Store, dbMigrationOperation, c.Logger)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to tear down migrated database")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	dbMigrationOperation.State = model.InstallationDBMigrationStateCommitted
+	err = c.Store.UpdateInstallationDBMigrationOperationState(dbMigrationOperation)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to set operation status to committed")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, dbMigrationOperation)
+}
+
+// handleRollbackInstallationDatabaseMigration responds to POST /api/installations/operations/database/migration/{migration}/rollback,
+// rollbacks database migration.
+func handleRollbackInstallationDatabaseMigration(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	migrationID := vars["migration"]
+
+	c.Logger = c.Logger.WithField("action", "rollback-installation-database-migration").
+		WithField("migration-operation", migrationID)
+
+	dbMigrationOperation, status, unlockOnce := lockInstallationDBMigrationOperation(c, migrationID)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	newState := model.InstallationDBMigrationStateRollbackRequested
+
+	if !dbMigrationOperation.ValidTransitionState(newState) {
+		c.Logger.Warn("Cannot rollback migration, invalid state")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	installationDTO, status, unlockInstOnce := lockInstallation(c, dbMigrationOperation.InstallationID)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockInstOnce()
+
+	if installationDTO.State != model.InstallationStateHibernating {
+		c.Logger.Error("Installation needs to be hibernated to be rolled back")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err := c.Store.TriggerInstallationDBMigrationRollback(dbMigrationOperation, installationDTO.Installation)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to trigger db migration rollback")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	unlockOnce()
+	c.Supervisor.Do()
+
+	w.WriteHeader(http.StatusAccepted)
+	outputJSON(c, w, dbMigrationOperation)
+}
+
+func validateDBMigration(c *Context, installation *model.Installation, migrationRequest *model.InstallationDBMigrationRequest, currentDB *model.MultitenantDatabase) error {
+	if migrationRequest.DestinationDatabase != model.InstallationDatabaseMultiTenantRDSPostgres ||
+		installation.Database != model.InstallationDatabaseMultiTenantRDSPostgres {
+		return errors.Errorf("db migration is supported when both source and destination are %q database", model.InstallationDatabaseMultiTenantRDSPostgres)
+	}
+
+	if migrationRequest.DestinationMultiTenant == nil {
+		return errors.New("destination database data not provided")
+	}
+
+	destinationDB, err := c.Store.GetMultitenantDatabase(migrationRequest.DestinationMultiTenant.DatabaseID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get destination multi-tenant database")
+	}
+	if destinationDB == nil {
+		return errors.Errorf("destination database with id %q not found", migrationRequest.DestinationMultiTenant.DatabaseID)
+	}
+	if destinationDB.DatabaseType != model.DatabaseEngineTypePostgres {
+		return errors.Errorf("destination database is not Postgres")
+	}
+
+	if currentDB.ID == destinationDB.ID {
+		return errors.New("destination database is the same as current")
+	}
+
+	if currentDB.VpcID != destinationDB.VpcID {
+		return errors.New("databases VPCs do not match, only migration inside the same VPC is supported")
+	}
+
+	err = common.ValidateDBMigrationDestination(c.Store, destinationDB, installation.ID, aws.DefaultRDSMultitenantDatabasePostgresCountLimit)
+	if err != nil {
+		return errors.Wrap(err, "destination database validation failed")
+	}
+
+	return nil
+}

--- a/internal/api/installation_db_migration.go
+++ b/internal/api/installation_db_migration.go
@@ -73,7 +73,7 @@ func handleTriggerInstallationDatabaseMigration(c *Context, w http.ResponseWrite
 
 	currentDB, err := c.Store.GetMultitenantDatabaseForInstallationID(installationDTO.ID)
 	if err != nil {
-		c.Logger.WithError(err).Errorf("failed to get current multi-tenant database for installation")
+		c.Logger.WithError(err).Error("Failed to get current multi-tenant database for installation")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -306,9 +306,6 @@ func validateDBMigration(c *Context, installation *model.Installation, migration
 	}
 	if destinationDB == nil {
 		return errors.Errorf("destination database with id %q not found", migrationRequest.DestinationMultiTenant.DatabaseID)
-	}
-	if destinationDB.DatabaseType != model.DatabaseEngineTypePostgres {
-		return errors.Errorf("destination database is not Postgres")
 	}
 
 	if currentDB.ID == destinationDB.ID {

--- a/internal/api/installation_db_migration.go
+++ b/internal/api/installation_db_migration.go
@@ -16,8 +16,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// initInstallationMigration registers installation migration operation endpoints on the given router.
-func initInstallationMigration(apiRouter *mux.Router, context *Context) {
+// initInstallationDBMigration registers installation migration operation endpoints on the given router.
+func initInstallationDBMigration(apiRouter *mux.Router, context *Context) {
 	addContext := func(handler contextHandlerFunc) *contextHandler {
 		return newContextHandler(context, handler)
 	}

--- a/internal/api/installation_db_migration_test.go
+++ b/internal/api/installation_db_migration_test.go
@@ -1,0 +1,383 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api_test
+
+import (
+	"github.com/golang/mock/gomock"
+	mocks "github.com/mattermost/mattermost-cloud/internal/mocks/model"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTriggerInstallationDBMigration(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+	installation1, err := client.CreateInstallation(
+		&model.CreateInstallationRequest{
+			OwnerID:   "owner",
+			DNS:       "dns1.example.com",
+			Database:  model.InstallationDatabaseMultiTenantRDSPostgres,
+			Filestore: model.InstallationFilestoreBifrost,
+		})
+	require.NoError(t, err)
+	installation1.State = model.InstallationStateHibernating
+	err = sqlStore.UpdateInstallation(installation1.Installation)
+	require.NoError(t, err)
+
+	currentDB := &model.MultitenantDatabase{
+		ID:            "database1",
+		VpcID:         "vpc1",
+		DatabaseType:  model.DatabaseEngineTypePostgres,
+		Installations: model.MultitenantDatabaseInstallations{installation1.ID},
+	}
+	err = sqlStore.CreateMultitenantDatabase(currentDB)
+	require.NoError(t, err)
+
+	destinationDB := &model.MultitenantDatabase{
+		ID:           "database2",
+		VpcID:        "vpc1",
+		DatabaseType: model.DatabaseEngineTypePostgres,
+	}
+	err = sqlStore.CreateMultitenantDatabase(destinationDB)
+	require.NoError(t, err)
+
+	migrationRequest := &model.InstallationDBMigrationRequest{
+		InstallationID:         installation1.ID,
+		DestinationDatabase:    model.InstallationDatabaseMultiTenantRDSPostgres,
+		DestinationMultiTenant: &model.MultiTenantDBMigrationData{DatabaseID: "database2"},
+	}
+
+	migrationOperation, err := client.MigrateInstallationDatabase(migrationRequest)
+	require.NoError(t, err)
+
+	assert.Equal(t, model.InstallationDBMigrationStateRequested, migrationOperation.State)
+	assert.Equal(t, installation1.ID, migrationOperation.InstallationID)
+
+	installation, err := sqlStore.GetInstallation(installation1.ID, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, model.InstallationStateDBMigrationInProgress, installation.State)
+
+	t.Run("fail to trigger migration if states is not hibernating", func(t *testing.T) {
+		migrationOperation, err = client.MigrateInstallationDatabase(migrationRequest)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+
+	installation1.State = model.InstallationStateHibernating
+	err = sqlStore.UpdateInstallation(installation1.Installation)
+	require.NoError(t, err)
+
+	t.Run("fail to trigger migration if other migration succeeded but not committed", func(t *testing.T) {
+		succeededMigration := &model.InstallationDBMigrationOperation{State: model.InstallationDBMigrationStateSucceeded, InstallationID: installation1.ID}
+		err = sqlStore.CreateInstallationDBMigrationOperation(succeededMigration)
+		require.NoError(t, err)
+		defer func() {
+			err := sqlStore.DeleteInstallationDBRestorationOperation(succeededMigration.ID)
+			assert.NoError(t, err)
+		}()
+
+		migrationOperation, err = client.MigrateInstallationDatabase(migrationRequest)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+
+	t.Run("fail to trigger migration if destination database not supported", func(t *testing.T) {
+		migrationRequest := &model.InstallationDBMigrationRequest{
+			InstallationID:      installation1.ID,
+			DestinationDatabase: model.InstallationDatabaseMysqlOperator,
+		}
+		migrationOperation, err = client.MigrateInstallationDatabase(migrationRequest)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+
+	t.Run("fail to trigger migration if destination database not found", func(t *testing.T) {
+		migrationRequest := &model.InstallationDBMigrationRequest{
+			InstallationID:         installation1.ID,
+			DestinationDatabase:    model.InstallationDatabaseMultiTenantRDSPostgres,
+			DestinationMultiTenant: &model.MultiTenantDBMigrationData{DatabaseID: "unknown"},
+		}
+		migrationOperation, err = client.MigrateInstallationDatabase(migrationRequest)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+
+	t.Run("fail to trigger migration if destination database same as current", func(t *testing.T) {
+		migrationRequest := &model.InstallationDBMigrationRequest{
+			InstallationID:         installation1.ID,
+			DestinationDatabase:    model.InstallationDatabaseMultiTenantRDSPostgres,
+			DestinationMultiTenant: &model.MultiTenantDBMigrationData{DatabaseID: "database1"},
+		}
+		migrationOperation, err = client.MigrateInstallationDatabase(migrationRequest)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+
+	t.Run("fail to trigger migration if destination database in different vpc", func(t *testing.T) {
+		destinationDB := &model.MultitenantDatabase{
+			ID:           "database3",
+			VpcID:        "vpc2",
+			DatabaseType: model.DatabaseEngineTypePostgres,
+		}
+		err = sqlStore.CreateMultitenantDatabase(destinationDB)
+		require.NoError(t, err)
+
+		migrationRequest := &model.InstallationDBMigrationRequest{
+			InstallationID:         installation1.ID,
+			DestinationDatabase:    model.InstallationDatabaseMultiTenantRDSPostgres,
+			DestinationMultiTenant: &model.MultiTenantDBMigrationData{DatabaseID: "database3"},
+		}
+		migrationOperation, err = client.MigrateInstallationDatabase(migrationRequest)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+}
+
+func TestGetInstallationDBMigrationOperations(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	installation1 := testutil.CreateBackupCompatibleInstallation(t, sqlStore)
+	installation2 := testutil.CreateBackupCompatibleInstallation(t, sqlStore)
+
+	migrationOperations := []*model.InstallationDBMigrationOperation{
+		{
+			InstallationID: installation1.ID,
+			State:          model.InstallationDBMigrationStateRequested,
+		},
+		{
+			InstallationID: installation1.ID,
+			State:          model.InstallationDBMigrationStateFailed,
+		},
+		{
+			InstallationID: installation2.ID,
+			State:          model.InstallationDBMigrationStateRequested,
+		},
+		{
+			InstallationID: installation2.ID,
+			State:          model.InstallationDBMigrationStateRequested,
+		},
+		{
+			InstallationID: installation2.ID,
+			State:          model.InstallationDBMigrationStateSucceeded,
+		},
+	}
+
+	for i := range migrationOperations {
+		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOperations[i])
+		require.NoError(t, err)
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	for _, testCase := range []struct {
+		description string
+		filter      model.GetInstallationDBMigrationOperationsRequest
+		found       []*model.InstallationDBMigrationOperation
+	}{
+		{
+			description: "all not deleted",
+			filter:      model.GetInstallationDBMigrationOperationsRequest{Paging: model.AllPagesNotDeleted()},
+			found:       migrationOperations,
+		},
+		{
+			description: "1 per page",
+			filter:      model.GetInstallationDBMigrationOperationsRequest{Paging: model.Paging{PerPage: 1}},
+			found:       []*model.InstallationDBMigrationOperation{migrationOperations[4]},
+		},
+		{
+			description: "2nd page",
+			filter:      model.GetInstallationDBMigrationOperationsRequest{Paging: model.Paging{PerPage: 1, Page: 1}},
+			found:       []*model.InstallationDBMigrationOperation{migrationOperations[3]},
+		},
+		{
+			description: "filter by installation ID",
+			filter:      model.GetInstallationDBMigrationOperationsRequest{Paging: model.AllPagesNotDeleted(), InstallationID: installation1.ID},
+			found:       []*model.InstallationDBMigrationOperation{migrationOperations[0], migrationOperations[1]},
+		},
+		{
+			description: "filter by state",
+			filter:      model.GetInstallationDBMigrationOperationsRequest{Paging: model.AllPagesNotDeleted(), State: string(model.InstallationDBMigrationStateRequested)},
+			found:       []*model.InstallationDBMigrationOperation{migrationOperations[0], migrationOperations[2], migrationOperations[3]},
+		},
+		{
+			description: "no results",
+			filter:      model.GetInstallationDBMigrationOperationsRequest{Paging: model.AllPagesNotDeleted(), InstallationID: "no-existent"},
+			found:       []*model.InstallationDBMigrationOperation{},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+
+			backups, err := client.GetInstallationDBMigrationOperations(&testCase.filter)
+			require.NoError(t, err)
+			require.Equal(t, len(testCase.found), len(backups))
+
+			for i := 0; i < len(testCase.found); i++ {
+				assert.Equal(t, testCase.found[i], backups[len(testCase.found)-1-i])
+			}
+		})
+	}
+}
+
+func TestGetInstallationDBMigrationOperation(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	migrationOp := &model.InstallationDBMigrationOperation{
+		InstallationID: "installation",
+		State:          model.InstallationDBMigrationStateRequested,
+	}
+	err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
+	require.NoError(t, err)
+
+	fetchedOp, err := client.GetInstallationDBMigrationOperation(migrationOp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, migrationOp, fetchedOp)
+
+	t.Run("return 404 if operation not found", func(t *testing.T) {
+		_, err = client.GetInstallationDBMigrationOperation("not-real")
+		require.EqualError(t, err, "failed with status code 404")
+	})
+}
+
+type dbProviderMock struct {
+	mock *mocks.MockDatabase
+}
+
+func (dbp *dbProviderMock) GetDatabase(installationID, dbType string) model.Database {
+	return dbp.mock
+}
+
+func TestCommitInstallationDBMigrationOperation(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+	ctrl := gomock.NewController(t)
+
+	dbMock := mocks.NewMockDatabase(ctrl)
+	dbProviderMock := &dbProviderMock{mock: dbMock}
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+		DBProvider: dbProviderMock,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	migrationOp := &model.InstallationDBMigrationOperation{
+		InstallationID: "installation",
+		State:          model.InstallationDBMigrationStateSucceeded,
+	}
+	err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
+	require.NoError(t, err)
+
+	gomock.InOrder(dbMock.EXPECT().
+		TeardownMigrated(sqlStore, migrationOp, gomock.Any()).
+		Return(nil))
+
+	committedOp, err := client.CommitInstallationDBMigration(migrationOp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, model.InstallationDBMigrationStateCommitted, committedOp.State)
+
+	t.Run("fail if migration not succeeded", func(t *testing.T) {
+		_, err := client.CommitInstallationDBMigration(committedOp.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+
+		committedOp.State = model.InstallationDBMigrationStateFailed
+		err = sqlStore.UpdateInstallationDBMigrationOperationState(committedOp)
+		require.NoError(t, err)
+
+		_, err = client.CommitInstallationDBMigration(committedOp.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+}
+
+func TestRollbackInstallationDBMigrationOperation(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	installation := &model.Installation{DNS: "dns.com", State: model.InstallationStateHibernating}
+	err := sqlStore.CreateInstallation(installation, nil)
+	require.NoError(t, err)
+
+	migrationOp := &model.InstallationDBMigrationOperation{
+		InstallationID: installation.ID,
+		State:          model.InstallationDBMigrationStateSucceeded,
+	}
+	err = sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
+	require.NoError(t, err)
+
+	rollbackOP, err := client.RollbackInstallationDBMigration(migrationOp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, model.InstallationDBMigrationStateRollbackRequested, rollbackOP.State)
+	installation, err = sqlStore.GetInstallation(installation.ID, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, model.InstallationStateDBMigrationRollbackInProgress, installation.State)
+
+	t.Run("failed to trigger rollback when installation in non-hibernating state", func(t *testing.T) {
+		_, err = client.RollbackInstallationDBMigration(migrationOp.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+}

--- a/model/client.go
+++ b/model/client.go
@@ -610,6 +610,97 @@ func (c *Client) GetInstallationDBRestoration(id string) (*InstallationDBRestora
 	}
 }
 
+// MigrateInstallationDatabase requests installation db migration from the configured provisioning server.
+func (c *Client) MigrateInstallationDatabase(request *InstallationDBMigrationRequest) (*InstallationDBMigrationOperation, error) {
+	resp, err := c.doPost(c.buildURL("/api/installations/operations/database/migrations"), request)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return NewDBMigrationOperationFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// CommitInstallationDBMigration commits installation db migration from the configured provisioning server.
+func (c *Client) CommitInstallationDBMigration(id string) (*InstallationDBMigrationOperation, error) {
+	resp, err := c.doPost(c.buildURL("/api/installations/operations/database/migration/%s/commit", id), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return NewDBMigrationOperationFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// RollbackInstallationDBMigration triggers installation db migration rollback from the configured provisioning server.
+func (c *Client) RollbackInstallationDBMigration(id string) (*InstallationDBMigrationOperation, error) {
+	resp, err := c.doPost(c.buildURL("/api/installations/operations/database/migration/%s/rollback", id), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return NewDBMigrationOperationFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// GetInstallationDBMigrationOperations fetches the list of installation db migration operations from the configured provisioning server.
+func (c *Client) GetInstallationDBMigrationOperations(request *GetInstallationDBMigrationOperationsRequest) ([]*InstallationDBMigrationOperation, error) {
+	u, err := url.Parse(c.buildURL("/api/installations/operations/database/migrations"))
+	if err != nil {
+		return nil, err
+	}
+	request.ApplyToURL(u)
+
+	resp, err := c.doGet(u.String())
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return NewDBMigrationOperationsFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// GetInstallationDBMigrationOperation fetches the specified installation db migration operation from the configured provisioning server.
+func (c *Client) GetInstallationDBMigrationOperation(id string) (*InstallationDBMigrationOperation, error) {
+	resp, err := c.doGet(c.buildURL("/api/installations/operations/database/migration/%s", id))
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return NewDBMigrationOperationFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // AddInstallationAnnotations adds annotations to the given installation.
 func (c *Client) AddInstallationAnnotations(installationID string, annotationsRequest *AddAnnotationsRequest) (*InstallationDTO, error) {
 	resp, err := c.doPost(c.buildURL("/api/installation/%s/annotations", installationID), annotationsRequest)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR contains the following changes:
- Add API for DB migrations, to perform following operations:
  - Trigger DB migration
  - List migration operations
  - Get migration operation
  - Commit migration
  - Rollback migration

Committing migration is synchronous operation that does not involve supervisor to make it simpler. All it does is removing logical database from the previously used DB cluster.

DB migration rollback is asynchronous operation. It works by switching Installation to use old DB cluster, therefore old logical database. All changes made to database after migration will be lost. The rollback cannot be performed if migration was already committed.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-35892

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add API for database migrations
```
