### PR TITLE
Fix AWAT import completion synchronization bug

### DIFF
--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -105,88 +105,6 @@ func NewImportSupervisor(awsClient toolsAWS.AWS, awat AWATClient, store importSt
 	}
 }
 
-// completeImports transitions Installations back to stable after
-// checking with the AWAT to make sure that it has detected the
-// completion of the import
-func (s *ImportSupervisor) completeImports() error {
-	installationList, err := s.store.GetInstallations(
-		&model.InstallationFilter{
-			Paging: model.AllPagesNotDeleted(),
-			State:  model.InstallationStateImportComplete,
-		}, false, false)
-	if err != nil {
-		return errors.Wrap(err, "failed to list Installations")
-	}
-
-	for _, installation := range installationList {
-		importStatusList, err := s.awatClient.GetImportStatusesByInstallation(installation.ID)
-		if err != nil {
-			s.logger.WithError(err).Warnf("failed to get Import status for Installation %s", installation.ID)
-			continue
-		}
-		if len(importStatusList) == 0 {
-			s.logger.Warnf("no imports found for Installation with state %s, %s", installation.State, installation.ID)
-			continue
-		}
-		// find the most recently completed Import; that's the only one we
-		// care about
-		var mostRecentImport *awat.ImportStatus
-		for _, is := range importStatusList {
-			if is.State != awat.ImportStateComplete {
-				// An import is still running against this Installation.
-				// Multiple parallel imports against an Installation are not supported.
-				break
-			}
-			if mostRecentImport == nil || is.CompleteAt > mostRecentImport.CompleteAt {
-				mostRecentImport = is
-			}
-		}
-		if mostRecentImport == nil {
-			// an Import might still be running
-			continue
-		}
-
-		locked, err := s.store.LockInstallation(installation.ID, s.ID)
-		if err != nil {
-			return errors.Wrapf(err, "failed to lock Installation %s", installation.ID)
-		}
-		if !locked {
-			return errors.Errorf("failed to lock Installation %s", installation.ID)
-		}
-		defer func() {
-			unlocked, err := s.store.UnlockInstallation(installation.ID, s.ID, false)
-			if err != nil {
-				s.logger.WithError(err).Warnf("failed to unlock Installation %s to mark Import %s complete", installation.ID, mostRecentImport.ID)
-				return
-			}
-			if !unlocked {
-				s.logger.Warnf("failed to unlock Installation %s to mark Import %s complete", installation.ID, mostRecentImport.ID)
-			}
-		}()
-
-		// no Imports are running, the Installation may be moved to stable
-		installation.State = model.InstallationStateStable
-		err = s.store.UpdateInstallation(installation)
-		if err != nil {
-			s.logger.WithError(err).Error("failed to mark Installation stable")
-			// this continue is currently redundant but if anything is ever
-			// added to this function after this if stanza, it will be good
-			// to already have so it isn't omitted by mistake
-			continue
-		}
-		err = webhook.SendToAllWebhooks(s.store, &model.WebhookPayload{
-			Type:      model.TypeInstallation,
-			ID:        installation.ID,
-			NewState:  model.InstallationStateStable,
-			OldState:  model.InstallationStateImportComplete,
-			ExtraData: map[string]string{"TranslationID": mostRecentImport.TranslationID, "ImportID": mostRecentImport.ID},
-		}, s.logger.WithField("webhookEvent", model.InstallationStateImportComplete))
-
-	}
-
-	return nil
-}
-
 // Do checks to see if there is an Import that is ready to be
 // imported, and if so, does that. Otherwise, it does nothing.
 func (s *ImportSupervisor) Do() error {
@@ -497,5 +415,98 @@ func (s *ImportSupervisor) waitForImportToComplete(mmctl *mmctl, mattermostJobID
 
 	s.logger.Infof("Import Job %s successfully completed", resp.ID)
 	s.logger.Debugf("Completed with output %s", output)
+	return nil
+}
+
+// completeImports transitions Installations back to stable after
+// checking with the AWAT to make sure that it has detected the
+// completion of the import
+func (s *ImportSupervisor) completeImports() error {
+	installationList, err := s.store.GetInstallations(
+		&model.InstallationFilter{
+			Paging: model.AllPagesNotDeleted(),
+			State:  model.InstallationStateImportComplete,
+		}, false, false)
+	if err != nil {
+		return errors.Wrap(err, "failed to list Installations")
+	}
+
+	for _, installation := range installationList {
+		err = s.checkInstallation(installation)
+		if err != nil {
+			s.logger.WithError(err).Warnf("failed to check to see if Installation %s has completed its import", installation.ID)
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (s *ImportSupervisor) checkInstallation(installation *model.Installation) error {
+	importStatusList, err := s.awatClient.GetImportStatusesByInstallation(installation.ID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get Import status for Installation %s", installation.ID)
+	}
+	if len(importStatusList) == 0 {
+		return errors.Wrapf(err, "no imports found for Installation with state %s, %s", installation.State, installation.ID)
+	}
+	// find the most recently completed Import; that's the only one we
+	// care about
+	var mostRecentImport *awat.ImportStatus
+	for _, is := range importStatusList {
+		if is.State != awat.ImportStateComplete {
+			// An import is still running against this Installation.
+			// Multiple parallel imports against an Installation are not supported.
+			break
+		}
+		if mostRecentImport == nil || is.CompleteAt > mostRecentImport.CompleteAt {
+			mostRecentImport = is
+		}
+	}
+	if mostRecentImport == nil {
+		// an Import might still be running
+		return nil
+	}
+
+	locked, err := s.store.LockInstallation(installation.ID, s.ID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to lock Installation %s", installation.ID)
+	}
+	if !locked {
+		return errors.Errorf("failed to lock Installation %s", installation.ID)
+	}
+	defer func() {
+		unlocked, err := s.store.UnlockInstallation(installation.ID, s.ID, false)
+		if err != nil {
+			s.logger.WithError(err).Warnf("failed to unlock Installation %s to mark Import %s complete", installation.ID, mostRecentImport.ID)
+			return
+		}
+		if !unlocked {
+			s.logger.Warnf("failed to unlock Installation %s to mark Import %s complete", installation.ID, mostRecentImport.ID)
+		}
+	}()
+
+	installation, err = s.store.GetInstallation(installation.ID, false, false)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get Installation %s after locking", installation.ID)
+	}
+
+	// no Imports are running, the Installation may be moved to stable
+	installation.State = model.InstallationStateStable
+	err = s.store.UpdateInstallation(installation)
+	if err != nil {
+		return errors.Wrap(err, "failed to mark Installation stable")
+	}
+	err = webhook.SendToAllWebhooks(s.store, &model.WebhookPayload{
+		Type:      model.TypeInstallation,
+		ID:        installation.ID,
+		NewState:  model.InstallationStateStable,
+		OldState:  model.InstallationStateImportComplete,
+		ExtraData: map[string]string{"TranslationID": mostRecentImport.TranslationID, "ImportID": mostRecentImport.ID},
+	}, s.logger.WithField("webhookEvent", model.InstallationStateImportComplete))
+	if err != nil {
+		return errors.Wrap(err, "failed to send webhook")
+	}
+
 	return nil
 }

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -119,9 +119,6 @@ func (s *ImportSupervisor) completeImports() error {
 	}
 
 	for _, installation := range installationList {
-		if installation == nil {
-			continue
-		}
 		importStatusList, err := s.awatClient.GetImportStatusesByInstallation(installation.ID)
 		if err != nil {
 			s.logger.WithError(err).Warnf("failed to get Import status for Installation %s", installation.ID)

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -158,6 +158,14 @@ func (s *ImportSupervisor) completeImports() error {
 			// to already have so it isn't omitted by mistake
 			continue
 		}
+		err = webhook.SendToAllWebhooks(s.store, &model.WebhookPayload{
+			Type:      model.TypeInstallation,
+			ID:        installation.ID,
+			NewState:  model.InstallationStateStable,
+			OldState:  model.InstallationStateImportComplete,
+			ExtraData: map[string]string{"TranslationID": mostRecentImport.TranslationID, "ImportID": mostRecentImport.ID},
+		}, s.logger.WithField("webhookEvent", model.InstallationStateImportComplete))
+
 	}
 
 	return nil

--- a/internal/supervisor/import_test.go
+++ b/internal/supervisor/import_test.go
@@ -69,6 +69,10 @@ func TestImportSupervisor(t *testing.T) {
 		}
 
 		awatClient.EXPECT().
+			GetImportStatusesByInstallation(installationID).
+			Return([]*awatModel.ImportStatus{}, nil)
+
+		awatClient.EXPECT().
 			ReleaseLockOnImport(importID)
 
 		aws.EXPECT().
@@ -115,6 +119,10 @@ func TestImportSupervisor(t *testing.T) {
 			Filestore: "bifrost",
 			State:     "stable",
 		}
+
+		awatClient.EXPECT().
+			GetImportStatusesByInstallation(installationID).
+			Return([]*awatModel.ImportStatus{}, nil)
 
 		awatClient.EXPECT().
 			ReleaseLockOnImport(importID)
@@ -215,6 +223,10 @@ func TestImportSupervisor(t *testing.T) {
 			S3LargeCopy(&sourceBucket, &inputArchive, &destBucket,
 				gomock.Any()).
 			Return(errors.New("some AWS error"))
+
+		awatClient.EXPECT().
+			GetImportStatusesByInstallation(installationID).
+			Return([]*awatModel.ImportStatus{}, nil)
 
 		err := importSupervisor.Do()
 		assert.Error(t, err, "error not handled properly")

--- a/internal/supervisor/import_test.go
+++ b/internal/supervisor/import_test.go
@@ -155,6 +155,10 @@ func TestImportSupervisor(t *testing.T) {
 			Return(
 				nil, nil)
 
+		awatClient.EXPECT().
+			GetImportStatusesByInstallation(gomock.Any()).
+			Return([]*awatModel.ImportStatus{}, nil)
+
 		err := importSupervisor.Do()
 		assert.NoError(t, err, "error after no work found")
 	})
@@ -174,6 +178,10 @@ func TestImportSupervisor(t *testing.T) {
 			GetTranslationReadyToImport(gomock.Any()).
 			Return(
 				nil, errors.New("some error from AWAT"))
+
+		awatClient.EXPECT().
+			GetImportStatusesByInstallation(gomock.Any()).
+			Return([]*awatModel.ImportStatus{}, nil)
 
 		err := importSupervisor.Do()
 		assert.Error(t, err, "expected failure due to error from AWAT")

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -64,6 +64,10 @@ func (s *mockInstallationStore) GetInstallation(installationID string, includeGr
 	return s.Installation, nil
 }
 
+func (s *mockInstallationStore) GetInstallations(installationFilter *model.InstallationFilter, includeGroupConfig, includeGroupConfigOverrides bool) ([]*model.Installation, error) {
+	return []*model.Installation{s.Installation}, nil
+}
+
 func (s *mockInstallationStore) GetUnlockedInstallationsPendingWork() ([]*model.Installation, error) {
 	return s.UnlockedInstallationsPendingWork, nil
 }

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -65,6 +65,14 @@ func (s *mockInstallationStore) GetInstallation(installationID string, includeGr
 }
 
 func (s *mockInstallationStore) GetInstallations(installationFilter *model.InstallationFilter, includeGroupConfig, includeGroupConfigOverrides bool) ([]*model.Installation, error) {
+	if s.Installation == nil {
+		s.Installation = &model.Installation{
+			ID: model.NewID(),
+		}
+	}
+	if installationFilter.State == model.InstallationStateImportComplete {
+		s.Installation.State = model.InstallationStateStable
+	}
 	return []*model.Installation{s.Installation}, nil
 }
 

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -47,6 +47,10 @@ const (
 	// Workspace archive is being imported from another service or
 	// on-premise
 	InstallationStateImportInProgress = "import-in-progress"
+	// InstallationStateImportComplete is an installation whose import
+	// is complete but whose completion has not yet been noted by the
+	// AWAT. It is otherwise the same as a stable state.
+	InstallationStateImportComplete = "import-complete"
 	// InstallationStateDeletionRequested is an installation to be deleted.
 	InstallationStateDeletionRequested = "deletion-requested"
 	// InstallationStateDeletionInProgress is an installation being deleted.
@@ -96,6 +100,7 @@ var AllInstallationStates = []string{
 	InstallationStateUpdateInProgress,
 	InstallationStateUpdateFailed,
 	InstallationStateImportInProgress,
+	InstallationStateImportComplete,
 	InstallationStateDeletionRequested,
 	InstallationStateDeletionInProgress,
 	InstallationStateDeletionFinalCleanup,
@@ -188,6 +193,7 @@ var (
 			InstallationStateUpdateInProgress,
 			InstallationStateUpdateFailed,
 			InstallationStateImportInProgress,
+			InstallationStateImportComplete,
 			InstallationStateHibernationRequested,
 			InstallationStateHibernationInProgress,
 			InstallationStateHibernating,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds a new state to Installations to represent when the Provisioner's Import Supervisor has finished supervising an ongoing import: `import-complete`. This new state allows for better synchronization with the AWAT, in order to solve the synchronization issue described here https://github.com/mattermost/awat/pull/18#discussion_r686629564 once and for all

Previously when an import was completed, the Import Supervisor would move an Installation's state back to `stable`, but this created an ambiguity for the AWAT in determining whether an Import was completed or had never been started.

Now, when the import is completed, the Import Supervisor will move the Installation to the `import-complete` state, and the AWAT will eventually receive that information via polling for the Installation's status, and mark the import complete in its database.

In order to move the Installation back to `stable`, the Import Supervisor will also now, before performing an import if one is available, check any Installations in `import-complete` state against the AWAT. If the AWAT is in agreement that the most recently completed import it has seen for that Installation is complete, then the Installation is moved to `stable`.

This extra state and functionality in the supervisor should resolve the possible race condition / synchronization problem Szymon identified and that doesn't seem to be avoidable with heuristics and boolean logic ;)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
This PR is necessary to unblock https://github.com/mattermost/awat/pull/18

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added new state import-complete to aid state synchronization with AWAT at end of imports
```
