### PR TITLE
Add installation updates to wake-up requests

### DIFF
--- a/model/client.go
+++ b/model/client.go
@@ -498,8 +498,8 @@ func (c *Client) HibernateInstallation(installationID string) (*InstallationDTO,
 }
 
 // WakeupInstallation wakes an installation from hibernation.
-func (c *Client) WakeupInstallation(installationID string) (*InstallationDTO, error) {
-	resp, err := c.doPost(c.buildURL("/api/installation/%s/wakeup", installationID), nil)
+func (c *Client) WakeupInstallation(installationID string, request *PatchInstallationRequest) (*InstallationDTO, error) {
+	resp, err := c.doPost(c.buildURL("/api/installation/%s/wakeup", installationID), request)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows installation configuration to be updated as the
installation is woken up from hibernation.

Fixes https://mattermost.atlassian.net/browse/MM-36384

```release-note
Add installation updates to wake-up requests
```
