### PR TITLE
Set `binary_parameters=yes` for PGBouncer databases

### DIFF
--- a/internal/tools/aws/database_multitenant_pgbouncer.go
+++ b/internal/tools/aws/database_multitenant_pgbouncer.go
@@ -738,27 +738,22 @@ func (d *RDSMultitenantPGBouncerDatabase) GenerateDatabaseSecret(store model.Ins
 		return nil, errors.Wrap(err, "failed to unmarshal secret payload")
 	}
 
-	databaseConnectionString, databaseReadReplicasString :=
+	databaseConnectionString, databaseReadReplicasString, databaseConnectionCheck :=
 		MattermostPostgresPGBouncerConnStrings(
 			installationSecret.MasterUsername,
 			installationSecret.MasterPassword,
 			installationDatabaseName,
 		)
-	databaseConnectionCheck := databaseConnectionString
-
-	secretStringData := map[string]string{
-		"DB_CONNECTION_STRING":              databaseConnectionString,
-		"MM_SQLSETTINGS_DATASOURCEREPLICAS": databaseReadReplicasString,
-	}
-	if len(databaseConnectionCheck) != 0 {
-		secretStringData["DB_CONNECTION_CHECK_URL"] = databaseConnectionCheck
-	}
 
 	databaseSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: installationSecretName,
 		},
-		StringData: secretStringData,
+		StringData: map[string]string{
+			"DB_CONNECTION_STRING":              databaseConnectionString,
+			"MM_SQLSETTINGS_DATASOURCEREPLICAS": databaseReadReplicasString,
+			"DB_CONNECTION_CHECK_URL":           databaseConnectionCheck,
+		},
 	}
 
 	logger.Debug("AWS RDS multitenant PGBouncer database configuration generated for cluster installation")

--- a/internal/tools/aws/helpers_sql.go
+++ b/internal/tools/aws/helpers_sql.go
@@ -43,13 +43,18 @@ func MattermostPostgresConnStrings(schema, username, password string, dbCluster 
 
 // MattermostPostgresPGBouncerConnStrings formats the connection strings used by
 // Mattermost servers to access a PostgreSQL database with a PGBouncer proxy.
-func MattermostPostgresPGBouncerConnStrings(username, password, database string) (string, string) {
-	dbConnection := fmt.Sprintf("postgres://%s:%s@pgbouncer.pgbouncer:5432/%s?connect_timeout=10&sslmode=disable",
+//
+// Regarding binary_parameters:
+// https://blog.bullgare.com/2019/06/pgbouncer-and-prepared-statements
+func MattermostPostgresPGBouncerConnStrings(username, password, database string) (string, string, string) {
+	dbConnection := fmt.Sprintf("postgres://%s:%s@pgbouncer.pgbouncer:5432/%s?connect_timeout=10&sslmode=disable&binary_parameters=yes",
 		username, password, database)
-	readReplicas := fmt.Sprintf("postgres://%s:%s@pgbouncer.pgbouncer:5432/%s-ro?connect_timeout=10&sslmode=disable",
+	readReplicas := fmt.Sprintf("postgres://%s:%s@pgbouncer.pgbouncer:5432/%s-ro?connect_timeout=10&sslmode=disable&binary_parameters=yes",
+		username, password, database)
+	connectionCheck := fmt.Sprintf("postgres://%s:%s@pgbouncer.pgbouncer:5432/%s?connect_timeout=10&sslmode=disable",
 		username, password, database)
 
-	return dbConnection, readReplicas
+	return dbConnection, readReplicas, connectionCheck
 }
 
 // RDSPostgresConnString formats the connection string used by the provisioner


### PR DESCRIPTION
This appears to correct an issue with PGBouncer transaction pooling
where errors were sometimes encountered on PG prepared statements.
The result of the change is that all query parameters will now be
sent as a binary when using the PGBouncer proxy.

Understanding of the issue as well as the fix was all due to this awesome
blog post: https://blog.bullgare.com/2019/06/pgbouncer-and-prepared-statements

Reviewers please note this callout:
> The only problem we’ve run into in a golang application is about saving JSONb parameters.

I am hoping this change works out for us and that there is no known conflict
with this in product.

Fixes https://mattermost.atlassian.net/browse/MM-36988

```release-note
Set `binary_parameters=yes` for PGBouncer databases
```
