### PR TITLE
Update CRDs instead of patching

### DIFF
--- a/k8s/custom_resources.go
+++ b/k8s/custom_resources.go
@@ -22,7 +22,7 @@ import (
 
 func (kc *KubeClient) createOrUpdateCustomResourceDefinitionBetaV1(crd *apixv1beta1.CustomResourceDefinition) (metav1.Object, error) {
 	ctx := context.TODO()
-	_, err := kc.ApixClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(ctx, crd.GetName(), metav1.GetOptions{})
+	oldCRD, err := kc.ApixClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(ctx, crd.GetName(), metav1.GetOptions{})
 	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
@@ -31,25 +31,13 @@ func (kc *KubeClient) createOrUpdateCustomResourceDefinitionBetaV1(crd *apixv1be
 		return kc.ApixClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
 	}
 
-	// TODO: investigate issue where standard update fails
-	// Trying to use a standard update on CRDs failed for the mysql operator
-	// custom resources definitions. This seems to be related to an issue
-	// where a last-modified value is set after the CRD is deployed to the
-	// kubernetes cluster.
-	// Error: invalid: metadata.resourceVersion: Invalid value: 0x0: must be
-	// specified for an update
-	// Workaround: https://github.com/zalando/postgres-operator/pull/558
-	patch, err := json.Marshal(crd)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not marshal new Custom Resource Defintion")
-	}
-
-	return kc.ApixClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Patch(ctx, crd.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	crd.ResourceVersion = oldCRD.ResourceVersion
+	return kc.ApixClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{})
 }
 
 func (kc *KubeClient) createOrUpdateCustomResourceDefinitionV1(crd *apixv1.CustomResourceDefinition) (metav1.Object, error) {
 	ctx := context.TODO()
-	_, err := kc.ApixClientset.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.GetName(), metav1.GetOptions{})
+	oldCRD, err := kc.ApixClientset.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.GetName(), metav1.GetOptions{})
 	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
@@ -58,12 +46,8 @@ func (kc *KubeClient) createOrUpdateCustomResourceDefinitionV1(crd *apixv1.Custo
 		return kc.ApixClientset.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
 	}
 
-	patch, err := json.Marshal(crd)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not marshal new Custom Resource Defintion")
-	}
-
-	return kc.ApixClientset.ApiextensionsV1().CustomResourceDefinitions().Patch(ctx, crd.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	crd.ResourceVersion = oldCRD.ResourceVersion
+	return kc.ApixClientset.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{})
 }
 
 func (kc *KubeClient) createOrUpdateClusterInstallation(namespace string, ci *mmv1alpha1.ClusterInstallation) (metav1.Object, error) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
In some cases `Patching` CRD is not analogous to `Get` + `Update` as some fields are not handled properly.
Given that we fetch resources prior anyway and there should not be conflicting updates on CRDs we might as well rewrite `resourceVersion` and do `Update` to avoid issues with `Patch`.

Example issue:
```
"error":"CustomResourceDefinition.apiextensions.k8s.io \"mysqlclusters.mysql.presslabs.org\" is invalid: spec.preserveUnknownFields: Invalid value: true: must be false in order to use defaults in the schema"
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-39916

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Update CRDs instead of patching
```
