### PR TITLE
Fix wrong label on SLI Prometheus queries

### DIFF
--- a/internal/provisioner/kops_provisioner_installation_sli.go
+++ b/internal/provisioner/kops_provisioner_installation_sli.go
@@ -37,7 +37,7 @@ func (provisioner *KopsProvisioner) makeSLIs(clusterInstallation *model.ClusterI
 					Objective:   99.9,
 					Description: "Availability metric for mattermost API",
 					SLI: slothv1.SLI{Events: &slothv1.SLIEvents{
-						ErrorQuery: "sum(rate(mattermost_api_time_count{job='" + installationName + "',code=~'(5..|429)'}[{{.window}}]))",
+						ErrorQuery: "sum(rate(mattermost_api_time_count{job='" + installationName + "',status_code=~'(5..|429)'}[{{.window}}]))",
 						TotalQuery: "sum(rate(mattermost_api_time_count{job='" + installationName + "'}[{{.window}}]))",
 					}},
 					Alerting: slothv1.Alerting{


### PR DESCRIPTION
Typo. Used accidentally code instead of status_code
Issue: MM-37305

#### Summary
Typo. Used accidentally code instead of status_code


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37305

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fix typo on label on SLI/SLOs creation query
```
