### PR TITLE
Update kops to 1.20, k8s to 1.20.8 and terraform to 0.12.31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ DOCKER_BUILD_IMAGE = golang:1.16.2
 DOCKER_BASE_IMAGE = alpine:3.13.2
 
 ## Tool Versions
-TERRAFORM_VERSION=0.12.29
-KOPS_VERSION=v1.19.1
+TERRAFORM_VERSION=0.12.31
+KOPS_VERSION=v1.20.2
 HELM_VERSION=v3.5.3
-KUBECTL_VERSION=v1.19.8
+KUBECTL_VERSION=v1.20.8
 
 ################################################################################
 


### PR DESCRIPTION
#### Summary
Updating provisioner to use kops 1.20.2, kubernetes to be updated to 1.20.8 and terraform 0.12.31

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36174

#### Release Note

```release-note
Update kOps and kubernetes to 1.20
```
