### PR TITLE
MM-37097-migration-fix-installation-bifrost

### DIFF
--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -204,8 +204,10 @@ func getMultitenantBucketNameForVPC(vpcID string, client *Client) (string, error
 // the provided installation resides in. Installations with multiple cluster
 // installations are currently not supported.
 func getVPCForInstallation(installationID string, store model.InstallationDatabaseStoreInterface, client *Client) (*ec2.Vpc, error) {
+	var isActive = true
 	clusterInstallations, err := store.GetClusterInstallations(&model.ClusterInstallationFilter{
 		Paging:         model.AllPagesWithDeleted(),
+		IsActive:       &isActive,
 		InstallationID: installationID,
 	})
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Retrieve only active cluster installations during VPC search for an installation.
Modify the `getVPCForInstallation` function to only retrieve active cluster installations as Installations with multiple cluster
installations are currently not supported.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37097

#### Release Note
<!--
f no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Retrieve only active cluster installations during VPC search for an installation.
```
