### PR TITLE
Standardize multitenant database IDs

### DIFF
--- a/internal/api/databases_test.go
+++ b/internal/api/databases_test.go
@@ -78,7 +78,7 @@ func TestGetDatabases(t *testing.T) {
 
 	t.Run("results", func(t *testing.T) {
 		database1 := &model.MultitenantDatabase{
-			ID: model.NewID(),
+			RdsClusterID: model.NewID(),
 		}
 		err := sqlStore.CreateMultitenantDatabase(database1)
 		require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestGetDatabases(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 
 		database2 := &model.MultitenantDatabase{
-			ID: model.NewID(),
+			RdsClusterID: model.NewID(),
 		}
 		err = sqlStore.CreateMultitenantDatabase(database2)
 		require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestGetDatabases(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 
 		database3 := &model.MultitenantDatabase{
-			ID: model.NewID(),
+			RdsClusterID: model.NewID(),
 		}
 		err = sqlStore.CreateMultitenantDatabase(database3)
 		require.NoError(t, err)

--- a/internal/api/installation_db_migration_test.go
+++ b/internal/api/installation_db_migration_test.go
@@ -49,7 +49,7 @@ func TestTriggerInstallationDBMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	currentDB := &model.MultitenantDatabase{
-		ID:            "database1",
+		RdsClusterID:  "cluster1",
 		VpcID:         "vpc1",
 		DatabaseType:  model.DatabaseEngineTypePostgres,
 		Installations: model.MultitenantDatabaseInstallations{installation1.ID},
@@ -58,7 +58,7 @@ func TestTriggerInstallationDBMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	destinationDB := &model.MultitenantDatabase{
-		ID:           "database2",
+		RdsClusterID: "cluster2",
 		VpcID:        "vpc1",
 		DatabaseType: model.DatabaseEngineTypePostgres,
 	}
@@ -68,7 +68,7 @@ func TestTriggerInstallationDBMigration(t *testing.T) {
 	migrationRequest := &model.InstallationDBMigrationRequest{
 		InstallationID:         installation1.ID,
 		DestinationDatabase:    model.InstallationDatabaseMultiTenantRDSPostgres,
-		DestinationMultiTenant: &model.MultiTenantDBMigrationData{DatabaseID: "database2"},
+		DestinationMultiTenant: &model.MultiTenantDBMigrationData{DatabaseID: destinationDB.ID},
 	}
 
 	migrationOperation, err := client.MigrateInstallationDatabase(migrationRequest)

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1436,7 +1436,7 @@ var migrations = []migration{
 				SharedLogicalDatabaseMappingsRaw BYTEA NULL,
 				MaxInstallationsPerLogicalDatabase BIGINT NOT NULL,
 				CreateAt BIGINT NOT NULL,
-				DeleteAt BIGINT NOT NULL,             
+				DeleteAt BIGINT NOT NULL,
 				LockAcquiredBy TEXT NULL,
 				LockAcquiredAt BIGINT NOT NULL
 			);

--- a/internal/store/multitenant_database.go
+++ b/internal/store/multitenant_database.go
@@ -22,6 +22,7 @@ func init() {
 	multitenantDatabaseSelect = sq.
 		Select(
 			"ID",
+			"RdsClusterID",
 			"VpcID",
 			"DatabaseType",
 			"State",
@@ -172,10 +173,7 @@ func (sqlStore *SQLStore) GetMultitenantDatabaseForInstallationID(installationID
 
 // CreateMultitenantDatabase records the supplied multitenant database to the datastore.
 func (sqlStore *SQLStore) CreateMultitenantDatabase(multitenantDatabase *model.MultitenantDatabase) error {
-	if multitenantDatabase.ID == "" {
-		return errors.New("multitenant database ID must not be empty")
-	}
-
+	multitenantDatabase.ID = model.NewID()
 	multitenantDatabase.CreateAt = model.GetMillis()
 
 	installationsJSON, err := json.Marshal(multitenantDatabase.Installations)
@@ -195,6 +193,7 @@ func (sqlStore *SQLStore) CreateMultitenantDatabase(multitenantDatabase *model.M
 		Insert("MultitenantDatabase").
 		SetMap(map[string]interface{}{
 			"ID":                                 multitenantDatabase.ID,
+			"RdsClusterID":                       multitenantDatabase.RdsClusterID,
 			"VpcID":                              multitenantDatabase.VpcID,
 			"DatabaseType":                       multitenantDatabase.DatabaseType,
 			"State":                              multitenantDatabase.State,

--- a/internal/store/multitenant_database_test.go
+++ b/internal/store/multitenant_database_test.go
@@ -60,13 +60,13 @@ func (s *TestMultitenantDatabaseSuite) SetupTest() {
 	s.lockerID = s.installationID0
 
 	s.database1 = &model.MultitenantDatabase{
-		ID:    "database_id0",
-		VpcID: "vpc_id0",
+		RdsClusterID: "database_id0",
+		VpcID:        "vpc_id0",
 	}
 
 	s.database2 = &model.MultitenantDatabase{
-		ID:    "database_id1",
-		VpcID: "vpc_id1",
+		RdsClusterID: "database_id1",
+		VpcID:        "vpc_id1",
 	}
 
 	s.database1.Installations = model.MultitenantDatabaseInstallations{s.installationID0, s.installationID1}
@@ -89,20 +89,14 @@ func TestMultitenantDatabase(t *testing.T) {
 
 func (s *TestMultitenantDatabaseSuite) TestCreate() {
 	db := model.MultitenantDatabase{
-		ID:    "database_some_id",
-		VpcID: "database_vpc_id",
+		RdsClusterID: "database_some_id",
+		VpcID:        "database_vpc_id",
 	}
 	err := s.sqlStore.CreateMultitenantDatabase(&db)
 	s.Assert().NoError(err)
 	s.Assert().Greater(db.CreateAt, int64(0))
 
 	err = s.sqlStore.CreateMultitenantDatabase(&db)
-	s.Assert().Error(err)
-}
-
-func (s *TestMultitenantDatabaseSuite) TestCreateNilIDError() {
-	db := model.MultitenantDatabase{}
-	err := s.sqlStore.CreateMultitenantDatabase(&db)
 	s.Assert().Error(err)
 }
 
@@ -159,7 +153,7 @@ func (s *TestMultitenantDatabaseSuite) TestGetLimitConstraintFilterNotNil() {
 
 func (s *TestMultitenantDatabaseSuite) TestGetLimitConstraintAll() {
 	db := model.MultitenantDatabase{
-		ID: "database_id5",
+		RdsClusterID: "database_id5",
 	}
 	err := s.sqlStore.CreateMultitenantDatabase(&db)
 	s.Assert().NoError(err)
@@ -249,7 +243,7 @@ func (s *TestMultitenantDatabaseSuite) TestGetMultitenantDatabaseForInstallation
 
 func (s *TestMultitenantDatabaseSuite) TestGetMultitenantDatabaseForInstallationIDErrorMany() {
 	db := model.MultitenantDatabase{
-		ID: "database_some_id",
+		RdsClusterID: "database_some_id",
 	}
 	db.Installations = model.MultitenantDatabaseInstallations{s.installationID0}
 	err := s.sqlStore.CreateMultitenantDatabase(&db)
@@ -308,7 +302,7 @@ func TestGetMultitenantDatabases_WeightCalculation(t *testing.T) {
 	}
 
 	database1 := &model.MultitenantDatabase{
-		ID:            "database_id0",
+		RdsClusterID:  "database_id0",
 		VpcID:         "vpc_id0",
 		Installations: installationIDs,
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -158,6 +158,7 @@ func (sqlStore *SQLStore) selectBuilder(q sqlx.Queryer, dest interface{}, b buil
 // It allows the use of *sqlx.Db and *sqlx.Tx.
 type execer interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
 	DriverName() string
 }
 

--- a/internal/supervisor/db_migration_test.go
+++ b/internal/supervisor/db_migration_test.go
@@ -241,7 +241,6 @@ func TestDBMigrationSupervisor_Do(t *testing.T) {
 }
 
 func TestDBMigrationSupervisor_Supervise(t *testing.T) {
-
 	t.Run("trigger backup", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)

--- a/internal/tools/aws/database_multitenant_pgbouncer.go
+++ b/internal/tools/aws/database_multitenant_pgbouncer.go
@@ -111,7 +111,7 @@ func (d *RDSMultitenantPGBouncerDatabase) Provision(store model.InstallationData
 		"logical-database":  databaseName,
 	})
 
-	rdsCluster, err := describeRDSCluster(database.ID, d.client)
+	rdsCluster, err := describeRDSCluster(database.RdsClusterID, d.client)
 	if err != nil {
 		return errors.Wrapf(err, "failed to describe the multitenant RDS cluster ID %s", database.ID)
 	}
@@ -296,7 +296,7 @@ func (d *RDSMultitenantPGBouncerDatabase) getMultitenantDatabasesFromResourceTag
 		}
 
 		multitenantDatabase := model.MultitenantDatabase{
-			ID:                                 *rdsClusterID,
+			RdsClusterID:                       *rdsClusterID,
 			VpcID:                              vpcID,
 			DatabaseType:                       d.databaseType,
 			State:                              model.DatabaseStateProvisioningRequested,
@@ -655,7 +655,7 @@ func (d *RDSMultitenantPGBouncerDatabase) connectRDSCluster(database, endpoint, 
 	return closeFunc, nil
 }
 
-func (d *RDSMultitenantPGBouncerDatabase) ensureMultitenantDatabaseSecretIsCreated(rdsClusterID, VpcID *string) (*RDSSecret, error) {
+func (d *RDSMultitenantPGBouncerDatabase) ensureMultitenantDatabaseSecretIsCreated(rdsClusterID, vpcID *string) (*RDSSecret, error) {
 	installationSecretName := RDSMultitenantPGBouncerSecretName(d.installationID)
 
 	installationSecretValue, err := d.client.Service().secretsManager.GetSecretValue(&secretsmanager.GetSecretValueInput{
@@ -680,7 +680,7 @@ func (d *RDSMultitenantPGBouncerDatabase) ensureMultitenantDatabaseSecretIsCreat
 			},
 			{
 				Key:   aws.String(trimTagPrefix(VpcIDTagKey)),
-				Value: VpcID,
+				Value: vpcID,
 			},
 			{
 				Key:   aws.String(trimTagPrefix(DefaultMattermostInstallationIDTagKey)),
@@ -796,7 +796,7 @@ func (d *RDSMultitenantPGBouncerDatabase) Teardown(store model.InstallationDatab
 // removeInstallationFromPGBouncerDatabase performs the work necessary to
 // remove a single installation schema from a multitenant PGBouncer RDS cluster.
 func (d *RDSMultitenantPGBouncerDatabase) removeInstallationPGBouncerResources(database *model.MultitenantDatabase, store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
-	rdsCluster, err := describeRDSCluster(database.ID, d.client)
+	rdsCluster, err := describeRDSCluster(database.RdsClusterID, d.client)
 	if err != nil {
 		return errors.Wrap(err, "failed to describe multitenant database")
 	}

--- a/model/multitenant_database.go
+++ b/model/multitenant_database.go
@@ -14,6 +14,7 @@ import (
 // installation databases.
 type MultitenantDatabase struct {
 	ID                                 string
+	RdsClusterID                       string
 	VpcID                              string
 	DatabaseType                       string
 	State                              string
@@ -136,8 +137,8 @@ func (l *SharedLogicalDatabases) RemoveInstallation(installationID string) {
 	}
 }
 
-// MultitenantDatabaseFilter filters results based on a specific installation ID, Vpc ID and a number of
-// installation's limit.
+// MultitenantDatabaseFilter describes the parameters used to constrain a set of
+// MultitenantDatabases.
 type MultitenantDatabaseFilter struct {
 	Paging
 	LockerID               string


### PR DESCRIPTION
This changes the ID value used to reference multitenant databases
in the provisioner from the existing cluster name to the standard
26 random character IDs. The migration process also handles
creating random IDs for existing databases. Lastly, this also
includes new logic to store rds cluster endpoints for non-pgbouncer
databases.

Fixes https://mattermost.atlassian.net/browse/MM-37441

```release-note
Standardize multitenant database IDs
```
