### PR TITLE
Add DB migration e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,15 @@ verify-mocks:  $(MOCKGEN) mocks
 		echo "generated files are out of date, run make mocks"; exit 1; \
 	fi
 
+.PHONY: e2e
+e2e:
+	@echo Warning!
+	@echo This may require adjusting some environment variables like DESTINATION_DB.
+	@echo For full configuration check TestConfig struct in ./e2e/tests/dbmigration/suite.go
+	@echo
+	@echo Starting e2e test.
+	go test ./e2e/tests/dbmigration -tags=e2e -v -timeout 30m
+
 ## --------------------------------------
 ## Tooling Binaries
 ## --------------------------------------

--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ Run the go tests to test:
 $ go test ./...
 ```
 
+#### DB Migration end-to-end tests
+
+There are some end-to-end tests located in `./e2e` directory. 
+
+Tests can be run with `make e2e`.
+
+E2e test for DB migration requires the following setup:
+- Local instance of Provisioner.
+- Workload cluster able to handle at least 2 installations of size `1000users`.
+- 2 Multi tenant Postgres databases provisioned in the same VPC as the workload cluster.
+- The destination database to which the migration can be performed should be exported as environment variable `DESTINATION_DB`.
+- Kubeconfig of workload cluster exported locally.
+
 ### Deleting a cluster and installations
 Before deleting a cluster you will **have** to delete the installations first on it.
 

--- a/e2e/pkg/db_migration.go
+++ b/e2e/pkg/db_migration.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package pkg
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+// WaitForDBMigrationToFinish waits for DB migration to reach state Succeeded.
+func WaitForDBMigrationToFinish(client *model.Client, opID string, log logrus.FieldLogger) error {
+	err := WaitForFunc(NewWaitConfig(20*time.Minute, 10*time.Second, 2, log), func() (bool, error) {
+		operation, err := client.GetInstallationDBMigrationOperation(opID)
+		if err != nil {
+			return false, errors.Wrap(err, "while waiting for db migration")
+		}
+
+		if operation.State == model.InstallationDBMigrationStateSucceeded {
+			return true, nil
+		}
+		if operation.State == model.InstallationDBMigrationStateFailed {
+			return false, fmt.Errorf("db migration operation %q failed", operation.ID)
+		}
+
+		log.Infof("DB migration %s not finished: %s", opID, operation.State)
+		return false, nil
+	})
+	return err
+}
+
+// WaitForDBMigrationRollbackToFinish waits for DB migration to reach state RollbackFinished.
+func WaitForDBMigrationRollbackToFinish(client *model.Client, opID string, log logrus.FieldLogger) error {
+	err := WaitForFunc(NewWaitConfig(10*time.Minute, 10*time.Second, 2, log), func() (bool, error) {
+		operation, err := client.GetInstallationDBMigrationOperation(opID)
+		if err != nil {
+			return false, errors.Wrap(err, "while waiting for db migration rollback")
+		}
+
+		if operation.State == model.InstallationDBMigrationStateRollbackFinished {
+			return true, nil
+		}
+
+		log.Infof("DB migration rollback %s not finished: %s", opID, operation.State)
+		return false, nil
+	})
+	return err
+}

--- a/e2e/pkg/dns.go
+++ b/e2e/pkg/dns.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package pkg
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+const (
+	installationDNSFormat = "e2e-test-%s.%s.cloud.mattermost.com"
+)
+
+// GetDNS returns e2e test dns with random suffix.
+func GetDNS(env string) string {
+	installationDNS := fmt.Sprintf(installationDNSFormat, randStringBytes(4), env)
+	return installationDNS
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyz"
+
+func randStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}

--- a/e2e/pkg/dns.go
+++ b/e2e/pkg/dns.go
@@ -17,8 +17,7 @@ const (
 
 // GetDNS returns e2e test dns with random suffix.
 func GetDNS(env string) string {
-	installationDNS := fmt.Sprintf(installationDNSFormat, randStringBytes(4), env)
-	return installationDNS
+	return fmt.Sprintf(installationDNSFormat, randStringBytes(4), env)
 }
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyz"

--- a/e2e/pkg/export.go
+++ b/e2e/pkg/export.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package pkg
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/pkg/errors"
+)
+
+// SQLSettings is struct copied from Mattermost Server
+type SQLSettings struct {
+	DriverName                  *string
+	DataSource                  *string
+	DataSourceReplicas          []string
+	DataSourceSearchReplicas    []string
+	MaxIdleConns                *int
+	ConnMaxLifetimeMilliseconds *int
+	MaxOpenConns                *int
+	Trace                       *bool
+	AtRestEncryptKey            *string
+	QueryTimeout                *int
+}
+
+// GetConnectionString fetches the connection string from cluster request's config.
+func GetConnectionString(client *model.Client, clusterInstallationID string) (string, error) {
+	out, err := client.RunMattermostCLICommandOnClusterInstallation(clusterInstallationID, []string{"config", "show", "--json"})
+	if err != nil {
+		return "", errors.Wrap(err, "while execing config show")
+	}
+
+	settings := struct {
+		SQLSettings SQLSettings
+	}{}
+
+	err = json.Unmarshal(out, &settings)
+	if err != nil {
+		return "", errors.Wrap(err, "while unmarshalling sql setting")
+	}
+
+	return *settings.SQLSettings.DataSource, nil
+}
+
+// BulkLine represents bulk export line.
+type BulkLine struct {
+	Type string `json:"type"`
+}
+
+// ExportStats are statistics of bulk export.
+type ExportStats struct {
+	Teams          int
+	Channels       int
+	Users          int
+	Posts          int
+	DirectChannels int
+	DirectPosts    int
+}
+
+// GetBulkExportStats runs mattermost bulk export on the cluster request and counts teams, channels, users and posts.
+func GetBulkExportStats(client *model.Client, kubeClient kubernetes.Interface, clusterInstallationID, installationID string, logger logrus.FieldLogger) (ExportStats, error) {
+	fileName := fmt.Sprintf("export-ci-%s.json", clusterInstallationID)
+
+	_, err := client.RunMattermostCLICommandOnClusterInstallation(clusterInstallationID, []string{"export", "bulk", fileName})
+	if err != nil {
+		return ExportStats{}, errors.Wrap(err, "while execing export csv")
+	}
+
+	podClient := kubeClient.CoreV1().Pods(installationID)
+
+	pods, err := podClient.List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app=mattermost",
+	})
+	if err != nil {
+		return ExportStats{}, errors.Wrap(err, "while getting pods")
+	}
+
+	destination := fileName
+	defer func() {
+		err := os.Remove(destination)
+		if err != nil {
+			logger.WithError(err).Warnf("failed to cleanup file %s", destination)
+		}
+	}()
+
+	// The solution with `kubectl cp` is pretty hacky, but should be fine for the purpose of tests.
+
+	// File will exist on only one pod.
+	// If file does not exist kubectl cp exits with 0 code but does not change local file.
+	for _, pod := range pods.Items {
+		copyFrom := fmt.Sprintf("%s/%s:/mattermost/%s", pod.Namespace, pod.Name, fileName)
+		cmd := exec.Command("kubectl", "cp", copyFrom, destination)
+		err := cmd.Run()
+		if err != nil {
+			return ExportStats{}, errors.Wrap(err, "while copying import file from pod")
+		}
+	}
+
+	file, err := os.Open(destination)
+	if err != nil {
+		return ExportStats{}, errors.Wrap(err, "failed to open export file")
+	}
+	defer file.Close()
+
+	exportStats := ExportStats{}
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := BulkLine{}
+		err := json.Unmarshal(scanner.Bytes(), &line)
+		if err != nil {
+			return ExportStats{}, errors.Wrap(err, "while unmarshalling export line")
+		}
+
+		switch line.Type {
+		case "team":
+			exportStats.Teams++
+		case "channel":
+			exportStats.Channels++
+		case "post":
+			exportStats.Posts++
+		case "user":
+			exportStats.Users++
+		case "direct_channel":
+			exportStats.DirectChannels++
+		case "direct_post":
+			exportStats.DirectPosts++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return ExportStats{}, errors.Wrap(err, "error scaning export file")
+	}
+
+	return exportStats, nil
+}

--- a/e2e/pkg/installation.go
+++ b/e2e/pkg/installation.go
@@ -22,7 +22,7 @@ func WaitForInstallationAvailability(dns string, log logrus.FieldLogger) error {
 	err := WaitForFunc(NewWaitConfig(20*time.Minute, 20*time.Second, 2, log), func() (bool, error) {
 		resp, err := http.Get(pingURL(dns))
 		if err != nil {
-			log.WithError(err).Error("Error while pining request")
+			log.WithError(err).Errorf("Error while making ping request to Installation %s", dns)
 			return false, nil
 		}
 		return resp.StatusCode == http.StatusOK, nil

--- a/e2e/pkg/installation.go
+++ b/e2e/pkg/installation.go
@@ -11,10 +11,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/mattermost/mattermost-cloud/model"
+
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // WaitForInstallationAvailability pings installation until it responds successfully.

--- a/e2e/pkg/installation.go
+++ b/e2e/pkg/installation.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package pkg
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+// WaitForInstallationAvailability pings installation until it responds successfully.
+func WaitForInstallationAvailability(dns string, log logrus.FieldLogger) error {
+	err := WaitForFunc(NewWaitConfig(20*time.Minute, 20*time.Second, 2, log), func() (bool, error) {
+		resp, err := http.Get(pingURL(dns))
+		if err != nil {
+			log.WithError(err).Error("Error while pining request")
+			return false, nil
+		}
+		return resp.StatusCode == http.StatusOK, nil
+	})
+
+	return err
+}
+
+// WaitForHibernation waits until Installation is fully hibernated.
+func WaitForHibernation(client *model.Client, installationID string, log logrus.FieldLogger) error {
+	err := WaitForFunc(NewWaitConfig(5*time.Minute, 10*time.Second, 2, log), func() (bool, error) {
+		installation, err := client.GetInstallation(installationID, &model.GetInstallationRequest{})
+		if err != nil {
+			return false, errors.Wrap(err, "while waiting for hibernation")
+		}
+
+		if installation.State == model.InstallationStateHibernating {
+			return true, nil
+		}
+		log.Infof("Installation %s not hibernated: %s", installationID, installation.State)
+		return false, nil
+	})
+	return err
+}
+
+// WaitForStable waits until Installation reaches Stable state.
+func WaitForStable(client *model.Client, installationID string, log logrus.FieldLogger) error {
+	err := WaitForFunc(NewWaitConfig(5*time.Minute, 10*time.Second, 2, log), func() (bool, error) {
+		installation, err := client.GetInstallation(installationID, &model.GetInstallationRequest{})
+		if err != nil {
+			return false, errors.Wrap(err, "while waiting for stable")
+		}
+
+		if installation.State == model.InstallationStateStable {
+			return true, nil
+		}
+		log.Infof("Installation %s not stable: %s", installationID, installation.State)
+		return false, nil
+	})
+	return err
+}
+
+func pingURL(dns string) string {
+	return fmt.Sprintf("https://%s/api/v4/system/ping", dns)
+}

--- a/e2e/pkg/installation_builder.go
+++ b/e2e/pkg/installation_builder.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package pkg
+
+import "github.com/mattermost/mattermost-cloud/model"
+
+// InstallationBuilder is a helper to create CreateInstallationRequest.
+type InstallationBuilder struct {
+	request *model.CreateInstallationRequest
+}
+
+// NewInstallationBuilderWithDefaults sets up new InstallationBuilder with resonable defaults.
+func NewInstallationBuilderWithDefaults() *InstallationBuilder {
+	return &InstallationBuilder{request: &model.CreateInstallationRequest{
+		OwnerID:   "e2e-test",
+		Version:   "stable",
+		Image:     "mattermost/mattermost-enterprise-edition",
+		Size:      "1000users",
+		Affinity:  "multitenant",
+		Database:  model.InstallationDatabaseMultiTenantRDSPostgres,
+		Filestore: model.InstallationFilestoreBifrost,
+	}}
+}
+
+// DB sets database type used for Installation.
+func (b *InstallationBuilder) DB(db string) *InstallationBuilder {
+	b.request.Database = db
+	return b
+}
+
+// FileStore sets file store type used for Installation.
+func (b *InstallationBuilder) FileStore(fileStore string) *InstallationBuilder {
+	b.request.Filestore = fileStore
+	return b
+}
+
+// DNS sets DNS for Installation.
+func (b *InstallationBuilder) DNS(dns string) *InstallationBuilder {
+	b.request.DNS = dns
+	return b
+}
+
+// Version sets Mattermost version used for Installation.
+func (b *InstallationBuilder) Version(version string) *InstallationBuilder {
+	b.request.Version = version
+	return b
+}
+
+// Owner sets Installation's owner.
+func (b *InstallationBuilder) Owner(owner string) *InstallationBuilder {
+	b.request.OwnerID = owner
+	return b
+}
+
+// Group sets Installation's group.
+func (b *InstallationBuilder) Group(group string) *InstallationBuilder {
+	b.request.GroupID = group
+	return b
+}
+
+// CreateRequest returns CreateInstallationRequest based on the builder.
+func (b *InstallationBuilder) CreateRequest() *model.CreateInstallationRequest {
+	return b.request
+}

--- a/e2e/pkg/installation_builder.go
+++ b/e2e/pkg/installation_builder.go
@@ -13,7 +13,7 @@ type InstallationBuilder struct {
 	request *model.CreateInstallationRequest
 }
 
-// NewInstallationBuilderWithDefaults sets up new InstallationBuilder with resonable defaults.
+// NewInstallationBuilderWithDefaults sets up new InstallationBuilder with reasonable defaults.
 func NewInstallationBuilderWithDefaults() *InstallationBuilder {
 	return &InstallationBuilder{request: &model.CreateInstallationRequest{
 		OwnerID:   "e2e-test",

--- a/e2e/pkg/k8s.go
+++ b/e2e/pkg/k8s.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package pkg
+
+import (
+	"path/filepath"
+
+	restclient "k8s.io/client-go/rest"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+)
+
+// GetK8sConfig gets K8s config either from inside the cluster or local directory.
+func GetK8sConfig() (*restclient.Config, error) {
+	k8sConfig, err := restclient.InClusterConfig()
+	if err != nil {
+		home := homedir.HomeDir()
+		k8sConfPath := filepath.Join(home, ".kube", "config")
+		k8sConfig, err = clientcmd.BuildConfigFromFlags("", k8sConfPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return k8sConfig, nil
+}

--- a/e2e/pkg/wait.go
+++ b/e2e/pkg/wait.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package pkg
+
+import (
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// WaitConfig contains configuration for WaitForFunc.
+type WaitConfig struct {
+	Timeout        time.Duration
+	Interval       time.Duration
+	TolerateErrors int
+	Logger         logrus.FieldLogger
+}
+
+// NewWaitConfig create new WaitConfig.
+func NewWaitConfig(timeout, interval time.Duration, tolerateErrs int, log logrus.FieldLogger) WaitConfig {
+	return WaitConfig{
+		Timeout:        timeout,
+		Interval:       interval,
+		TolerateErrors: tolerateErrs,
+		Logger:         log,
+	}
+}
+
+// WaitForFunc waits until `isReady` returns `true`, error is returned or timeout reached.
+func WaitForFunc(cfg WaitConfig, isReady func() (bool, error)) error {
+	done := time.After(cfg.Timeout)
+	errsCount := 0
+
+	for {
+		ready, err := isReady()
+		if err != nil {
+			if cfg.Logger != nil {
+				cfg.Logger.WithError(err).Error("error while waiting for condition")
+			}
+			errsCount++
+			if errsCount > cfg.TolerateErrors {
+				return errors.Wrap(err, "while checking if condition is ready")
+			}
+		} else {
+			if ready {
+				return nil
+			}
+			if cfg.Logger != nil {
+				cfg.Logger.Debug("condition not ready")
+			}
+			errsCount = 0
+		}
+
+		select {
+		case <-done:
+			return fmt.Errorf("timeout waiting for condition")
+		default:
+			time.Sleep(cfg.Interval)
+		}
+	}
+}

--- a/e2e/pkg/wait.go
+++ b/e2e/pkg/wait.go
@@ -8,8 +8,9 @@ package pkg
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
 )

--- a/e2e/tests/dbmigration/db_migration_test.go
+++ b/e2e/tests/dbmigration/db_migration_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package dbmigration
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBMigration_Commit(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	t.Parallel()
+
+	test, err := SetupDBMigrationCommitTest()
+	require.NoError(t, err)
+
+	if test.Cleanup {
+		defer func() {
+			err := test.Suite.InstallationSuite.Cleanup(context.Background())
+			assert.NoError(t, err)
+		}()
+	}
+
+	err = test.Run()
+	assert.NoError(t, err)
+}
+
+func TestDBMigration_Rollback(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	t.Parallel()
+
+	test, err := SetupDBMigrationRollbackTest()
+	require.NoError(t, err)
+
+	if test.Cleanup {
+		defer func() {
+			err := test.Suite.InstallationSuite.Cleanup(context.Background())
+			assert.NoError(t, err)
+		}()
+	}
+
+	err = test.Run()
+	assert.NoError(t, err)
+}

--- a/e2e/tests/dbmigration/steps.go
+++ b/e2e/tests/dbmigration/steps.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package dbmigration
+
+import (
+	"github.com/mattermost/mattermost-cloud/e2e/workflow"
+)
+
+func baseMigrationSteps(dbMigSuite *workflow.DBMigrationSuite) []*workflow.Step {
+	return []*workflow.Step{
+		{
+			Name:      "CreateInstallation",
+			Func:      dbMigSuite.CreateInstallation,
+			DependsOn: []string{},
+		},
+		{
+			Name:      "GetMultiTenantDBID",
+			Func:      dbMigSuite.GetMultiTenantDBID,
+			DependsOn: []string{"CreateInstallation"},
+		},
+		{
+			Name:      "GetCI",
+			Func:      dbMigSuite.GetCI,
+			DependsOn: []string{"CreateInstallation"},
+		},
+		{
+			Name:      "PopulateSampleData",
+			Func:      dbMigSuite.PopulateSampleData,
+			DependsOn: []string{"GetCI"},
+		},
+		{
+			Name:      "GetConnectionStrAndExport",
+			Func:      dbMigSuite.GetConnectionStrAndExport,
+			DependsOn: []string{"PopulateSampleData"},
+		},
+		{
+			Name:      "HibernateInstallationBeforeMigration",
+			Func:      dbMigSuite.HibernateInstallation,
+			DependsOn: []string{"GetConnectionStrAndExport"},
+		},
+		{
+			Name:      "RunDBMigration",
+			Func:      dbMigSuite.RunDBMigration,
+			DependsOn: []string{"HibernateInstallationBeforeMigration"},
+		},
+		{
+			Name:      "WakeUpInstallationAfterMigration",
+			Func:      dbMigSuite.WakeUpInstallation,
+			DependsOn: []string{"RunDBMigration"},
+		},
+		{
+			Name:      "AssertMigrationSuccessful",
+			Func:      dbMigSuite.AssertMigrationSuccessful,
+			DependsOn: []string{"WakeUpInstallationAfterMigration"},
+		},
+	}
+}
+
+func commitDBMigrationWorkflow(dbMigSuite *workflow.DBMigrationSuite) *workflow.Workflow {
+	steps := baseMigrationSteps(dbMigSuite)
+
+	steps = append(steps, &workflow.Step{
+		Name:      "CommitMigration",
+		Func:      dbMigSuite.CommitMigration,
+		DependsOn: []string{"AssertMigrationSuccessful"},
+	})
+
+	return workflow.NewWorkflow(steps)
+}
+
+func rollbackDBMigrationWorkflow(dbMigSuite *workflow.DBMigrationSuite) *workflow.Workflow {
+	steps := baseMigrationSteps(dbMigSuite)
+
+	steps = append(steps, &workflow.Step{
+		Name:      "HibernateInstallationBeforeRollback",
+		Func:      dbMigSuite.HibernateInstallation,
+		DependsOn: []string{"AssertMigrationSuccessful"},
+	})
+	steps = append(steps, &workflow.Step{
+		Name:      "RollbackMigration",
+		Func:      dbMigSuite.RollbackMigration,
+		DependsOn: []string{"HibernateInstallationBeforeRollback"},
+	})
+	steps = append(steps, &workflow.Step{
+		Name:      "WakeUpInstallationAfterRollback",
+		Func:      dbMigSuite.WakeUpInstallation,
+		DependsOn: []string{"RollbackMigration"},
+	})
+	steps = append(steps, &workflow.Step{
+		Name:      "AssertRollbackSuccessful",
+		Func:      dbMigSuite.AssertRollbackSuccessful,
+		DependsOn: []string{"WakeUpInstallationAfterRollback"},
+	})
+
+	return workflow.NewWorkflow(steps)
+}

--- a/e2e/tests/dbmigration/suite.go
+++ b/e2e/tests/dbmigration/suite.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package dbmigration
+
+import (
+	"encoding/json"
+
+	"github.com/mattermost/mattermost-cloud/e2e/pkg"
+	"github.com/mattermost/mattermost-cloud/e2e/workflow"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vrischmann/envconfig"
+	"k8s.io/client-go/kubernetes"
+)
+
+// TestConfig is test configuration coming from env vars.
+type TestConfig struct {
+	CloudURL                  string `envconfig:"default=http://localhost:8075"`
+	DestinationDB             string
+	InstallationDBType        string `envconfig:"default=aws-multitenant-rds-postgres"`
+	InstallationFileStoreType string `envconfig:"default=bifrost"`
+	Environment               string `envconfig:"default=dev"`
+	Cleanup                   bool   `envconfig:"default=true"`
+}
+
+// Test holds all data required for a db migration test.
+type Test struct {
+	Logger   logrus.FieldLogger
+	Suite    *workflow.DBMigrationSuite
+	Workflow *workflow.Workflow
+	Cleanup  bool
+}
+
+// SetupDBMigrationCommitTest sets up DB Migration tests which commits the migration.
+func SetupDBMigrationCommitTest() (*Test, error) {
+	logger := logrus.WithField("test", "db-migration-commit")
+
+	config, err := readConfig(logger)
+	if err != nil {
+		return nil, err
+	}
+
+	suite, err := setupDBMigrationTestSuite(config, logger)
+	if err != nil {
+		return nil, err
+	}
+	work := commitDBMigrationWorkflow(suite)
+
+	return &Test{
+		Logger:   logger,
+		Suite:    suite,
+		Workflow: work,
+		Cleanup:  config.Cleanup,
+	}, nil
+}
+
+// SetupDBMigrationRollbackTest sets up DB Migration tests which rollbacks the migration.
+func SetupDBMigrationRollbackTest() (*Test, error) {
+	logger := logrus.WithField("test", "db-migration-rollback")
+
+	config, err := readConfig(logger)
+	if err != nil {
+		return nil, err
+	}
+
+	suite, err := setupDBMigrationTestSuite(config, logger)
+	if err != nil {
+		return nil, err
+	}
+	work := rollbackDBMigrationWorkflow(suite)
+
+	return &Test{
+		Logger:   logger,
+		Suite:    suite,
+		Workflow: work,
+		Cleanup:  config.Cleanup,
+	}, nil
+}
+
+func readConfig(logger logrus.FieldLogger) (TestConfig, error) {
+	var config TestConfig
+	err := envconfig.Init(&config)
+	if err != nil {
+		return TestConfig{}, errors.Wrap(err, "unable to read environment configuration")
+	}
+
+	configJSON, err := json.Marshal(config)
+	if err != nil {
+		return TestConfig{}, errors.Wrap(err, "failed to marshal config to json")
+	}
+
+	logger.Infof("Test Config: %s", configJSON)
+
+	return config, nil
+}
+
+func setupDBMigrationTestSuite(config TestConfig, logger logrus.FieldLogger) (*workflow.DBMigrationSuite, error) {
+	client := model.NewClient(config.CloudURL)
+
+	params := workflow.DBMigrationSuiteParams{
+		InstallationSuiteParams: workflow.InstallationSuiteParams{
+			DBType:        config.InstallationDBType,
+			FileStoreType: config.InstallationFileStoreType,
+		},
+		DestinationDBID: config.DestinationDB,
+	}
+
+	kubeClient, err := getKubeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return workflow.NewDBMigrationSuite(params, config.Environment, client, kubeClient, logger), nil
+}
+
+func getKubeClient() (kubernetes.Interface, error) {
+	k8sConfig, err := pkg.GetK8sConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting kubeconfig")
+	}
+
+	clientset, err := kubernetes.NewForConfig(k8sConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "while creating kube client")
+	}
+
+	return clientset, nil
+}
+
+// Run runs the test workflow.
+func (w *Test) Run() error {
+	err := workflow.RunWorkflow(w.Workflow, w.Logger)
+	if err != nil {
+		return errors.Wrap(err, "error running workflow")
+	}
+	return nil
+}

--- a/e2e/workflow/db_migration.go
+++ b/e2e/workflow/db_migration.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package workflow
+
+import (
+	"context"
+	"strings"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/mattermost/mattermost-cloud/e2e/pkg"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// NewDBMigrationSuite creates new DBMigrationSuite.
+func NewDBMigrationSuite(params DBMigrationSuiteParams, env string, client *model.Client, kubeClient kubernetes.Interface, logger logrus.FieldLogger) *DBMigrationSuite {
+	installationSuite := NewInstallationSuite(params.InstallationSuiteParams, env, client, kubeClient, logger)
+
+	return &DBMigrationSuite{
+		InstallationSuite: installationSuite,
+		client:            client,
+		kubeClient:        kubeClient,
+		logger:            logger.WithField("suite", "db-migration"),
+		Params:            params,
+		Meta:              DBMigrationSuiteMeta{},
+	}
+}
+
+// DBMigrationSuite stores parameters and metadata used when running tests.
+type DBMigrationSuite struct {
+	*InstallationSuite
+
+	client     *model.Client
+	kubeClient kubernetes.Interface
+	logger     logrus.FieldLogger
+
+	Params DBMigrationSuiteParams
+	Meta   DBMigrationSuiteMeta
+}
+
+// DBMigrationSuiteParams are parameters passed to test.
+type DBMigrationSuiteParams struct {
+	InstallationSuiteParams
+	DestinationDBID string
+}
+
+// DBMigrationSuiteMeta is a metadata generated when running various methods of the suite.
+type DBMigrationSuiteMeta struct {
+	SourceDBID           string
+	MigrationOperationID string
+
+	MigratedDBConnStr string
+}
+
+// GetMultiTenantDBID fetches multi tenant database id for installation.
+func (w *DBMigrationSuite) GetMultiTenantDBID(ctx context.Context) error {
+	dbs, err := w.client.GetMultitenantDatabases(&model.GetDatabasesRequest{
+		Paging: model.AllPagesNotDeleted(),
+	})
+	if err != nil {
+		return errors.Wrap(err, "while getting multi tenant dbs")
+	}
+
+	installationDB, found := findInstallationDB(dbs, w.InstallationSuite.Meta.InstallationID)
+	if !found {
+		return errors.New("failed to find multi tenant database for installation")
+	}
+	w.logger.Infof("Found installation multi tenant db with ID: %s", installationDB.ID)
+
+	w.Meta.SourceDBID = installationDB.ID
+
+	return nil
+}
+
+// RunDBMigration runs DB migration of suite's installation.
+func (w *DBMigrationSuite) RunDBMigration(ctx context.Context) error {
+	if w.Meta.MigrationOperationID == "" {
+		migrationOP, err := w.client.MigrateInstallationDatabase(&model.InstallationDBMigrationRequest{
+			InstallationID:         w.InstallationSuite.Meta.InstallationID,
+			DestinationDatabase:    model.InstallationDatabaseMultiTenantRDSPostgres,
+			DestinationMultiTenant: &model.MultiTenantDBMigrationData{DatabaseID: w.Params.DestinationDBID},
+		})
+		if err != nil {
+			return errors.Wrap(err, "while triggering migration")
+		}
+		w.Meta.MigrationOperationID = migrationOP.ID
+	}
+
+	err := pkg.WaitForDBMigrationToFinish(w.client, w.Meta.MigrationOperationID, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while waiting for migration")
+	}
+
+	return nil
+}
+
+// AssertMigrationSuccessful asserts that DB migration correctly adjusted connection string and no data was lost.
+func (w *DBMigrationSuite) AssertMigrationSuccessful(ctx context.Context) error {
+	connStr, err := pkg.GetConnectionString(w.client, w.InstallationSuite.Meta.ClusterInstallationID)
+	if err != nil {
+		return errors.Wrap(err, "while getting connection str")
+	}
+	w.Meta.MigratedDBConnStr = connStr
+
+	if w.InstallationSuite.Meta.ConnectionString == w.Meta.MigratedDBConnStr {
+		return errors.New("error: connection strings are equal")
+	}
+
+	if !strings.Contains(w.Meta.MigratedDBConnStr, w.Params.DestinationDBID) {
+		return errors.New("error: migrated connection string does not contain destination db id")
+	}
+
+	export, err := pkg.GetBulkExportStats(w.client, w.kubeClient, w.InstallationSuite.Meta.ClusterInstallationID, w.InstallationSuite.Meta.InstallationID, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while getting CSV export")
+	}
+	w.logger.Infof("Bulk export stats after migration: %v", export)
+	if export != w.InstallationSuite.Meta.BulkExportStats {
+		return errors.Errorf("error: export after migration differs from original export, original: %v, new: %v", w.InstallationSuite.Meta.BulkExportStats, export)
+	}
+
+	return nil
+}
+
+// CommitMigration commits DB migration.
+func (w *DBMigrationSuite) CommitMigration(ctx context.Context) error {
+	migrationOP, err := w.client.CommitInstallationDBMigration(w.Meta.MigrationOperationID)
+	if err != nil {
+		return errors.Wrap(err, "while committing migration")
+	}
+	if migrationOP.State != model.InstallationDBMigrationStateCommitted {
+		return errors.Errorf("installation db migration state in not commited, state: %s", migrationOP.State)
+	}
+
+	return nil
+}
+
+// RollbackMigration rolls back DB migration.
+func (w *DBMigrationSuite) RollbackMigration(ctx context.Context) error {
+	migrationOP, err := w.client.GetInstallationDBMigrationOperation(w.Meta.MigrationOperationID)
+	if err != nil {
+		return errors.Wrap(err, "while getting migration operation to roll back")
+	}
+	if migrationOP.State == model.InstallationDBMigrationStateRollbackFinished {
+		w.logger.Info("db migration already rolled back")
+		return nil
+	}
+
+	if migrationOP.State == model.InstallationDBMigrationStateSucceeded {
+		migrationOP, err = w.client.RollbackInstallationDBMigration(w.Meta.MigrationOperationID)
+		if err != nil {
+			return errors.Wrap(err, "while rolling back migration")
+		}
+	}
+
+	if migrationOP.State != model.InstallationDBMigrationStateRollbackRequested {
+		return errors.Errorf("db migration operation is in unexpected state: %s", migrationOP.State)
+	}
+
+	err = pkg.WaitForDBMigrationRollbackToFinish(w.client, migrationOP.ID, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while waiting for rollback to finish")
+	}
+
+	return nil
+}
+
+// AssertRollbackSuccessful that DB migration rollback was performed successfully.
+func (w *DBMigrationSuite) AssertRollbackSuccessful(ctx context.Context) error {
+	connStr, err := pkg.GetConnectionString(w.client, w.InstallationSuite.Meta.ClusterInstallationID)
+	if err != nil {
+		return errors.Wrap(err, "while getting connection str")
+	}
+
+	if w.InstallationSuite.Meta.ConnectionString != connStr {
+		return errors.New("error: connection string does not match original connection string")
+	}
+
+	if !strings.Contains(connStr, w.Meta.SourceDBID) {
+		return errors.New("error: connection string does not contain source db id")
+	}
+
+	export, err := pkg.GetBulkExportStats(w.client, w.kubeClient, w.InstallationSuite.Meta.ClusterInstallationID, w.InstallationSuite.Meta.InstallationID, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while getting CSV export")
+	}
+	w.logger.Infof("Bulk export stats after rollback: %v", export)
+	if export != w.InstallationSuite.Meta.BulkExportStats {
+		return errors.Errorf("error: export after rollback differs from original export, original: %v, new: %v", w.InstallationSuite.Meta.BulkExportStats, export)
+	}
+
+	return nil
+}
+
+func findInstallationDB(dbs []*model.MultitenantDatabase, installationID string) (model.MultitenantDatabase, bool) {
+	for _, db := range dbs {
+		if db.Installations.Contains(installationID) {
+			return *db, true
+		}
+	}
+	return model.MultitenantDatabase{}, false
+}

--- a/e2e/workflow/engine.go
+++ b/e2e/workflow/engine.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// StepFunc defines the structure of functions called as steps.
+type StepFunc func(ctx context.Context) error
+
+// Step is a single step in a workflow.
+type Step struct {
+	Name      string
+	Func      StepFunc
+	Done      bool
+	DependsOn []string
+}
+
+// NewWorkflow creates new Workflow.
+func NewWorkflow(steps []*Step) *Workflow {
+	stepsMap := make(map[string]*Step, len(steps))
+	workflow := Workflow{stepsMap}
+
+	return workflow.AddStep(steps...)
+}
+
+// Workflow is steps based workflow.
+type Workflow struct {
+	Steps map[string]*Step
+}
+
+// AddStep add step to the Workflow.
+func (w *Workflow) AddStep(step ...*Step) *Workflow {
+	for i, s := range step {
+		w.Steps[s.Name] = step[i]
+	}
+	return w
+}
+
+// RunWorkflow runs Workflow considering all dependencies.
+func RunWorkflow(workflow *Workflow, logger logrus.FieldLogger) error {
+	runner := &runner{
+		workflow: *workflow,
+		queue:    make([]Step, 0, len(workflow.Steps)),
+		inQueue:  make(map[string]bool, len(workflow.Steps)),
+		retries:  3,
+	}
+
+	err := runner.makeQueue()
+	if err != nil {
+		return errors.Wrap(err, "failed to make queue")
+	}
+
+	ctx := context.Background()
+
+	for _, step := range runner.queue {
+		if step.Done {
+			logger.Infof("Step %s marked as done, skipping", step.Name)
+			continue
+		}
+
+		logrus.Infof("Running step: %s", step.Name)
+		err := step.Func(ctx)
+		for i := 1; i < runner.retries && err != nil; i++ {
+			logger.WithError(err).Errorf("Step %s failed %d times, waiting 3 seconds before retry", step.Name, i)
+			time.Sleep(3 * time.Second)
+			err = step.Func(ctx)
+		}
+		if err != nil {
+			return errors.Wrapf(err, "Step %s failed %d times", step.Name, runner.retries)
+		}
+		logger.Infof("Step %s finished successfully", step.Name)
+		workflow.Steps[step.Name].Done = true
+	}
+
+	logger.Infof("Workflow finished")
+
+	return nil
+}
+
+type runner struct {
+	retries  int
+	queue    []Step
+	workflow Workflow
+	inQueue  map[string]bool
+}
+
+func (l *runner) makeQueue() error {
+	for _, step := range l.workflow.Steps {
+		err := l.addToQueue(step)
+		if err != nil {
+			return errors.Wrap(err, "error while adding step to queue")
+		}
+	}
+
+	return nil
+}
+
+func (l *runner) addToQueue(step *Step) error {
+	if step == nil {
+		return fmt.Errorf("cannot add nil step to queue")
+	}
+	if l.inQueue[step.Name] {
+		return nil
+	}
+
+	for _, d := range step.DependsOn {
+		dep, found := l.workflow.Steps[d]
+		if !found {
+			return fmt.Errorf("step %q not found in workflow but step %q depends on it", d, step.Name)
+		}
+		err := l.addToQueue(dep)
+		if err != nil {
+			return err
+		}
+	}
+
+	l.queue = append(l.queue, *step)
+	l.inQueue[step.Name] = true
+
+	return nil
+}

--- a/e2e/workflow/installation.go
+++ b/e2e/workflow/installation.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package workflow
+
+import (
+	"context"
+
+	"github.com/mattermost/mattermost-cloud/e2e/pkg"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+)
+
+// NewInstallationSuite creates new Installation testing suite.
+func NewInstallationSuite(params InstallationSuiteParams, env string, client *model.Client, kubeClient kubernetes.Interface, logger logrus.FieldLogger) *InstallationSuite {
+	return &InstallationSuite{
+		client:     client,
+		kubeClient: kubeClient,
+		logger:     logger.WithField("suite", "installation"),
+		env:        env,
+		Params:     params,
+		Meta:       InstallationSuiteMeta{},
+	}
+}
+
+// InstallationSuite is testing suite for Installations.
+type InstallationSuite struct {
+	client     *model.Client
+	kubeClient kubernetes.Interface
+	logger     logrus.FieldLogger
+	env        string
+
+	Params InstallationSuiteParams
+	Meta   InstallationSuiteMeta
+}
+
+// InstallationSuiteParams contains parameters for InstallationSuite.
+type InstallationSuiteParams struct {
+	DBType        string
+	FileStoreType string
+}
+
+// InstallationSuiteMeta contains metadata for InstallationSuite.
+type InstallationSuiteMeta struct {
+	InstallationID        string
+	InstallationDNS       string
+	ClusterInstallationID string
+	ConnectionString      string
+	BulkExportStats       pkg.ExportStats
+}
+
+// CreateInstallation creates new Installation and waits for it to reach stable state.
+func (w *InstallationSuite) CreateInstallation(ctx context.Context) error {
+	if w.Meta.InstallationID == "" {
+		installationBuilder := pkg.NewInstallationBuilderWithDefaults().
+			DNS(pkg.GetDNS(w.env)).
+			DB(w.Params.DBType).
+			FileStore(w.Params.FileStoreType)
+
+		installation, err := w.client.CreateInstallation(installationBuilder.CreateRequest())
+		if err != nil {
+			return errors.Wrap(err, "while creating installation")
+		}
+		w.logger.Infof("Installation created: %s", installation.ID)
+		w.Meta.InstallationID = installation.ID
+		w.Meta.InstallationDNS = installation.DNS
+	}
+
+	err := pkg.WaitForStable(w.client, w.Meta.InstallationID, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while waiting for installation creation")
+	}
+
+	err = pkg.WaitForInstallationAvailability(w.Meta.InstallationDNS, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while waiting for installation DNS")
+	}
+
+	return nil
+}
+
+// GetCI gets ClusterInstallation for an Installation being the part of test suite and saves it in metadata.
+func (w *InstallationSuite) GetCI(ctx context.Context) error {
+	ci, err := w.client.GetClusterInstallations(&model.GetClusterInstallationsRequest{InstallationID: w.Meta.InstallationID, Paging: model.AllPagesNotDeleted()})
+	if err != nil {
+		return errors.Wrap(err, "while getting CI")
+	}
+	w.Meta.ClusterInstallationID = ci[0].ID
+
+	return nil
+}
+
+// GetConnectionStrAndExport saves db connection string currently configured for installation and export statistics.
+func (w *InstallationSuite) GetConnectionStrAndExport(ctx context.Context) error {
+	connectionString, err := pkg.GetConnectionString(w.client, w.Meta.ClusterInstallationID)
+	if err != nil {
+		return errors.Wrap(err, "while getting connection str")
+	}
+	w.Meta.ConnectionString = connectionString
+
+	exportStats, err := pkg.GetBulkExportStats(w.client, w.kubeClient, w.Meta.ClusterInstallationID, w.Meta.InstallationID, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while getting CSV export")
+	}
+	w.Meta.BulkExportStats = exportStats
+	w.logger.Infof("Bulk export stats: %v", exportStats)
+
+	return nil
+}
+
+// PopulateSampleData populates installation with sample data.
+func (w *InstallationSuite) PopulateSampleData(ctx context.Context) error {
+	// Do not generate guest user as by default guest accounts are disabled,
+	// which results in guest users being deactivated when Mattermost restarts.
+	_, err := w.client.RunMattermostCLICommandOnClusterInstallation(w.Meta.ClusterInstallationID, []string{"sampledata", "--teams", "4", "--channels-per-team", "15", "--guests", "0"})
+	if err != nil {
+		return errors.Wrap(err, "while populating sample data for CI")
+	}
+	w.logger.Info("Sample data generated")
+
+	return nil
+}
+
+// HibernateInstallation hibernates installation and waits for it to get hibernated.
+func (w *InstallationSuite) HibernateInstallation(ctx context.Context) error {
+	installation, err := w.client.GetInstallation(w.Meta.InstallationID, &model.GetInstallationRequest{})
+	if err != nil {
+		return errors.Wrap(err, "while getting installation to hibernate")
+	}
+	if installation.State == model.InstallationStateHibernating {
+		w.logger.Info("installation already hibernating")
+		return nil
+	}
+
+	installation, err = w.client.HibernateInstallation(w.Meta.InstallationID)
+	if err != nil {
+		return errors.Wrap(err, "while hibernating installation")
+	}
+
+	err = pkg.WaitForHibernation(w.client, w.Meta.InstallationID, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while waiting for installation to hibernate")
+	}
+
+	return nil
+}
+
+// WakeUpInstallation wakes up installation and waits for it to reach stable state.
+func (w *InstallationSuite) WakeUpInstallation(ctx context.Context) error {
+	installation, err := w.client.GetInstallation(w.Meta.InstallationID, &model.GetInstallationRequest{})
+	if err != nil {
+		return errors.Wrap(err, "while getting installation to wake up")
+	}
+	if installation.State == model.InstallationStateStable {
+		w.logger.Info("installation already woken up")
+		return nil
+	}
+
+	if installation.State == model.InstallationStateHibernating {
+		installation, err = w.client.WakeupInstallation(w.Meta.InstallationID, nil)
+		if err != nil {
+			return errors.Wrap(err, "while waking up installation")
+		}
+	}
+
+	if installation.State != model.InstallationStateWakeUpRequested &&
+		installation.State != model.InstallationStateUpdateInProgress {
+		return errors.Errorf("installation is in unexpected state: %s", installation.State)
+	}
+
+	err = pkg.WaitForStable(w.client, w.Meta.InstallationID, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while waiting for installation to wake up")
+	}
+
+	return nil
+}
+
+// Cleanup cleans up installation saved in suite metadata.
+func (w *InstallationSuite) Cleanup(ctx context.Context) error {
+	installation, err := w.client.GetInstallation(w.Meta.InstallationID, &model.GetInstallationRequest{})
+	if err != nil {
+		return errors.Wrap(err, "while getting installation to wake up")
+	}
+	if installation.State == model.InstallationStateDeleted {
+		w.logger.Info("installation already deleted")
+		return nil
+	}
+	if installation.State == model.InstallationStateDeletionRequested ||
+		installation.State == model.InstallationStateDeletionInProgress ||
+		installation.State == model.InstallationStateDeletionFinalCleanup {
+		w.logger.Info("installation already marked for deletion")
+		return nil
+	}
+
+	err = w.client.DeleteInstallation(w.Meta.InstallationID)
+	if err != nil {
+		return errors.Wrap(err, "while requesting installation removal")
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.7.0
+	github.com/vrischmann/envconfig v1.3.0
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.20.6
 	k8s.io/apiextensions-apiserver v0.20.2

--- a/go.sum
+++ b/go.sum
@@ -807,6 +807,7 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
+github.com/vrischmann/envconfig v1.3.0 h1:4XIvQTXznxmWMnjouj0ST5lFo/WAYf5Exgl3x82crEk=
 github.com/vrischmann/envconfig v1.3.0/go.mod h1:bbvxFYJdRSpXrhS63mBFtKJzkDiNkyArOLXtY6q0kuI=
 github.com/wgliang/cron v0.0.0-20180129105837-79834306f643/go.mod h1:8vrxYe6J+ZIHJViXE2UhdSbbu3VWHGxLo+QzdqeGDvM=
 github.com/wiggin77/cfg v1.0.2/go.mod h1:b3gotba2e5bXTqTW48DwIFoLc+4lWKP7WPi/CdvZ4aE=


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR introduces the Installation DB migration e2e test I heavily used when developing the feature.
It directly tests Installation DB migration and indirectly tests DB backup and restore.

For the test to run 2 multitenant DB clusters are required in the VPC of a cluster.

We can later enhance tests so that they can do all necessary setup or run as a part of a larger e2e test.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add DB migration e2e test
```
