### PR TITLE
Add multitenant database update API endpoint

### DIFF
--- a/cmd/cloud/databases.go
+++ b/cmd/cloud/databases.go
@@ -12,12 +12,18 @@ import (
 
 func init() {
 	databaseCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
+	databaseCmd.PersistentFlags().Bool("dry-run", false, "When set to true, only print the API request without sending it.")
 
 	databaseListCmd.Flags().String("vpc-id", "", "The VPC ID by which to filter databases.")
 	databaseListCmd.Flags().String("database-type", "", "The database type by which to filter databases.")
 	registerPagingFlags(databaseListCmd)
 
+	databaseUpdateCmd.Flags().String("database", "", "The id of the database to be updated.")
+	databaseUpdateCmd.Flags().Int64("max-installations-per-logical-db", 10, "The maximum number of installations permitted in a single logical database (only applies to proxy databases).")
+	databaseUpdateCmd.MarkFlagRequired("database")
+
 	databaseCmd.AddCommand(databaseListCmd)
+	databaseCmd.AddCommand(databaseUpdateCmd)
 }
 
 var databaseCmd = &cobra.Command{
@@ -53,5 +59,39 @@ var databaseListCmd = &cobra.Command{
 		}
 
 		return nil
+	},
+}
+
+var databaseUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update an database's configuration",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		databaseID, _ := command.Flags().GetString("database")
+
+		request := &model.PatchDatabaseRequest{
+			MaxInstallationsPerLogicalDatabase: getInt64FlagPointer(command, "max-installations-per-logical-db"),
+		}
+
+		dryRun, _ := command.Flags().GetBool("dry-run")
+		if dryRun {
+			err := printJSON(request)
+			if err != nil {
+				return errors.Wrap(err, "failed to print API request")
+			}
+
+			return nil
+		}
+
+		database, err := client.UpdateMultitenantDatabase(databaseID, request)
+		if err != nil {
+			return errors.Wrap(err, "failed to update database")
+		}
+
+		return printJSON(database)
 	},
 }

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -36,7 +36,6 @@ func initCluster(apiRouter *mux.Router, context *Context) {
 	clusterRouter.Handle("/utilities", addContext(handleGetAllUtilityMetadata)).Methods("GET")
 	clusterRouter.Handle("/annotations", addContext(handleAddClusterAnnotations)).Methods("POST")
 	clusterRouter.Handle("/annotation/{annotation-name}", addContext(handleDeleteClusterAnnotation)).Methods("DELETE")
-
 	clusterRouter.Handle("", addContext(handleDeleteCluster)).Methods("DELETE")
 }
 

--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -44,3 +44,7 @@ func (s *mockProvisioner) GetClusterResources(*model.Cluster, bool) (*k8s.Cluste
 func sToP(s string) *string {
 	return &s
 }
+
+func iToP(i int64) *int64 {
+	return &i
+}

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -17,8 +17,11 @@ func initDatabases(apiRouter *mux.Router, context *Context) {
 		return newContextHandler(context, handler)
 	}
 
-	databaseRouter := apiRouter.PathPrefix("/databases").Subrouter()
-	databaseRouter.Handle("", addContext(handleGetDatabases)).Methods("GET")
+	databasesRouter := apiRouter.PathPrefix("/databases").Subrouter()
+	databasesRouter.Handle("", addContext(handleGetDatabases)).Methods("GET")
+
+	databaseRouter := apiRouter.PathPrefix("/database/{database}").Subrouter()
+	databaseRouter.Handle("", addContext(handleUpdateDatabase)).Methods("PUT")
 }
 
 // handleGetDatabases responds to GET /api/databases, returning a list of
