### PR TITLE
Bump kubecost version to 1.86.1

### DIFF
--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -34,7 +34,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"teleport":                          {Chart: "0.3.0", ValuesPath: ""},
 				"pgbouncer":                         {Chart: "1.1.0", ValuesPath: ""},
 				"stackrox-secured-cluster-services": {Chart: "62.0.0", ValuesPath: ""},
-				"kubecost":                          {Chart: "1.83.1", ValuesPath: ""},
+				"kubecost":                          {Chart: "1.86.1", ValuesPath: ""},
 				"node-problem-detector":             {Chart: "2.0.5", ValuesPath: ""},
 			},
 		}
@@ -99,7 +99,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"teleport":                          {Chart: "0.3.0", ValuesPath: ""},
 				"pgbouncer":                         {Chart: "1.1.0", ValuesPath: ""},
 				"stackrox-secured-cluster-services": {Chart: "62.0.0", ValuesPath: ""},
-				"kubecost":                          {Chart: "1.83.1", ValuesPath: ""},
+				"kubecost":                          {Chart: "1.86.1", ValuesPath: ""},
 				"node-problem-detector":             {Chart: "2.0.5", ValuesPath: ""},
 			},
 		}, clusterRequest)

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -70,7 +70,7 @@ var DefaultUtilityVersions map[string]*HelmUtilityVersion = map[string]*HelmUtil
 	// StackroxDefaultVersion defines the default version for the Helm chart
 	StackroxCanonicalName: {Chart: "62.0.0", ValuesPath: ""},
 	// KubecostDefaultVersion defines the default version for the Helm chart
-	KubecostCanonicalName: {Chart: "1.83.1", ValuesPath: ""},
+	KubecostCanonicalName: {Chart: "1.86.1", ValuesPath: ""},
 	// NodeProblemDetectorDefaultVersion defines the default version for the Helm chart
 	NodeProblemDetectorCanonicalName: {Chart: "2.0.5", ValuesPath: ""},
 }

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -100,7 +100,7 @@ func TestGetActualVersion(t *testing.T) {
 				Teleport:            &HelmUtilityVersion{Chart: "teleport-0.3.0"},
 				Pgbouncer:           &HelmUtilityVersion{Chart: "pgbouncer-1.1.0"},
 				Stackrox:            &HelmUtilityVersion{Chart: "stackrox-secured-cluster-services-62.0.0"},
-				Kubecost:            &HelmUtilityVersion{Chart: "cost-analyzer-1.83.1"},
+				Kubecost:            &HelmUtilityVersion{Chart: "cost-analyzer-1.86.1"},
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "node-problem-detector-2.0.5"},
 			},
 		},
@@ -128,7 +128,7 @@ func TestGetActualVersion(t *testing.T) {
 	assert.Equal(t, &HelmUtilityVersion{Chart: "stackrox-secured-cluster-services-62.0.0"}, version)
 
 	version = c.ActualUtilityVersion(KubecostCanonicalName)
-	assert.Equal(t, &HelmUtilityVersion{Chart: "cost-analyzer-1.83.1"}, version)
+	assert.Equal(t, &HelmUtilityVersion{Chart: "cost-analyzer-1.86.1"}, version)
 
 	version = c.ActualUtilityVersion(NodeProblemDetectorCanonicalName)
 	assert.Equal(t, &HelmUtilityVersion{Chart: "node-problem-detector-2.0.5"}, version)
@@ -159,7 +159,7 @@ func TestGetDesiredVersion(t *testing.T) {
 				Teleport:            &HelmUtilityVersion{Chart: "teleport-0.3.0"},
 				Pgbouncer:           &HelmUtilityVersion{Chart: "pgbouncer-1.1.0"},
 				Stackrox:            &HelmUtilityVersion{Chart: "stackrox-secured-cluster-services-62.0.0"},
-				Kubecost:            &HelmUtilityVersion{Chart: "cost-analyzer-1.83.1"},
+				Kubecost:            &HelmUtilityVersion{Chart: "cost-analyzer-1.86.1"},
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "node-problem-detector-2.0.5"},
 			},
 		},


### PR DESCRIPTION
Issue: MM-38481

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Bump kubecost version to 1.86.1

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38481

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Bump kubecost version to 1.86.1.
This version fixes some legacy metrics reliance.
```
