### PR TITLE
MM-37571-locking-installations for all type of installations

### DIFF
--- a/internal/store/cluster_installation_test.go
+++ b/internal/store/cluster_installation_test.go
@@ -738,7 +738,7 @@ func TestSwitchDNS(t *testing.T) {
 
 	clusterInstallation3 := &model.ClusterInstallation{
 		ClusterID:      sourceClusterID,
-		InstallationID: installation2.ID,
+		InstallationID: installation3.ID,
 		Namespace:      "namespace_12",
 		State:          model.ClusterInstallationStateCreationRequested,
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fix for locking both hibernating & non hibernating installations during dns switch with some test coverage.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37571

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fix for locking both hibernating & non hibernating installations during dns switch with some test coverage.
```
