### PR TITLE
Add database resource list and get API endpoints

### DIFF
--- a/cmd/cloud/databases.go
+++ b/cmd/cloud/databases.go
@@ -13,27 +13,61 @@ import (
 func init() {
 	databaseCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
 	databaseCmd.PersistentFlags().Bool("dry-run", false, "When set to true, only print the API request without sending it.")
+	databaseCmd.AddCommand(multitenantDatabaseCmd)
+	databaseCmd.AddCommand(logicalDatabaseCmd)
+	databaseCmd.AddCommand(databaseSchemaCmd)
 
-	databaseListCmd.Flags().String("vpc-id", "", "The VPC ID by which to filter databases.")
-	databaseListCmd.Flags().String("database-type", "", "The database type by which to filter databases.")
-	registerPagingFlags(databaseListCmd)
+	// Multitenant Databases
+	multitenantDatabaseListCmd.Flags().String("vpc-id", "", "The VPC ID by which to filter mulitenant databases.")
+	multitenantDatabaseListCmd.Flags().String("database-type", "", "The database type by which to filter mulitenant databases.")
+	registerPagingFlags(multitenantDatabaseListCmd)
 
-	databaseUpdateCmd.Flags().String("database", "", "The id of the database to be updated.")
-	databaseUpdateCmd.Flags().Int64("max-installations-per-logical-db", 10, "The maximum number of installations permitted in a single logical database (only applies to proxy databases).")
-	databaseUpdateCmd.MarkFlagRequired("database")
+	multitenantDatabaseGetCmd.Flags().String("multitenant-database", "", "The id of the mulitenant database to be fetched.")
+	multitenantDatabaseGetCmd.MarkFlagRequired("multitenant-database")
 
-	databaseCmd.AddCommand(databaseListCmd)
-	databaseCmd.AddCommand(databaseUpdateCmd)
+	multitenantDatabaseUpdateCmd.Flags().String("multitenant-database", "", "The id of the mulitenant database to be updated.")
+	multitenantDatabaseUpdateCmd.Flags().Int64("max-installations-per-logical-db", 10, "The maximum number of installations permitted in a single logical database (only applies to proxy databases).")
+	multitenantDatabaseUpdateCmd.MarkFlagRequired("multitenant-database")
+
+	multitenantDatabaseCmd.AddCommand(multitenantDatabaseListCmd)
+	multitenantDatabaseCmd.AddCommand(multitenantDatabaseGetCmd)
+	multitenantDatabaseCmd.AddCommand(multitenantDatabaseUpdateCmd)
+
+	// Logical Databases
+	logicalDatabaseListCmd.Flags().String("multitenant-database-id", "", "The multitenant database ID by which to filter logical databases.")
+	registerPagingFlags(logicalDatabaseListCmd)
+
+	logicalDatabaseGetCmd.Flags().String("logical-database", "", "The id of the logical database to be fetched.")
+	logicalDatabaseGetCmd.MarkFlagRequired("logical-database")
+
+	logicalDatabaseCmd.AddCommand(logicalDatabaseListCmd)
+	logicalDatabaseCmd.AddCommand(logicalDatabaseGetCmd)
+
+	// Database Schemas
+	databaseSchemaListCmd.Flags().String("logical-database-id", "", "The logical database ID by which to filter database schemas.")
+	databaseSchemaListCmd.Flags().String("installation-id", "", "The installation ID by which to filter database schemas.")
+	registerPagingFlags(databaseSchemaListCmd)
+
+	databaseSchemaGetCmd.Flags().String("database-schema", "", "The id of the database schema to be fetched.")
+	databaseSchemaGetCmd.MarkFlagRequired("database-schema")
+
+	databaseSchemaCmd.AddCommand(databaseSchemaListCmd)
+	databaseSchemaCmd.AddCommand(databaseSchemaGetCmd)
 }
 
 var databaseCmd = &cobra.Command{
 	Use:   "database",
-	Short: "View information on known external multitenant databases",
+	Short: "Manipulate database resources managed by the provisioning server.",
 }
 
-var databaseListCmd = &cobra.Command{
+var multitenantDatabaseCmd = &cobra.Command{
+	Use:   "multitenant",
+	Short: "Manage and view multitenant database resources.",
+}
+
+var multitenantDatabaseListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List multitenant databases that are currently in use.",
+	Short: "List known multitenant databases.",
 	RunE: func(command *cobra.Command, args []string) error {
 		command.SilenceUsage = true
 
@@ -44,13 +78,13 @@ var databaseListCmd = &cobra.Command{
 		databaseType, _ := command.Flags().GetString("database-type")
 		paging := parsePagingFlags(command)
 
-		databases, err := client.GetMultitenantDatabases(&model.GetDatabasesRequest{
+		databases, err := client.GetMultitenantDatabases(&model.GetMultitenantDatabasesRequest{
 			VpcID:        vpcID,
 			DatabaseType: databaseType,
 			Paging:       paging,
 		})
 		if err != nil {
-			return errors.Wrap(err, "failed to query databases")
+			return errors.Wrap(err, "failed to query multitenant databases")
 		}
 
 		err = printJSON(databases)
@@ -62,18 +96,44 @@ var databaseListCmd = &cobra.Command{
 	},
 }
 
-var databaseUpdateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Update an database's configuration",
+var multitenantDatabaseGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get a particular multitenant database.",
 	RunE: func(command *cobra.Command, args []string) error {
 		command.SilenceUsage = true
 
 		serverAddress, _ := command.Flags().GetString("server")
 		client := model.NewClient(serverAddress)
 
-		databaseID, _ := command.Flags().GetString("database")
+		multitenantDatabaseID, _ := command.Flags().GetString("multitenant-database")
+		multitenantDatabase, err := client.GetMultitenantDatabase(multitenantDatabaseID)
+		if err != nil {
+			return errors.Wrap(err, "failed to query multitenant database")
+		}
+		if multitenantDatabase == nil {
+			return nil
+		}
 
-		request := &model.PatchDatabaseRequest{
+		err = printJSON(multitenantDatabase)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var multitenantDatabaseUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update an multitenant database's configuration",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		multitenantDatabaseID, _ := command.Flags().GetString("multitenant-database")
+		request := &model.PatchMultitenantDatabaseRequest{
 			MaxInstallationsPerLogicalDatabase: getInt64FlagPointer(command, "max-installations-per-logical-db"),
 		}
 
@@ -87,11 +147,135 @@ var databaseUpdateCmd = &cobra.Command{
 			return nil
 		}
 
-		database, err := client.UpdateMultitenantDatabase(databaseID, request)
+		multitenantDatabase, err := client.UpdateMultitenantDatabase(multitenantDatabaseID, request)
 		if err != nil {
-			return errors.Wrap(err, "failed to update database")
+			return errors.Wrap(err, "failed to update multitenant database")
 		}
 
-		return printJSON(database)
+		return printJSON(multitenantDatabase)
+	},
+}
+
+var logicalDatabaseCmd = &cobra.Command{
+	Use:   "logical",
+	Short: "Manage and view logical database resources.",
+}
+
+var logicalDatabaseListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List logical databases.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		multitenantDatabaseID, _ := command.Flags().GetString("multitenant-database-id")
+		paging := parsePagingFlags(command)
+
+		logicalDatabases, err := client.GetLogicalDatabases(&model.GetLogicalDatabasesRequest{
+			MultitenantDatabaseID: multitenantDatabaseID,
+			Paging:                paging,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to query logical databases")
+		}
+
+		err = printJSON(logicalDatabases)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var logicalDatabaseGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get a particular logical database.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		logicalDatabaseID, _ := command.Flags().GetString("logical-database")
+		logicalDatabase, err := client.GetLogicalDatabase(logicalDatabaseID)
+		if err != nil {
+			return errors.Wrap(err, "failed to query logical database")
+		}
+		if logicalDatabase == nil {
+			return nil
+		}
+
+		err = printJSON(logicalDatabase)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var databaseSchemaCmd = &cobra.Command{
+	Use:   "schema",
+	Short: "Manage and view database schema resources.",
+}
+
+var databaseSchemaListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List database schemas.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		logicalDatabaseID, _ := command.Flags().GetString("logical-database-id")
+		installationID, _ := command.Flags().GetString("installation-id")
+		paging := parsePagingFlags(command)
+
+		logicalDatabases, err := client.GetDatabaseSchemas(&model.GetDatabaseSchemaRequest{
+			LogicalDatabaseID: logicalDatabaseID,
+			InstallationID:    installationID,
+			Paging:            paging,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to query database schemas")
+		}
+
+		err = printJSON(logicalDatabases)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var databaseSchemaGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get a particular database schema.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		databaseSchemaID, _ := command.Flags().GetString("database-schema")
+		databaseSchema, err := client.GetDatabaseSchema(databaseSchemaID)
+		if err != nil {
+			return errors.Wrap(err, "failed to query database schema")
+		}
+		if databaseSchema == nil {
+			return nil
+		}
+
+		err = printJSON(databaseSchema)
+		if err != nil {
+			return err
+		}
+
+		return nil
 	},
 }

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -5,10 +5,7 @@
 package api
 
 import (
-	"net/http"
-
 	"github.com/gorilla/mux"
-	"github.com/mattermost/mattermost-cloud/model"
 )
 
 // initDatabases registers database endpoints on the given router.
@@ -17,79 +14,15 @@ func initDatabases(apiRouter *mux.Router, context *Context) {
 		return newContextHandler(context, handler)
 	}
 
+	// TODO: retire these endpoints
 	databasesRouter := apiRouter.PathPrefix("/databases").Subrouter()
-	databasesRouter.Handle("", addContext(handleGetDatabases)).Methods("GET")
+	databasesRouter.Handle("", addContext(handleGetMultitenantDatabases)).Methods("GET")
 
-	databaseRouter := apiRouter.PathPrefix("/database/{database}").Subrouter()
-	databaseRouter.Handle("", addContext(handleUpdateDatabase)).Methods("PUT")
-}
+	databaseRouter := apiRouter.PathPrefix("/database/{multitenant_database:[A-Za-z0-9]{26}}").Subrouter()
+	databaseRouter.Handle("", addContext(handleUpdateMultitenantDatabase)).Methods("PUT")
 
-// handleGetDatabases responds to GET /api/databases, returning a list of
-// multitenant databases.
-func handleGetDatabases(c *Context, w http.ResponseWriter, r *http.Request) {
-	paging, err := parsePaging(r.URL)
-	if err != nil {
-		c.Logger.WithError(err).Error("failed to parse paging parameters")
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	vpcID, databaseType := parseDatabaseListRequest(r.URL)
-
-	filter := &model.MultitenantDatabaseFilter{
-		VpcID:                 vpcID,
-		DatabaseType:          databaseType,
-		Paging:                paging,
-		MaxInstallationsLimit: model.NoInstallationsLimit,
-	}
-
-	databases, err := c.Store.GetMultitenantDatabases(filter)
-	if err != nil {
-		c.Logger.WithError(err).Error("failed to query multitenant databases")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	if databases == nil {
-		databases = []*model.MultitenantDatabase{}
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	outputJSON(c, w, databases)
-}
-
-// handleUpdateDatabase responds to PUT /api/database/{database}, updating the
-// database configuration values.
-func handleUpdateDatabase(c *Context, w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	databaseID := vars["database"]
-	c.Logger = c.Logger.WithField("database", databaseID)
-
-	patchDatabaseRequest, err := model.NewPatchDatabaseRequestFromReader(r.Body)
-	if err != nil {
-		c.Logger.WithError(err).Error("failed to decode request")
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	database, status, unlockOnce := lockDatabase(c, databaseID)
-	if status != 0 {
-		w.WriteHeader(status)
-		return
-	}
-	defer unlockOnce()
-
-	if patchDatabaseRequest.Apply(database) {
-		err = c.Store.UpdateMultitenantDatabase(database)
-		if err != nil {
-			c.Logger.WithError(err).Error("failed to update database")
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-	}
-
-	unlockOnce()
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	outputJSON(c, w, database)
+	// Begin new endpoints
+	initMultitenantDatabases(databasesRouter, context)
+	initLogicalDatabases(databasesRouter, context)
+	initDatabaseSchemas(databasesRouter, context)
 }

--- a/internal/api/db_database_schema.go
+++ b/internal/api/db_database_schema.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+// initDatabases registers database schema endpoints on the given router.
+func initDatabaseSchemas(apiRouter *mux.Router, context *Context) {
+	addContext := func(handler contextHandlerFunc) *contextHandler {
+		return newContextHandler(context, handler)
+	}
+
+	DatabaseSchemasRouter := apiRouter.PathPrefix("/database_schemas").Subrouter()
+	DatabaseSchemasRouter.Handle("", addContext(handleGetDatabaseSchemas)).Methods("GET")
+
+	DatabaseSchemaRouter := apiRouter.PathPrefix("/database_schema/{database_schema:[A-Za-z0-9]{26}}").Subrouter()
+	DatabaseSchemaRouter.Handle("", addContext(handleGetDatabaseSchema)).Methods("GET")
+}
+
+// handleGetDatabaseSchemas responds to GET /api/databases/database_schemas,
+// returning a list of database schemas.
+func handleGetDatabaseSchemas(c *Context, w http.ResponseWriter, r *http.Request) {
+	paging, err := parsePaging(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse paging parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	filter := &model.DatabaseSchemaFilter{
+		LogicalDatabaseID: parseString(r.URL, "logical_database_id", ""),
+		InstallationID:    parseString(r.URL, "installation_id", ""),
+		Paging:            paging,
+	}
+
+	databaseSchemas, err := c.Store.GetDatabaseSchemas(filter)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query database schemas")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if databaseSchemas == nil {
+		databaseSchemas = []*model.DatabaseSchema{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, databaseSchemas)
+}
+
+// handleGetDatabaseSchema responds to GET /api/databases/database_schemas/{database_schema},
+// returning the database schema in question.
+func handleGetDatabaseSchema(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	databaseSchemaID := vars["database_schema"]
+	c.Logger = c.Logger.WithField("database_schema", databaseSchemaID)
+
+	databaseSchema, err := c.Store.GetDatabaseSchema(databaseSchemaID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query database schema")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if databaseSchema == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, databaseSchema)
+}

--- a/internal/api/db_database_schema.go
+++ b/internal/api/db_database_schema.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/model"
 )
 
-// initDatabases registers database schema endpoints on the given router.
+// initDatabaseSchemas registers database schema endpoints on the given router.
 func initDatabaseSchemas(apiRouter *mux.Router, context *Context) {
 	addContext := func(handler contextHandlerFunc) *contextHandler {
 		return newContextHandler(context, handler)

--- a/internal/api/db_database_schema_test.go
+++ b/internal/api/db_database_schema_test.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDatabaseSchemas(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	t.Run("no logical databases", func(t *testing.T) {
+		logicalDatabases, err := client.GetDatabaseSchemas(&model.GetDatabaseSchemaRequest{
+			Paging: model.AllPagesWithDeleted(),
+		})
+		require.NoError(t, err)
+		require.Empty(t, logicalDatabases)
+	})
+
+	t.Run("parameter handling", func(t *testing.T) {
+		t.Run("invalid page", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases/database_schemas?page=invalid&per_page=100", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("invalid perPage", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases/database_schemas?page=0&per_page=invalid", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("no paging parameters", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases/database_schemas", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("missing page", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases/database_schemas?per_page=100", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("missing perPage", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases/database_schemas?page=1", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	})
+
+	t.Run("results", func(t *testing.T) {
+		dbs1 := &model.DatabaseSchema{
+			LogicalDatabaseID: model.NewID(),
+		}
+		err := sqlStore.CreateDatabaseSchema(dbs1)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		installationID := model.NewID()
+		dbs2 := &model.DatabaseSchema{
+			LogicalDatabaseID: model.NewID(),
+			InstallationID:    installationID,
+		}
+		err = sqlStore.CreateDatabaseSchema(dbs2)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		dbs3 := &model.DatabaseSchema{
+			LogicalDatabaseID: model.NewID(),
+		}
+		err = sqlStore.CreateDatabaseSchema(dbs3)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		t.Run("get databases", func(t *testing.T) {
+			testCases := []struct {
+				Description string
+				Request     *model.GetDatabaseSchemaRequest
+				Expected    []*model.DatabaseSchema
+			}{
+				{
+					"page 0, perPage 2, exclude deleted",
+					&model.GetDatabaseSchemaRequest{
+						Paging: model.Paging{
+							Page:           0,
+							PerPage:        2,
+							IncludeDeleted: false,
+						},
+					},
+					[]*model.DatabaseSchema{dbs1, dbs2},
+				},
+
+				{
+					"page 1, perPage 2, exclude deleted",
+					&model.GetDatabaseSchemaRequest{
+						Paging: model.Paging{
+							Page:           1,
+							PerPage:        2,
+							IncludeDeleted: false,
+						},
+					},
+					[]*model.DatabaseSchema{dbs3},
+				},
+
+				{
+					"page 0, perPage 2, include deleted",
+					&model.GetDatabaseSchemaRequest{
+						Paging: model.Paging{
+							Page:           0,
+							PerPage:        2,
+							IncludeDeleted: true,
+						},
+					},
+					[]*model.DatabaseSchema{dbs1, dbs2},
+				},
+
+				{
+					"page 1, perPage 2, include deleted",
+					&model.GetDatabaseSchemaRequest{
+						Paging: model.Paging{
+							Page:           1,
+							PerPage:        2,
+							IncludeDeleted: true,
+						},
+					},
+					[]*model.DatabaseSchema{dbs3},
+				},
+
+				{
+					"installation id",
+					&model.GetDatabaseSchemaRequest{
+						Paging:         model.AllPagesWithDeleted(),
+						InstallationID: installationID,
+					},
+					[]*model.DatabaseSchema{dbs2},
+				},
+			}
+
+			for _, testCase := range testCases {
+				t.Run(testCase.Description, func(t *testing.T) {
+					logicalDatabases, err := client.GetDatabaseSchemas(testCase.Request)
+					require.NoError(t, err)
+					require.Equal(t, testCase.Expected, logicalDatabases)
+				})
+			}
+		})
+	})
+}
+
+func TestGetDatabaseSchema(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	databaseSchema := &model.DatabaseSchema{
+		InstallationID: model.NewID(),
+	}
+
+	err := sqlStore.CreateDatabaseSchema(databaseSchema)
+	require.NoError(t, err)
+	assert.NotEmpty(t, databaseSchema.ID)
+
+	t.Run("success", func(t *testing.T) {
+		fetchedDatabaseSchema, err := client.GetDatabaseSchema(databaseSchema.ID)
+		require.NoError(t, err)
+		assert.Equal(t, databaseSchema, fetchedDatabaseSchema)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		fetchedDatabaseSchema, err := client.GetDatabaseSchema(model.NewID())
+		require.NoError(t, err)
+		assert.Nil(t, fetchedDatabaseSchema)
+	})
+}

--- a/internal/api/db_logical_database.go
+++ b/internal/api/db_logical_database.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/model"
 )
 
-// initDatabases registers database endpoints on the given router.
+// initLogicalDatabases registers logical database endpoints on the given router.
 func initLogicalDatabases(apiRouter *mux.Router, context *Context) {
 	addContext := func(handler contextHandlerFunc) *contextHandler {
 		return newContextHandler(context, handler)
@@ -24,8 +24,8 @@ func initLogicalDatabases(apiRouter *mux.Router, context *Context) {
 	LogicalDatabaseRouter.Handle("", addContext(handleGetLogicalDatabase)).Methods("GET")
 }
 
-// handleGetMultitenantDatabases responds to GET /api/databases/multitenant_databases,
-// returning a list of multitenant databases.
+// handleGetLogicalDatabases responds to GET /api/databases/logical_databases,
+// returning a list of logical databases.
 func handleGetLogicalDatabases(c *Context, w http.ResponseWriter, r *http.Request) {
 	paging, err := parsePaging(r.URL)
 	if err != nil {
@@ -54,8 +54,8 @@ func handleGetLogicalDatabases(c *Context, w http.ResponseWriter, r *http.Reques
 	outputJSON(c, w, logicalDatabases)
 }
 
-// handleGetMultitenantDatabase responds to GET /api/databases/multitenant_database/{multitenant_database},
-// returning the multitenant database in question.
+// handleGetLogicalDatabase responds to GET /api/databases/logical_database/{logical_database},
+// returning the logical database in question.
 func handleGetLogicalDatabase(c *Context, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	logicalDatabaseID := vars["logical_database"]

--- a/internal/api/db_logical_database.go
+++ b/internal/api/db_logical_database.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+// initDatabases registers database endpoints on the given router.
+func initLogicalDatabases(apiRouter *mux.Router, context *Context) {
+	addContext := func(handler contextHandlerFunc) *contextHandler {
+		return newContextHandler(context, handler)
+	}
+
+	LogicalDatabasesRouter := apiRouter.PathPrefix("/logical_databases").Subrouter()
+	LogicalDatabasesRouter.Handle("", addContext(handleGetLogicalDatabases)).Methods("GET")
+
+	LogicalDatabaseRouter := apiRouter.PathPrefix("/logical_database/{logical_database:[A-Za-z0-9]{26}}").Subrouter()
+	LogicalDatabaseRouter.Handle("", addContext(handleGetLogicalDatabase)).Methods("GET")
+}
+
+// handleGetMultitenantDatabases responds to GET /api/databases/multitenant_databases,
+// returning a list of multitenant databases.
+func handleGetLogicalDatabases(c *Context, w http.ResponseWriter, r *http.Request) {
+	paging, err := parsePaging(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse paging parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	filter := &model.LogicalDatabaseFilter{
+		MultitenantDatabaseID: parseString(r.URL, "multitenant_database_id", ""),
+		Paging:                paging,
+	}
+
+	logicalDatabases, err := c.Store.GetLogicalDatabases(filter)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query logical databases")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if logicalDatabases == nil {
+		logicalDatabases = []*model.LogicalDatabase{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, logicalDatabases)
+}
+
+// handleGetMultitenantDatabase responds to GET /api/databases/multitenant_database/{multitenant_database},
+// returning the multitenant database in question.
+func handleGetLogicalDatabase(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	logicalDatabaseID := vars["logical_database"]
+	c.Logger = c.Logger.WithField("logical_database", logicalDatabaseID)
+
+	logicalDatabase, err := c.Store.GetLogicalDatabase(logicalDatabaseID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query logical database")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if logicalDatabase == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, logicalDatabase)
+}

--- a/internal/api/db_logical_database_test.go
+++ b/internal/api/db_logical_database_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLogicalDatabases(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	t.Run("no logical databases", func(t *testing.T) {
+		logicalDatabases, err := client.GetLogicalDatabases(&model.GetLogicalDatabasesRequest{
+			Paging: model.AllPagesWithDeleted(),
+		})
+		require.NoError(t, err)
+		require.Empty(t, logicalDatabases)
+	})
+
+	t.Run("parameter handling", func(t *testing.T) {
+		t.Run("invalid page", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases/logical_databases?page=invalid&per_page=100", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("invalid perPage", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases/logical_databases?page=0&per_page=invalid", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("no paging parameters", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases/logical_databases", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("missing page", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases/logical_databases?per_page=100", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("missing perPage", func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("%s/api/databases/logical_databases?page=1", ts.URL))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	})
+
+	t.Run("results", func(t *testing.T) {
+		ldb1 := &model.LogicalDatabase{
+			MultitenantDatabaseID: model.NewID(),
+		}
+		err := sqlStore.CreateLogicalDatabase(ldb1)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		ldb2 := &model.LogicalDatabase{
+			MultitenantDatabaseID: model.NewID(),
+		}
+		err = sqlStore.CreateLogicalDatabase(ldb2)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		ldb3 := &model.LogicalDatabase{
+			MultitenantDatabaseID: model.NewID(),
+		}
+		err = sqlStore.CreateLogicalDatabase(ldb3)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		t.Run("get databases", func(t *testing.T) {
+			testCases := []struct {
+				Description string
+				Request     *model.GetLogicalDatabasesRequest
+				Expected    []*model.LogicalDatabase
+			}{
+				{
+					"page 0, perPage 2, exclude deleted",
+					&model.GetLogicalDatabasesRequest{
+						Paging: model.Paging{
+							Page:           0,
+							PerPage:        2,
+							IncludeDeleted: false,
+						},
+					},
+					[]*model.LogicalDatabase{ldb1, ldb2},
+				},
+
+				{
+					"page 1, perPage 2, exclude deleted",
+					&model.GetLogicalDatabasesRequest{
+						Paging: model.Paging{
+							Page:           1,
+							PerPage:        2,
+							IncludeDeleted: false,
+						},
+					},
+					[]*model.LogicalDatabase{ldb3},
+				},
+
+				{
+					"page 0, perPage 2, include deleted",
+					&model.GetLogicalDatabasesRequest{
+						Paging: model.Paging{
+							Page:           0,
+							PerPage:        2,
+							IncludeDeleted: true,
+						},
+					},
+					[]*model.LogicalDatabase{ldb1, ldb2},
+				},
+
+				{
+					"page 1, perPage 2, include deleted",
+					&model.GetLogicalDatabasesRequest{
+						Paging: model.Paging{
+							Page:           1,
+							PerPage:        2,
+							IncludeDeleted: true,
+						},
+					},
+					[]*model.LogicalDatabase{ldb3},
+				},
+			}
+
+			for _, testCase := range testCases {
+				t.Run(testCase.Description, func(t *testing.T) {
+					logicalDatabases, err := client.GetLogicalDatabases(testCase.Request)
+					require.NoError(t, err)
+					require.Equal(t, testCase.Expected, logicalDatabases)
+				})
+			}
+		})
+	})
+}
+
+func TestGetLogicalDatabase(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Logger:     logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+
+	logicalDatabase := &model.LogicalDatabase{
+		MultitenantDatabaseID: model.NewID(),
+	}
+
+	err := sqlStore.CreateLogicalDatabase(logicalDatabase)
+	require.NoError(t, err)
+	assert.NotEmpty(t, logicalDatabase.ID)
+
+	t.Run("success", func(t *testing.T) {
+		fetchedLogicalDatabase, err := client.GetLogicalDatabase(logicalDatabase.ID)
+		require.NoError(t, err)
+		assert.Equal(t, logicalDatabase, fetchedLogicalDatabase)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		fetchedLogicalDatabase, err := client.GetLogicalDatabase(model.NewID())
+		require.NoError(t, err)
+		assert.Nil(t, fetchedLogicalDatabase)
+	})
+}

--- a/internal/api/db_multitenant_database.go
+++ b/internal/api/db_multitenant_database.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/model"
 )
 
-// initDatabases registers database endpoints on the given router.
+// initMultitenantDatabases registers multitenant database endpoints on the given router.
 func initMultitenantDatabases(apiRouter *mux.Router, context *Context) {
 	addContext := func(handler contextHandlerFunc) *contextHandler {
 		return newContextHandler(context, handler)

--- a/internal/api/db_multitenant_database.go
+++ b/internal/api/db_multitenant_database.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+// initDatabases registers database endpoints on the given router.
+func initMultitenantDatabases(apiRouter *mux.Router, context *Context) {
+	addContext := func(handler contextHandlerFunc) *contextHandler {
+		return newContextHandler(context, handler)
+	}
+
+	MultitenantDatabasesRouter := apiRouter.PathPrefix("/multitenant_databases").Subrouter()
+	MultitenantDatabasesRouter.Handle("", addContext(handleGetMultitenantDatabases)).Methods("GET")
+
+	MultitenantDatabaseRouter := apiRouter.PathPrefix("/multitenant_database/{multitenant_database:[A-Za-z0-9]{26}}").Subrouter()
+	MultitenantDatabaseRouter.Handle("", addContext(handleGetMultitenantDatabase)).Methods("GET")
+	MultitenantDatabaseRouter.Handle("", addContext(handleUpdateMultitenantDatabase)).Methods("PUT")
+}
+
+// handleGetMultitenantDatabases responds to GET /api/databases/multitenant_databases,
+// returning a list of multitenant databases.
+func handleGetMultitenantDatabases(c *Context, w http.ResponseWriter, r *http.Request) {
+	paging, err := parsePaging(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse paging parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	filter := &model.MultitenantDatabaseFilter{
+		VpcID:                 parseString(r.URL, "vpc_id", ""),
+		DatabaseType:          parseString(r.URL, "database_type", ""),
+		Paging:                paging,
+		MaxInstallationsLimit: model.NoInstallationsLimit,
+	}
+
+	multitenantDatabases, err := c.Store.GetMultitenantDatabases(filter)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query multitenant databases")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if multitenantDatabases == nil {
+		multitenantDatabases = []*model.MultitenantDatabase{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, multitenantDatabases)
+}
+
+// handleGetMultitenantDatabase responds to GET /api/databases/multitenant_database/{multitenant_database},
+// returning the multitenant database in question.
+func handleGetMultitenantDatabase(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	multitenantDatabaseID := vars["multitenant_database"]
+	c.Logger = c.Logger.WithField("multitenant_database", multitenantDatabaseID)
+
+	multitenantDatabase, err := c.Store.GetMultitenantDatabase(multitenantDatabaseID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query multitenant database")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if multitenantDatabase == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, multitenantDatabase)
+}
+
+// handleUpdateMultitenantDatabase responds to PUT /api/databases/multitenant_database/{multitenant_database},
+// updating the database configuration values.
+func handleUpdateMultitenantDatabase(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	multitenantDatabaseID := vars["multitenant_database"]
+	c.Logger = c.Logger.WithField("multitenant_database", multitenantDatabaseID)
+
+	patchDatabaseRequest, err := model.NewPatchMultitenantDatabaseRequestFromReader(r.Body)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to decode request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	multitenantDatabase, status, unlockOnce := lockDatabase(c, multitenantDatabaseID)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	if patchDatabaseRequest.Apply(multitenantDatabase) {
+		err = c.Store.UpdateMultitenantDatabase(multitenantDatabase)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to update multitenant database")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	unlockOnce()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, multitenantDatabase)
+}

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -718,5 +718,4 @@ func TestGroupsStatus(t *testing.T) {
 			}
 		}
 	})
-
 }

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -91,10 +91,3 @@ func parseGroupConfig(u *url.URL) (bool, bool, error) {
 
 	return includeGroupConfig, includeGroupConfigOverrides, nil
 }
-
-func parseDatabaseListRequest(u *url.URL) (string, string) {
-	vpcID := parseString(u, "vpc_id", "")
-	databaseType := parseString(u, "database_type", "")
-
-	return vpcID, databaseType
-}

--- a/internal/mocks/model/installation_database.go
+++ b/internal/mocks/model/installation_database.go
@@ -203,21 +203,6 @@ func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetClusterInstalla
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterInstallations", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetClusterInstallations), filter)
 }
 
-// GetMultitenantDatabase mocks base method
-func (m *MockInstallationDatabaseStoreInterface) GetMultitenantDatabase(multitenantdatabaseID string) (*model.MultitenantDatabase, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMultitenantDatabase", multitenantdatabaseID)
-	ret0, _ := ret[0].(*model.MultitenantDatabase)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMultitenantDatabase indicates an expected call of GetMultitenantDatabase
-func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetMultitenantDatabase(multitenantdatabaseID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultitenantDatabase", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetMultitenantDatabase), multitenantdatabaseID)
-}
-
 // GetMultitenantDatabases mocks base method
 func (m *MockInstallationDatabaseStoreInterface) GetMultitenantDatabases(filter *model.MultitenantDatabaseFilter) ([]*model.MultitenantDatabase, error) {
 	m.ctrl.T.Helper()
@@ -231,6 +216,21 @@ func (m *MockInstallationDatabaseStoreInterface) GetMultitenantDatabases(filter 
 func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetMultitenantDatabases(filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultitenantDatabases", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetMultitenantDatabases), filter)
+}
+
+// GetMultitenantDatabase mocks base method
+func (m *MockInstallationDatabaseStoreInterface) GetMultitenantDatabase(multitenantdatabaseID string) (*model.MultitenantDatabase, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMultitenantDatabase", multitenantdatabaseID)
+	ret0, _ := ret[0].(*model.MultitenantDatabase)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMultitenantDatabase indicates an expected call of GetMultitenantDatabase
+func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetMultitenantDatabase(multitenantdatabaseID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultitenantDatabase", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetMultitenantDatabase), multitenantdatabaseID)
 }
 
 // GetMultitenantDatabaseForInstallationID mocks base method
@@ -349,6 +349,66 @@ func (m *MockInstallationDatabaseStoreInterface) UnlockMultitenantDatabases(ids 
 func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) UnlockMultitenantDatabases(ids, lockerID, force interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlockMultitenantDatabases", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).UnlockMultitenantDatabases), ids, lockerID, force)
+}
+
+// GetLogicalDatabases mocks base method
+func (m *MockInstallationDatabaseStoreInterface) GetLogicalDatabases(filter *model.LogicalDatabaseFilter) ([]*model.LogicalDatabase, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogicalDatabases", filter)
+	ret0, _ := ret[0].([]*model.LogicalDatabase)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLogicalDatabases indicates an expected call of GetLogicalDatabases
+func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetLogicalDatabases(filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogicalDatabases", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetLogicalDatabases), filter)
+}
+
+// GetLogicalDatabase mocks base method
+func (m *MockInstallationDatabaseStoreInterface) GetLogicalDatabase(logicalDatabaseID string) (*model.LogicalDatabase, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogicalDatabase", logicalDatabaseID)
+	ret0, _ := ret[0].(*model.LogicalDatabase)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLogicalDatabase indicates an expected call of GetLogicalDatabase
+func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetLogicalDatabase(logicalDatabaseID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogicalDatabase", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetLogicalDatabase), logicalDatabaseID)
+}
+
+// GetDatabaseSchemas mocks base method
+func (m *MockInstallationDatabaseStoreInterface) GetDatabaseSchemas(filter *model.DatabaseSchemaFilter) ([]*model.DatabaseSchema, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDatabaseSchemas", filter)
+	ret0, _ := ret[0].([]*model.DatabaseSchema)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDatabaseSchemas indicates an expected call of GetDatabaseSchemas
+func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetDatabaseSchemas(filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatabaseSchemas", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetDatabaseSchemas), filter)
+}
+
+// GetDatabaseSchema mocks base method
+func (m *MockInstallationDatabaseStoreInterface) GetDatabaseSchema(databaseSchemaID string) (*model.DatabaseSchema, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDatabaseSchema", databaseSchemaID)
+	ret0, _ := ret[0].(*model.DatabaseSchema)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDatabaseSchema indicates an expected call of GetDatabaseSchema
+func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetDatabaseSchema(databaseSchemaID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatabaseSchema", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetDatabaseSchema), databaseSchemaID)
 }
 
 // GetSingleTenantDatabaseConfigForInstallation mocks base method

--- a/internal/store/db_database_schema.go
+++ b/internal/store/db_database_schema.go
@@ -85,6 +85,11 @@ func (sqlStore *SQLStore) GetDatabaseSchemaForInstallationID(installationID stri
 	return nil, errors.Errorf("expected no more than one database schema, but got %d", len(databaseSchemas))
 }
 
+// CreateDatabaseSchema records the supplied database schema to the datastore.
+func (sqlStore *SQLStore) CreateDatabaseSchema(databaseSchema *model.DatabaseSchema) error {
+	return sqlStore.createDatabaseSchema(sqlStore.db, databaseSchema)
+}
+
 // createDatabaseSchema records the supplied database schema to the datastore.
 func (sqlStore *SQLStore) createDatabaseSchema(db execer, databaseSchema *model.DatabaseSchema) error {
 	databaseSchema.ID = model.NewID()

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -275,6 +275,22 @@ func (m mockMultitenantDBStore) DeleteInstallationProxyDatabaseResources(multite
 	return nil
 }
 
+func (s *mockMultitenantDBStore) GetDatabaseSchemas(filter *model.DatabaseSchemaFilter) ([]*model.DatabaseSchema, error) {
+	return nil, nil
+}
+
+func (m *mockMultitenantDBStore) GetDatabaseSchema(databaseSchemaID string) (*model.DatabaseSchema, error) {
+	return nil, nil
+}
+
+func (s *mockMultitenantDBStore) GetLogicalDatabases(filter *model.LogicalDatabaseFilter) ([]*model.LogicalDatabase, error) {
+	return nil, nil
+}
+
+func (m *mockMultitenantDBStore) GetLogicalDatabase(logicalDatabaseID string) (*model.LogicalDatabase, error) {
+	return nil, nil
+}
+
 type mockInstallationProvisioner struct {
 	UseCustomClusterResources bool
 	CustomClusterResources    *k8s.ClusterResources

--- a/model/client.go
+++ b/model/client.go
@@ -1108,7 +1108,7 @@ func (c *Client) LeaveGroup(installationID string, request *LeaveGroupRequest) e
 }
 
 // GetMultitenantDatabases fetches the list of multitenant databases from the configured provisioning server.
-func (c *Client) GetMultitenantDatabases(request *GetDatabasesRequest) ([]*MultitenantDatabase, error) {
+func (c *Client) GetMultitenantDatabases(request *GetMultitenantDatabasesRequest) ([]*MultitenantDatabase, error) {
 	u, err := url.Parse(c.buildURL("/api/databases"))
 	if err != nil {
 		return nil, err
@@ -1131,8 +1131,28 @@ func (c *Client) GetMultitenantDatabases(request *GetDatabasesRequest) ([]*Multi
 	}
 }
 
+// GetMultitenantDatabase fetches the multitenant database from the configured provisioning server.
+func (c *Client) GetMultitenantDatabase(multitenantDatabaseID string) (*MultitenantDatabase, error) {
+	resp, err := c.doGet(c.buildURL("/api/databases/multitenant_database/%s", multitenantDatabaseID))
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return MultitenantDatabaseFromReader(resp.Body)
+
+	case http.StatusNotFound:
+		return nil, nil
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // UpdateMultitenantDatabase updates a multitenant database.
-func (c *Client) UpdateMultitenantDatabase(databaseID string, request *PatchDatabaseRequest) (*MultitenantDatabase, error) {
+func (c *Client) UpdateMultitenantDatabase(databaseID string, request *PatchMultitenantDatabaseRequest) (*MultitenantDatabase, error) {
 	resp, err := c.doPut(c.buildURL("/api/database/%s", databaseID), request)
 	if err != nil {
 		return nil, err
@@ -1142,6 +1162,94 @@ func (c *Client) UpdateMultitenantDatabase(databaseID string, request *PatchData
 	switch resp.StatusCode {
 	case http.StatusOK:
 		return MultitenantDatabaseFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// GetLogicalDatabases fetches the list of logical databases from the configured provisioning server.
+func (c *Client) GetLogicalDatabases(request *GetLogicalDatabasesRequest) ([]*LogicalDatabase, error) {
+	u, err := url.Parse(c.buildURL("/api/databases/logical_databases"))
+	if err != nil {
+		return nil, err
+	}
+
+	request.ApplyToURL(u)
+
+	resp, err := c.doGet(u.String())
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return LogicalDatabasesFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// GetLogicalDatabase fetches the logical database from the configured provisioning server.
+func (c *Client) GetLogicalDatabase(logicalDatabaseID string) (*LogicalDatabase, error) {
+	resp, err := c.doGet(c.buildURL("/api/databases/logical_database/%s", logicalDatabaseID))
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return LogicalDatabaseFromReader(resp.Body)
+
+	case http.StatusNotFound:
+		return nil, nil
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// GetDatabaseSchemas fetches the list of database schemas from the configured provisioning server.
+func (c *Client) GetDatabaseSchemas(request *GetDatabaseSchemaRequest) ([]*DatabaseSchema, error) {
+	u, err := url.Parse(c.buildURL("/api/databases/database_schemas"))
+	if err != nil {
+		return nil, err
+	}
+
+	request.ApplyToURL(u)
+
+	resp, err := c.doGet(u.String())
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return DatababseSchemasFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// GetDatabaseSchema fetches the database schema from the configured provisioning server.
+func (c *Client) GetDatabaseSchema(multitenantDatabaseID string) (*DatabaseSchema, error) {
+	resp, err := c.doGet(c.buildURL("/api/databases/database_schema/%s", multitenantDatabaseID))
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return DatababseSchemaFromReader(resp.Body)
+
+	case http.StatusNotFound:
+		return nil, nil
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)

--- a/model/installation_database.go
+++ b/model/installation_database.go
@@ -59,8 +59,8 @@ type Database interface {
 // https://github.com/mattermost/mattermost-cloud/pull/209#discussion_r424597373
 type InstallationDatabaseStoreInterface interface {
 	GetClusterInstallations(filter *ClusterInstallationFilter) ([]*ClusterInstallation, error)
-	GetMultitenantDatabase(multitenantdatabaseID string) (*MultitenantDatabase, error)
 	GetMultitenantDatabases(filter *MultitenantDatabaseFilter) ([]*MultitenantDatabase, error)
+	GetMultitenantDatabase(multitenantdatabaseID string) (*MultitenantDatabase, error)
 	GetMultitenantDatabaseForInstallationID(installationID string) (*MultitenantDatabase, error)
 	GetInstallationsTotalDatabaseWeight(installationIDs []string) (float64, error)
 	CreateMultitenantDatabase(multitenantDatabase *MultitenantDatabase) error
@@ -69,6 +69,10 @@ type InstallationDatabaseStoreInterface interface {
 	UnlockMultitenantDatabase(multitenantdatabaseID, lockerID string, force bool) (bool, error)
 	LockMultitenantDatabases(ids []string, lockerID string) (bool, error)
 	UnlockMultitenantDatabases(ids []string, lockerID string, force bool) (bool, error)
+	GetLogicalDatabases(filter *LogicalDatabaseFilter) ([]*LogicalDatabase, error)
+	GetLogicalDatabase(logicalDatabaseID string) (*LogicalDatabase, error)
+	GetDatabaseSchemas(filter *DatabaseSchemaFilter) ([]*DatabaseSchema, error)
+	GetDatabaseSchema(databaseSchemaID string) (*DatabaseSchema, error)
 	GetSingleTenantDatabaseConfigForInstallation(installationID string) (*SingleTenantDatabaseConfig, error)
 	GetProxyDatabaseResourcesForInstallation(installationID string) (*DatabaseResourceGrouping, error)
 	GetOrCreateProxyDatabaseResourcesForInstallation(installationID, multitenantDatabaseID string) (*DatabaseResourceGrouping, error)

--- a/model/multitenant_database.go
+++ b/model/multitenant_database.go
@@ -156,26 +156,78 @@ type DatabaseSchemaFilter struct {
 
 // MultitenantDatabasesFromReader decodes a json-encoded list of multitenant databases from the given io.Reader.
 func MultitenantDatabasesFromReader(reader io.Reader) ([]*MultitenantDatabase, error) {
-	databases := []*MultitenantDatabase{}
+	multitenantDatabases := []*MultitenantDatabase{}
 	decoder := json.NewDecoder(reader)
 
-	err := decoder.Decode(&databases)
+	err := decoder.Decode(&multitenantDatabases)
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
 
-	return databases, nil
+	return multitenantDatabases, nil
 }
 
 // MultitenantDatabaseFromReader decodes a json-encoded multitenant database from the given io.Reader.
 func MultitenantDatabaseFromReader(reader io.Reader) (*MultitenantDatabase, error) {
-	database := &MultitenantDatabase{}
+	multitenantDatabase := &MultitenantDatabase{}
 	decoder := json.NewDecoder(reader)
 
-	err := decoder.Decode(&database)
+	err := decoder.Decode(&multitenantDatabase)
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
 
-	return database, nil
+	return multitenantDatabase, nil
+}
+
+// LogicalDatabasesFromReader decodes a json-encoded list of logical databases from the given io.Reader.
+func LogicalDatabasesFromReader(reader io.Reader) ([]*LogicalDatabase, error) {
+	logicalDatabases := []*LogicalDatabase{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&logicalDatabases)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return logicalDatabases, nil
+}
+
+// LogicalDatabaseFromReader decodes a json-encoded logical database from the given io.Reader.
+func LogicalDatabaseFromReader(reader io.Reader) (*LogicalDatabase, error) {
+	logicalDatabase := &LogicalDatabase{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&logicalDatabase)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return logicalDatabase, nil
+}
+
+// DatababseSchemasFromReader decodes a json-encoded list of database schemas from the given io.Reader.
+func DatababseSchemasFromReader(reader io.Reader) ([]*DatabaseSchema, error) {
+	databaseSchemas := []*DatabaseSchema{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&databaseSchemas)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return databaseSchemas, nil
+}
+
+// DatababseSchemaFromReader decodes a json-encoded database schema from the given io.Reader.
+func DatababseSchemaFromReader(reader io.Reader) (*DatabaseSchema, error) {
+	databaseSchema := &DatabaseSchema{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&databaseSchema)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return databaseSchema, nil
 }

--- a/model/multitenant_database_request.go
+++ b/model/multitenant_database_request.go
@@ -12,15 +12,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetDatabasesRequest describes the parameters to request a list of multitenant databases.
-type GetDatabasesRequest struct {
+// GetMultitenantDatabasesRequest describes the parameters to request a list of
+// multitenant databases.
+type GetMultitenantDatabasesRequest struct {
 	Paging
 	VpcID        string
 	DatabaseType string
 }
 
 // ApplyToURL modifies the given url to include query string parameters for the request.
-func (request *GetDatabasesRequest) ApplyToURL(u *url.URL) {
+func (request *GetMultitenantDatabasesRequest) ApplyToURL(u *url.URL) {
 	q := u.Query()
 	q.Add("vpc_id", request.VpcID)
 	q.Add("database_type", request.DatabaseType)
@@ -29,14 +30,14 @@ func (request *GetDatabasesRequest) ApplyToURL(u *url.URL) {
 	u.RawQuery = q.Encode()
 }
 
-// PatchDatabaseRequest specifies the parameters for an updated multitenant
-// database.
-type PatchDatabaseRequest struct {
+// PatchMultitenantDatabaseRequest specifies the parameters for an updated
+// multitenant database.
+type PatchMultitenantDatabaseRequest struct {
 	MaxInstallationsPerLogicalDatabase *int64
 }
 
 // Validate validates the values of a multitenant database patch request.
-func (p *PatchDatabaseRequest) Validate() error {
+func (p *PatchMultitenantDatabaseRequest) Validate() error {
 	if p.MaxInstallationsPerLogicalDatabase != nil && *p.MaxInstallationsPerLogicalDatabase < int64(1) {
 		return errors.New("MaxInstallationsPerLogicalDatabase must be 1 or greater")
 	}
@@ -45,7 +46,7 @@ func (p *PatchDatabaseRequest) Validate() error {
 }
 
 // Apply applies the patch to the given multitenant database.
-func (p *PatchDatabaseRequest) Apply(database *MultitenantDatabase) bool {
+func (p *PatchMultitenantDatabaseRequest) Apply(database *MultitenantDatabase) bool {
 	var applied bool
 
 	if database.DatabaseType == DatabaseEngineTypePostgresProxy {
@@ -58,19 +59,53 @@ func (p *PatchDatabaseRequest) Apply(database *MultitenantDatabase) bool {
 	return applied
 }
 
-// NewPatchDatabaseRequestFromReader will create a PatchDatabaseRequest from an
-// io.Reader with JSON data.
-func NewPatchDatabaseRequestFromReader(reader io.Reader) (*PatchDatabaseRequest, error) {
-	var patchDatabaseRequest PatchDatabaseRequest
-	err := json.NewDecoder(reader).Decode(&patchDatabaseRequest)
+// NewPatchMultitenantDatabaseRequestFromReader will create a PatchMultitenantDatabaseRequest
+// from an io.Reader with JSON data.
+func NewPatchMultitenantDatabaseRequestFromReader(reader io.Reader) (*PatchMultitenantDatabaseRequest, error) {
+	var patchMultitenantDatabaseRequest PatchMultitenantDatabaseRequest
+	err := json.NewDecoder(reader).Decode(&patchMultitenantDatabaseRequest)
 	if err != nil && err != io.EOF {
-		return nil, errors.Wrap(err, "failed to decode patch database request")
+		return nil, errors.Wrap(err, "failed to decode patch multitenant database request")
 	}
 
-	err = patchDatabaseRequest.Validate()
+	err = patchMultitenantDatabaseRequest.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid patch database request")
+		return nil, errors.Wrap(err, "invalid patch multitenant database request")
 	}
 
-	return &patchDatabaseRequest, nil
+	return &patchMultitenantDatabaseRequest, nil
+}
+
+// GetLogicalDatabasesRequest describes the parameters to request a list of
+// logical databases.
+type GetLogicalDatabasesRequest struct {
+	Paging
+	MultitenantDatabaseID string
+}
+
+// ApplyToURL modifies the given url to include query string parameters for the request.
+func (request *GetLogicalDatabasesRequest) ApplyToURL(u *url.URL) {
+	q := u.Query()
+	q.Add("multitenant_database_id", request.MultitenantDatabaseID)
+	request.Paging.AddToQuery(q)
+
+	u.RawQuery = q.Encode()
+}
+
+// GetDatabaseSchemaRequest describes the parameters to request a list of
+// database schemas.
+type GetDatabaseSchemaRequest struct {
+	Paging
+	LogicalDatabaseID string
+	InstallationID    string
+}
+
+// ApplyToURL modifies the given url to include query string parameters for the request.
+func (request *GetDatabaseSchemaRequest) ApplyToURL(u *url.URL) {
+	q := u.Query()
+	q.Add("logical_database_id", request.LogicalDatabaseID)
+	q.Add("installation_id", request.InstallationID)
+	request.Paging.AddToQuery(q)
+
+	u.RawQuery = q.Encode()
 }


### PR DESCRIPTION
These new endpoints allow for clients to view database resources
that the provisioner is managing.

Note that the old database endpoints will be removed at a later
date.

Fixes https://mattermost.atlassian.net/browse/MM-38467

```release-note
Add database resource list and get API endpoints
```
