### PR TITLE
Add installation deployment report command

### DIFF
--- a/cmd/cloud/backup.go
+++ b/cmd/cloud/backup.go
@@ -7,7 +7,6 @@ package main
 import (
 	"os"
 
-	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
@@ -100,7 +99,7 @@ var backupListCmd = &cobra.Command{
 					backup.InstallationID,
 					string(backup.State),
 					backup.ClusterInstallationID,
-					utils.TimeFromMillis(backup.RequestAt).Format("2006-01-02 15:04:05 -0700 MST"),
+					model.TimeFromMillis(backup.RequestAt).Format("2006-01-02 15:04:05 -0700 MST"),
 				})
 			}
 			table.Render()

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -656,12 +656,7 @@ var installationDeploymentReportCmd = &cobra.Command{
 		output += fmt.Sprintf(" ├ Database Type: %s\n", installation.Database)
 		if model.IsMultiTenantRDS(installation.Database) {
 			databases, err := client.GetMultitenantDatabases(&model.GetDatabasesRequest{
-				DatabaseType: model.DatabaseEngineTypePostgresProxy,
-				Paging: model.Paging{
-					Page:           0,
-					PerPage:        model.AllPerPage,
-					IncludeDeleted: true,
-				},
+				Paging: model.AllPagesWithDeleted(),
 			})
 			if err != nil {
 				return errors.Wrap(err, "failed to query installation database")
@@ -689,11 +684,7 @@ var installationDeploymentReportCmd = &cobra.Command{
 
 		clusterInstallations, err := client.GetClusterInstallations(&model.GetClusterInstallationsRequest{
 			InstallationID: installation.ID,
-			Paging: model.Paging{
-				Page:           0,
-				PerPage:        model.AllPerPage,
-				IncludeDeleted: true,
-			},
+			Paging:         model.AllPagesWithDeleted(),
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to query cluster installations")

--- a/cmd/cloud/installation_operation_db_migration.go
+++ b/cmd/cloud/installation_operation_db_migration.go
@@ -7,7 +7,6 @@ package main
 import (
 	"os"
 
-	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
@@ -126,7 +125,7 @@ var installationDBMigrationsListCmd = &cobra.Command{
 					migration.ID,
 					migration.InstallationID,
 					string(migration.State),
-					utils.TimeFromMillis(migration.RequestAt).Format("2006-01-02 15:04:05 -0700 MST"),
+					model.TimeFromMillis(migration.RequestAt).Format("2006-01-02 15:04:05 -0700 MST"),
 				})
 			}
 			table.Render()

--- a/cmd/cloud/installation_operation_restoration.go
+++ b/cmd/cloud/installation_operation_restoration.go
@@ -7,7 +7,6 @@ package main
 import (
 	"os"
 
-	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
@@ -105,7 +104,7 @@ var installationRestorationsListCmd = &cobra.Command{
 					string(restoration.State),
 					restoration.ClusterInstallationID,
 					restoration.TargetInstallationState,
-					utils.TimeFromMillis(restoration.RequestAt).Format("2006-01-02 15:04:05 -0700 MST"),
+					model.TimeFromMillis(restoration.RequestAt).Format("2006-01-02 15:04:05 -0700 MST"),
 				})
 			}
 			table.Render()

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -189,7 +189,7 @@ func (sqlStore *SQLStore) CreateCluster(cluster *model.Cluster, annotations []*m
 // createCluster records the given cluster to the database, assigning it a unique ID.
 func (sqlStore *SQLStore) createCluster(execer execer, cluster *model.Cluster) error {
 	cluster.ID = model.NewID()
-	cluster.CreateAt = GetMillis()
+	cluster.CreateAt = model.GetMillis()
 
 	rawMetadata, err := buildRawMetadata(cluster)
 	if err != nil {
@@ -251,7 +251,7 @@ func (sqlStore *SQLStore) UpdateCluster(cluster *model.Cluster) error {
 func (sqlStore *SQLStore) DeleteCluster(id string) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Update("Cluster").
-		Set("DeleteAt", GetMillis()).
+		Set("DeleteAt", model.GetMillis()).
 		Where("ID = ?", id).
 		Where("DeleteAt = 0"),
 	)

--- a/internal/store/cluster_installation.go
+++ b/internal/store/cluster_installation.go
@@ -136,7 +136,7 @@ func (sqlStore *SQLStore) UpdateClusterInstallationsActiveStatus(db execer, clus
 func (sqlStore *SQLStore) DeleteClusterInstallation(id string) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Update("ClusterInstallation").
-		Set("DeleteAt", GetMillis()).
+		Set("DeleteAt", model.GetMillis()).
 		Where("ID = ?", id).
 		Where("DeleteAt = 0"),
 	)
@@ -244,7 +244,7 @@ func (sqlStore *SQLStore) MigrateClusterInstallations(clusterInstallations []*mo
 // createClusterInstallation records the cluster installation(s) as a single transaction to the database, assigning it a unique ID.
 func (sqlStore *SQLStore) createClusterInstallation(db execer, clusterInstallation *model.ClusterInstallation) error {
 	clusterInstallation.ID = model.NewID()
-	clusterInstallation.CreateAt = GetMillis()
+	clusterInstallation.CreateAt = model.GetMillis()
 
 	_, err := sqlStore.execBuilder(db, sq.
 		Insert("ClusterInstallation").

--- a/internal/store/group.go
+++ b/internal/store/group.go
@@ -298,7 +298,7 @@ func (sqlStore *SQLStore) GetGroups(filter *model.GroupFilter) ([]*model.Group, 
 // CreateGroup records the given group to the database, assigning it a unique ID.
 func (sqlStore *SQLStore) CreateGroup(group *model.Group) error {
 	group.ID = model.NewID()
-	group.CreateAt = GetMillis()
+	group.CreateAt = model.GetMillis()
 	envVarMap, err := group.MattermostEnv.ToJSON()
 	if err != nil {
 		return err
@@ -383,7 +383,7 @@ func (sqlStore *SQLStore) UpdateGroup(group *model.Group, forceUpdateSequence bo
 func (sqlStore *SQLStore) DeleteGroup(id string) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Update(`"Group"`).
-		Set("DeleteAt", GetMillis()).
+		Set("DeleteAt", model.GetMillis()).
 		Where("ID = ?", id).
 		Where("DeleteAt = 0"),
 	)

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -325,7 +325,7 @@ func (sqlStore *SQLStore) CreateInstallation(installation *model.Installation, a
 
 func (sqlStore *SQLStore) createInstallation(db execer, installation *model.Installation) error {
 	installation.ID = model.NewID()
-	installation.CreateAt = GetMillis()
+	installation.CreateAt = model.GetMillis()
 
 	envJSON, err := json.Marshal(installation.MattermostEnv)
 	if err != nil {
@@ -495,7 +495,7 @@ func (sqlStore *SQLStore) GetInstallationsTotalDatabaseWeight(installationIDs []
 func (sqlStore *SQLStore) DeleteInstallation(id string) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Update("Installation").
-		Set("DeleteAt", GetMillis()).
+		Set("DeleteAt", model.GetMillis()).
 		Where("ID = ?", id).
 		Where("DeleteAt = 0"),
 	)

--- a/internal/store/installation_backup.go
+++ b/internal/store/installation_backup.go
@@ -146,7 +146,7 @@ func (sqlStore *SQLStore) getCount(builder sq.SelectBuilder) (int64, error) {
 // CreateInstallationBackup records installation backup to the database, assigning it a unique ID.
 func (sqlStore *SQLStore) CreateInstallationBackup(backup *model.InstallationBackup) error {
 	backup.ID = model.NewID()
-	backup.RequestAt = GetMillis()
+	backup.RequestAt = model.GetMillis()
 
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Insert(backupTable).
@@ -277,7 +277,7 @@ func (sqlStore *SQLStore) updateInstallationBackupState(db execer, backup *model
 func (sqlStore *SQLStore) DeleteInstallationBackup(id string) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Update(backupTable).
-		Set("DeleteAt", GetMillis()).
+		Set("DeleteAt", model.GetMillis()).
 		Where("ID = ?", id).
 		Where("DeleteAt = ?", 0))
 	if err != nil {

--- a/internal/store/installation_db_migration.go
+++ b/internal/store/installation_db_migration.go
@@ -158,7 +158,7 @@ func (sqlStore *SQLStore) CreateInstallationDBMigrationOperation(dbMigration *mo
 // createInstallationDBMigration records installation db migration to the database, assigning it a unique ID.
 func (sqlStore *SQLStore) createInstallationDBMigration(db execer, dbMigration *model.InstallationDBMigrationOperation) error {
 	dbMigration.ID = model.NewID()
-	dbMigration.RequestAt = GetMillis()
+	dbMigration.RequestAt = model.GetMillis()
 
 	insertMap := map[string]interface{}{
 		"ID":                                   dbMigration.ID,
@@ -300,7 +300,7 @@ func (sqlStore *SQLStore) updateInstallationDBMigrationFields(db execer, id stri
 func (sqlStore *SQLStore) DeleteInstallationDBMigrationOperation(id string) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Update(installationDBMigrationTable).
-		Set("DeleteAt", GetMillis()).
+		Set("DeleteAt", model.GetMillis()).
 		Where("ID = ?", id).
 		Where("DeleteAt = ?", 0))
 	if err != nil {

--- a/internal/store/installation_db_restoration_operation.go
+++ b/internal/store/installation_db_restoration_operation.go
@@ -85,7 +85,7 @@ func (sqlStore *SQLStore) CreateInstallationDBRestorationOperation(dbRestoration
 
 func (sqlStore *SQLStore) createInstallationDBRestoration(db execer, dbRestoration *model.InstallationDBRestorationOperation) error {
 	dbRestoration.ID = model.NewID()
-	dbRestoration.RequestAt = GetMillis()
+	dbRestoration.RequestAt = model.GetMillis()
 
 	_, err := sqlStore.execBuilder(db, sq.
 		Insert(installationDBRestorationTable).
@@ -201,7 +201,7 @@ func (sqlStore *SQLStore) updateInstallationDBRestorationFields(db execer, id st
 func (sqlStore *SQLStore) DeleteInstallationDBRestorationOperation(id string) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Update(installationDBRestorationTable).
-		Set("DeleteAt", GetMillis()).
+		Set("DeleteAt", model.GetMillis()).
 		Where("ID = ?", id).
 		Where("DeleteAt = ?", 0))
 	if err != nil {

--- a/internal/store/lock.go
+++ b/internal/store/lock.go
@@ -6,6 +6,7 @@ package store
 
 import (
 	sq "github.com/Masterminds/squirrel"
+	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 )
 
@@ -15,7 +16,7 @@ func (sqlStore *SQLStore) lockRows(table string, ids []string, lockerID string) 
 		Update(table).
 		SetMap(map[string]interface{}{
 			"LockAcquiredBy": lockerID,
-			"LockAcquiredAt": GetMillis(),
+			"LockAcquiredAt": model.GetMillis(),
 		}).
 		Where(sq.Eq{
 			"ID":             ids,

--- a/internal/store/multitenant_database.go
+++ b/internal/store/multitenant_database.go
@@ -176,7 +176,7 @@ func (sqlStore *SQLStore) CreateMultitenantDatabase(multitenantDatabase *model.M
 		return errors.New("multitenant database ID must not be empty")
 	}
 
-	multitenantDatabase.CreateAt = GetMillis()
+	multitenantDatabase.CreateAt = model.GetMillis()
 
 	installationsJSON, err := json.Marshal(multitenantDatabase.Installations)
 	if err != nil {

--- a/internal/store/util.go
+++ b/internal/store/util.go
@@ -5,16 +5,9 @@
 package store
 
 import (
-	"time"
-
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-cloud/model"
 )
-
-// GetMillis is a convenience method to get milliseconds since epoch.
-func GetMillis() int64 {
-	return time.Now().UnixNano() / int64(time.Millisecond)
-}
 
 func applyPagingFilter(builder sq.SelectBuilder, paging model.Paging) sq.SelectBuilder {
 	if paging.PerPage != model.AllPerPage {

--- a/internal/store/webhook.go
+++ b/internal/store/webhook.go
@@ -57,7 +57,7 @@ func (sqlStore *SQLStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.Web
 // CreateWebhook records the given webhook to the database, assigning it a unique ID.
 func (sqlStore *SQLStore) CreateWebhook(webhook *model.Webhook) error {
 	webhook.ID = model.NewID()
-	webhook.CreateAt = GetMillis()
+	webhook.CreateAt = model.GetMillis()
 
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Insert("Webhooks").
@@ -81,7 +81,7 @@ func (sqlStore *SQLStore) CreateWebhook(webhook *model.Webhook) error {
 func (sqlStore *SQLStore) DeleteWebhook(id string) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Update("Webhooks").
-		Set("DeleteAt", GetMillis()).
+		Set("DeleteAt", model.GetMillis()).
 		Where("ID = ?", id).
 		Where("DeleteAt = 0"),
 	)

--- a/internal/supervisor/db_migration.go
+++ b/internal/supervisor/db_migration.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
-
 	"github.com/mattermost/mattermost-cloud/internal/provisioner"
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/internal/webhook"
@@ -436,7 +434,7 @@ func (s *DBMigrationSupervisor) finalizeMigration(dbMigration *model.Installatio
 		logger.WithError(err).Error("Unable to process and send webhooks")
 	}
 
-	dbMigration.CompleteAt = utils.GetMillis()
+	dbMigration.CompleteAt = model.GetMillis()
 	err = s.store.UpdateInstallationDBMigrationOperation(dbMigration)
 	if err != nil {
 		logger.WithError(err).Errorf("Failed to set complete at for db migration")

--- a/model/installation.go
+++ b/model/installation.go
@@ -92,6 +92,22 @@ func (i *Installation) ToDTO(annotations []*Annotation) *InstallationDTO {
 	}
 }
 
+// CreationDateString returns a standardized date string for an installation's
+// creation.
+func (i *Installation) CreationDateString() string {
+	return TimeFromMillis(i.CreateAt).Format("Jan 2 2006")
+}
+
+// DeletionDateString returns a standardized date string for an installation's
+// deletion or 'n/a' if not deleted.
+func (i *Installation) DeletionDateString() string {
+	if i.DeleteAt == 0 {
+		return "n/a"
+	}
+
+	return TimeFromMillis(i.DeleteAt).Format("Jan 2 2006")
+}
+
 // GetDatabaseWeight returns a value corresponding to the
 // TODO: maybe consider installation size in the future as well?
 func (i *Installation) GetDatabaseWeight() float64 {

--- a/model/installation_database.go
+++ b/model/installation_database.go
@@ -142,12 +142,6 @@ func (d *MysqlOperatorDatabase) RefreshResourceMetadata(store InstallationDataba
 	return nil
 }
 
-// InternalDatabase returns true if the installation's database is internal
-// to the kubernetes cluster it is running on.
-func (i *Installation) InternalDatabase() bool {
-	return i.Database == InstallationDatabaseMysqlOperator
-}
-
 // IsSupportedDatabase returns true if the given database string is supported.
 func IsSupportedDatabase(database string) bool {
 	switch database {
@@ -164,11 +158,30 @@ func IsSupportedDatabase(database string) bool {
 	return true
 }
 
-// IsSingleTenantRDS returns true if the given database is single tenant db.
+// InternalDatabase returns true if the installation's database is internal
+// to the kubernetes cluster it is running on.
+func (i *Installation) InternalDatabase() bool {
+	return i.Database == InstallationDatabaseMysqlOperator
+}
+
+// IsSingleTenantRDS returns true if the given database is single tenant RDS db.
 func IsSingleTenantRDS(database string) bool {
 	switch database {
 	case InstallationDatabaseSingleTenantRDSMySQL:
 	case InstallationDatabaseSingleTenantRDSPostgres:
+	default:
+		return false
+	}
+
+	return true
+}
+
+// IsMultiTenantRDS returns true if the given database is multitenant RDS db.
+func IsMultiTenantRDS(database string) bool {
+	switch database {
+	case InstallationDatabaseMultiTenantRDSMySQL:
+	case InstallationDatabaseMultiTenantRDSPostgres:
+	case InstallationDatabaseMultiTenantRDSPostgresPGBouncer:
 	default:
 		return false
 	}

--- a/model/installation_database_test.go
+++ b/model/installation_database_test.go
@@ -64,15 +64,38 @@ func TestIsSingleTenantDatabase(t *testing.T) {
 		{"", false},
 		{"unknown", false},
 		{model.InstallationDatabaseMysqlOperator, false},
-		{model.InstallationDatabaseMultiTenantRDSPostgres, false},
-		{model.InstallationDatabaseMultiTenantRDSMySQL, false},
 		{model.InstallationDatabaseSingleTenantRDSMySQL, true},
 		{model.InstallationDatabaseSingleTenantRDSPostgres, true},
+		{model.InstallationDatabaseMultiTenantRDSPostgres, false},
+		{model.InstallationDatabaseMultiTenantRDSMySQL, false},
+		{model.InstallationDatabaseMultiTenantRDSPostgresPGBouncer, false},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.database, func(t *testing.T) {
 			assert.Equal(t, tc.isSingleTenant, model.IsSingleTenantRDS(tc.database))
+		})
+	}
+}
+
+func TestIsMultiTenantDatabase(t *testing.T) {
+	var testCases = []struct {
+		database       string
+		isSingleTenant bool
+	}{
+		{"", false},
+		{"unknown", false},
+		{model.InstallationDatabaseMysqlOperator, false},
+		{model.InstallationDatabaseSingleTenantRDSMySQL, false},
+		{model.InstallationDatabaseSingleTenantRDSPostgres, false},
+		{model.InstallationDatabaseMultiTenantRDSPostgres, true},
+		{model.InstallationDatabaseMultiTenantRDSMySQL, true},
+		{model.InstallationDatabaseMultiTenantRDSPostgresPGBouncer, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.database, func(t *testing.T) {
+			assert.Equal(t, tc.isSingleTenant, model.IsMultiTenantRDS(tc.database))
 		})
 	}
 }

--- a/model/time.go
+++ b/model/time.go
@@ -2,16 +2,16 @@
 // See LICENSE.txt for license information.
 //
 
-package utils
+package model
 
 import "time"
-
-// TimeFromMillis converts time in milliseconds to time.Time.
-func TimeFromMillis(millis int64) time.Time {
-	return time.Unix(0, millis*int64(time.Millisecond))
-}
 
 // GetMillis is a convenience method to get milliseconds since epoch.
 func GetMillis() int64 {
 	return time.Now().UnixNano() / int64(time.Millisecond)
+}
+
+// TimeFromMillis converts time in milliseconds to time.Time.
+func TimeFromMillis(millis int64) time.Time {
+	return time.Unix(0, millis*int64(time.Millisecond))
 }


### PR DESCRIPTION
This new command outputs information for all resources related to
an installation's deployment for quick review.

Also, some commonly used time logic has been refactored into the
model package to eliminate duplication.

Note: I know the report string format logic is pretty "meh". It was
just meant to be a quick win and I didn't find a go library that gave
me what I was looking for so this will have to do for now.

Fixes https://mattermost.atlassian.net/browse/MM-37461

```release-note
Add installation deployment report command
```
