### PR TITLE
Installation weight calculation fix for zero installations

### DIFF
--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -474,6 +474,10 @@ func (sqlStore *SQLStore) UpdateInstallationCRVersion(installationID, crVersion 
 // GetInstallationsTotalDatabaseWeight returns the total weight value of the
 // provided installations.
 func (sqlStore *SQLStore) GetInstallationsTotalDatabaseWeight(installationIDs []string) (float64, error) {
+	if len(installationIDs) == 0 {
+		return float64(0), nil
+	}
+
 	installations, err := sqlStore.GetInstallations(&model.InstallationFilter{
 		InstallationIDs: installationIDs,
 		Paging:          model.AllPagesNotDeleted(),

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -961,23 +961,35 @@ func TestGetInstallationsTotalDatabaseWeight(t *testing.T) {
 
 	time.Sleep(1 * time.Millisecond)
 
-	totalWeight, err := sqlStore.GetInstallationsTotalDatabaseWeight([]string{installation1.ID})
-	require.NoError(t, err)
-	assert.Equal(t, installation1.GetDatabaseWeight(), totalWeight)
-	assert.Equal(t, model.DefaultDatabaseWeight, totalWeight)
-
-	totalWeight, err = sqlStore.GetInstallationsTotalDatabaseWeight([]string{installation3.ID})
-	require.NoError(t, err)
-	assert.Equal(t, installation3.GetDatabaseWeight(), totalWeight)
-	assert.Equal(t, model.HibernatingDatabaseWeight, totalWeight)
-
-	totalWeight, err = sqlStore.GetInstallationsTotalDatabaseWeight([]string{
-		installation1.ID,
-		installation2.ID,
-		installation3.ID,
+	t.Run("no installations in filter", func(t *testing.T) {
+		totalWeight, err := sqlStore.GetInstallationsTotalDatabaseWeight([]string{})
+		require.NoError(t, err)
+		assert.Equal(t, float64(0), totalWeight)
 	})
-	require.NoError(t, err)
-	assert.Equal(t, installation1.GetDatabaseWeight()+installation2.GetDatabaseWeight()+installation3.GetDatabaseWeight(), totalWeight)
+
+	t.Run("stable installation", func(t *testing.T) {
+		totalWeight, err := sqlStore.GetInstallationsTotalDatabaseWeight([]string{installation1.ID})
+		require.NoError(t, err)
+		assert.Equal(t, installation1.GetDatabaseWeight(), totalWeight)
+		assert.Equal(t, model.DefaultDatabaseWeight, totalWeight)
+	})
+
+	t.Run("hibernating installation", func(t *testing.T) {
+		totalWeight, err := sqlStore.GetInstallationsTotalDatabaseWeight([]string{installation3.ID})
+		require.NoError(t, err)
+		assert.Equal(t, installation3.GetDatabaseWeight(), totalWeight)
+		assert.Equal(t, model.HibernatingDatabaseWeight, totalWeight)
+	})
+
+	t.Run("three installations", func(t *testing.T) {
+		totalWeight, err := sqlStore.GetInstallationsTotalDatabaseWeight([]string{
+			installation1.ID,
+			installation2.ID,
+			installation3.ID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, installation1.GetDatabaseWeight()+installation2.GetDatabaseWeight()+installation3.GetDatabaseWeight(), totalWeight)
+	})
 }
 
 func TestDeleteInstallation(t *testing.T) {


### PR DESCRIPTION
This corrects the installation DB weight calculation logic when
an empty list of installations has been passed in.

Fixes https://mattermost.atlassian.net/browse/MM-38610

```release-note
Installation weight calculation fix for zero installations
```
