### PR TITLE
[MM-36420] Add flags and logic to control mysql and minio operator deployments in cloud clusters.

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -30,7 +30,7 @@ func init() {
 	installationCreateCmd.Flags().String("size", model.InstallationDefaultSize, "The size of the installation. Accepts 100users, 1000users, 5000users, 10000users, 25000users, miniSingleton, or miniHA. Defaults to 100users.")
 	installationCreateCmd.Flags().String("affinity", model.InstallationAffinityIsolated, "How other installations may be co-located in the same cluster.")
 	installationCreateCmd.Flags().String("license", "", "The Mattermost License to use in the server.")
-	installationCreateCmd.Flags().String("database", model.InstallationDatabaseMysqlOperator, "The Mattermost server database type. Accepts mysql-operator, aws-rds, aws-rds-postgres, or aws-multitenant-rds")
+	installationCreateCmd.Flags().String("database", model.InstallationDatabaseMysqlOperator, "The Mattermost server database type. Accepts mysql-operator, aws-rds, aws-rds-postgres, aws-multitenant-rds, or aws-multitenant-rds-postgres")
 	installationCreateCmd.Flags().String("filestore", model.InstallationFilestoreMinioOperator, "The Mattermost server filestore type. Accepts minio-operator, aws-s3, bifrost, or aws-multitenant-s3")
 	installationCreateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	installationCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the installation. Accepts multiple values, for example: '... --annotation abc --annotation def'")

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -55,6 +55,8 @@ func init() {
 	serverCmd.PersistentFlags().Bool("dev", false, "Set sane defaults for development")
 	serverCmd.PersistentFlags().String("backup-restore-tool-image", "mattermost/backup-restore-tool:latest", "Image of Backup Restore Tool to use.")
 	serverCmd.PersistentFlags().Int32("backup-job-ttl-seconds", 3600, "Number of seconds after which finished backup jobs will be cleaned up. Set to negative value to not cleanup or 0 to cleanup immediately.")
+	serverCmd.PersistentFlags().Bool("deploy-mysql-operator", true, "Whether to deploy the mysql operator.")
+	serverCmd.PersistentFlags().Bool("deploy-minio-operator", true, "Whether to deploy the minio operator.")
 
 	// Supervisors
 	serverCmd.PersistentFlags().Int("poll", 30, "The interval in seconds to poll for background work.")
@@ -170,6 +172,10 @@ var serverCmd = &cobra.Command{
 		backupRestoreToolImage, _ := command.Flags().GetString("backup-restore-tool-image")
 		backupJobTTL, _ := command.Flags().GetInt32("backup-job-ttl-seconds")
 
+		deployMySQLOperator, _ := command.Flags().GetBool("deploy-mysql-operator")
+		deployMinioOperator, _ := command.Flags().GetBool("deploy-minio-operator")
+		model.SetDeployOperators(deployMySQLOperator, deployMinioOperator)
+
 		wd, err := os.Getwd()
 		if err != nil {
 			wd = "error getting working directory"
@@ -208,6 +214,8 @@ var serverCmd = &cobra.Command{
 			"backup-job-ttl-seconds":                 backupJobTTL,
 			"debug":                                  debugMode,
 			"dev-mode":                               devMode,
+			"deploy-mysql-operator":                  deployMySQLOperator,
+			"deploy-minio-operator":                  deployMinioOperator,
 		}).Info("Starting Mattermost Provisioning Server")
 
 		deprecationWarnings(logger, command)
@@ -248,6 +256,8 @@ var serverCmd = &cobra.Command{
 			VpnCIDRList:             vpnListCIDR,
 			Owner:                   owner,
 			UseExistingAWSResources: useExistingResources,
+			DeployMysqlOperator:     deployMySQLOperator,
+			DeployMinioOperator:     deployMinioOperator,
 		}
 
 		// Setup the provisioner for actually effecting changes to clusters.

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -388,6 +388,8 @@ func TestDeleteGroup(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
 
+	model.SetDeployOperators(true, true)
+
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
 		Store:      sqlStore,

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -21,6 +21,8 @@ type ProvisioningParams struct {
 	VpnCIDRList             []string
 	Owner                   string
 	UseExistingAWSResources bool
+	DeployMysqlOperator     bool
+	DeployMinioOperator     bool
 }
 
 // KopsProvisioner provisions clusters using kops+terraform.

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -24,6 +24,18 @@ func SetRequireAnnotatedInstallations(val bool) {
 	requireAnnotatedInstallations = val
 }
 
+// deployMySQLOperator if set, MySQL operator will be deployed
+var deployMySQLOperator bool
+
+// deployMinioOperator if set, Minio operator will be deployed
+var deployMinioOperator bool
+
+// SetDeployOperators is called with a value based on a CLI flag.
+func SetDeployOperators(mysql, minio bool) {
+	deployMySQLOperator = mysql
+	deployMinioOperator = minio
+}
+
 // CreateInstallationRequest specifies the parameters for a new installation.
 type CreateInstallationRequest struct {
 	OwnerID         string
@@ -111,6 +123,13 @@ func (request *CreateInstallationRequest) Validate() error {
 		if err != nil {
 			return errors.Wrap(err, "single tenant database config is invalid")
 		}
+	}
+
+	if !deployMinioOperator && request.Filestore == "minio-operator" {
+		return errors.Errorf("minio filestore cannot be used when minio operator is not deployed")
+	}
+	if !deployMySQLOperator && request.Database == "mysql-operator" {
+		return errors.Errorf("mysql operator database cannot be used when mysql operator is not deployed")
 	}
 	return checkSpaces(request)
 }

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestCreateInstallationRequestValid(t *testing.T) {
+	model.SetDeployOperators(true, true)
 	var testCases = []struct {
 		testName     string
 		requireError bool


### PR DESCRIPTION
#### Summary
- Add flags and logic to control mysql and minio operator deployments in cloud clusters.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-36420

#### Release Note
```release-note
- Add flags and logic to control mysql and minio operator deployments in cloud clusters.
```
