### PR TITLE
[MM-39516] Update provisioner to use new rotator release with drain speed control

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -95,6 +95,7 @@ func init() {
 	clusterUpgradeCmd.Flags().Int("evict-grace-period", 600, "The pod eviction grace period when draining in seconds.")
 	clusterUpgradeCmd.Flags().Int("wait-between-rotations", 60, "Τhe time to wait between each rotation of a group of nodes.")
 	clusterUpgradeCmd.Flags().Int("wait-between-drains", 60, "The time to wait between each node drain in a group of nodes.")
+	clusterUpgradeCmd.Flags().Int("wait-between-pod-evictions", 1, "The time to wait between each pod eviction in a node drain.")
 	clusterUpgradeCmd.MarkFlagRequired("cluster")
 
 	clusterResizeCmd.Flags().String("cluster", "", "The id of the cluster to be resized.")
@@ -327,14 +328,16 @@ var clusterUpgradeCmd = &cobra.Command{
 		evictGracePeriod, _ := command.Flags().GetInt("evict-grace-period")
 		waitBetweenRotations, _ := command.Flags().GetInt("wait-between-rotations")
 		waitBetweenDrains, _ := command.Flags().GetInt("wait-between-drains")
+		waitBetweenPodEvictions, _ := command.Flags().GetInt("wait-between-pod-evictions")
 
 		rotatorConfig := model.RotatorConfig{
-			UseRotator:           &useRotator,
-			MaxScaling:           &maxScaling,
-			MaxDrainRetries:      &maxDrainRetries,
-			EvictGracePeriod:     &evictGracePeriod,
-			WaitBetweenRotations: &waitBetweenRotations,
-			WaitBetweenDrains:    &waitBetweenDrains,
+			UseRotator:              &useRotator,
+			MaxScaling:              &maxScaling,
+			MaxDrainRetries:         &maxDrainRetries,
+			EvictGracePeriod:        &evictGracePeriod,
+			WaitBetweenRotations:    &waitBetweenRotations,
+			WaitBetweenDrains:       &waitBetweenDrains,
+			WaitBetweenPodEvictions: &waitBetweenPodEvictions,
 		}
 
 		request := &model.PatchUpgradeClusterRequest{

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/lib/pq v1.8.0
 	github.com/mattermost/awat v0.0.0-20210616202500-f0bdd4f43f90
 	github.com/mattermost/mattermost-operator v1.15.0
-	github.com/mattermost/rotator v0.1.2
+	github.com/mattermost/rotator v0.2.0
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -833,8 +833,8 @@ github.com/mattermost/mattermost-operator v1.15.0 h1:/eJmOV6XZs3BGsLAhwC5K9PhL1i
 github.com/mattermost/mattermost-operator v1.15.0/go.mod h1:9esaQrOcruyyGQme3AnXGnoCDbpER7XAifDVu3HlCm8=
 github.com/mattermost/mattermost-server/v5 v5.23.0/go.mod h1:nMrt08IvThjybZpXPe/nqe/oJuvJxhqKkGI+m7M0R00=
 github.com/mattermost/mmetl v0.0.2-0.20210316151859-38824e5f5efd/go.mod h1:w6GNqrudkzs/GddfgqkgUqsXVQ/4ImK5JJfNj5KJeUQ=
-github.com/mattermost/rotator v0.1.2 h1:vBs/bRArFgKGx82QnVHxheH2qF3XdUupuRe/gWs1C/0=
-github.com/mattermost/rotator v0.1.2/go.mod h1:1oxWiEhVdZRckZ0uHGd5Zqf04yynm4U/YGHUPsf4sQ8=
+github.com/mattermost/rotator v0.2.0 h1:R3dlMHZjGR7t5T2bk76heDwpypl9rd2sZj4GoAZyuWU=
+github.com/mattermost/rotator v0.2.0/go.mod h1:1oxWiEhVdZRckZ0uHGd5Zqf04yynm4U/YGHUPsf4sQ8=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattermost/viper v1.0.4/go.mod h1:uc5hKG9lv4/KRwPOt2c1omOyirS/UnuA2TytiZQSFHM=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -719,15 +719,16 @@ func (provisioner *KopsProvisioner) RotateClusterNodes(cluster *model.Cluster) e
 	clientset, err := kubernetes.NewForConfig(k8sClient.GetConfig())
 
 	clusterRotator := rotatorModel.Cluster{
-		ClusterID:            cluster.ID,
-		MaxScaling:           *cluster.ProvisionerMetadataKops.RotatorRequest.Config.MaxScaling,
-		RotateMasters:        true,
-		RotateWorkers:        true,
-		MaxDrainRetries:      *cluster.ProvisionerMetadataKops.RotatorRequest.Config.MaxDrainRetries,
-		EvictGracePeriod:     *cluster.ProvisionerMetadataKops.RotatorRequest.Config.EvictGracePeriod,
-		WaitBetweenRotations: *cluster.ProvisionerMetadataKops.RotatorRequest.Config.WaitBetweenRotations,
-		WaitBetweenDrains:    *cluster.ProvisionerMetadataKops.RotatorRequest.Config.WaitBetweenDrains,
-		ClientSet:            clientset,
+		ClusterID:               cluster.ID,
+		MaxScaling:              *cluster.ProvisionerMetadataKops.RotatorRequest.Config.MaxScaling,
+		RotateMasters:           true,
+		RotateWorkers:           true,
+		MaxDrainRetries:         *cluster.ProvisionerMetadataKops.RotatorRequest.Config.MaxDrainRetries,
+		EvictGracePeriod:        *cluster.ProvisionerMetadataKops.RotatorRequest.Config.EvictGracePeriod,
+		WaitBetweenRotations:    *cluster.ProvisionerMetadataKops.RotatorRequest.Config.WaitBetweenRotations,
+		WaitBetweenDrains:       *cluster.ProvisionerMetadataKops.RotatorRequest.Config.WaitBetweenDrains,
+		WaitBetweenPodEvictions: *cluster.ProvisionerMetadataKops.RotatorRequest.Config.WaitBetweenPodEvictions,
+		ClientSet:               clientset,
 	}
 
 	rotatorMetadata := cluster.ProvisionerMetadataKops.RotatorRequest.Status

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -206,6 +206,9 @@ func (p *PatchUpgradeClusterRequest) Validate() error {
 			if p.RotatorConfig.WaitBetweenRotations == nil {
 				return errors.Errorf("rotator config wait between rotations should be set")
 			}
+			if p.RotatorConfig.WaitBetweenPodEvictions == nil {
+				return errors.Errorf("rotator config wait between pod evictions should be set")
+			}
 		}
 	}
 

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -63,12 +63,13 @@ type RotatorMetadata struct {
 
 // RotatorConfig is the config setup for the Rotator tool run
 type RotatorConfig struct {
-	UseRotator           *bool `json:"use-rotator,omitempty"`
-	MaxScaling           *int  `json:"max-scaling,omitempty"`
-	MaxDrainRetries      *int  `json:"max-drain-retries,omitempty"`
-	EvictGracePeriod     *int  `json:"evict-grace-period,omitempty"`
-	WaitBetweenRotations *int  `json:"wait-between-rotations,omitempty"`
-	WaitBetweenDrains    *int  `json:"wait-between-drains,omitempty"`
+	UseRotator              *bool `json:"use-rotator,omitempty"`
+	MaxScaling              *int  `json:"max-scaling,omitempty"`
+	MaxDrainRetries         *int  `json:"max-drain-retries,omitempty"`
+	EvictGracePeriod        *int  `json:"evict-grace-period,omitempty"`
+	WaitBetweenRotations    *int  `json:"wait-between-rotations,omitempty"`
+	WaitBetweenDrains       *int  `json:"wait-between-drains,omitempty"`
+	WaitBetweenPodEvictions *int  `json:"wait-between-pod-evictions,omitempty"`
 }
 
 // ValidateChangeRequest ensures that the ChangeRequest has at least one


### PR DESCRIPTION
#### Summary
- Update provisioner to use new rotator release with drain speed control
Rotator v0.2.0: https://github.com/mattermost/rotator/releases/tag/v0.2.0

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-39516

#### Release Note

```release-note
- Update provisioner to use new rotator release with drain speed control
```
