### PR TITLE
[testwick] Add ability to sleep before post a message to slow down

### DIFF
--- a/cmd/tools/testwick/main.go
+++ b/cmd/tools/testwick/main.go
@@ -34,6 +34,7 @@ type testerCfg struct {
 	samples               int
 	channelSamples        int
 	messagesSamples       int
+	messagesSamplesSleep  time.Duration
 }
 
 var testerConfig = testerCfg{}
@@ -58,6 +59,7 @@ func init() {
 	testerCmd.PersistentFlags().IntVar(&testerConfig.samples, "samples", 1, "The number of samples installations to interact with")
 	testerCmd.PersistentFlags().IntVar(&testerConfig.channelSamples, "channel-samples", 1, "The number of channel samples to create in installation")
 	testerCmd.PersistentFlags().IntVar(&testerConfig.messagesSamples, "channel-messages", 100, "The number of channel messages to post")
+	testerCmd.PersistentFlags().DurationVar(&testerConfig.messagesSamplesSleep, "channel-messages-sleep", 10*time.Second, "The number of time to sleep before post the next message")
 	testerCmd.PersistentFlags().StringVar(&testerConfig.owner, "owner", "testwick", "The owner of the installation. Prefer to keep the default")
 	testerCmd.PersistentFlags().StringVar(&testerConfig.installationSize, "installation-size", "100users", "The size of the installation")
 	testerCmd.PersistentFlags().StringVar(&testerConfig.installationAffinity, "installation-affinity", cmodel.InstallationAffinityMultiTenant, "The installation affinity type eg. multitenant")
@@ -136,7 +138,7 @@ var testerCmd = &cobra.Command{
 						Func: testwicker.CreateIncomingWebhook(),
 					}, testwick.Step{
 						Name: "PostMessages",
-						Func: testwicker.PostMessage(testerConfig.messagesSamples),
+						Func: testwicker.PostMessage(testerConfig.messagesSamples, testerConfig.messagesSamplesSleep),
 					})
 				}
 				workflow.AddStep(testwick.Step{

--- a/cmd/tools/testwick/wicker/testwicker.go
+++ b/cmd/tools/testwick/wicker/testwicker.go
@@ -92,7 +92,7 @@ func (w *TestWicker) DeleteInstallation() func(w *TestWicker, ctx context.Contex
 
 // PostMessage post messages to the different channels which are created
 // automatically by the wicker
-func (w *TestWicker) PostMessage(samples int) func(w *TestWicker, ctx context.Context) error {
+func (w *TestWicker) PostMessage(samples int, sleepDuration time.Duration) func(w *TestWicker, ctx context.Context) error {
 	return func(w *TestWicker, _ context.Context) error {
 		w.logger.WithField("DNS", w.installation.DNS).Info("Posting messages")
 		if w.channelID == "" {
@@ -107,6 +107,7 @@ func (w *TestWicker) PostMessage(samples int) func(w *TestWicker, ctx context.Co
 			if response.StatusCode != 201 {
 				return fmt.Errorf("failed to post a message status = %d, message = %s", response.StatusCode, response.Error.Message)
 			}
+			time.Sleep(sleepDuration)
 		}
 		return nil
 	}

--- a/cmd/tools/testwick/wicker/testwicker_test.go
+++ b/cmd/tools/testwick/wicker/testwicker_test.go
@@ -309,7 +309,7 @@ func TestPostMessage(t *testing.T) {
 			}
 			v.setup(wicker)
 
-			f := wicker.PostMessage(1)
+			f := wicker.PostMessage(1, 10)
 			err := f(wicker, context.TODO())
 
 			v.expected(wicker, err)


### PR DESCRIPTION
#### Summary
Add an extra flag in `testwick` to slow down between posting messages in channels, so we can control the speed.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/MM-39397

#### Release Note
```release-note
[testwick] Add sleep between posting messages in channels
```
