### PR TITLE
Remove alerting block from installation SLIs

### DIFF
--- a/internal/provisioner/kops_provisioner_installation_sli.go
+++ b/internal/provisioner/kops_provisioner_installation_sli.go
@@ -39,18 +39,9 @@ func (provisioner *KopsProvisioner) makeSLIs(clusterInstallation *model.ClusterI
 					Objective:   99.9,
 					Description: "Availability metric for mattermost API",
 					SLI: slothv1.SLI{Events: &slothv1.SLIEvents{
-						ErrorQuery: "sum(rate(mattermost_api_time_count{job='" + installationName + "',status_code=~'(5..|429)'}[{{.window}}]))",
+						ErrorQuery: "sum(rate(mattermost_api_time_count{job='" + installationName + "',status_code=~'(5..|429|499)'}[{{.window}}]))",
 						TotalQuery: "sum(rate(mattermost_api_time_count{job='" + installationName + "'}[{{.window}}]))",
 					}},
-					Alerting: slothv1.Alerting{
-						Name: installationName + "-service-HighAPIErrorRate",
-						Labels: map[string]string{
-							"category": "availability",
-						},
-						Annotations: map[string]string{
-							"summary": "High error rate on requests responses",
-						},
-					},
 				}},
 		},
 	}


### PR DESCRIPTION
Moved to a generalized alerting approach with thanos.
Issue: MM-38470

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Remove alerting block from installation SLIs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38470

#### Release Note

```release-note
Remove alerting block from installation SLIs.
Moved to a generalized alerting approach with thanos.
```
