### PR TITLE
MM-38760 Upgrade Fluent-bit helm chart version to 0.17.0

### DIFF
--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -26,7 +26,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			Zones:              []string{"us-east-1a"},
 			Networking:         "amazon-vpc-routed-eni",
 			DesiredUtilityVersions: map[string]*model.HelmUtilityVersion{
-				"fluentbit":                         {Chart: "0.16.6", ValuesPath: ""},
+				"fluentbit":                         {Chart: "0.17.0", ValuesPath: ""},
 				"nginx":                             {Chart: "2.15.0", ValuesPath: ""},
 				"nginx-internal":                    {Chart: "2.15.0", ValuesPath: ""},
 				"prometheus-operator":               {Chart: "18.0.3", ValuesPath: ""},
@@ -91,7 +91,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			Zones:              []string{"zone1", "zone2"},
 			Networking:         "amazon-vpc-routed-eni",
 			DesiredUtilityVersions: map[string]*model.HelmUtilityVersion{
-				"fluentbit":                         {Chart: "0.16.6", ValuesPath: ""},
+				"fluentbit":                         {Chart: "0.17.0", ValuesPath: ""},
 				"nginx":                             {Chart: "2.15.0", ValuesPath: ""},
 				"nginx-internal":                    {Chart: "2.15.0", ValuesPath: ""},
 				"prometheus-operator":               {Chart: "18.0.3", ValuesPath: ""},

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -62,7 +62,7 @@ var DefaultUtilityVersions map[string]*HelmUtilityVersion = map[string]*HelmUtil
 	// NginxInternalDefaultVersion defines the default version for the Helm chart
 	NginxInternalCanonicalName: {Chart: "2.15.0", ValuesPath: ""},
 	// FluentbitDefaultVersion defines the default version for the Helm chart
-	FluentbitCanonicalName: {Chart: "0.16.6", ValuesPath: ""},
+	FluentbitCanonicalName: {Chart: "0.17.0", ValuesPath: ""},
 	// TeleportDefaultVersion defines the default version for the Helm chart
 	TeleportCanonicalName: {Chart: "0.3.0", ValuesPath: ""},
 	// PgbouncerDefaultVersion defines the default version for the Helm chart


### PR DESCRIPTION
#### Summary
Upgrade Fluent-bit helm chart version to 0.17.0

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38760

#### Release Note

```release-note
Upgrade Fluent-bit helm chart version to 0.17.0
```
