### PR TITLE
Add extra fields in table for cluster list

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -488,17 +488,23 @@ var clusterListCmd = &cobra.Command{
 		if outputToTable {
 			table := tablewriter.NewWriter(os.Stdout)
 			table.SetAlignment(tablewriter.ALIGN_LEFT)
-			table.SetHeader([]string{"ID", "STATE", "VERSION", "MASTER NODES", "WORKER NODES", "NETWORKING", "VPC"})
+			table.SetHeader([]string{"ID", "STATE", "VERSION", "MASTER NODES", "WORKER NODES", "AMI ID", "NETWORKING", "VPC", "STATUS"})
 
 			for _, cluster := range clusters {
+				status := "offline"
+				if cluster.AllowInstallations {
+					status = "online"
+				}
 				table.Append([]string{
 					cluster.ID,
 					cluster.State,
 					cluster.ProvisionerMetadataKops.Version,
 					fmt.Sprintf("%d x %s", cluster.ProvisionerMetadataKops.MasterCount, cluster.ProvisionerMetadataKops.MasterInstanceType),
 					fmt.Sprintf("%d x %s (max %d)", cluster.ProvisionerMetadataKops.NodeMinCount, cluster.ProvisionerMetadataKops.NodeInstanceType, cluster.ProvisionerMetadataKops.NodeMaxCount),
+					cluster.ProvisionerMetadataKops.AMI,
 					cluster.ProvisionerMetadataKops.Networking,
 					cluster.ProvisionerMetadataKops.VPC,
+					status,
 				})
 			}
 			table.Render()


### PR DESCRIPTION
#### Summary
Extra fields added:
- Status of the cluster `online`/ `offline` accordingly to `AllowInstalaltions`
- AMI-ID of the nodes

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38053

#### Release Note
```release-note
Add extra fields for AMI ID and Status of the cluster in the following command:

cloud cluster list --table
```
