### PR TITLE
Ensure multitenant DB users are removed

### DIFF
--- a/internal/tools/aws/database_multitenant.go
+++ b/internal/tools/aws/database_multitenant.go
@@ -542,7 +542,8 @@ func (d *RDSMultitenantDatabase) RollbackMigration(store model.InstallationDatab
 	rdsID := *rdsCluster.DBClusterIdentifier
 	logger = logger.WithField("rds-cluster-id", rdsID)
 
-	err = d.dropDatabase(rdsID, *rdsCluster.Endpoint, logger)
+	username := MattermostMultitenantDatabaseUsername(d.installationID)
+	err = d.cleanupDatabase(rdsID, *rdsCluster.Endpoint, username, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to drop destination database")
 	}
@@ -909,7 +910,8 @@ func (d *RDSMultitenantDatabase) removeInstallationFromMultitenantDatabase(datab
 
 	logger = logger.WithField("rds-cluster-id", *rdsCluster.DBClusterIdentifier)
 
-	err = d.dropDatabase(database.RdsClusterID, *rdsCluster.Endpoint, logger)
+	username := MattermostMultitenantDatabaseUsername(d.installationID)
+	err = d.cleanupDatabase(database.RdsClusterID, *rdsCluster.Endpoint, username, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to drop multitenant database")
 	}
@@ -943,7 +945,8 @@ func (d *RDSMultitenantDatabase) removeMigratedInstallationFromMultitenantDataba
 
 	logger = logger.WithField("rds-cluster-id", *rdsCluster.DBClusterIdentifier)
 
-	err = d.dropDatabase(database.RdsClusterID, *rdsCluster.Endpoint, logger)
+	username := MattermostMultitenantDatabaseUsername(d.installationID)
+	err = d.cleanupDatabase(database.RdsClusterID, *rdsCluster.Endpoint, username, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to drop migrated database")
 	}
@@ -957,7 +960,7 @@ func (d *RDSMultitenantDatabase) removeMigratedInstallationFromMultitenantDataba
 	return nil
 }
 
-func (d *RDSMultitenantDatabase) dropDatabase(rdsClusterID, rdsClusterendpoint string, logger log.FieldLogger) error {
+func (d *RDSMultitenantDatabase) cleanupDatabase(rdsClusterID, rdsClusterendpoint, username string, logger log.FieldLogger) error {
 	databaseName := MattermostRDSDatabaseName(d.installationID)
 
 	masterSecretValue, err := d.client.Service().secretsManager.GetSecretValue(&secretsmanager.GetSecretValueInput{
@@ -979,6 +982,11 @@ func (d *RDSMultitenantDatabase) dropDatabase(rdsClusterID, rdsClusterendpoint s
 	err = d.dropDatabaseIfExists(ctx, databaseName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to drop multitenant RDS database name %s", databaseName)
+	}
+
+	err = dropUserIfExists(ctx, d.db, username)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete installation database user")
 	}
 
 	return nil
@@ -1017,10 +1025,7 @@ func (d *RDSMultitenantDatabase) ensureMultitenantDatabaseSecretIsCreated(rdsClu
 			},
 		}
 
-		// PostgreSQL username can't start with integers, so prepend something
-		// valid just in case. Name can't be longer than 32 characters for MySQL
-		// databases though.
-		username := fmt.Sprintf("user_%s", d.installationID)
+		username := MattermostMultitenantDatabaseUsername(d.installationID)
 		installationSecret, err = createDatabaseUserSecret(installationSecretName, username, description, tags, d.client)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create a multitenant RDS database secret %s", installationSecretName)

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -103,6 +103,12 @@ func RDSMultitenantSecretName(id string) string {
 	return fmt.Sprintf("rds-multitenant-%s", id)
 }
 
+// MattermostMultitenantDatabaseUsername formats the name of a Mattermost user for
+// use in a multitenant database.
+func MattermostMultitenantDatabaseUsername(installationID string) string {
+	return fmt.Sprintf("user_%s", installationID)
+}
+
 // RDSMultitenantPGBouncerSecretName formats the name of a secret used in a
 // multitenant PGBouncer RDS database.
 func RDSMultitenantPGBouncerSecretName(id string) string {


### PR DESCRIPTION
This corrects an issue where multitenant database users were not
deleted when database teardown occurred.

Note that pgbouncer databases were not affected by this.

Fixes https://mattermost.atlassian.net/browse/MM-38117

```release-note
Ensure multitenant DB users are removed
```