@@ -52,4 +55,41 @@ func handleGetDatabases(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	outputJSON(c, w, databases)
+}
+
+// handleUpdateDatabase responds to PUT /api/database/{database}, updating the
+// database configuration values.
+func handleUpdateDatabase(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	databaseID := vars["database"]
+	c.Logger = c.Logger.WithField("database", databaseID)
+
+	database, status, unlockOnce := lockDatabase(c, databaseID)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	patchDatabaseRequest, err := model.NewPatchDatabaseRequestFromReader(r.Body)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to decode request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if patchDatabaseRequest.Apply(database) {
+		err = c.Store.UpdateMultitenantDatabase(database)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to update database")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	unlockOnce()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	outputJSON(c, w, database)
 }

--- a/internal/api/databases_test.go
+++ b/internal/api/databases_test.go
@@ -1,0 +1,229 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDatabases(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	t.Run("no databases", func(t *testing.T) {
+		databases, err := client.GetMultitenantDatabases(&model.GetDatabasesRequest{
+			Paging: model.AllPagesWithDeleted(),
+		})
+		require.NoError(t, err)
+		require.Empty(t, databases)
+	})
+
+	t.Run("parameter handling", func(t *testing.T) {
+		t.Run("invalid page", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases?page=invalid&per_page=100", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("invalid perPage", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases?page=0&per_page=invalid", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("no paging parameters", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("missing page", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases?per_page=100", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("missing perPage", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases?page=1", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	})
+
+	t.Run("results", func(t *testing.T) {
+		database1 := &model.MultitenantDatabase{
+			ID: model.NewID(),
+		}
+		err := sqlStore.CreateMultitenantDatabase(database1)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		database2 := &model.MultitenantDatabase{
+			ID: model.NewID(),
+		}
+		err = sqlStore.CreateMultitenantDatabase(database2)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		database3 := &model.MultitenantDatabase{
+			ID: model.NewID(),
+		}
+		err = sqlStore.CreateMultitenantDatabase(database3)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		t.Run("get databases", func(t *testing.T) {
+			testCases := []struct {
+				Description string
+				Request     *model.GetDatabasesRequest
+				Expected    []*model.MultitenantDatabase
+			}{
+				{
+					"page 0, perPage 2, exclude deleted",
+					&model.GetDatabasesRequest{
+						Paging: model.Paging{
+							Page:           0,
+							PerPage:        2,
+							IncludeDeleted: false,
+						},
+					},
+					[]*model.MultitenantDatabase{database1, database2},
+				},
+
+				{
+					"page 1, perPage 2, exclude deleted",
+					&model.GetDatabasesRequest{
+						Paging: model.Paging{
+							Page:           1,
+							PerPage:        2,
+							IncludeDeleted: false,
+						},
+					},
+					[]*model.MultitenantDatabase{database3},
+				},
+
+				{
+					"page 0, perPage 2, include deleted",
+					&model.GetDatabasesRequest{
+						Paging: model.Paging{
+							Page:           0,
+							PerPage:        2,
+							IncludeDeleted: true,
+						},
+					},
+					[]*model.MultitenantDatabase{database1, database2},
+				},
+
+				{
+					"page 1, perPage 2, include deleted",
+					&model.GetDatabasesRequest{
+						Paging: model.Paging{
+							Page:           1,
+							PerPage:        2,
+							IncludeDeleted: true,
+						},
+					},
+					[]*model.MultitenantDatabase{database3},
+				},
+			}
+
+			for _, testCase := range testCases {
+				t.Run(testCase.Description, func(t *testing.T) {
+					databases, err := client.GetMultitenantDatabases(testCase.Request)
+					require.NoError(t, err)
+					require.Equal(t, testCase.Expected, databases)
+				})
+			}
+		})
+	})
+}
+
+func TestUpdateDatabase(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	database1 := &model.MultitenantDatabase{
+		ID:                                 model.NewID(),
+		DatabaseType:                       model.DatabaseEngineTypePostgresProxy,
+		MaxInstallationsPerLogicalDatabase: 5,
+	}
+	err := sqlStore.CreateMultitenantDatabase(database1)
+	require.NoError(t, err)
+
+	t.Run("invalid payload", func(t *testing.T) {
+		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/database/%s", ts.URL, database1.ID), bytes.NewReader([]byte("invalid")))
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(httpRequest)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("empty payload", func(t *testing.T) {
+		httpRequest, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/database/%s", ts.URL, database1.ID), bytes.NewReader([]byte("")))
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(httpRequest)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	})
+
+	t.Run("unknown database", func(t *testing.T) {
+		databases, err := client.UpdateMultitenantDatabase(model.NewID(), &model.PatchDatabaseRequest{})
+		require.EqualError(t, err, "failed with status code 404")
+		require.Nil(t, databases)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		database1, err := client.UpdateMultitenantDatabase(database1.ID,
+			&model.PatchDatabaseRequest{
+				MaxInstallationsPerLogicalDatabase: iToP(10),
+			})
+		require.NoError(t, err)
+		assert.Equal(t, int64(10), database1.MaxInstallationsPerLogicalDatabase)
+
+		database1, err = sqlStore.GetMultitenantDatabase(database1.ID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(10), database1.MaxInstallationsPerLogicalDatabase)
+	})
+}

--- a/internal/api/databases_test.go
+++ b/internal/api/databases_test.go
@@ -205,7 +205,7 @@ func TestUpdateDatabase(t *testing.T) {
 
 		resp, err := http.DefaultClient.Do(httpRequest)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusAccepted, resp.StatusCode)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("unknown database", func(t *testing.T) {

--- a/internal/store/multitenant_database.go
+++ b/internal/store/multitenant_database.go
@@ -194,19 +194,20 @@ func (sqlStore *SQLStore) CreateMultitenantDatabase(multitenantDatabase *model.M
 	_, err = sqlStore.execBuilder(sqlStore.db, sq.
 		Insert("MultitenantDatabase").
 		SetMap(map[string]interface{}{
-			"ID":                               multitenantDatabase.ID,
-			"VpcID":                            multitenantDatabase.VpcID,
-			"DatabaseType":                     multitenantDatabase.DatabaseType,
-			"State":                            multitenantDatabase.State,
-			"InstallationsRaw":                 installationsJSON,
-			"MigratedInstallationsRaw":         migratedInstallationsJSON,
-			"SharedLogicalDatabaseMappingsRaw": logicalDatabaseJSON,
-			"WriterEndpoint":                   multitenantDatabase.WriterEndpoint,
-			"ReaderEndpoint":                   multitenantDatabase.ReaderEndpoint,
-			"LockAcquiredBy":                   nil,
-			"LockAcquiredAt":                   0,
-			"CreateAt":                         multitenantDatabase.CreateAt,
-			"DeleteAt":                         0,
+			"ID":                                 multitenantDatabase.ID,
+			"VpcID":                              multitenantDatabase.VpcID,
+			"DatabaseType":                       multitenantDatabase.DatabaseType,
+			"State":                              multitenantDatabase.State,
+			"InstallationsRaw":                   installationsJSON,
+			"MigratedInstallationsRaw":           migratedInstallationsJSON,
+			"SharedLogicalDatabaseMappingsRaw":   logicalDatabaseJSON,
+			"MaxInstallationsPerLogicalDatabase": multitenantDatabase.MaxInstallationsPerLogicalDatabase,
+			"WriterEndpoint":                     multitenantDatabase.WriterEndpoint,
+			"ReaderEndpoint":                     multitenantDatabase.ReaderEndpoint,
+			"LockAcquiredBy":                     nil,
+			"LockAcquiredAt":                     0,
+			"CreateAt":                           multitenantDatabase.CreateAt,
+			"DeleteAt":                           0,
 		}),
 	)
 	if err != nil {

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -200,11 +200,11 @@ const (
 	DefaultRDSMultitenantDatabaseMySQLCountLimit = 10
 
 	// DefaultRDSMultitenantDatabasePostgresCountLimit is the maximum number of
-	// schemas allowed in a Posgres multitenant RDS database cluster.
+	// schemas allowed in a Postgres multitenant RDS database cluster.
 	DefaultRDSMultitenantDatabasePostgresCountLimit = 300
 
 	// DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit is the maximum
-	// number of schemas allowed in a Posgres multitenant RDS database cluster
+	// number of schemas allowed in a Postgres multitenant RDS database cluster
 	// with a PGBouncer proxy.
 	DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit = 1000
 

--- a/model/client.go
+++ b/model/client.go
@@ -1140,7 +1140,7 @@ func (c *Client) UpdateMultitenantDatabase(databaseID string, request *PatchData
 	defer closeBody(resp)
 
 	switch resp.StatusCode {
-	case http.StatusAccepted:
+	case http.StatusOK:
 		return MultitenantDatabaseFromReader(resp.Body)
 
 	default:

--- a/model/client.go
+++ b/model/client.go
@@ -1131,6 +1131,23 @@ func (c *Client) GetMultitenantDatabases(request *GetDatabasesRequest) ([]*Multi
 	}
 }
 
+// UpdateMultitenantDatabase updates a multitenant database.
+func (c *Client) UpdateMultitenantDatabase(databaseID string, request *PatchDatabaseRequest) (*MultitenantDatabase, error) {
+	resp, err := c.doPut(c.buildURL("/api/database/%s", databaseID), request)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return MultitenantDatabaseFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // CreateWebhook requests the creation of a webhook from the configured provisioning server.
 func (c *Client) CreateWebhook(request *CreateWebhookRequest) (*Webhook, error) {
 	resp, err := c.doPost(c.buildURL("/api/webhooks"), request)

--- a/model/multitenant_database.go
+++ b/model/multitenant_database.go
@@ -160,3 +160,16 @@ func MultitenantDatabasesFromReader(reader io.Reader) ([]*MultitenantDatabase, e
 
 	return databases, nil
 }
+
+// MultitenantDatabaseFromReader decodes a json-encoded multitenant database from the given io.Reader.
+func MultitenantDatabaseFromReader(reader io.Reader) (*MultitenantDatabase, error) {
+	database := &MultitenantDatabase{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&database)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return database, nil
+}

--- a/model/multitenant_database_request.go
+++ b/model/multitenant_database_request.go
@@ -5,7 +5,11 @@
 package model
 
 import (
+	"encoding/json"
+	"io"
 	"net/url"
+
+	"github.com/pkg/errors"
 )
 
 // GetDatabasesRequest describes the parameters to request a list of multitenant databases.
@@ -23,4 +27,50 @@ func (request *GetDatabasesRequest) ApplyToURL(u *url.URL) {
 	request.Paging.AddToQuery(q)
 
 	u.RawQuery = q.Encode()
+}
+
+// PatchDatabaseRequest specifies the parameters for an updated multitenant
+// database.
+type PatchDatabaseRequest struct {
+	MaxInstallationsPerLogicalDatabase *int64
+}
+
+// Validate validates the values of a multitenant database patch request.
+func (p *PatchDatabaseRequest) Validate() error {
+	if p.MaxInstallationsPerLogicalDatabase != nil && *p.MaxInstallationsPerLogicalDatabase < int64(1) {
+		return errors.New("MaxInstallationsPerLogicalDatabase must be 1 or greater")
+	}
+
+	return nil
+}
+
+// Apply applies the patch to the given multitenant database.
+func (p *PatchDatabaseRequest) Apply(database *MultitenantDatabase) bool {
+	var applied bool
+
+	if database.DatabaseType == DatabaseEngineTypePostgresProxy {
+		if p.MaxInstallationsPerLogicalDatabase != nil && *p.MaxInstallationsPerLogicalDatabase != database.MaxInstallationsPerLogicalDatabase {
+			applied = true
+			database.MaxInstallationsPerLogicalDatabase = *p.MaxInstallationsPerLogicalDatabase
+		}
+	}
+
+	return applied
+}
+
+// NewPatchDatabaseRequestFromReader will create a PatchDatabaseRequest from an
+// io.Reader with JSON data.
+func NewPatchDatabaseRequestFromReader(reader io.Reader) (*PatchDatabaseRequest, error) {
+	var patchDatabaseRequest PatchDatabaseRequest
+	err := json.NewDecoder(reader).Decode(&patchDatabaseRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode patch database request")
+	}
+
+	err = patchDatabaseRequest.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid patch database request")
+	}
+
+	return &patchDatabaseRequest, nil
 }


### PR DESCRIPTION
The new endpoint allows for updating `MaxInstallationsPerLogicalDatabase`
on proxy databases. This also includes tests for the existing database
list endpoint.

Fixes https://mattermost.atlassian.net/browse/MM-36949

```release-note
Add multitenant database update API endpoint
```
