### PR TITLE
Support importing Mattermost workspaces from the AWAT

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.8.0
-	github.com/mattermost/awat v0.0.0-20210430184220-463fd5614511
+	github.com/mattermost/awat v0.0.0-20210616202500-f0bdd4f43f90
 	github.com/mattermost/mattermost-operator v1.14.0
 	github.com/mattermost/rotator v0.1.2
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -530,6 +530,8 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/marstr/guid v0.0.0-20170427235115-8bdf7d1a087c/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattermost/awat v0.0.0-20210430184220-463fd5614511 h1:e2PZfje2OCuDWnTRiS7XuecSKr3reX67v+EwslZLpZA=
 github.com/mattermost/awat v0.0.0-20210430184220-463fd5614511/go.mod h1:1IdlNUGa6JbiO+JXLfl7/F2jGT8pFeQAUrm5QRkbmnw=
+github.com/mattermost/awat v0.0.0-20210616202500-f0bdd4f43f90 h1:Ktf4qHK/padM1ebC6lA3SWnspvTgV9ZQRZ4ZsXxGk5U=
+github.com/mattermost/awat v0.0.0-20210616202500-f0bdd4f43f90/go.mod h1:1IdlNUGa6JbiO+JXLfl7/F2jGT8pFeQAUrm5QRkbmnw=
 github.com/mattermost/blubr v0.0.0-20200113232543-f0ce67760aeb/go.mod h1:Tk99160Gy8m4rJPKIgYZrYneLepPCx5KPB3rp9+iK00=
 github.com/mattermost/blubr v0.0.0-20210505124256-5b36c16ffa07/go.mod h1:RW6eWGoIeenY/GKtuDcF+ggCNk/FZWR0gYgDxuLzQOM=
 github.com/mattermost/go-i18n v1.11.0/go.mod h1:RyS7FDNQlzF1PsjbJWHRI35exqaKGSO9qD4iv8QjE34=

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -247,6 +247,9 @@ func (s *ImportSupervisor) teamAlreadyExists(mmctl *mmctl, teamName string) (boo
 }
 
 func (s *ImportSupervisor) ensureTeamSettings(mmctl *mmctl, imprt *awat.ImportStatus) error {
+	if imprt.Type == awat.MattermostWorkspaceBackupType {
+		return nil
+	}
 	// ensure that the team exists
 	found, err := s.teamAlreadyExists(mmctl, imprt.Team)
 	if err != nil {

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -247,20 +247,19 @@ func (s *ImportSupervisor) teamAlreadyExists(mmctl *mmctl, teamName string) (boo
 }
 
 func (s *ImportSupervisor) ensureTeamSettings(mmctl *mmctl, imprt *awat.ImportStatus) error {
-	if imprt.Type == awat.MattermostWorkspaceBackupType {
-		return nil
-	}
-	// ensure that the team exists
-	found, err := s.teamAlreadyExists(mmctl, imprt.Team)
-	if err != nil {
-		return errors.Wrapf(err, "failed to determine if Team %s already exists in workspace", imprt.Team)
-	}
-
-	// if the team doesn't exist, create it
-	if !found {
-		output, err := mmctl.Run("team", "create", "--name", imprt.Team, "--display_name", imprt.Team)
+	if imprt.Type != awat.MattermostWorkspaceBackupType {
+		// ensure that the team exists
+		found, err := s.teamAlreadyExists(mmctl, imprt.Team)
 		if err != nil {
-			return errors.Wrapf(err, "failed to find or create team %s; full output was:%s\n", imprt.Team, string(output))
+			return errors.Wrapf(err, "failed to determine if Team %s already exists in workspace", imprt.Team)
+		}
+
+		// if the team doesn't exist, create it
+		if !found {
+			output, err := mmctl.Run("team", "create", "--name", imprt.Team, "--display_name", imprt.Team)
+			if err != nil {
+				return errors.Wrapf(err, "failed to find or create team %s; full output was:%s\n", imprt.Team, string(output))
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This change prevents the Provisioner from trying to sanitize incoming team names from Mattermost Workspace type imports. This is because Mattermost Workspace import types will not use the `Team` field, since Mattermost Bulk Import Format (MBIF) includes team names in the backup itself, and unlike other types of imports, a Mattermost Workspace import may contain multiple teams.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
No ticket, but this change is necessary for [AWAT PR #11](https://github.com/mattermost/awat/pull/11) to work properly.

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
