### PR TITLE
Fix for collecting kops node instance types

### DIFF
--- a/internal/tools/kops/instance_groups.go
+++ b/internal/tools/kops/instance_groups.go
@@ -56,7 +56,7 @@ func (c *Cmd) UpdateMetadata(metadata *model.KopsMetadata) error {
 	metadata.CustomInstanceGroups = make(model.KopsInstanceGroupsMetadata)
 
 	var masterIGCount, nodeIGCount, nodeMinCount, nodeMaxCount int64
-	var masterMachineType, AMI string
+	var masterMachineType, nodeMachineType, AMI string
 	for _, ig := range instanceGroups {
 		switch ig.Spec.Role {
 		case "Master":
@@ -93,6 +93,7 @@ func (c *Cmd) UpdateMetadata(metadata *model.KopsMetadata) error {
 
 			if strings.HasPrefix(ig.Metadata.Name, "nodes") {
 				nodeIGCount++
+				nodeMachineType = ig.Spec.MachineType
 				nodeMinCount += ig.Spec.MinSize
 				nodeMaxCount += ig.Spec.MaxSize
 				metadata.NodeInstanceGroups[ig.Metadata.Name] = model.KopsInstanceGroupMetadata{
@@ -136,6 +137,7 @@ func (c *Cmd) UpdateMetadata(metadata *model.KopsMetadata) error {
 	metadata.AMI = AMI
 	metadata.MasterInstanceType = masterMachineType
 	metadata.MasterCount = masterIGCount
+	metadata.NodeInstanceType = nodeMachineType
 	metadata.NodeMinCount = nodeMinCount
 	metadata.NodeMaxCount = nodeMaxCount
 	metadata.Networking = GetCurrentCni(networking)

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -22,14 +22,14 @@ type KopsMetadata struct {
 	NodeInstanceType     string
 	NodeMinCount         int64
 	NodeMaxCount         int64
+	VPC                  string
+	Networking           string
 	MasterInstanceGroups KopsInstanceGroupsMetadata
 	NodeInstanceGroups   KopsInstanceGroupsMetadata
-	CustomInstanceGroups KopsInstanceGroupsMetadata
+	CustomInstanceGroups KopsInstanceGroupsMetadata  `json:"CustomInstanceGroups,omitempty"`
 	ChangeRequest        *KopsMetadataRequestedState `json:"ChangeRequest,omitempty"`
 	RotatorRequest       *RotatorMetadata            `json:"RotatorRequest,omitempty"`
 	Warnings             []string                    `json:"Warnings,omitempty"`
-	Networking           string                      `json:"Networking,omitempty"`
-	VPC                  string                      `json:"VPC,omitempty"`
 }
 
 // KopsInstanceGroupsMetadata is a map of instance group names to their metadata.


### PR DESCRIPTION
The corrects the logic used to obtain the kops worker node type
after cluster changes. This also includes some small cluster object
JSON output updates.

Fixes https://mattermost.atlassian.net/browse/MM-38144

```release-note
Fix for collecting kops node instance types
```
