### PR TITLE
Add log message when Installation annotations do not match any cluster

### DIFF
--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -5,6 +5,7 @@
 package supervisor
 
 import (
+	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-cloud/internal/provisioner"
@@ -345,6 +346,9 @@ func (s *InstallationSupervisor) createInstallation(installation *model.Installa
 	if err != nil {
 		logger.WithError(err).Warn("Failed to query clusters")
 		return model.InstallationStateCreationRequested
+	}
+	if len(clusters) == 0 {
+		logger.Warnf("No clusters found matching the filter, installation annotations are: [%s]", strings.Join(getAnnotationsNames(annotations), ", "))
 	}
 
 	if s.scheduling.balanceInstallations {
@@ -1436,6 +1440,14 @@ func getAnnotationsIDs(annotations []*model.Annotation) []string {
 		ids = append(ids, ann.ID)
 	}
 	return ids
+}
+
+func getAnnotationsNames(annotations []*model.Annotation) []string {
+	names := make([]string, 0, len(annotations))
+	for _, ann := range annotations {
+		names = append(names, ann.Name)
+	}
+	return names
 }
 
 func elapsedTimeInSeconds(createAtMillis int64) float64 {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
To make it easier to troubleshoot add warning log if Installations annotations do not match any Cluster.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
- Add log message when Installation annotations do not match any cluster
```
