### PR TITLE
Add option to retry cluster creation from command line

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -52,6 +52,7 @@ func init() {
 	clusterCreateCmd.Flags().String("kubecost-values", "", "The branch name of the desired chart value file's version for Kubecost")
 	clusterCreateCmd.Flags().String("networking", "amazon-vpc-routed-eni", "Networking mode to use, for example: weave, calico, canal, amazon-vpc-routed-eni")
 	clusterCreateCmd.Flags().String("vpc", "", "Set to use a shared VPC")
+	clusterCreateCmd.Flags().String("cluster", "", "The id of the cluster. If provided and the cluster exists the creation will be retried ignoring other parameters.")
 
 	clusterCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the cluster. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 
@@ -75,7 +76,7 @@ func init() {
 	clusterProvisionCmd.Flags().String("pgbouncer-values", "", "The full Git URL of the desired chart values for PGBouncer")
 	clusterProvisionCmd.Flags().String("stackrox-values", "", "The full Git URL of the desired chart values for Stackrox")
 	clusterProvisionCmd.Flags().String("kubecost-values", "", "The branch name of the desired chart value file's version for Kubecost")
-	
+
 	clusterProvisionCmd.MarkFlagRequired("cluster")
 
 	clusterUpdateCmd.Flags().String("cluster", "", "The id of the cluster to be updated.")
@@ -146,6 +147,15 @@ var clusterCreateCmd = &cobra.Command{
 
 		serverAddress, _ := command.Flags().GetString("server")
 		client := model.NewClient(serverAddress)
+
+		clusterID, _ := command.Flags().GetString("cluster")
+		if clusterID != "" {
+			err := client.RetryCreateCluster(clusterID)
+			if err != nil {
+				return errors.Errorf("failed to retry cluster creation")
+			}
+			return nil
+		}
 
 		provider, _ := command.Flags().GetString("provider")
 		version, _ := command.Flags().GetString("version")
@@ -575,7 +585,7 @@ func processUtilityFlags(command *cobra.Command) map[string]*model.HelmUtilityVe
 	pgbouncerVersion, _ := command.Flags().GetString("pgbouncer-version")
 	stackroxVersion, _ := command.Flags().GetString("stackrox-version")
 	kubecostVersion, _ := command.Flags().GetString("kubecost-version")
-	
+
 	prometheusOperatorValues, _ := command.Flags().GetString("prometheus-operator-values")
 	thanosValues, _ := command.Flags().GetString("thanos-values")
 	fluentbitValues, _ := command.Flags().GetString("fluentbit-values")

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -152,7 +152,7 @@ var clusterCreateCmd = &cobra.Command{
 		if clusterID != "" {
 			err := client.RetryCreateCluster(clusterID)
 			if err != nil {
-				return errors.Errorf("failed to retry cluster creation")
+				return errors.Wrap(err, "failed to retry cluster creation")
 			}
 			return nil
 		}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Provisioner CLI was missing a way to retry cluster creation if it failed, which makes it hard to work with in case of some failure.

This PR adds the option to specify the `--cluster` flag to `cloud cluster create` command in which case, the CLI will attempt to retry the creation.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add option to retry cluster creation from command line
```
