### PR TITLE
Change k8s resource calculations

### DIFF
--- a/k8s/resources.go
+++ b/k8s/resources.go
@@ -31,9 +31,9 @@ func (r *ClusterResources) CalculateMemoryPercentUsed(additional int64) int {
 
 // CalculateTotalPodMilliResourceRequests calculates the total CPU and memory
 // milli resource requirements of a list of pods.
-func CalculateTotalPodMilliResourceRequests(pods *corev1.PodList) (int64, int64) {
+func CalculateTotalPodMilliResourceRequests(pods []corev1.Pod) (int64, int64) {
 	var totalCPU, totalMemory int64
-	for _, pod := range pods.Items {
+	for _, pod := range pods {
 		for _, container := range pod.Spec.Containers {
 			totalCPU += container.Resources.Requests.Cpu().MilliValue()
 			totalMemory += container.Resources.Requests.Memory().MilliValue()


### PR DESCRIPTION
Previously, resource calculations done on k8s clusters would take
all pods and nodes into account. This is an issue as custom kops
instance groups and master nodes could not run standard workloads
and should be ignored.

This change alters the calculation to only check the standard
worker nodes and the pods that are running on those nodes.

Fixes https://mattermost.atlassian.net/browse/MM-39075

```release-note
Change k8s resource calculations
```
