### PR TITLE
Improve secret manager secret cleanup

### DIFF
--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -146,6 +146,10 @@ const (
 	// existing installations.
 	cloudIDPrefix = "cloud-"
 
+	// defaultSecretManagerDeletionDays is the default number of days that
+	// secrets will be marked for deletion for when being removed.
+	defaultSecretManagerDeletionDays = 14
+
 	// iamSuffix is the suffix value used when referencing an AWS IAM secret.
 	// Warning:
 	// changing this value will break the connection to AWS resources for

--- a/internal/tools/aws/database_multitenant.go
+++ b/internal/tools/aws/database_multitenant.go
@@ -914,7 +914,7 @@ func (d *RDSMultitenantDatabase) removeInstallationFromMultitenantDatabase(datab
 		return errors.Wrap(err, "failed to drop multitenant database")
 	}
 
-	err = ensureSecretDeleted(RDSMultitenantSecretName(d.installationID), d.client)
+	err = d.client.secretsManagerEnsureSecretDeleted(RDSMultitenantSecretName(d.installationID), false, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete multitenant database secret")
 	}
@@ -979,17 +979,6 @@ func (d *RDSMultitenantDatabase) dropDatabase(rdsClusterID, rdsClusterendpoint s
 	err = d.dropDatabaseIfExists(ctx, databaseName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to drop multitenant RDS database name %s", databaseName)
-	}
-
-	return nil
-}
-
-func ensureSecretDeleted(secretName string, client *Client) error {
-	_, err := client.Service().secretsManager.DeleteSecret(&secretsmanager.DeleteSecretInput{
-		SecretId: aws.String(secretName),
-	})
-	if err != nil && !IsErrorCode(err, secretsmanager.ErrCodeResourceNotFoundException) {
-		return errors.Wrapf(err, "failed to delete secret %s", secretName)
 	}
 
 	return nil

--- a/internal/tools/aws/database_multitenant_pgbouncer.go
+++ b/internal/tools/aws/database_multitenant_pgbouncer.go
@@ -803,7 +803,7 @@ func (d *RDSMultitenantPGBouncerDatabase) removeInstallationPGBouncerResources(d
 
 	logger = logger.WithField("rds-cluster-id", *rdsCluster.DBClusterIdentifier)
 
-	err = ensureSecretDeleted(RDSMultitenantSecretName(d.installationID), d.client)
+	err = d.client.secretsManagerEnsureSecretDeleted(RDSMultitenantPGBouncerSecretName(d.installationID), false, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete multitenant database secret")
 	}


### PR DESCRIPTION
This change does the following:
 - Specifies 14 days for secret deletion instead of relying on the
   default of 30.
 - Corrects an issue where pgbouncer database secrets were not
   properly cleaned up.
 - Ensures all secret deletion goes through one set of logic that
   includes logging of actions taken.

Fixes https://mattermost.atlassian.net/browse/MM-38087 and https://mattermost.atlassian.net/browse/MM-38088

```release-note
Improve secret manager secret cleanup
```
