### PR TITLE
MM-37273 Fix validation of ValuesPath and Chart for utilities at cluster create time

### DIFF
--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -1177,7 +1177,7 @@ func TestGetAllUtilityMetadata(t *testing.T) {
 	assert.Equal(t, nilVersion, utilityMetadata.ActualVersions.Fluentbit)
 	assert.Equal(t, &model.HelmUtilityVersion{Chart: "stable"}, utilityMetadata.DesiredVersions.Nginx)
 	assert.Equal(t, &model.HelmUtilityVersion{Chart: "9.4.4", ValuesPath: ""}, utilityMetadata.DesiredVersions.PrometheusOperator)
-	assert.Equal(t, model.FluentbitDefaultVersion, utilityMetadata.DesiredVersions.Fluentbit)
+	assert.Equal(t, model.DefaultUtilityVersions[model.FluentbitCanonicalName], utilityMetadata.DesiredVersions.Fluentbit)
 }
 
 func TestClusterAnnotations(t *testing.T) {

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -31,6 +31,36 @@ type CreateClusterRequest struct {
 	VPC                    string                         `json:"vpc,omitempty"`
 }
 
+func (request *CreateClusterRequest) setUtilityDefaults(utilityName string) {
+	reqDesiredUtilityVersion, ok := request.DesiredUtilityVersions[utilityName]
+	if !ok {
+		request.DesiredUtilityVersions[utilityName] = DefaultUtilityVersions[utilityName]
+		return
+	}
+	if reqDesiredUtilityVersion.Chart == "" {
+		reqDesiredUtilityVersion.Chart = DefaultUtilityVersions[utilityName].Chart
+	}
+	if reqDesiredUtilityVersion.ValuesPath == "" {
+		reqDesiredUtilityVersion.ValuesPath = DefaultUtilityVersions[utilityName].ValuesPath
+	}
+}
+
+func (request *CreateClusterRequest) setUtilitiesDefaults() {
+	for _, utilityName := range []string{
+		PrometheusOperatorCanonicalName,
+		ThanosCanonicalName,
+		NginxCanonicalName,
+		NginxInternalCanonicalName,
+		FluentbitCanonicalName,
+		TeleportCanonicalName,
+		PgbouncerCanonicalName,
+		StackroxCanonicalName,
+		KubecostCanonicalName,
+	} {
+		request.setUtilityDefaults(utilityName)
+	}
+}
+
 // SetDefaults sets the default values for a cluster create request.
 func (request *CreateClusterRequest) SetDefaults() {
 	if len(request.Provider) == 0 {
@@ -63,49 +93,8 @@ func (request *CreateClusterRequest) SetDefaults() {
 	if request.DesiredUtilityVersions == nil {
 		request.DesiredUtilityVersions = make(map[string]*HelmUtilityVersion)
 	}
-	if _, ok := request.DesiredUtilityVersions[PrometheusOperatorCanonicalName]; !ok {
-		request.DesiredUtilityVersions[PrometheusOperatorCanonicalName] = PrometheusOperatorDefaultVersion
-	} else if request.DesiredUtilityVersions[PrometheusOperatorCanonicalName].Values() == "" {
-		request.DesiredUtilityVersions[PrometheusOperatorCanonicalName].ValuesPath = PrometheusOperatorDefaultVersion.ValuesPath
-	}
-	if _, ok := request.DesiredUtilityVersions[ThanosCanonicalName]; !ok {
-		request.DesiredUtilityVersions[ThanosCanonicalName] = ThanosDefaultVersion
-	} else if request.DesiredUtilityVersions[ThanosCanonicalName].Values() == "" {
-		request.DesiredUtilityVersions[ThanosCanonicalName].ValuesPath = ThanosDefaultVersion.ValuesPath
-	}
-	if _, ok := request.DesiredUtilityVersions[NginxCanonicalName]; !ok {
-		request.DesiredUtilityVersions[NginxCanonicalName] = NginxDefaultVersion
-	} else if request.DesiredUtilityVersions[NginxCanonicalName].Values() == "" {
-		request.DesiredUtilityVersions[NginxCanonicalName].ValuesPath = NginxDefaultVersion.ValuesPath
-	}
-	if _, ok := request.DesiredUtilityVersions[NginxInternalCanonicalName]; !ok {
-		request.DesiredUtilityVersions[NginxInternalCanonicalName] = NginxInternalDefaultVersion
-	} else if request.DesiredUtilityVersions[NginxInternalCanonicalName].Values() == "" {
-		request.DesiredUtilityVersions[NginxInternalCanonicalName].ValuesPath = NginxInternalDefaultVersion.ValuesPath
-	}
-	if _, ok := request.DesiredUtilityVersions[FluentbitCanonicalName]; !ok {
-		request.DesiredUtilityVersions[FluentbitCanonicalName] = FluentbitDefaultVersion
-	} else if request.DesiredUtilityVersions[FluentbitCanonicalName].Values() == "" {
-		request.DesiredUtilityVersions[FluentbitCanonicalName].ValuesPath = FluentbitDefaultVersion.ValuesPath
-	}
-	if _, ok := request.DesiredUtilityVersions[TeleportCanonicalName]; !ok {
-		request.DesiredUtilityVersions[TeleportCanonicalName] = TeleportDefaultVersion
-	} else if request.DesiredUtilityVersions[TeleportCanonicalName].Values() == "" {
-		request.DesiredUtilityVersions[TeleportCanonicalName].ValuesPath = TeleportDefaultVersion.ValuesPath
-	}
-	if _, ok := request.DesiredUtilityVersions[PgbouncerCanonicalName]; !ok {
-		request.DesiredUtilityVersions[PgbouncerCanonicalName] = PgbouncerDefaultVersion
-	} else if request.DesiredUtilityVersions[PgbouncerCanonicalName].Values() == "" {
-		request.DesiredUtilityVersions[PgbouncerCanonicalName].ValuesPath = PgbouncerDefaultVersion.ValuesPath
-	}
-	if _, ok := request.DesiredUtilityVersions[StackroxCanonicalName]; !ok {
-		request.DesiredUtilityVersions[StackroxCanonicalName] = StackroxDefaultVersion
-	} else if request.DesiredUtilityVersions[StackroxCanonicalName].Values() == "" {
-		request.DesiredUtilityVersions[StackroxCanonicalName].ValuesPath = StackroxDefaultVersion.ValuesPath
-	}
-	if _, ok := request.DesiredUtilityVersions[KubecostCanonicalName]; !ok {
-		request.DesiredUtilityVersions[KubecostCanonicalName] = KubecostDefaultVersion
-	}
+
+	request.setUtilitiesDefaults()
 }
 
 // Validate validates the values of a cluster create request.

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -284,27 +284,9 @@ func UtilityMetadataFromReader(reader io.Reader) (*UtilityMetadata, error) {
 // Gets the version for a utility from a utilityVersions struct using
 // the utility's name's string representation for lookup
 func getUtilityVersion(versions UtilityGroupVersions, utility string) *HelmUtilityVersion {
-	switch utility {
-	case PrometheusOperatorCanonicalName:
-		return versions.PrometheusOperator
-	case ThanosCanonicalName:
-		return versions.Thanos
-	case NginxCanonicalName:
-		return versions.Nginx
-	case NginxInternalCanonicalName:
-		return versions.NginxInternal
-	case FluentbitCanonicalName:
-		return versions.Fluentbit
-	case TeleportCanonicalName:
-		return versions.Teleport
-	case PgbouncerCanonicalName:
-		return versions.Pgbouncer
-	case StackroxCanonicalName:
-		return versions.Stackrox
-	case KubecostCanonicalName:
-		return versions.Kubecost
+	if r, ok := versions.AsMap()[utility]; ok {
+		return r
 	}
-
 	return nil
 }
 

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -87,68 +85,6 @@ func SetUtilityDefaults(url string) {
 	if KubecostDefaultVersion.ValuesPath == "" {
 		KubecostDefaultVersion.ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fkubecost_values.yaml?ref=master", url)
 	}
-}
-
-// UnmarshalJSON is a custom JSON unmarshaler that can handle both the
-// old Version string type and the new type. It is entirely
-// self-contained, including types, so that it can be easily removed
-// when no more clusters exist with the old version format.
-// TODO DELETE THIS
-func (h *UtilityGroupVersions) UnmarshalJSON(bytes []byte) error {
-	type utilityGroupVersions struct {
-		PrometheusOperator *HelmUtilityVersion
-		Thanos             *HelmUtilityVersion
-		Nginx              *HelmUtilityVersion
-		NginxInternal      *HelmUtilityVersion
-		Fluentbit          *HelmUtilityVersion
-		Teleport           *HelmUtilityVersion
-		Pgbouncer          *HelmUtilityVersion
-		Stackrox           *HelmUtilityVersion
-		Kubecost           *HelmUtilityVersion
-	}
-	type oldUtilityGroupVersions struct {
-		PrometheusOperator string
-		Thanos             string
-		Nginx              string
-		NginxInternal      string
-		Fluentbit          string
-		Teleport           string
-		Pgbouncer          string
-		Stackrox           string
-		Kubecost           string
-	}
-
-	var utilGrpVers *utilityGroupVersions = &utilityGroupVersions{}
-	var oldUtilGrpVers *oldUtilityGroupVersions = &oldUtilityGroupVersions{}
-	err := json.Unmarshal(bytes, utilGrpVers)
-	if err != nil {
-		secondErr := json.Unmarshal(bytes, oldUtilGrpVers)
-		if secondErr != nil {
-			return fmt.Errorf("%s and %s", errors.Wrap(err, "failed to unmarshal to new HelmUtilityVersion"), errors.Wrap(secondErr, "failed to unmarshal to old HelmUtilityVersion type"))
-		}
-
-		h.PrometheusOperator = &HelmUtilityVersion{Chart: oldUtilGrpVers.PrometheusOperator}
-		h.Thanos = &HelmUtilityVersion{Chart: oldUtilGrpVers.Thanos}
-		h.Nginx = &HelmUtilityVersion{Chart: oldUtilGrpVers.Nginx}
-		h.NginxInternal = &HelmUtilityVersion{Chart: oldUtilGrpVers.NginxInternal}
-		h.Fluentbit = &HelmUtilityVersion{Chart: oldUtilGrpVers.Fluentbit}
-		h.Teleport = &HelmUtilityVersion{Chart: oldUtilGrpVers.Teleport}
-		h.Pgbouncer = &HelmUtilityVersion{Chart: oldUtilGrpVers.Pgbouncer}
-		h.Stackrox = &HelmUtilityVersion{Chart: oldUtilGrpVers.Stackrox}
-		h.Kubecost = &HelmUtilityVersion{Chart: oldUtilGrpVers.Kubecost}
-		return nil
-	}
-
-	h.PrometheusOperator = utilGrpVers.PrometheusOperator
-	h.Thanos = utilGrpVers.Thanos
-	h.Nginx = utilGrpVers.Nginx
-	h.NginxInternal = utilGrpVers.NginxInternal
-	h.Fluentbit = utilGrpVers.Fluentbit
-	h.Teleport = utilGrpVers.Teleport
-	h.Pgbouncer = utilGrpVers.Pgbouncer
-	h.Stackrox = utilGrpVers.Stackrox
-	h.Kubecost = utilGrpVers.Kubecost
-	return nil
 }
 
 // UtilityGroupVersions holds the concrete metadata for any cluster

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -35,55 +35,56 @@ const (
 	GitlabOAuthTokenKey = "GITLAB_OAUTH_TOKEN"
 )
 
-var (
+// DefaultUtilityVersions holds the default values for all of the HelmUtilityVersions
+var DefaultUtilityVersions map[string]*HelmUtilityVersion = map[string]*HelmUtilityVersion{
 	// PrometheusOperatorDefaultVersion defines the default version for the Helm chart
-	PrometheusOperatorDefaultVersion = &HelmUtilityVersion{Chart: "9.4.4", ValuesPath: ""}
+	PrometheusOperatorCanonicalName: {Chart: "9.4.4", ValuesPath: ""},
 	// ThanosDefaultVersion defines the default version for the Helm chart
-	ThanosDefaultVersion = &HelmUtilityVersion{Chart: "3.2.2", ValuesPath: ""}
+	ThanosCanonicalName: {Chart: "3.2.2", ValuesPath: ""},
 	// NginxDefaultVersion defines the default version for the Helm chart
-	NginxDefaultVersion = &HelmUtilityVersion{Chart: "2.15.0", ValuesPath: ""}
+	NginxCanonicalName: {Chart: "2.15.0", ValuesPath: ""},
 	// NginxInternalDefaultVersion defines the default version for the Helm chart
-	NginxInternalDefaultVersion = &HelmUtilityVersion{Chart: "2.15.0", ValuesPath: ""}
+	NginxInternalCanonicalName: {Chart: "2.15.0", ValuesPath: ""},
 	// FluentbitDefaultVersion defines the default version for the Helm chart
-	FluentbitDefaultVersion = &HelmUtilityVersion{Chart: "0.15.8", ValuesPath: ""}
+	FluentbitCanonicalName: {Chart: "0.15.8", ValuesPath: ""},
 	// TeleportDefaultVersion defines the default version for the Helm chart
-	TeleportDefaultVersion = &HelmUtilityVersion{Chart: "0.3.0", ValuesPath: ""}
+	TeleportCanonicalName: {Chart: "0.3.0", ValuesPath: ""},
 	// PgbouncerDefaultVersion defines the default version for the Helm chart
-	PgbouncerDefaultVersion = &HelmUtilityVersion{Chart: "1.1.0", ValuesPath: ""}
+	PgbouncerCanonicalName: {Chart: "1.1.0", ValuesPath: ""},
 	// StackroxDefaultVersion defines the default version for the Helm chart
-	StackroxDefaultVersion = &HelmUtilityVersion{Chart: "62.0.0", ValuesPath: ""}
+	StackroxCanonicalName: {Chart: "62.0.0", ValuesPath: ""},
 	// KubecostDefaultVersion defines the default version for the Helm chart
-	KubecostDefaultVersion = &HelmUtilityVersion{Chart: "1.83.1", ValuesPath: ""}
-)
+	KubecostCanonicalName: {Chart: "1.83.1", ValuesPath: ""},
+}
 
 // SetUtilityDefaults is used to set Utility default version and values.
 func SetUtilityDefaults(url string) {
-	if PrometheusOperatorDefaultVersion.ValuesPath == "" {
-		PrometheusOperatorDefaultVersion.ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fprometheus_operator_values.yaml?ref=master", url)
+	if DefaultUtilityVersions[PrometheusOperatorCanonicalName].ValuesPath == "" {
+		DefaultUtilityVersions[PrometheusOperatorCanonicalName].ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fprometheus_operator_values.yaml?ref=master", url)
 	}
-	if ThanosDefaultVersion.ValuesPath == "" {
-		ThanosDefaultVersion.ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fthanos_values.yaml?ref=master", url)
+	if DefaultUtilityVersions[ThanosCanonicalName].ValuesPath == "" {
+		DefaultUtilityVersions[ThanosCanonicalName].ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fthanos_values.yaml?ref=master", url)
 	}
-	if NginxDefaultVersion.ValuesPath == "" {
-		NginxDefaultVersion.ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fnginx_values.yaml?ref=master", url)
+	if DefaultUtilityVersions[NginxCanonicalName].ValuesPath == "" {
+		DefaultUtilityVersions[NginxCanonicalName].ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fnginx_values.yaml?ref=master", url)
 	}
-	if NginxInternalDefaultVersion.ValuesPath == "" {
-		NginxInternalDefaultVersion.ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fnginx_internal_values.yaml?ref=master", url)
+	if DefaultUtilityVersions[NginxInternalCanonicalName].ValuesPath == "" {
+		DefaultUtilityVersions[NginxInternalCanonicalName].ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fnginx_internal_values.yaml?ref=master", url)
 	}
-	if FluentbitDefaultVersion.ValuesPath == "" {
-		FluentbitDefaultVersion.ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Ffluent-bit_values.yaml?ref=master", url)
+	if DefaultUtilityVersions[FluentbitCanonicalName].ValuesPath == "" {
+		DefaultUtilityVersions[FluentbitCanonicalName].ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Ffluent-bit_values.yaml?ref=master", url)
 	}
-	if TeleportDefaultVersion.ValuesPath == "" {
-		TeleportDefaultVersion.ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fteleport_values.yaml?ref=master", url)
+	if DefaultUtilityVersions[TeleportCanonicalName].ValuesPath == "" {
+		DefaultUtilityVersions[TeleportCanonicalName].ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fteleport_values.yaml?ref=master", url)
 	}
-	if PgbouncerDefaultVersion.ValuesPath == "" {
-		PgbouncerDefaultVersion.ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fpgbouncer_values.yaml?ref=master", url)
+	if DefaultUtilityVersions[PgbouncerCanonicalName].ValuesPath == "" {
+		DefaultUtilityVersions[PgbouncerCanonicalName].ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fpgbouncer_values.yaml?ref=master", url)
 	}
-	if StackroxDefaultVersion.ValuesPath == "" {
-		StackroxDefaultVersion.ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fstackrox_values.yaml?ref=master", url)
+	if DefaultUtilityVersions[StackroxCanonicalName].ValuesPath == "" {
+		DefaultUtilityVersions[StackroxCanonicalName].ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fstackrox_values.yaml?ref=master", url)
 	}
-	if KubecostDefaultVersion.ValuesPath == "" {
-		KubecostDefaultVersion.ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fkubecost_values.yaml?ref=master", url)
+	if DefaultUtilityVersions[KubecostCanonicalName].ValuesPath == "" {
+		DefaultUtilityVersions[KubecostCanonicalName].ValuesPath = fmt.Sprintf("%s/api/v4/projects/33/repository/files/dev%%2Fkubecost_values.yaml?ref=master", url)
 	}
 }
 

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -21,10 +21,10 @@ func TestSetUtilityVersion(t *testing.T) {
 	}
 
 	setUtilityVersion(u, NginxCanonicalName, &HelmUtilityVersion{Chart: "0.9"})
-	assert.Equal(t, u.Nginx, &HelmUtilityVersion{Chart: "0.9"})
+	assert.Equal(t, &HelmUtilityVersion{Chart: "0.9"}, u.Nginx)
 
 	setUtilityVersion(u, "an_error", &HelmUtilityVersion{Chart: "9"})
-	assert.Equal(t, u.Nginx, &HelmUtilityVersion{Chart: "0.9"})
+	assert.Equal(t, &HelmUtilityVersion{Chart: "0.9"}, u.Nginx)
 }
 
 func TestGetUtilityVersion(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This simplifies the routine used when creating a `CreateClusterRequest` to check and set defaults on unset fields.

The ticket specifies that we need this for provision as well, however I don't believe this is correct because empty fields are handled as meaning "no change desired" in the case of a ProvisionClusterRequest

The ticket also specifies that this routine was missing, however, I believe that a lot of the code I've removed was intended to prevent the bug this change resolves, however, SetDefaults had become very large and doesn't have the same behavior for all of the utilities, and I believe that this is an error induced by the large, repetitive, and largely hard-coded nature of that method.

- To resolve this, I've moved all of the hard-coded utility defaults into a map so that in SetDefaults() we can iterate through them to ensure the correct defaults for each utility.

- I have also unceremoniously removed some old migration code with a TODO that I left saying to remove it. That code was only necessary until the clusters were updated with that version of the code, but I see that instead of it being removed, it's been diligently updated to satisfy the compiler, so I've removed it as part of this PR so that we can stop doing that.

- Also I simplified `getUtilityVersion` so that it is no longer a huge switch statement that must be continually updated. I'd do the same thing for setUtilityVersion but that's a bit more involved haha.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-37273

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fixed version and valuespath validation for cluster utilities
```
