### PR TITLE
Fix inheriting desired Utilities from actual

### DIFF
--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -133,12 +133,7 @@ func handleCreateCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 		State:              model.ClusterStateCreationRequested,
 	}
 
-	err = cluster.SetUtilityDesiredVersions(createClusterRequest.DesiredUtilityVersions)
-	if err != nil {
-		c.Logger.WithError(err).Error("provided utility metadata could not be applied without error")
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
+	cluster.SetUtilityDesiredVersions(createClusterRequest.DesiredUtilityVersions)
 
 	annotations, err := model.AnnotationsFromStringSlice(createClusterRequest.Annotations)
 	if err != nil {
@@ -249,12 +244,7 @@ func handleProvisionCluster(c *Context, w http.ResponseWriter, r *http.Request) 
 	}
 	defer unlockOnce()
 
-	err = clusterDTO.SetUtilityDesiredVersions(provisionClusterRequest.DesiredUtilityVersions)
-	if err != nil {
-		c.Logger.WithError(err).Error("provided utility metadata could not be applied without error")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
+	clusterDTO.SetUtilityDesiredVersions(provisionClusterRequest.DesiredUtilityVersions)
 
 	if clusterDTO.State != newState {
 		webhookPayload := &model.WebhookPayload{


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When reprovisioning an existing cluster without specifying Utility values the `DesiredVersions` gets erased (set to `nil`) instead of the `ActualVersions` being used in its place (as it used to be). This causes Provisioner to panic as it tries to access the `nil` pointer.

I have discovered the issue while working on e2e tests. It does not affect CLI as we pass all Utilities there (they may contain empty version and values path but those are handled correctly by Provisioner).
Example request from CLI (works fine): 
```json
{
    "utility-versions": {
        "fluentbit": {
            "Chart": "",
            "ValuesPath": ""
        },
        "kubecost": {
            "Chart": "",
            "ValuesPath": ""
        },
        "nginx": {
            "Chart": "",
            "ValuesPath": ""
        },
        "nginx-internal": {
            "Chart": "",
            "ValuesPath": ""
        },
        "node-problem-detector": {
            "Chart": "",
            "ValuesPath": ""
        },
        "pgbouncer": {
            "Chart": "",
            "ValuesPath": ""
        },
        "prometheus-operator": {
            "Chart": "",
            "ValuesPath": ""
        },
        "stackrox-secured-cluster-services": {
            "Chart": "",
            "ValuesPath": ""
        },
        "teleport": {
            "Chart": "",
            "ValuesPath": ""
        },
        "thanos": {
            "Chart": "",
            "ValuesPath": ""
        }
    }
}
```

Example request to cause a panic:
```json
{
    "utility-versions": { }
}
```


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/secure/RapidBoard.jspa?rapidView=46&modal=detail&selectedIssue=MM-38422&assignee=5f5f309604897f006af4ae84

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fix inheriting desired Utilities from actual
```
