### PR TITLE
Add server flag to configure max installation schemas

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -57,6 +57,7 @@ func init() {
 	serverCmd.PersistentFlags().Int32("backup-job-ttl-seconds", 3600, "Number of seconds after which finished backup jobs will be cleaned up. Set to negative value to not cleanup or 0 to cleanup immediately.")
 	serverCmd.PersistentFlags().Bool("deploy-mysql-operator", true, "Whether to deploy the mysql operator.")
 	serverCmd.PersistentFlags().Bool("deploy-minio-operator", true, "Whether to deploy the minio operator.")
+	serverCmd.PersistentFlags().Int64("default-max-schemas-per-logical-database", 10, "When importing and creating new proxy multitenant databases, this value is used for MaxInstallationsPerLogicalDatabase.")
 
 	// Supervisors
 	serverCmd.PersistentFlags().Int("poll", 30, "The interval in seconds to poll for background work.")
@@ -102,6 +103,12 @@ var serverCmd = &cobra.Command{
 
 		debugHelm, _ := command.Flags().GetBool("debug-helm")
 		helm.SetVerboseHelmLogging(debugHelm)
+
+		maxSchemas, _ := command.Flags().GetInt64("default-max-schemas-per-logical-database")
+		err := model.SetDefaultProxyDatabaseMaxInstallationsPerLogicalDatabase(maxSchemas)
+		if err != nil {
+			return err
+		}
 
 		gitlabOAuthToken, _ := command.Flags().GetString("gitlab-oauth")
 		if len(gitlabOAuthToken) == 0 {

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -212,10 +212,6 @@ const (
 	// with a PGBouncer proxy.
 	DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit = 1000
 
-	// DefaultRDSMultitenantDatabasePostgresProxySchemaLimit is the maximum number of
-	// schemas created in each logical database of a proxied DB cluster.
-	DefaultRDSMultitenantDatabasePostgresProxySchemaLimit = 10
-
 	// RDSMultitenantDBClusterResourceNamePrefix identifies the prefix
 	// used for naming multitenant RDS DB cluster resources.
 	// For example: "rds-cluster-multitenant-00000000000000000-a0000000"

--- a/internal/tools/aws/database_multitenant_pgbouncer.go
+++ b/internal/tools/aws/database_multitenant_pgbouncer.go
@@ -296,7 +296,7 @@ func (d *RDSMultitenantPGBouncerDatabase) getMultitenantDatabasesFromResourceTag
 			State:                              model.DatabaseStateProvisioningRequested,
 			WriterEndpoint:                     *rdsCluster.Endpoint,
 			ReaderEndpoint:                     *rdsCluster.ReaderEndpoint,
-			MaxInstallationsPerLogicalDatabase: 10,
+			MaxInstallationsPerLogicalDatabase: model.GetDefaultProxyDatabaseMaxInstallationsPerLogicalDatabase(),
 		}
 
 		err = store.CreateMultitenantDatabase(&multitenantDatabase)

--- a/model/multitenant_database.go
+++ b/model/multitenant_database.go
@@ -7,7 +7,31 @@ package model
 import (
 	"encoding/json"
 	"io"
+
+	"github.com/pkg/errors"
 )
+
+// defaultProxyDatabaseMaxInstallationsPerLogicalDatabase is the default value
+// used for MaxInstallationsPerLogicalDatabase when new multitenant databases
+// are created.
+var defaultProxyDatabaseMaxInstallationsPerLogicalDatabase int64 = 10
+
+// SetDefaultProxyDatabaseMaxInstallationsPerLogicalDatabase is used to define
+// a new value for defaultProxyDatabaseMaxInstallationsPerLogicalDatabase.
+func SetDefaultProxyDatabaseMaxInstallationsPerLogicalDatabase(val int64) error {
+	if val < 1 {
+		return errors.New("MaxInstallationsPerLogicalDatabase must be set to 1 or higher")
+	}
+	defaultProxyDatabaseMaxInstallationsPerLogicalDatabase = val
+
+	return nil
+}
+
+// GetDefaultProxyDatabaseMaxInstallationsPerLogicalDatabase returns the value
+// of defaultProxyDatabaseMaxInstallationsPerLogicalDatabase.
+func GetDefaultProxyDatabaseMaxInstallationsPerLogicalDatabase() int64 {
+	return defaultProxyDatabaseMaxInstallationsPerLogicalDatabase
+}
 
 // MultitenantDatabase represents database infrastructure that contains multiple
 // installation databases.


### PR DESCRIPTION
This new flag controls what default value is used for
MaxInstallationsPerLogicalDatabase in newly created proxy
multitenant databases.

Fixes https://mattermost.atlassian.net/browse/MM-38224

```release-note
Add server flag to configure max installation schemas
```
