### PR TITLE
Installation removal fix for pgbouncer resource records

### DIFF
--- a/internal/store/db_helpers.go
+++ b/internal/store/db_helpers.go
@@ -165,12 +165,10 @@ func (sqlStore *SQLStore) DeleteInstallationProxyDatabaseResources(multitenantDa
 		return errors.Wrap(err, "failed to delete database schema")
 	}
 
-	if multitenantDatabase.Installations.Contains(databaseSchema.InstallationID) {
-		multitenantDatabase.Installations.Remove(databaseSchema.InstallationID)
-		err = sqlStore.updateMultitenantDatabase(tx, multitenantDatabase)
-		if err != nil {
-			return errors.Wrap(err, "failed to update multitenant database")
-		}
+	multitenantDatabase.Installations.Remove(databaseSchema.InstallationID)
+	err = sqlStore.updateMultitenantDatabase(tx, multitenantDatabase)
+	if err != nil {
+		return errors.Wrap(err, "failed to update multitenant database")
 	}
 
 	err = tx.Commit()


### PR DESCRIPTION
There was a chance that the `Installations` list could not be
properly updated in pgbouncer multitenant database resources when
installations were deleted. This change addresses the issue which
would occur when database weight calculations were done before
the installation schema was deleted.

Fixes https://mattermost.atlassian.net/browse/MM-38494

```release-note
Installation removal fix for pgbouncer resource records
```
