### PR TITLE
Revert "Remove alerting block from installation SLIs"

### DIFF
--- a/internal/provisioner/kops_provisioner_installation_sli.go
+++ b/internal/provisioner/kops_provisioner_installation_sli.go
@@ -39,9 +39,18 @@ func (provisioner *KopsProvisioner) makeSLIs(clusterInstallation *model.ClusterI
 					Objective:   99.9,
 					Description: "Availability metric for mattermost API",
 					SLI: slothv1.SLI{Events: &slothv1.SLIEvents{
-						ErrorQuery: "sum(rate(mattermost_api_time_count{job='" + installationName + "',status_code=~'(5..|429|499)'}[{{.window}}]))",
+						ErrorQuery: "sum(rate(mattermost_api_time_count{job='" + installationName + "',status_code=~'(5..|429)'}[{{.window}}]))",
 						TotalQuery: "sum(rate(mattermost_api_time_count{job='" + installationName + "'}[{{.window}}]))",
 					}},
+					Alerting: slothv1.Alerting{
+						Name: installationName + "-service-HighAPIErrorRate",
+						Labels: map[string]string{
+							"category": "availability",
+						},
+						Annotations: map[string]string{
+							"summary": "High error rate on requests responses",
+						},
+					},
 				}},
 		},
 	}


### PR DESCRIPTION
Reverts mattermost/mattermost-cloud#525


@stylianosrigas @Szymongib Unfortunately need to revert this change for now at least as breaking `sloth`  when you don't set Alerting block. So SLOs do not get in place.

Sorry for the inconvenience.
#### Release Note

```release-note
Reverts #525 
```
