### PR TITLE
Communicate error message to AWAT when an Import fails

### DIFF
--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -143,12 +143,11 @@ func (s *ImportSupervisor) Do() error {
 						CompleteAt: awat.Timestamp(),
 						Error:      workError,
 					})
-				if err != nil {
-					s.logger.WithError(err).Errorf("failed to report error to AWAT for Import %s", work.ID)
-					continue
+				if err == nil {
+					return
 				}
+				s.logger.WithError(err).Errorf("failed to report error to AWAT for Import %s", work.ID)
 				time.Sleep(time.Second * 5)
-				return
 			}
 		}()
 	}

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -134,6 +134,23 @@ func (s *ImportSupervisor) Do() error {
 	err = s.importTranslation(work)
 	if err != nil {
 		s.logger.WithError(err).Errorf("failed to perform work on Import %s", work.ID)
+		workError := err.Error()
+		go func() {
+			for {
+				err := s.awatClient.CompleteImport(
+					&awat.ImportCompletedWorkRequest{
+						ID:         work.ID,
+						CompleteAt: awat.Timestamp(),
+						Error:      workError,
+					})
+				if err != nil {
+					s.logger.WithError(err).Errorf("failed to report error to AWAT for Import %s", work.ID)
+					continue
+				}
+				time.Sleep(time.Second * 5)
+				return
+			}
+		}()
 	}
 
 	return err

--- a/internal/supervisor/import_test.go
+++ b/internal/supervisor/import_test.go
@@ -128,7 +128,8 @@ func TestImportSupervisor(t *testing.T) {
 			ReleaseLockOnImport(importID)
 
 		awatClient.EXPECT().
-			CompleteImport(gomock.Any())
+			CompleteImport(gomock.Any()).
+			Return(nil)
 
 		aws.EXPECT().
 			GetMultitenantBucketNameForInstallation(installationID, store).
@@ -239,7 +240,15 @@ func TestImportSupervisor(t *testing.T) {
 			GetImportStatusesByInstallation(installationID).
 			Return([]*awatModel.ImportStatus{}, nil)
 
+		awatClient.EXPECT().
+			CompleteImport(gomock.Any()).
+			Return(nil)
+
 		err := importSupervisor.Do()
+		time.Sleep(time.Second)
+		// sleep to avoid a race that only occurs in testing because some
+		// member of the MockAWATClient ceases to exist when tests are
+		// done, but the Supervisor in the actual code exists forever
 		assert.Error(t, err, "error not handled properly")
 	})
 }

--- a/internal/supervisor/import_test.go
+++ b/internal/supervisor/import_test.go
@@ -127,6 +127,9 @@ func TestImportSupervisor(t *testing.T) {
 		awatClient.EXPECT().
 			ReleaseLockOnImport(importID)
 
+		awatClient.EXPECT().
+			CompleteImport(gomock.Any())
+
 		aws.EXPECT().
 			GetMultitenantBucketNameForInstallation(installationID, store).
 			Return(destBucket, nil)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This change adds error reporting on failure to the Import Supervisor. When an Import fails, the Import Supervisor marks the Import as `complete` on the AWAT and sends over an error message. It retries this forever until the AWAT returns a non-error status code. This means that it will retry forever until success, unless the Provisioner is restarted before the AWAT stops having an error. This is the only scenario when data is lost, and the only data that's lost will be the error message. The Import will be moved to 'complete' on the AWAT side regardless, eventually, because the Installation is transitioned to `import-complete` and the AWAT will eventually poll & see that state.

There is a slightly more robust design for this, but it's not much more robust and it's a larger change, so I'll explain: the Provisioner could store this error message in the database & I could introduce another Installation state `import-failed`, to allow the AWAT to poll for the error & to allow the error message to avoid being lost if the Provisioner crashes before the AWAT can receive it, but the only scenario the more complicated design avoids is that one. Personally, I don't think it's worth the extra database column that needs to be added, and the extra state, and I think this PR will work perfectly in practice. If you guys disagree, I'll be happy to change the behavior in the PR (but since that's a bit more involved, I'll probably open a JIRA ticket so we can prioritize it).


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Did this as part of the e2e testing ticket

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
