### PR TITLE
Add ability to specify custom columns to table output

### DIFF
--- a/cmd/cloud/table_printer.go
+++ b/cmd/cloud/table_printer.go
@@ -6,13 +6,14 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/util/jsonpath"
-	"os"
-	"regexp"
-	"strings"
 )
 
 func registerTableOutputFlags(cmd *cobra.Command) {

--- a/cmd/cloud/table_printer.go
+++ b/cmd/cloud/table_printer.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"fmt"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/util/jsonpath"
+	"os"
+	"regexp"
+	"strings"
+)
+
+func registerTableOutputFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("table", false, "Whether to display the returned output list as a table or not.")
+	cmd.Flags().StringSlice("custom-columns", []string{}, "Custom columns for table output specified with jsonpath in form <column_name>:<jsonpath>. Example: --custom-columns=ID:.ID,State:.State,VPC:.ProvisionerMetadataKops.VPC")
+}
+
+func tableOutputEnabled(command *cobra.Command) (bool, []string) {
+	outputToTable, _ := command.Flags().GetBool("table")
+	customCols, _ := command.Flags().GetStringSlice("custom-columns")
+
+	return outputToTable || len(customCols) > 0, customCols
+}
+
+func printTable(columnNames []string, values [][]string) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeader(columnNames)
+
+	for _, v := range values {
+		table.Append(v)
+	}
+	table.Render()
+}
+
+func prepareTableData(customCols []string, data []interface{}) ([]string, [][]string, error) {
+	cc, err := parseCustomColumns(customCols)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to parse custom columns")
+	}
+
+	vals, err := makeValues(cc, data)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to make table values")
+	}
+
+	return cc.keys, vals, nil
+}
+
+type customColumns struct {
+	keys             []string
+	valueExpressions []*jsonpath.JSONPath
+}
+
+func parseCustomColumns(customCols []string) (customColumns, error) {
+	columnKeys := make([]string, 0, len(customCols))
+	columnExpressions := make([]*jsonpath.JSONPath, 0, len(customCols))
+
+	for i, expr := range customCols {
+		colSpec := strings.SplitN(expr, ":", 2)
+		if len(colSpec) != 2 {
+			return customColumns{}, fmt.Errorf("unexpected custom-columns spec: %s, expected <header>:<json-path-expr>", expr)
+		}
+		columnKeys = append(columnKeys, colSpec[0])
+
+		spec, err := relaxedJSONPathExpression(colSpec[1])
+		if err != nil {
+			return customColumns{}, err
+		}
+
+		parser := jsonpath.New(fmt.Sprintf("column%d", i)).AllowMissingKeys(true)
+		if err := parser.Parse(spec); err != nil {
+			return customColumns{}, errors.Wrapf(err, "failed to parse jsonpath expression %q", spec)
+		}
+
+		columnExpressions = append(columnExpressions, parser)
+	}
+
+	return customColumns{keys: columnKeys, valueExpressions: columnExpressions}, nil
+}
+
+func makeValues(cc customColumns, data []interface{}) ([][]string, error) {
+	rows := make([][]string, 0, len(data))
+	for _, elem := range data {
+		valRow, err := makeRow(cc.valueExpressions, elem)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, valRow)
+	}
+	return rows, nil
+}
+
+func makeRow(jpExpression []*jsonpath.JSONPath, data interface{}) ([]string, error) {
+	vals := make([]string, 0, len(jpExpression))
+
+	for _, exp := range jpExpression {
+		values, err := exp.FindResults(data)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to find expression results for data")
+		}
+
+		var valuesStr []string
+		if len(values) == 0 || len(values[0]) == 0 {
+			valuesStr = append(valuesStr, "<none>")
+		}
+
+		for arrIx := range values {
+			for valIx := range values[arrIx] {
+				valuesStr = append(valuesStr, fmt.Sprintf("%v", values[arrIx][valIx].Interface()))
+			}
+		}
+		vals = append(vals, strings.Join(valuesStr, ","))
+	}
+
+	return vals, nil
+}
+
+var jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)\}$|^\.?([^{}]+)$`)
+
+// relaxedJSONPathExpression attempts to be flexible with JSONPath expressions,
+// it accepts following formats:
+//	* {.ID}
+//	* {ID}
+//	* .ID
+//	* ID
+func relaxedJSONPathExpression(pathExpression string) (string, error) {
+	if len(pathExpression) == 0 {
+		return pathExpression, nil
+	}
+	submatches := jsonRegexp.FindStringSubmatch(pathExpression)
+	if submatches == nil {
+		return "", fmt.Errorf("unexpected path string, expected a 'name1.name2' or '.name1.name2' or '{name1.name2}' or '{.name1.name2}'")
+	}
+	if len(submatches) != 3 {
+		return "", fmt.Errorf("unexpected submatch list: %v", submatches)
+	}
+	var fieldSpec string
+	if len(submatches[1]) != 0 {
+		fieldSpec = submatches[1]
+	} else {
+		fieldSpec = submatches[2]
+	}
+	return fmt.Sprintf("{.%s}", fieldSpec), nil
+}

--- a/cmd/cloud/table_printer_test.go
+++ b/cmd/cloud/table_printer_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomColumnsTable(t *testing.T) {
+	columnsExpression := []string{"ID:.ID", "Owner:{.OwnerID}", "DNS:.DNS", "State:State", "FirstAnnotation:{Annotations[0].Name}", "Smell:.Smell"}
+
+	data := []interface{}{
+		model.InstallationDTO{
+			Installation: &model.Installation{
+				ID:      "installation-1",
+				OwnerID: "unit-test",
+				DNS:     "unit-test.mattermost.com",
+				State:   model.InstallationStateStable,
+			},
+			Annotations: []*model.Annotation{
+				{Name: "test", ID: "annotation-1"},
+			},
+		},
+		model.InstallationDTO{
+			Installation: &model.Installation{
+				ID:      "installation-2",
+				OwnerID: "unit-test",
+				DNS:     "unit-test2.mattermost.com",
+				State:   model.InstallationStateCreationInProgress,
+			},
+			Annotations: []*model.Annotation{
+				{Name: "test-123", ID: "annotation-2"},
+			},
+		},
+		model.InstallationDTO{
+			Installation: &model.Installation{
+				ID:    "installation-3",
+				DNS:   "unit-test3.mattermost.com",
+				State: model.InstallationStateDeleted,
+			},
+			Annotations: []*model.Annotation{
+				{Name: "test-123", ID: "annotation-2"},
+				{Name: "test", ID: "annotation-1"},
+			},
+		},
+	}
+
+	keys, vals, err := prepareTableData(columnsExpression, data)
+	require.NoError(t, err)
+
+	expectedVals := [][]string{
+		{"installation-1", "unit-test", "unit-test.mattermost.com", "stable", "test", "<none>"},
+		{"installation-2", "unit-test", "unit-test2.mattermost.com", "creation-in-progress", "test-123", "<none>"},
+		{"installation-3", "", "unit-test3.mattermost.com", "deleted", "test-123", "<none>"},
+	}
+
+	assert.Equal(t, []string{"ID", "Owner", "DNS", "State", "FirstAnnotation", "Smell"}, keys)
+	assert.Equal(t, expectedVals, vals)
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Table output is great to display multiple objects at the same time in a very concise way but I sometimes find myself missing some data there or I just need a fraction of data to make it easier to check some things. 

This PR makes it possible to specify the `--custom-columns` flag for listing desired fields in form of table output.
The syntax is analogous to the `kubectl -o custom-columns` in from of: `<column_name>:<jsonpath>` separated with coma.

The PR also unifies some of the table output logic.

Examples:
```
cloud installation list --custom-columns="ID:.ID,Name:.DNS,Owner:.OwnerID"
```
```
cloud cluster list --custom-columns=ID:.ID,State:.State,VPC:.ProvisionerMetadataKops.VPC,Nginx:.UtilityMetadata.ActualVersions.Nginx.Chart
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
This is open-source Friday contribution 😄 

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add ability to specify custom columns for the table output
```
