### PR TITLE
Add PGBouncer installation databases

### DIFF
--- a/cmd/tools/ctest/database.go
+++ b/cmd/tools/ctest/database.go
@@ -38,6 +38,7 @@ func runDatabaseTests(command *cobra.Command, c chan *model.WebhookPayload) []st
 	license, _ := command.Flags().GetString("license")
 
 	databaseTypes := []string{
+		model.InstallationDatabaseMultiTenantRDSPostgresPGBouncer,
 		model.InstallationDatabaseMultiTenantRDSPostgres,
 		model.InstallationDatabaseMultiTenantRDSMySQL,
 		model.InstallationDatabaseSingleTenantRDSPostgres,

--- a/cmd/tools/ctest/main.go
+++ b/cmd/tools/ctest/main.go
@@ -14,7 +14,7 @@ import (
 const (
 	defaultListenerPort      = "8085"
 	defaultLocalServerAPI    = "http://localhost:8075"
-	defaultMattermostVersion = "5.28.1"
+	defaultMattermostVersion = "5.36.1"
 )
 
 var rootCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost-cloud
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Masterminds/squirrel v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -62,7 +62,6 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
@@ -313,7 +312,6 @@ github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -441,7 +439,6 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
@@ -528,8 +525,6 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/marstr/guid v0.0.0-20170427235115-8bdf7d1a087c/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
-github.com/mattermost/awat v0.0.0-20210430184220-463fd5614511 h1:e2PZfje2OCuDWnTRiS7XuecSKr3reX67v+EwslZLpZA=
-github.com/mattermost/awat v0.0.0-20210430184220-463fd5614511/go.mod h1:1IdlNUGa6JbiO+JXLfl7/F2jGT8pFeQAUrm5QRkbmnw=
 github.com/mattermost/awat v0.0.0-20210616202500-f0bdd4f43f90 h1:Ktf4qHK/padM1ebC6lA3SWnspvTgV9ZQRZ4ZsXxGk5U=
 github.com/mattermost/awat v0.0.0-20210616202500-f0bdd4f43f90/go.mod h1:1IdlNUGa6JbiO+JXLfl7/F2jGT8pFeQAUrm5QRkbmnw=
 github.com/mattermost/blubr v0.0.0-20200113232543-f0ce67760aeb/go.mod h1:Tk99160Gy8m4rJPKIgYZrYneLepPCx5KPB3rp9+iK00=
@@ -847,14 +842,12 @@ go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.5.1/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
-go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.4.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
-go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.8.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -912,7 +905,6 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -921,7 +913,6 @@ golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1142,7 +1133,6 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1150,7 +1140,6 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
-gomodules.xyz/jsonpatch/v2 v2.1.0 h1:Phva6wqu+xR//Njw6iorylFFgn/z547tw5Ne3HZPQ+k=
 gomodules.xyz/jsonpatch/v2 v2.1.0/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
@@ -1303,7 +1292,6 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.0.0-20181014053814-bbf5c193d86c/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/api v0.17.4/go.mod h1:5qxx6vjmwUVG2nHQTKGlLts8Tbok8PzHl4vHtVFuZCA=
@@ -1356,7 +1344,6 @@ k8s.io/component-base v0.17.4/go.mod h1:5BRqHMbbQPm2kKu35v3G+CpVq4K0RJKC7TRioF0I
 k8s.io/component-base v0.18.6/go.mod h1:knSVsibPR5K6EW2XOjEHik6sdU5nCvKMrzMt2D4In14=
 k8s.io/component-base v0.18.8/go.mod h1:00frPRDas29rx58pPCxNkhUfPbwajlyyvu8ruNgSErU=
 k8s.io/component-base v0.20.1/go.mod h1:guxkoJnNoh8LNrbtiQOlyp2Y2XFCZQmrcg2n/DeYNLk=
-k8s.io/component-base v0.20.2 h1:LMmu5I0pLtwjpp5009KLuMGFqSc2S2isGw8t1hpYKLE=
 k8s.io/component-base v0.20.2/go.mod h1:pzFtCiwe/ASD0iV7ySMu8SYVJjCapNM9bjvk7ptpKh0=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -441,3 +441,18 @@ func (mr *MockAWSMockRecorder) TagResourcesByCluster(clusterResources, clusterID
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourcesByCluster", reflect.TypeOf((*MockAWS)(nil).TagResourcesByCluster), clusterResources, clusterID, owner, logger)
 }
+
+// SecretsManagerGetPGBouncerAuthUserPassword mocks base method
+func (m *MockAWS) SecretsManagerGetPGBouncerAuthUserPassword(vpcID string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretsManagerGetPGBouncerAuthUserPassword", vpcID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SecretsManagerGetPGBouncerAuthUserPassword indicates an expected call of SecretsManagerGetPGBouncerAuthUserPassword
+func (mr *MockAWSMockRecorder) SecretsManagerGetPGBouncerAuthUserPassword(vpcID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretsManagerGetPGBouncerAuthUserPassword", reflect.TypeOf((*MockAWS)(nil).SecretsManagerGetPGBouncerAuthUserPassword), vpcID)
+}

--- a/internal/mocks/model/installation_database.go
+++ b/internal/mocks/model/installation_database.go
@@ -365,3 +365,41 @@ func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetSingleTenantDat
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSingleTenantDatabaseConfigForInstallation", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetSingleTenantDatabaseConfigForInstallation), installationID)
 }
+
+// MockClusterUtilityDatabaseStoreInterface is a mock of ClusterUtilityDatabaseStoreInterface interface
+type MockClusterUtilityDatabaseStoreInterface struct {
+	ctrl     *gomock.Controller
+	recorder *MockClusterUtilityDatabaseStoreInterfaceMockRecorder
+}
+
+// MockClusterUtilityDatabaseStoreInterfaceMockRecorder is the mock recorder for MockClusterUtilityDatabaseStoreInterface
+type MockClusterUtilityDatabaseStoreInterfaceMockRecorder struct {
+	mock *MockClusterUtilityDatabaseStoreInterface
+}
+
+// NewMockClusterUtilityDatabaseStoreInterface creates a new mock instance
+func NewMockClusterUtilityDatabaseStoreInterface(ctrl *gomock.Controller) *MockClusterUtilityDatabaseStoreInterface {
+	mock := &MockClusterUtilityDatabaseStoreInterface{ctrl: ctrl}
+	mock.recorder = &MockClusterUtilityDatabaseStoreInterfaceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockClusterUtilityDatabaseStoreInterface) EXPECT() *MockClusterUtilityDatabaseStoreInterfaceMockRecorder {
+	return m.recorder
+}
+
+// GetMultitenantDatabases mocks base method
+func (m *MockClusterUtilityDatabaseStoreInterface) GetMultitenantDatabases(filter *model.MultitenantDatabaseFilter) ([]*model.MultitenantDatabase, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMultitenantDatabases", filter)
+	ret0, _ := ret[0].([]*model.MultitenantDatabase)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMultitenantDatabases indicates an expected call of GetMultitenantDatabases
+func (mr *MockClusterUtilityDatabaseStoreInterfaceMockRecorder) GetMultitenantDatabases(filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultitenantDatabases", reflect.TypeOf((*MockClusterUtilityDatabaseStoreInterface)(nil).GetMultitenantDatabases), filter)
+}

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -782,11 +782,11 @@ func (provisioner *KopsProvisioner) DeleteCluster(cluster *model.Cluster, awsCli
 
 	logger.Info("Deleting cluster")
 
-	kopsClient, err := provisioner.getCachedKopsClient(cluster.ProvisionerMetadataKops.Name, logger)
+	kopsClient, err := provisioner.getCachedKopsClient(kopsMetadata.Name, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to get kops client from cache")
 	}
-	defer provisioner.invalidateCachedKopsClientOnError(err, cluster.ProvisionerMetadataKops.Name, logger)
+	defer provisioner.invalidateCachedKopsClientOnError(err, kopsMetadata.Name, logger)
 
 	ugh, err := newUtilityGroupHandle(kopsClient, provisioner, cluster, awsClient, logger)
 	if err != nil {
@@ -854,7 +854,7 @@ func (provisioner *KopsProvisioner) DeleteCluster(cluster *model.Cluster, awsCli
 		return errors.Wrap(err, "failed to release cluster VPC")
 	}
 
-	provisioner.invalidateCachedKopsClient(cluster.ProvisionerMetadataKops.Name, logger)
+	provisioner.invalidateCachedKopsClient(kopsMetadata.Name, logger)
 
 	logger.Info("Successfully deleted cluster")
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1324,4 +1324,47 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.28.0"), semver.MustParse("0.29.0"), func(e execer) error {
+		_, err := e.Exec(`
+				ALTER TABLE MultitenantDatabase
+				ADD COLUMN State TEXT NOT NULL DEFAULT 'stable';
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+				ALTER TABLE MultitenantDatabase
+				ADD COLUMN SharedLogicalDatabaseMappingsRaw BYTEA NULL;
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+				ALTER TABLE MultitenantDatabase
+				ADD COLUMN MaxInstallationsPerLogicalDatabase BIGINT NOT NULL DEFAULT '0';
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+				ALTER TABLE MultitenantDatabase
+				ADD COLUMN WriterEndpoint TEXT NULL;
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+				ALTER TABLE MultitenantDatabase
+				ADD COLUMN ReaderEndpoint TEXT NULL;
+		`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1337,7 +1337,7 @@ var migrations = []migration{
 		}
 		return nil
 	}},
-	{semver.MustParse("0.28.0"), semver.MustParse("0.29.0"), func(e execer) error {
+	{semver.MustParse("0.29.0"), semver.MustParse("0.30.0"), func(e execer) error {
 		_, err := e.Exec(`
 				ALTER TABLE MultitenantDatabase
 				ADD COLUMN State TEXT NOT NULL DEFAULT 'stable';

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1351,7 +1351,7 @@ var migrations = []migration{
 
 		_, err = e.Exec(`
 				ALTER TABLE MultitenantDatabase
-				ADD COLUMN WriterEndpoint TEXT NULL;
+				ADD COLUMN WriterEndpoint TEXT NOT NULL DEFAULT '';
 		`)
 		if err != nil {
 			return err
@@ -1359,7 +1359,7 @@ var migrations = []migration{
 
 		_, err = e.Exec(`
 				ALTER TABLE MultitenantDatabase
-				ADD COLUMN ReaderEndpoint TEXT NULL;
+				ADD COLUMN ReaderEndpoint TEXT NOT NULL DEFAULT '';
 		`)
 		if err != nil {
 			return err

--- a/internal/supervisor/cluster_installation_test.go
+++ b/internal/supervisor/cluster_installation_test.go
@@ -60,6 +60,10 @@ func (s *mockClusterInstallationStore) GetInstallationBackups(filter *model.Inst
 	return nil, nil
 }
 
+func (s *mockClusterInstallationStore) GetMultitenantDatabases(filter *model.MultitenantDatabaseFilter) ([]*model.MultitenantDatabase, error) {
+	return nil, nil
+}
+
 func (s *mockClusterInstallationStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error) {
 	return nil, nil
 }

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -314,6 +314,10 @@ func (p *mockInstallationProvisioner) RefreshSecrets(cluster *model.Cluster, ins
 	return nil
 }
 
+func (p *mockInstallationProvisioner) PrepareClusterUtilities(cluster *model.Cluster, installation *model.Installation, store model.ClusterUtilityDatabaseStoreInterface, awsClient aws.AWS) error {
+	return nil
+}
+
 // TODO(gsagula): this can be replaced with /internal/mocks/aws-tools/AWS.go so that inputs and other variants
 // can be tested.
 type mockAWS struct{}
@@ -439,6 +443,10 @@ func (a *mockAWS) GetVpcResourcesByVpcID(vpcID string, logger log.FieldLogger) (
 }
 func (a *mockAWS) TagResourcesByCluster(clusterResources aws.ClusterResources, clusterID string, owner string, logger log.FieldLogger) error {
 	return nil
+}
+
+func (a *mockAWS) SecretsManagerGetPGBouncerAuthUserPassword(vpcID string) (string, error) {
+	return "password", nil
 }
 
 func TestInstallationSupervisorDo(t *testing.T) {

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -79,6 +79,8 @@ type AWS interface {
 
 	GetVpcResourcesByVpcID(vpcID string, logger log.FieldLogger) (ClusterResources, error)
 	TagResourcesByCluster(clusterResources ClusterResources, clusterID string, owner string, logger log.FieldLogger) error
+
+	SecretsManagerGetPGBouncerAuthUserPassword(vpcID string) (string, error)
 }
 
 // Client is a client for interacting with AWS resources in a single AWS account.

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -203,6 +203,11 @@ const (
 	// schemas allowed in a Posgres multitenant RDS database cluster.
 	DefaultRDSMultitenantDatabasePostgresCountLimit = 300
 
+	// DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit is the maximum
+	// number of schemas allowed in a Posgres multitenant RDS database cluster
+	// with a PGBouncer proxy.
+	DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit = 1000
+
 	// DefaultRDSMultitenantDatabasePostgresProxySchemaLimit is the maximum number of
 	// schemas created in each logical database of a proxied DB cluster.
 	DefaultRDSMultitenantDatabasePostgresProxySchemaLimit = 10

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -203,6 +203,10 @@ const (
 	// schemas allowed in a Posgres multitenant RDS database cluster.
 	DefaultRDSMultitenantDatabasePostgresCountLimit = 300
 
+	// DefaultRDSMultitenantDatabasePostgresProxySchemaLimit is the maximum number of
+	// schemas created in each logical database of a proxied DB cluster.
+	DefaultRDSMultitenantDatabasePostgresProxySchemaLimit = 10
+
 	// RDSMultitenantDBClusterResourceNamePrefix identifies the prefix
 	// used for naming multitenant RDS DB cluster resources.
 	// For example: "rds-cluster-multitenant-00000000000000000-a0000000"
@@ -215,10 +219,16 @@ const (
 	DefaultMattermostInstallationIDTagKey = "tag:InstallationId"
 
 	// DefaultMattermostDatabaseUsername is the default username used for
-	// connectting to a Mattermost database.
+	// connecting to a Mattermost database.
 	// Warning:
 	// changing this value may break the connection to existing installations.
 	DefaultMattermostDatabaseUsername = "mmcloud"
+
+	// DefaultPGBouncerAuthUsername is the default username used for authorizing
+	// pgbouncer connections to a shared database.
+	// Warning:
+	// changing this value may break the connection to existing databases.
+	DefaultPGBouncerAuthUsername = "pgbouncer"
 
 	// DefaultResourceTypeClusterRDS is the default resource type used by
 	// AWS to identify an RDS cluster.
@@ -269,6 +279,13 @@ const (
 	// Warning:
 	// changing this value will break the connection to AWS resources for existing installations.
 	DefaultRDSMultitenantDatabaseTypeTagValue = "multitenant-rds"
+
+	// DefaultRDSMultitenantDatabaseDBProxyTypeTagValue key used to identify a
+	// multitenant database cluster with pooled connections of type
+	// multitenant-rds-dbproxy.
+	// Warning:
+	// changing this value will break the connection to AWS resources for existing installations.
+	DefaultRDSMultitenantDatabaseDBProxyTypeTagValue = "multitenant-rds-dbproxy"
 
 	// RDSMultitenantPurposeTagKey is the key used to identify the purpose
 	// of an RDS cluster.

--- a/internal/tools/aws/database_multitenant.go
+++ b/internal/tools/aws/database_multitenant.go
@@ -205,7 +205,7 @@ func (d *RDSMultitenantDatabase) Snapshot(store model.InstallationDatabaseStoreI
 }
 
 // GenerateDatabaseSecret creates the k8s database spec and secret for
-// accessing a multitenant database inside a RDS multitenant cluster.
+// accessing a single database inside a RDS multitenant cluster.
 func (d *RDSMultitenantDatabase) GenerateDatabaseSecret(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) (*corev1.Secret, error) {
 	err := d.IsValid()
 	if err != nil {

--- a/internal/tools/aws/database_multitenant_pgbouncer.go
+++ b/internal/tools/aws/database_multitenant_pgbouncer.go
@@ -1,0 +1,919 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package aws
+
+import (
+	"context"
+	"crypto/md5"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/rds"
+	gt "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	// Database drivers
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+)
+
+// RDSMultitenantPGBouncerDatabase is a database backed by RDS that supports
+// multi-tenancy and pooled connections.
+type RDSMultitenantPGBouncerDatabase struct {
+	databaseType   string
+	installationID string
+	instanceID     string
+	db             SQLDatabaseManager
+	client         *Client
+}
+
+// NewRDSMultitenantPGBouncerDatabase returns a new instance of
+// RDSMultitenantPGBouncerDatabase that implements database interface.
+func NewRDSMultitenantPGBouncerDatabase(databaseType, instanceID, installationID string, client *Client) *RDSMultitenantPGBouncerDatabase {
+	return &RDSMultitenantPGBouncerDatabase{
+		databaseType:   databaseType,
+		instanceID:     instanceID,
+		installationID: installationID,
+		client:         client,
+	}
+}
+
+// IsValid returns if the given RDSMultitenantDatabase configuration is valid.
+func (d *RDSMultitenantPGBouncerDatabase) IsValid() error {
+	if len(d.installationID) == 0 {
+		return errors.New("installation ID is not set")
+	}
+
+	switch d.databaseType {
+	case model.DatabaseEngineTypePostgresProxy:
+	default:
+		return errors.Errorf("invalid pgbouncer database type %s", d.databaseType)
+	}
+
+	return nil
+}
+
+// DatabaseTypeTagValue returns the tag value used for filtering RDS cluster
+// resources based on database type.
+func (d *RDSMultitenantPGBouncerDatabase) DatabaseTypeTagValue() string {
+	return DatabaseTypePostgresSQLAurora
+}
+
+// MaxSupportedDatabases returns the maximum number of databases supported on
+// one RDS cluster for this database type.
+func (d *RDSMultitenantPGBouncerDatabase) MaxSupportedDatabases() int {
+	if d.databaseType == model.DatabaseEngineTypeMySQL {
+		return DefaultRDSMultitenantDatabaseMySQLCountLimit
+	}
+
+	return DefaultRDSMultitenantDatabasePostgresCountLimit
+}
+
+// Provision claims a multitenant RDS cluster and creates a database schema for
+// the installation.
+func (d *RDSMultitenantPGBouncerDatabase) Provision(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	err := d.IsValid()
+	if err != nil {
+		return errors.Wrap(err, "pgbouncer database configuration is invalid")
+	}
+
+	logger = logger.WithField("database-type", d.databaseType)
+	logger.Info("Provisioning Multitenant AWS RDS PGBouncer database")
+
+	vpc, err := getVPCForInstallation(d.installationID, store, d.client)
+	if err != nil {
+		return errors.Wrap(err, "failed to find cluster installation VPC")
+	}
+
+	database, unlockFn, err := d.getAndLockAssignedProxiedDatabase(store, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to get and lock assigned database")
+	}
+	if database == nil {
+		logger.Debug("Assigning installation to multitenant proxy database")
+		database, unlockFn, err = d.assignInstallationToProxiedDatabaseAndLock(*vpc.VpcId, store, logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to assign installation to a multitenant proxy database")
+		}
+	}
+	defer unlockFn()
+
+	databaseName := database.SharedLogicalDatabaseMappings.GetLogicalDatabaseName(d.installationID)
+	logger = logger.WithFields(log.Fields{
+		"assigned-database": database.ID,
+		"logical-database":  databaseName,
+	})
+
+	rdsCluster, err := describeRDSCluster(database.ID, d.client)
+	if err != nil {
+		return errors.Wrapf(err, "failed to describe the multitenant RDS cluster ID %s", database.ID)
+	}
+	if *rdsCluster.Status != DefaultRDSStatusAvailable {
+		return errors.Errorf("multitenant RDS cluster ID %s is not available (status: %s)", database.ID, *rdsCluster.Status)
+	}
+
+	rdsID := *rdsCluster.DBClusterIdentifier
+	logger = logger.WithField("rds-cluster-id", rdsID)
+
+	if database.State == model.DatabaseStateProvisioningRequested {
+		err = d.provisionPGBouncerDatabase(*vpc.VpcId, rdsCluster, logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to provision pgbouncer database")
+		}
+
+		database.State = model.DatabaseStateStable
+		err = store.UpdateMultitenantDatabase(database)
+		if err != nil {
+			return errors.Wrap(err, "failed to update state on provisioned pgbouncer database")
+		}
+	}
+
+	err = d.ensureLogicalDatabaseExists(databaseName, *vpc.VpcId, rdsCluster, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to ensure the logical database is created")
+	}
+
+	err = d.ensureLogicalDatabaseSetup(databaseName, *vpc.VpcId, rdsCluster, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to ensure the logical database is setup")
+	}
+
+	err = updateCounterTagWithCurrentWeight(database, rdsCluster, store, d.client, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to update counter tag with current weight")
+	}
+
+	logger.Infof("Installation %s assigned to pgbouncer multitenant database", d.installationID)
+
+	return nil
+}
+
+// This helper method finds a multitenant RDS cluster that is ready for receiving a database installation. The lookup
+// for multitenant databases will happen in order:
+//	1. fetch a multitenant database by installation ID.
+//	2. fetch all multitenant databases in the store which are under the max number of installations limit.
+//	3. fetch all multitenant databases in the RDS cluster that are under the max number of installations limit.
+func (d *RDSMultitenantPGBouncerDatabase) assignInstallationToProxiedDatabaseAndLock(vpcID string, store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) (*model.MultitenantDatabase, func(), error) {
+	multitenantDatabases, err := store.GetMultitenantDatabases(&model.MultitenantDatabaseFilter{
+		DatabaseType:          d.databaseType,
+		MaxInstallationsLimit: d.MaxSupportedDatabases(),
+		VpcID:                 vpcID,
+		Paging:                model.AllPagesNotDeleted(),
+	})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get available multitenant databases")
+	}
+
+	if len(multitenantDatabases) == 0 {
+		logger.Infof("No %s multitenant databases with less than %d installations found in the datastore; fetching all available resources from AWS", d.databaseType, d.MaxSupportedDatabases())
+
+		multitenantDatabases, err = d.getMultitenantDatabasesFromResourceTags(vpcID, store, logger)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to fetch new multitenant databases from AWS")
+		}
+	}
+
+	if len(multitenantDatabases) == 0 {
+		return nil, nil, errors.New("no multitenant proxy databases are currently available for new installations")
+	}
+
+	// We want to be smart about how we assign the installation to a database.
+	// Find the database with the most installations on it to keep utilization
+	// as close to maximim efficiency as possible.
+	selectedDatabase := &model.MultitenantDatabase{}
+	for _, multitenantDatabase := range multitenantDatabases {
+		if multitenantDatabase.Installations.Count() >= selectedDatabase.Installations.Count() {
+			selectedDatabase = multitenantDatabase
+		}
+	}
+
+	unlockFn, err := lockMultitenantDatabase(selectedDatabase.ID, d.instanceID, store, logger)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to lock selected database")
+	}
+	// Now that we have selected one and have a lock, ensure the database hasn't
+	// been updated.
+	selectedDatabase, err = store.GetMultitenantDatabase(selectedDatabase.ID)
+	if err != nil {
+		unlockFn()
+		return nil, nil, errors.Wrap(err, "failed to refresh multitenant database after lock")
+	}
+
+	// Finish assigning the installation.
+	selectedDatabase.Installations.Add(d.installationID)
+	selectedDatabase.AddInstallationToLogicalDatabaseMapping(d.installationID)
+	err = store.UpdateMultitenantDatabase(selectedDatabase)
+	if err != nil {
+		unlockFn()
+		return nil, nil, errors.Wrap(err, "failed to save installation to selected database")
+	}
+
+	return selectedDatabase, unlockFn, nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) getMultitenantDatabasesFromResourceTags(vpcID string, store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) ([]*model.MultitenantDatabase, error) {
+	databaseType := d.DatabaseTypeTagValue()
+
+	resourceNames, err := d.client.resourceTaggingGetAllResources(gt.GetResourcesInput{
+		TagFilters: []*gt.TagFilter{
+			{
+				Key:    aws.String(trimTagPrefix(RDSMultitenantPurposeTagKey)),
+				Values: []*string{aws.String(RDSMultitenantPurposeTagValueProvisioning)},
+			},
+			{
+				Key:    aws.String(trimTagPrefix(RDSMultitenantOwnerTagKey)),
+				Values: []*string{aws.String(RDSMultitenantOwnerTagValueCloudTeam)},
+			},
+			{
+				Key:    aws.String(DefaultAWSTerraformProvisionedKey),
+				Values: []*string{aws.String(DefaultAWSTerraformProvisionedValueTrue)},
+			},
+			{
+				Key:    aws.String(trimTagPrefix(DefaultRDSMultitenantDatabaseTypeTagKey)),
+				Values: []*string{aws.String(DefaultRDSMultitenantDatabaseDBProxyTypeTagValue)},
+			},
+			{
+				Key:    aws.String(trimTagPrefix(VpcIDTagKey)),
+				Values: []*string{&vpcID},
+			},
+			{
+				Key:    aws.String(trimTagPrefix(CloudInstallationDatabaseTagKey)),
+				Values: []*string{&databaseType},
+			},
+			{
+				Key: aws.String(trimTagPrefix(RDSMultitenantInstallationCounterTagKey)),
+			},
+			{
+				Key: aws.String(trimTagPrefix(DefaultRDSMultitenantDatabaseIDTagKey)),
+			},
+		},
+		ResourceTypeFilters: []*string{aws.String(DefaultResourceTypeClusterRDS)},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get available multitenant RDS resources")
+	}
+
+	var multitenantDatabases []*model.MultitenantDatabase
+
+	for _, resource := range resourceNames {
+		resourceARN, err := arn.Parse(*resource.ResourceARN)
+		if err != nil {
+			return nil, err
+		}
+		if !strings.Contains(resourceARN.Resource, RDSMultitenantDBClusterResourceNamePrefix) {
+			logger.Warnf("Provisioner skipped RDS resource (%s) because name does not have a correct multitenant database prefix (%s)", resourceARN.Resource, RDSMultitenantDBClusterResourceNamePrefix)
+			continue
+		}
+
+		rdsClusterID, err := getRDSClusterIDFromResourceTags(d.MaxSupportedDatabases(), resource.Tags)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get a multitenant RDS cluster ID from AWS resource tags")
+		}
+		if rdsClusterID == nil {
+			continue
+		}
+
+		ready, err := isRDSClusterEndpointsReady(*rdsClusterID, d.client)
+		if err != nil {
+			logger.WithError(err).Errorf("Failed to check RDS cluster status. Skipping RDS cluster ID %s", *rdsClusterID)
+			continue
+		}
+		if !ready {
+			continue
+		}
+
+		rdsCluster, err := describeRDSCluster(*rdsClusterID, d.client)
+		if err != nil {
+			logger.WithError(err).Errorf("Failed to describe the multitenant RDS cluster ID %s", *rdsClusterID)
+			continue
+		}
+
+		multitenantDatabase := model.MultitenantDatabase{
+			ID:                                 *rdsClusterID,
+			VpcID:                              vpcID,
+			DatabaseType:                       d.databaseType,
+			State:                              model.DatabaseStateProvisioningRequested,
+			WriterEndpoint:                     *rdsCluster.Endpoint,
+			ReaderEndpoint:                     *rdsCluster.ReaderEndpoint,
+			MaxInstallationsPerLogicalDatabase: 10,
+		}
+
+		err = store.CreateMultitenantDatabase(&multitenantDatabase)
+		if err != nil {
+			logger.WithError(err).Errorf("Failed to create a multitenant database. Skipping RDS cluster ID %s", *rdsClusterID)
+			continue
+		}
+
+		logger.Debugf("Added multitenant database %s to the datastore", multitenantDatabase.ID)
+
+		multitenantDatabases = append(multitenantDatabases, &multitenantDatabase)
+	}
+
+	return multitenantDatabases, nil
+}
+
+// getAssignedMultitenantDatabaseResources returns the assigned multitenant
+// database if there is one or nil if there is not. An error is returned if the
+// installation is assigned to more than one database.
+func (d *RDSMultitenantPGBouncerDatabase) getAndLockAssignedProxiedDatabase(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) (*model.MultitenantDatabase, func(), error) {
+	multitenantDatabases, err := store.GetMultitenantDatabases(&model.MultitenantDatabaseFilter{
+		DatabaseType:          d.databaseType,
+		InstallationID:        d.installationID,
+		MaxInstallationsLimit: model.NoInstallationsLimit,
+		Paging:                model.AllPagesNotDeleted(),
+	})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to query for multitenant databases")
+	}
+	if len(multitenantDatabases) > 1 {
+		return nil, nil, errors.Errorf("expected no more than 1 assigned database for installation, but found %d", len(multitenantDatabases))
+	}
+	if len(multitenantDatabases) == 0 {
+		return nil, nil, nil
+	}
+
+	unlockFn, err := lockMultitenantDatabase(multitenantDatabases[0].ID, d.instanceID, store, logger)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to lock multitenant database")
+	}
+	// Take no chances that the stored multitenant database was updated between
+	// retrieving it and locking it. We know this installation is assigned to
+	// exactly one multitenant database at this point so we can use the store
+	// function to directly retrieve it.
+	database, err := store.GetMultitenantDatabaseForInstallationID(d.installationID)
+	if err != nil {
+		unlockFn()
+		return nil, nil, errors.Wrap(err, "failed to refresh multitenant database after lock")
+	}
+
+	return database, unlockFn, nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) provisionPGBouncerDatabase(vpcID string, rdsCluster *rds.DBCluster, logger log.FieldLogger) error {
+	rdsID := *rdsCluster.DBClusterIdentifier
+
+	logger.Infof("Provisioning PGBouncer database %s", rdsID)
+
+	masterSecretValue, err := d.client.Service().secretsManager.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: rdsCluster.DBClusterIdentifier,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to find the master secret for the multitenant proxy cluster %s", rdsID)
+	}
+
+	authUserSecret, err := d.ensurePGBouncerAuthUserSecretIsCreated(&rdsID, &vpcID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to ensure the pgbouncer auth user secret was created for %s", rdsID)
+	}
+
+	close, err := d.connectRDSCluster(rdsPostgresDefaultSchema, *rdsCluster.Endpoint, DefaultMattermostDatabaseUsername, *masterSecretValue.SecretString)
+	if err != nil {
+		return errors.Wrapf(err, "failed to connect to the multitenant proxy cluster %s", rdsID)
+	}
+	defer close(logger)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(DefaultMySQLContextTimeSeconds*time.Second))
+	defer cancel()
+
+	query := fmt.Sprintf("SELECT 1 FROM pg_roles WHERE rolname='%s'", authUserSecret.MasterUsername)
+	rows, err := d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run database user check SQL command")
+	}
+	if rows.Next() {
+		// User already exists.
+		return nil
+	}
+
+	query = fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s'", authUserSecret.MasterUsername, authUserSecret.MasterPassword)
+	_, err = d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.New("failed to run create pgbouncer auth user SQL command: error suppressed")
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) ensurePGBouncerAuthUserSecretIsCreated(rdsClusterID, VpcID *string) (*RDSSecret, error) {
+	authUserSecretName := PGBouncerAuthUserSecretName(*VpcID)
+
+	secretValue, err := d.client.Service().secretsManager.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(authUserSecretName),
+	})
+	if err != nil && !IsErrorCode(err, secretsmanager.ErrCodeResourceNotFoundException) {
+		return nil, errors.Wrapf(err, "failed to get pgbouncer auth user secret %s", authUserSecretName)
+	}
+
+	var secret *RDSSecret
+	if secretValue != nil && secretValue.SecretString != nil {
+		secret, err = unmarshalSecretPayload(*secretValue.SecretString)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to unmarshal pgbouncer auth user secret %s", authUserSecretName)
+		}
+	} else {
+		description := RDSMultitenantPGBouncerClusterSecretDescription(*VpcID)
+		tags := []*secretsmanager.Tag{
+			{
+				Key:   aws.String(trimTagPrefix(DefaultRDSMultitenantDatabaseIDTagKey)),
+				Value: rdsClusterID,
+			},
+			{
+				Key:   aws.String(trimTagPrefix(VpcIDTagKey)),
+				Value: VpcID,
+			},
+		}
+
+		secret, err = createDatabaseUserSecret(authUserSecretName, DefaultPGBouncerAuthUsername, description, tags, d.client)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create a multitenant RDS database secret %s", authUserSecretName)
+		}
+	}
+
+	return secret, nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) ensureLogicalDatabaseExists(databaseName, vpcID string, rdsCluster *rds.DBCluster, logger log.FieldLogger) error {
+	rdsID := *rdsCluster.DBClusterIdentifier
+
+	masterSecretValue, err := d.client.Service().secretsManager.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: rdsCluster.DBClusterIdentifier,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to find the master secret for the multitenant proxy cluster %s", rdsID)
+	}
+
+	close, err := d.connectRDSCluster(rdsPostgresDefaultSchema, *rdsCluster.Endpoint, DefaultMattermostDatabaseUsername, *masterSecretValue.SecretString)
+	if err != nil {
+		return errors.Wrapf(err, "failed to connect to the multitenant proxy cluster %s", rdsID)
+	}
+	defer close(logger)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(DefaultMySQLContextTimeSeconds*time.Second))
+	defer cancel()
+
+	err = d.ensureDatabaseIsCreated(ctx, databaseName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create database in multitenant proxy cluster %s", rdsID)
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) ensureLogicalDatabaseSetup(databaseName, vpcID string, rdsCluster *rds.DBCluster, logger log.FieldLogger) error {
+	rdsID := *rdsCluster.DBClusterIdentifier
+
+	masterSecretValue, err := d.client.Service().secretsManager.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: rdsCluster.DBClusterIdentifier,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to find the master secret for the multitenant proxy cluster %s", rdsID)
+	}
+
+	close, err := d.connectRDSCluster(databaseName, *rdsCluster.Endpoint, DefaultMattermostDatabaseUsername, *masterSecretValue.SecretString)
+	if err != nil {
+		return errors.Wrapf(err, "failed to connect to the multitenant proxy cluster %s", rdsID)
+	}
+	defer close(logger)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(DefaultMySQLContextTimeSeconds*time.Second))
+	defer cancel()
+
+	err = d.ensurePGBouncerDatabasePrep(ctx, databaseName, DefaultPGBouncerAuthUsername)
+	if err != nil {
+		return errors.Wrap(err, "failed to perform pgbouncer setup")
+	}
+
+	installationSecret, err := d.ensureMultitenantDatabaseSecretIsCreated(rdsCluster.DBClusterIdentifier, &vpcID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get a secret for installation")
+	}
+
+	err = d.ensureDatabaseUserIsCreated(ctx, installationSecret.MasterUsername, installationSecret.MasterPassword)
+	if err != nil {
+		return errors.Wrap(err, "failed to create Mattermost database user")
+	}
+
+	err = d.ensureInstallationUserAddedToUsersTable(ctx, installationSecret.MasterUsername, installationSecret.MasterPassword)
+	if err != nil {
+		return errors.Wrap(err, "failed to create Mattermost user entry for PGBouncer")
+	}
+
+	err = d.ensureMasterUserHasRole(ctx, installationSecret.MasterUsername)
+	if err != nil {
+		return errors.Wrap(err, "failed to ensure master user has installation role")
+	}
+
+	err = d.ensureSchemaIsCreated(ctx, installationSecret.MasterUsername)
+	if err != nil {
+		return errors.Wrap(err, "failed to grant permissions to Mattermost database user")
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) ensureDatabaseIsCreated(ctx context.Context, databaseName string) error {
+	query := fmt.Sprintf(`SELECT datname FROM pg_catalog.pg_database WHERE lower(datname) = lower('%s');`, databaseName)
+	rows, err := d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run database exists SQL command")
+	}
+	if rows.Next() {
+		return nil
+	}
+
+	query = fmt.Sprintf(`CREATE DATABASE %s`, databaseName)
+	_, err = d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run create database SQL command")
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) ensureInstallationUserAddedToUsersTable(ctx context.Context, username, password string) error {
+	query := fmt.Sprintf("SELECT usename FROM pgbouncer.pgbouncer_users WHERE usename = '%s';", username)
+	rows, err := d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run installation pgbouncer user exists SQL command")
+	}
+	if rows.Next() {
+		return nil
+	}
+
+	query = fmt.Sprintf(`INSERT INTO pgbouncer.pgbouncer_users (usename, passwd) VALUES ('%s', 'md5%x')`, username, md5.Sum([]byte(password+username)))
+	_, err = d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run create pgbouncer installation user SQL command")
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) ensurePGBouncerDatabasePrep(ctx context.Context, databaseName, pgbouncerUsername string) error {
+	err := d.ensureMasterUserHasRole(ctx, pgbouncerUsername)
+	if err != nil {
+		return errors.Wrap(err, "failed to run master user has pgbouncer role SQL command")
+	}
+
+	err = d.ensureSchemaIsCreated(ctx, pgbouncerUsername)
+	if err != nil {
+		return errors.Wrap(err, "failed to run pgbouncer schema is created SQL command")
+	}
+
+	query := fmt.Sprintf(`ALTER DATABASE %s SET search_path = "$user"`, databaseName)
+	_, err = d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run database search path set SQL command")
+	}
+
+	query = fmt.Sprintf(`
+	CREATE TABLE IF NOT EXISTS %s.pgbouncer_users(
+	usename NAME PRIMARY KEY,
+	passwd TEXT NOT NULL
+	)`, pgbouncerUsername)
+	_, err = d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run pgbouncer user table creation SQL command")
+	}
+
+	query = fmt.Sprintf(`
+	CREATE OR REPLACE FUNCTION %s.get_auth(uname TEXT) RETURNS TABLE (usename name, passwd text) as
+	$$
+	  SELECT usename, passwd FROM pgbouncer.pgbouncer_users WHERE usename=$1;
+	$$
+	LANGUAGE sql SECURITY DEFINER;`,
+		pgbouncerUsername)
+	_, err = d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run auth user lookup query SQL command")
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) ensureDatabaseUserIsCreated(ctx context.Context, username, password string) error {
+	query := fmt.Sprintf("SELECT 1 FROM pg_roles WHERE rolname='%s'", username)
+	rows, err := d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run database user check SQL command")
+	}
+	if rows.Next() {
+		return nil
+	}
+
+	query = fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s'", username, password)
+	_, err = d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.New("failed to run create user SQL command: error suppressed")
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) ensureMasterUserHasRole(ctx context.Context, role string) error {
+	query := fmt.Sprintf("GRANT %s TO %s;", role, DefaultMattermostDatabaseUsername)
+	_, err := d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run grant role SQL command")
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) ensureSchemaIsCreated(ctx context.Context, username string) error {
+	query := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS AUTHORIZATION %s", username)
+	_, err := d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run create schema SQL command")
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) connectRDSCluster(database, endpoint, username, password string) (func(logger log.FieldLogger), error) {
+	db, err := sql.Open("postgres", RDSPostgresConnString(database, endpoint, username, password))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to connect to postgres database")
+	}
+
+	d.db = db
+
+	closeFunc := func(logger log.FieldLogger) {
+		err := d.db.Close()
+		if err != nil {
+			logger.WithError(err).Errorf("Failed to close the connection with multitenant RDS cluster endpoint %s", endpoint)
+		}
+	}
+
+	return closeFunc, nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) ensureMultitenantDatabaseSecretIsCreated(rdsClusterID, VpcID *string) (*RDSSecret, error) {
+	installationSecretName := RDSMultitenantPGBouncerSecretName(d.installationID)
+
+	installationSecretValue, err := d.client.Service().secretsManager.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(installationSecretName),
+	})
+	if err != nil && !IsErrorCode(err, secretsmanager.ErrCodeResourceNotFoundException) {
+		return nil, errors.Wrapf(err, "failed to get multitenant RDS database secret %s", installationSecretName)
+	}
+
+	var installationSecret *RDSSecret
+	if installationSecretValue != nil && installationSecretValue.SecretString != nil {
+		installationSecret, err = unmarshalSecretPayload(*installationSecretValue.SecretString)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to unmarshal multitenant RDS database secret %s", installationSecretName)
+		}
+	} else {
+		description := RDSMultitenantClusterSecretDescription(d.installationID, *rdsClusterID)
+		tags := []*secretsmanager.Tag{
+			{
+				Key:   aws.String(trimTagPrefix(DefaultRDSMultitenantDatabaseIDTagKey)),
+				Value: rdsClusterID,
+			},
+			{
+				Key:   aws.String(trimTagPrefix(VpcIDTagKey)),
+				Value: VpcID,
+			},
+			{
+				Key:   aws.String(trimTagPrefix(DefaultMattermostInstallationIDTagKey)),
+				Value: aws.String(d.installationID),
+			},
+		}
+
+		username := MattermostPGBouncerDatabaseUsername(d.installationID)
+		installationSecret, err = createDatabaseUserSecret(installationSecretName, username, description, tags, d.client)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create a multitenant RDS database secret %s", installationSecretName)
+		}
+	}
+
+	return installationSecret, nil
+}
+
+// GenerateDatabaseSecret creates the k8s database spec and secret for
+// accessing a multitenant database inside a RDS multitenant cluster with
+// a PGBouncer proxy.
+func (d *RDSMultitenantPGBouncerDatabase) GenerateDatabaseSecret(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) (*corev1.Secret, error) {
+	err := d.IsValid()
+	if err != nil {
+		return nil, errors.Wrap(err, "pgbouncer database configuration is invalid")
+	}
+
+	multitenantDatabase, err := store.GetMultitenantDatabaseForInstallationID(d.installationID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query for the multitenant database")
+	}
+
+	unlock, err := lockMultitenantDatabase(multitenantDatabase.ID, d.instanceID, store, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to lock multitenant database")
+	}
+	defer unlock()
+
+	installationDatabaseName := multitenantDatabase.SharedLogicalDatabaseMappings.GetLogicalDatabaseName(d.installationID)
+	logger = logger.WithFields(log.Fields{
+		"multitenant-rds-database": installationDatabaseName,
+		"database-type":            d.databaseType,
+	})
+
+	installationSecretName := RDSMultitenantPGBouncerSecretName(d.installationID)
+
+	result, err := d.client.Service().secretsManager.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: &installationSecretName,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get secret value for database")
+	}
+
+	installationSecret, err := unmarshalSecretPayload(*result.SecretString)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal secret payload")
+	}
+
+	databaseConnectionString, databaseReadReplicasString :=
+		MattermostPostgresPGBouncerConnStrings(
+			installationSecret.MasterUsername,
+			installationSecret.MasterPassword,
+			installationDatabaseName,
+		)
+	databaseConnectionCheck := databaseConnectionString
+
+	secretStringData := map[string]string{
+		"DB_CONNECTION_STRING":              databaseConnectionString,
+		"MM_SQLSETTINGS_DATASOURCEREPLICAS": databaseReadReplicasString,
+	}
+	if len(databaseConnectionCheck) != 0 {
+		secretStringData["DB_CONNECTION_CHECK_URL"] = databaseConnectionCheck
+	}
+
+	databaseSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: installationSecretName,
+		},
+		StringData: secretStringData,
+	}
+
+	logger.Debug("AWS RDS multitenant PGBouncer database configuration generated for cluster installation")
+
+	return databaseSecret, nil
+}
+
+// Teardown removes all AWS resources related to a RDS multitenant database.
+func (d *RDSMultitenantPGBouncerDatabase) Teardown(store model.InstallationDatabaseStoreInterface, keepData bool, logger log.FieldLogger) error {
+	logger.Info("Tearing down RDS multitenant PGBouncer database")
+
+	err := d.IsValid()
+	if err != nil {
+		return errors.Wrap(err, "multitenant database configuration is invalid")
+	}
+
+	if keepData {
+		logger.Warn("Keepdata is set to true on this server, but this is not yet supported for RDS multitenant PGBouncer databases")
+	}
+
+	database, unlockFn, err := d.getAndLockAssignedProxiedDatabase(store, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to get assigned multitenant database")
+	}
+	if database != nil {
+		defer unlockFn()
+		err = d.removeInstallationPGBouncerResources(database, store, logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to remove installation database")
+		}
+	} else {
+		logger.Debug("No multitenant databases found for this installation; skipping...")
+	}
+
+	logger.Info("Multitenant RDS PGBouncer database teardown complete")
+
+	return nil
+}
+
+// removeInstallationFromPGBouncerDatabase performs the work necessary to
+// remove a single installation schema from a multitenant PGBouncer RDS cluster.
+func (d *RDSMultitenantPGBouncerDatabase) removeInstallationPGBouncerResources(database *model.MultitenantDatabase, store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	rdsCluster, err := describeRDSCluster(database.ID, d.client)
+	if err != nil {
+		return errors.Wrap(err, "failed to describe multitenant database")
+	}
+
+	logger = logger.WithField("rds-cluster-id", *rdsCluster.DBClusterIdentifier)
+
+	err = ensureSecretDeleted(RDSMultitenantSecretName(d.installationID), d.client)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete multitenant database secret")
+	}
+
+	databaseName := database.SharedLogicalDatabaseMappings.GetLogicalDatabaseName(d.installationID)
+	username := MattermostPGBouncerDatabaseUsername(d.installationID)
+
+	err = d.cleanupDatabase(*rdsCluster.DBClusterIdentifier, *rdsCluster.Endpoint, databaseName, username, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to cleanup pgbouncer database")
+	}
+
+	database.Installations.Remove(d.installationID)
+	database.SharedLogicalDatabaseMappings.RemoveInstallation(d.installationID)
+	err = updateCounterTagWithCurrentWeight(database, rdsCluster, store, d.client, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to update counter tag with current weight")
+	}
+
+	err = store.UpdateMultitenantDatabase(database)
+	if err != nil {
+		return errors.Wrapf(err, "failed to remove installation ID %s from multitenant datastore", d.installationID)
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) cleanupDatabase(rdsClusterID, rdsClusterendpoint, databaseName, installationUsername string, logger log.FieldLogger) error {
+	masterSecretValue, err := d.client.Service().secretsManager.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(rdsClusterID),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to get master secret by ID %s", rdsClusterID)
+	}
+
+	close, err := d.connectRDSCluster(databaseName, rdsClusterendpoint, DefaultMattermostDatabaseUsername, *masterSecretValue.SecretString)
+	if err != nil {
+		return errors.Wrapf(err, "failed to connect to multitenant RDS cluster ID %s", rdsClusterID)
+	}
+	defer close(logger)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(DefaultMySQLContextTimeSeconds*time.Second))
+	defer cancel()
+
+	err = dropSchemaIfExists(ctx, d.db, installationUsername)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete installation schema")
+	}
+
+	err = dropUserIfExists(ctx, d.db, installationUsername)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete installation database user")
+	}
+
+	err = d.deleteInstallationUsernameEntry(ctx, installationUsername)
+	if err != nil {
+		return errors.Wrap(err, "failed to remove installation database user from pgbouncer table")
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) deleteInstallationUsernameEntry(ctx context.Context, username string) error {
+	query := fmt.Sprintf(`DELETE FROM  pgbouncer.pgbouncer_users WHERE usename = '%s'`, username)
+	_, err := d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run delete installation user SQL command")
+	}
+
+	return nil
+}
+
+// Unsupported Methods
+
+// Snapshot creates a snapshot of single RDS multitenant database.
+func (d *RDSMultitenantPGBouncerDatabase) Snapshot(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	return errors.New("not implemented")
+}
+
+// MigrateOut migrating out of MySQL Operator managed database is not supported.
+func (d *RDSMultitenantPGBouncerDatabase) MigrateOut(store model.InstallationDatabaseStoreInterface, dbMigration *model.InstallationDBMigrationOperation, logger log.FieldLogger) error {
+	return errors.New("database migration is not supported for PGBouncer database")
+}
+
+// MigrateTo migration to MySQL Operator managed database is not supported.
+func (d *RDSMultitenantPGBouncerDatabase) MigrateTo(store model.InstallationDatabaseStoreInterface, dbMigration *model.InstallationDBMigrationOperation, logger log.FieldLogger) error {
+	return errors.New("database migration is not supported for PGBouncer database")
+}
+
+// TeardownMigrated tearing down migrated databases is not supported for MySQL Operator managed database.
+func (d *RDSMultitenantPGBouncerDatabase) TeardownMigrated(store model.InstallationDatabaseStoreInterface, migrationOp *model.InstallationDBMigrationOperation, logger log.FieldLogger) error {
+	return errors.New("tearing down migrated installations is not supported for PGBouncer database")
+}
+
+// RollbackMigration rolling back migration is not supported for MySQL Operator managed database.
+func (d *RDSMultitenantPGBouncerDatabase) RollbackMigration(store model.InstallationDatabaseStoreInterface, dbMigration *model.InstallationDBMigrationOperation, logger log.FieldLogger) error {
+	return errors.New("rolling back db migration is not supported for PGBouncer database")
+}
+
+// RefreshResourceMetadata ensures various operator database resource's metadata
+// are correct.
+func (d *RDSMultitenantPGBouncerDatabase) RefreshResourceMetadata(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	return nil
+}

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
@@ -104,6 +103,24 @@ func RDSMultitenantSecretName(id string) string {
 	return fmt.Sprintf("rds-multitenant-%s", id)
 }
 
+// RDSMultitenantPGBouncerSecretName formats the name of a secret used in a
+// multitenant PGBouncer RDS database.
+func RDSMultitenantPGBouncerSecretName(id string) string {
+	return fmt.Sprintf("rds-multitenant-pgbouncer-%s", id)
+}
+
+// PGBouncerAuthUserSecretName formats the name of a secret used for the
+// pgbouncer auth user.
+func PGBouncerAuthUserSecretName(vpcID string) string {
+	return fmt.Sprintf("rds-multitenant-pgbouncer-authuser-%s", vpcID)
+}
+
+// MattermostPGBouncerDatabaseUsername formats the name of a Mattermost user for
+// use in a PGBouncer database.
+func MattermostPGBouncerDatabaseUsername(installationID string) string {
+	return fmt.Sprintf("id_%s", installationID)
+}
+
 // MattermostMultitenantS3Name formats the name of a Mattermost S3 multitenant
 // filestore bucket name.
 func MattermostMultitenantS3Name(environmentName, vpcID string) string {
@@ -115,45 +132,16 @@ func MattermostRDSDatabaseName(installationID string) string {
 	return fmt.Sprintf("%s%s", rdsDatabaseNamePrefix, installationID)
 }
 
-// MattermostMySQLConnStrings formats the connection string used for accessing a
-// Mattermost database.
-func MattermostMySQLConnStrings(schema, username, password string, dbCluster *rds.DBCluster) (string, string) {
-	dbConnection := fmt.Sprintf("mysql://%s:%s@tcp(%s:3306)/%s?charset=utf8mb4%%2Cutf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
-		username, password, *dbCluster.Endpoint, schema)
-	readReplicas := fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?charset=utf8mb4%%2Cutf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
-		username, password, *dbCluster.ReaderEndpoint, schema)
-
-	return dbConnection, readReplicas
-}
-
-// RDSMySQLConnString formats the connection string used by the provisioner for
-// accessing a MySQL RDS cluster.
-func RDSMySQLConnString(schema, endpoint, username, password string) string {
-	return fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?interpolateParams=true&charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
-		username, password, endpoint, schema)
-}
-
-// MattermostPostgresConnStrings formats the connection strings used by Mattermost
-// servers to access a PostgreSQL database.
-func MattermostPostgresConnStrings(schema, username, password string, dbCluster *rds.DBCluster) (string, string) {
-	dbConnection := fmt.Sprintf("postgres://%s:%s@%s:5432/%s?connect_timeout=10",
-		username, password, *dbCluster.Endpoint, schema)
-	readReplicas := fmt.Sprintf("postgres://%s:%s@%s:5432/%s?connect_timeout=10",
-		username, password, *dbCluster.ReaderEndpoint, schema)
-
-	return dbConnection, readReplicas
-}
-
-// RDSPostgresConnString formats the connection string used by the provisioner
-// for accessing a Postgres RDS cluster.
-func RDSPostgresConnString(schema, endpoint, username, password string) string {
-	return fmt.Sprintf("postgres://%s:%s@%s:5432/%s?connect_timeout=10",
-		username, password, endpoint, schema)
-}
-
-// RDSMultitenantClusterSecretDescription formats the text used for the describing a multitenant database's secret key.
+// RDSMultitenantClusterSecretDescription formats the text used for describing a
+// multitenant database's secret key.
 func RDSMultitenantClusterSecretDescription(installationID, rdsClusterID string) string {
 	return fmt.Sprintf("Used for accessing installation ID: %s database managed by RDS cluster ID: %s", installationID, rdsClusterID)
+}
+
+// RDSMultitenantPGBouncerClusterSecretDescription formats the text used for
+// describing a PGBouncer auth user secret key.
+func RDSMultitenantPGBouncerClusterSecretDescription(vpcID string) string {
+	return fmt.Sprintf("The PGBouncer auth user credentials for VPC ID: %s", vpcID)
 }
 
 // GetMultitenantBucketNameForInstallation is a convenience function

--- a/internal/tools/aws/helpers_sql.go
+++ b/internal/tools/aws/helpers_sql.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/pkg/errors"
+)
+
+// MattermostMySQLConnStrings formats the connection string used for accessing a
+// Mattermost database.
+func MattermostMySQLConnStrings(schema, username, password string, dbCluster *rds.DBCluster) (string, string) {
+	dbConnection := fmt.Sprintf("mysql://%s:%s@tcp(%s:3306)/%s?charset=utf8mb4%%2Cutf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
+		username, password, *dbCluster.Endpoint, schema)
+	readReplicas := fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?charset=utf8mb4%%2Cutf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
+		username, password, *dbCluster.ReaderEndpoint, schema)
+
+	return dbConnection, readReplicas
+}
+
+// RDSMySQLConnString formats the connection string used by the provisioner for
+// accessing a MySQL RDS cluster.
+func RDSMySQLConnString(schema, endpoint, username, password string) string {
+	return fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?interpolateParams=true&charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&tls=skip-verify",
+		username, password, endpoint, schema)
+}
+
+// MattermostPostgresConnStrings formats the connection strings used by Mattermost
+// servers to access a PostgreSQL database.
+func MattermostPostgresConnStrings(schema, username, password string, dbCluster *rds.DBCluster) (string, string) {
+	dbConnection := fmt.Sprintf("postgres://%s:%s@%s:5432/%s?connect_timeout=10",
+		username, password, *dbCluster.Endpoint, schema)
+	readReplicas := fmt.Sprintf("postgres://%s:%s@%s:5432/%s?connect_timeout=10",
+		username, password, *dbCluster.ReaderEndpoint, schema)
+
+	return dbConnection, readReplicas
+}
+
+// MattermostPostgresPGBouncerConnStrings formats the connection strings used by
+// Mattermost servers to access a PostgreSQL database with a PGBouncer proxy.
+func MattermostPostgresPGBouncerConnStrings(username, password, database string) (string, string) {
+	dbConnection := fmt.Sprintf("postgres://%s:%s@pgbouncer.pgbouncer:5432/%s?connect_timeout=10&sslmode=disable",
+		username, password, database)
+	readReplicas := fmt.Sprintf("postgres://%s:%s@pgbouncer.pgbouncer:5432/%s-ro?connect_timeout=10&sslmode=disable",
+		username, password, database)
+
+	return dbConnection, readReplicas
+}
+
+// RDSPostgresConnString formats the connection string used by the provisioner
+// for accessing a Postgres RDS cluster.
+func RDSPostgresConnString(schema, endpoint, username, password string) string {
+	return fmt.Sprintf("postgres://%s:%s@%s:5432/%s?connect_timeout=10",
+		username, password, endpoint, schema)
+}
+
+func dropUserIfExists(ctx context.Context, db SQLDatabaseManager, username string) error {
+	query := fmt.Sprintf("DROP USER IF EXISTS %s", username)
+	_, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run drop user SQL command")
+	}
+
+	return nil
+}
+
+func dropSchemaIfExists(ctx context.Context, db SQLDatabaseManager, schemaName string) error {
+	query := fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schemaName)
+	_, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run drop schema SQL command")
+	}
+
+	return nil
+}

--- a/internal/tools/utils/utils.go
+++ b/internal/tools/utils/utils.go
@@ -131,6 +131,8 @@ func (r *ResourceUtil) GetDatabase(installationID, dbType string) model.Database
 		return aws.NewRDSMultitenantDatabase(model.DatabaseEngineTypeMySQL, r.instanceID, installationID, r.awsClient)
 	case model.InstallationDatabaseMultiTenantRDSPostgres:
 		return aws.NewRDSMultitenantDatabase(model.DatabaseEngineTypePostgres, r.instanceID, installationID, r.awsClient)
+	case model.InstallationDatabaseMultiTenantRDSPostgresPGBouncer:
+		return aws.NewRDSMultitenantPGBouncerDatabase(model.DatabaseEngineTypePostgresProxy, r.instanceID, installationID, r.awsClient)
 	}
 
 	// Warning: we should never get here as it would mean that we didn't match

--- a/manifests/pgbouncer-manifests/pgbouncer-configmap.yaml
+++ b/manifests/pgbouncer-manifests/pgbouncer-configmap.yaml
@@ -22,3 +22,4 @@ data:
     max_client_conn = 10000
     max_db_connections = 20
     [databases]
+    * =

--- a/model/installation_database.go
+++ b/model/installation_database.go
@@ -27,11 +27,17 @@ const (
 	// InstallationDatabaseMultiTenantRDSPostgres is a PostgreSQL multitenant
 	// database hosted via Amazon RDS.
 	InstallationDatabaseMultiTenantRDSPostgres = "aws-multitenant-rds-postgres"
+	// InstallationDatabaseMultiTenantRDSPostgresPGBouncer is a PostgreSQL
+	// multitenant database hosted via Amazon RDS that has pooled connections.
+	InstallationDatabaseMultiTenantRDSPostgresPGBouncer = "aws-multitenant-rds-postgres-pgbouncer"
 
 	// DatabaseEngineTypeMySQL is a MySQL database.
 	DatabaseEngineTypeMySQL = "mysql"
 	// DatabaseEngineTypePostgres is a PostgreSQL database.
 	DatabaseEngineTypePostgres = "postgres"
+	// DatabaseEngineTypePostgresProxy is a PostgreSQL database that is
+	// configured for proxied connections.
+	DatabaseEngineTypePostgresProxy = "postgres-proxy"
 )
 
 // Database is the interface for managing Mattermost databases.
@@ -64,6 +70,12 @@ type InstallationDatabaseStoreInterface interface {
 	LockMultitenantDatabases(ids []string, lockerID string) (bool, error)
 	UnlockMultitenantDatabases(ids []string, lockerID string, force bool) (bool, error)
 	GetSingleTenantDatabaseConfigForInstallation(installationID string) (*SingleTenantDatabaseConfig, error)
+}
+
+// ClusterUtilityDatabaseStoreInterface is the interface necessary for SQLStore
+// functionality to update cluster utilities as needed.
+type ClusterUtilityDatabaseStoreInterface interface {
+	GetMultitenantDatabases(filter *MultitenantDatabaseFilter) ([]*MultitenantDatabase, error)
 }
 
 // MysqlOperatorDatabase is a database backed by the MySQL operator.
@@ -143,6 +155,7 @@ func IsSupportedDatabase(database string) bool {
 	case InstallationDatabaseSingleTenantRDSPostgres:
 	case InstallationDatabaseMultiTenantRDSMySQL:
 	case InstallationDatabaseMultiTenantRDSPostgres:
+	case InstallationDatabaseMultiTenantRDSPostgresPGBouncer:
 	case InstallationDatabaseMysqlOperator:
 	default:
 		return false

--- a/model/installation_database_test.go
+++ b/model/installation_database_test.go
@@ -44,6 +44,9 @@ func TestIsSupportedDatabase(t *testing.T) {
 		{model.InstallationDatabaseMysqlOperator, true},
 		{model.InstallationDatabaseSingleTenantRDSMySQL, true},
 		{model.InstallationDatabaseSingleTenantRDSPostgres, true},
+		{model.InstallationDatabaseMultiTenantRDSMySQL, true},
+		{model.InstallationDatabaseMultiTenantRDSPostgres, true},
+		{model.InstallationDatabaseMultiTenantRDSPostgresPGBouncer, true},
 	}
 
 	for _, tc := range testCases {

--- a/model/multitenant_database_states.go
+++ b/model/multitenant_database_states.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+const (
+	// DatabaseStateStable is an database in a stable state.
+	DatabaseStateStable = "stable"
+	// DatabaseStateProvisioningRequested is an database that requires provisioning.
+	DatabaseStateProvisioningRequested = "provisioning-requested"
+)


### PR DESCRIPTION
This new database type pools database connections via the PGBouncer
utility running inside the cluster. Installations are assigned to
a logical database in the database cluster and are given a schema
in which to store their data. Authentication is performed through
an authorization query from a pgbouncer user to the backing database
to ensure the user credentials are valid.

This change also includes a large amount of refactoring in the AWS
package in an attempt to reuse existing logic.

Fixes https://mattermost.atlassian.net/browse/MM-34809 and https://mattermost.atlassian.net/browse/MM-34810

Reviewers Notes:
 - This is very light on unit tests. These will be added as soon as we validate that connection pooling is leading to the expected scaling increase in the test account.
 - Logical databases are currently hardcoded to 10 installation schemas. API endpoints will be added for updating this as soon our initial tests conclude with positive results.
 - There is a lot of additional refactoring that should be done in the aws package to simplify logic and remove duplicated code.
 - The mappings for schema > logical database are currently stored directly in the multitenant database object. This probably isn't the best longterm solution and will be remedied with a follow-up database migration.

Results from a full ctest database suite run:
```
INFO[2021-07-01T13:46:17-04:00] ====================================================
INFO[2021-07-01T13:46:17-04:00] TEST RESULTS
INFO[2021-07-01T13:46:17-04:00] ====================================================
INFO[2021-07-01T13:46:17-04:00] PASS: aws-multitenant-rds-postgres-pgbouncer (0.91 minutes)
INFO[2021-07-01T13:46:17-04:00] PASS: aws-multitenant-rds-postgres (0.67 minutes)
INFO[2021-07-01T13:46:17-04:00] PASS: aws-multitenant-rds (0.83 minutes)
INFO[2021-07-01T13:46:17-04:00] PASS: aws-rds-postgres (5.63 minutes)
INFO[2021-07-01T13:46:17-04:00] PASS: aws-rds (5.20 minutes)
INFO[2021-07-01T13:46:17-04:00] PASS: mysql-operator (2.30 minutes)
INFO[2021-07-01T13:46:17-04:00] ====================================================
```

Release Notes
```release-note
Add PGBouncer installation databases
```
