### PR TITLE
Delete k8s-spot-termination-handler upon re-provision

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -331,6 +331,13 @@ func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster, aws
 		return errors.Wrap(err, "failed to delete APIService v1beta1.metrics.k8s.io")
 	}
 
+	err = k8sClient.Clientset.AppsV1().DaemonSets("kube-system").Delete(ctx, "k8s-spot-termination-handler", metav1.DeleteOptions{})
+	if k8sErrors.IsNotFound(err) {
+		logger.Info("DaemonSet k8s-spot-termination-handler not found; skipping...")
+	} else if err != nil {
+		return errors.Wrap(err, "failed to delete DaemonSet k8s-spot-termination-handler")
+	}
+
 	// TODO: determine if we want to hard-code the k8s resource objects in code.
 	// For now, we will ingest manifest files to deploy the mattermost operator.
 	files := []k8s.ManifestFile{


### PR DESCRIPTION
Fixes cases where sometimes when k8s-spot-termination-handler has 0 pods stucks and fails during re-provision.
Issue: MM-37912

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fixes cases where sometimes when k8s-spot-termination-handler has 0 pods stucks and fails during re-provision.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37912

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fixes a bug on provisioning of k8s-spot-termination-handler daemonSet.
```
