### PR TITLE
Make AWS tests compatible with gomock 1.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,4 @@ require (
 	k8s.io/kube-aggregator v0.18.8
 )
 
-replace github.com/golang/mock v1.6.0 => github.com/golang/mock v1.4.4
-
 replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6

--- a/go.sum
+++ b/go.sum
@@ -699,9 +699,10 @@ github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFU
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
-github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/tools/aws/client_test.go
+++ b/internal/tools/aws/client_test.go
@@ -194,7 +194,10 @@ func (a *AWSTestSuite) TearDown() {
 }
 
 func TestAWSSuite(t *testing.T) {
-	suite.Run(t, NewAWSTestSuite(t))
+	testSuite := NewAWSTestSuite(t)
+	defer testSuite.TearDown()
+
+	suite.Run(t, testSuite)
 }
 
 func newClientDummyCache() *cache {

--- a/internal/tools/aws/database_migration_test.go
+++ b/internal/tools/aws/database_migration_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/golang/mock/gomock"
-	testlib "github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"

--- a/internal/tools/aws/database_multitenant_test.go
+++ b/internal/tools/aws/database_multitenant_test.go
@@ -10,12 +10,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	gt "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/golang/mock/gomock"
-
-	testlib "github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/mattermost/mattermost-cloud/model"
+	log "github.com/sirupsen/logrus"
 )
 
 // Tests provisioning a multitenante database. Use this test for deriving other tests.

--- a/internal/tools/aws/database_test.go
+++ b/internal/tools/aws/database_test.go
@@ -21,7 +21,6 @@ import (
 	testlib "github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -219,11 +218,6 @@ func (a *AWSTestSuite) TestSnapshot() {
 			a.Assert().Equal(*input.Tags[0].Key, DefaultClusterInstallationSnapshotTagKey)
 			a.Assert().Equal(*input.Tags[0].Value, RDSSnapshotTagValue(CloudID(a.ClusterA.ID)))
 		}).Times(1),
-
-		a.Mocks.Log.Logger.EXPECT().
-			WithField("installation-id", a.InstallationA.ID).
-			Return(testlib.NewLoggerEntry()).
-			Times(1),
 	)
 
 	err := database.Snapshot(a.Mocks.AWS.store, a.Mocks.Log.Logger)
@@ -249,11 +243,6 @@ func (a *AWSTestSuite) TestSnapshotError() {
 		a.Mocks.API.RDS.EXPECT().
 			CreateDBClusterSnapshot(gomock.Any()).
 			Return(nil, errors.New("database is not stable")).
-			Times(1),
-
-		a.Mocks.Log.Logger.EXPECT().
-			WithField("installation-id", a.InstallationA.ID).
-			Return(testlib.NewLoggerEntry()).
 			Times(1),
 	)
 
@@ -337,10 +326,6 @@ func (a *AWSTestSuite) SetExpectCreateDBInstance() {
 				a.Assert().Equal(*input.DBClusterIdentifier, CloudID(a.InstallationA.ID))
 				a.Assert().Equal(*input.DBInstanceIdentifier, RDSReplicaInstanceID(a.InstallationA.ID, 0))
 			}),
-
-		a.Mocks.Log.Logger.EXPECT().WithField("db-instance-name", RDSMasterInstanceID(a.InstallationA.ID)).
-			Return(testlib.NewLoggerEntry()).
-			Times(1),
 	)
 }
 
@@ -355,7 +340,7 @@ func TestDatabaseProvision(t *testing.T) {
 		return
 	}
 
-	logger := logrus.New()
+	logger := log.New()
 	database := NewRDSDatabase(model.DatabaseEngineTypeMySQL, id, &Client{
 		mux: &sync.Mutex{},
 	})
@@ -370,7 +355,7 @@ func TestDatabaseTeardown(t *testing.T) {
 		return
 	}
 
-	logger := logrus.New()
+	logger := log.New()
 	database := NewRDSDatabase(model.DatabaseEngineTypeMySQL, id, &Client{
 		mux: &sync.Mutex{},
 	})

--- a/internal/tools/aws/ec2_test.go
+++ b/internal/tools/aws/ec2_test.go
@@ -11,10 +11,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
-	testlib "github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,12 +30,9 @@ func (a *AWSTestSuite) TestTagResource() {
 }
 
 func (a *AWSTestSuite) TestTagResourceError() {
-	a.Mocks.Log.Logger.EXPECT().
-		WithFields(logrus.Fields{"tag-key": "tag-key", "tag-value": "tag-value"}).
-		Return(testlib.NewLoggerEntry()).Times(1).
-		After(a.Mocks.API.EC2.EXPECT().
-			CreateTags(gomock.Any()).
-			Return(nil, errors.New("invalid tag")))
+	a.Mocks.API.EC2.EXPECT().
+		CreateTags(gomock.Any()).
+		Return(nil, errors.New("invalid tag"))
 
 	err := a.Mocks.AWS.TagResource(a.ResourceID, "tag-key", "tag-value", a.Mocks.Log.Logger)
 	a.Assert().Error(err)
@@ -56,13 +52,6 @@ func (a *AWSTestSuite) TestUntagResource() {
 }
 
 func (a *AWSTestSuite) TestUntagResourceEmptyResourceID() {
-	a.Mocks.Log.Logger.EXPECT().
-		WithFields(logrus.Fields{"tag-key": "tag-key", "tag-value": "tag-value"}).
-		Return(testlib.NewLoggerEntry()).Times(1).
-		After(a.Mocks.API.EC2.EXPECT().
-			DeleteTags(gomock.Any()).
-			Return(&ec2.DeleteTagsOutput{}, nil))
-
 	err := a.Mocks.AWS.UntagResource("", "tag-key", "tag-value", a.Mocks.Log.Logger)
 
 	a.Assert().Error(err)
@@ -70,12 +59,9 @@ func (a *AWSTestSuite) TestUntagResourceEmptyResourceID() {
 }
 
 func (a *AWSTestSuite) TestUntagResourceError() {
-	a.Mocks.Log.Logger.EXPECT().
-		WithFields(logrus.Fields{"tag-key": "tag-key", "tag-value": "tag-value"}).
-		Return(testlib.NewLoggerEntry()).Times(1).
-		After(a.Mocks.API.EC2.EXPECT().
-			DeleteTags(gomock.Any()).
-			Return(nil, errors.New("tag not found")))
+	a.Mocks.API.EC2.EXPECT().
+		DeleteTags(gomock.Any()).
+		Return(nil, errors.New("tag not found"))
 
 	err := a.Mocks.AWS.UntagResource(a.ResourceID, "tag-key", "tag-value", a.Mocks.Log.Logger)
 
@@ -84,27 +70,17 @@ func (a *AWSTestSuite) TestUntagResourceError() {
 }
 
 func (a *AWSTestSuite) TestIsValidAMIEmptyResourceID() {
-	a.Mocks.Log.Logger.EXPECT().
-		WithFields(logrus.Fields{}).
-		Return(testlib.NewLoggerEntry()).Times(1).
-		After(a.Mocks.API.EC2.EXPECT().
-			DescribeImages(gomock.Any()).
-			Return(nil, errors.New("tag not found")))
-
 	ok, err := a.Mocks.AWS.IsValidAMI("", a.Mocks.Log.Logger)
 	a.Assert().NoError(err)
 	a.Assert().True(ok)
 }
 
 func (a *AWSTestSuite) TestIsValidAMI() {
-	a.Mocks.Log.Logger.EXPECT().
-		WithFields(logrus.Fields{}).
-		Return(testlib.NewLoggerEntry()).Times(1).
-		After(a.Mocks.API.EC2.EXPECT().
-			DescribeImages(gomock.Any()).
-			Return(&ec2.DescribeImagesOutput{
-				Images: make([]*ec2.Image, 2),
-			}, nil))
+	a.Mocks.API.EC2.EXPECT().
+		DescribeImages(gomock.Any()).
+		Return(&ec2.DescribeImagesOutput{
+			Images: make([]*ec2.Image, 2),
+		}, nil)
 
 	ok, err := a.Mocks.AWS.IsValidAMI(a.ResourceID, a.Mocks.Log.Logger)
 	a.Assert().NoError(err)
@@ -112,14 +88,11 @@ func (a *AWSTestSuite) TestIsValidAMI() {
 }
 
 func (a *AWSTestSuite) TestIsValidAMINoImages() {
-	a.Mocks.Log.Logger.EXPECT().
-		WithFields(logrus.Fields{}).
-		Return(testlib.NewLoggerEntry()).Times(1).
-		After(a.Mocks.API.EC2.EXPECT().
-			DescribeImages(gomock.Any()).
-			Return(&ec2.DescribeImagesOutput{
-				Images: make([]*ec2.Image, 0),
-			}, nil))
+	a.Mocks.API.EC2.EXPECT().
+		DescribeImages(gomock.Any()).
+		Return(&ec2.DescribeImagesOutput{
+			Images: make([]*ec2.Image, 0),
+		}, nil)
 
 	ok, err := a.Mocks.AWS.IsValidAMI(a.ResourceID, a.Mocks.Log.Logger)
 
@@ -128,14 +101,11 @@ func (a *AWSTestSuite) TestIsValidAMINoImages() {
 }
 
 func (a *AWSTestSuite) TestIsValidAMIError() {
-	a.Mocks.Log.Logger.EXPECT().
-		WithFields(logrus.Fields{}).
-		Return(testlib.NewLoggerEntry()).Times(1).
-		After(a.Mocks.API.EC2.EXPECT().
-			DescribeImages(gomock.Any()).
-			Return(nil, errors.New("resource id not found")))
+	a.Mocks.API.EC2.EXPECT().
+		DescribeImages(gomock.Any()).
+		Return(nil, errors.New("resource id not found"))
 
-	ok, err := a.Mocks.AWS.IsValidAMI(a.ResourceID, log.New())
+	ok, err := a.Mocks.AWS.IsValidAMI(a.ResourceID, a.Mocks.Log.Logger)
 
 	a.Assert().Error(err)
 	a.Assert().False(ok)

--- a/internal/tools/aws/rds_test.go
+++ b/internal/tools/aws/rds_test.go
@@ -7,10 +7,9 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/golang/mock/gomock"
-	testlib "github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/pkg/errors"
 )
 
@@ -56,26 +55,6 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterCreated() {
 		}).
 		Times(1)
 
-	a.Mocks.API.KMS.EXPECT().
-		CreateKey(gomock.Any()).
-		Return(&kms.CreateKeyOutput{
-			KeyMetadata: &kms.KeyMetadata{
-				KeyId: aws.String(a.RDSEncryptionKeyID),
-			},
-		}, nil).
-		Do(func(input *kms.CreateKeyInput) {
-			a.Assert().Equal(*input.Description, "Key used for encrypting RDS database")
-		}).
-		Times(1)
-
-	a.Mocks.API.KMS.EXPECT().
-		CreateAlias(gomock.Any()).
-		Return(nil, nil).
-		Do(func(input *kms.CreateAliasInput) {
-			a.Assert().Equal(*input.AliasName, KMSAliasNameRDS(CloudID(a.InstallationA.ID)))
-		}).
-		Times(1)
-
 	// Retrive the Availability Zones.
 	a.Mocks.API.EC2.EXPECT().DescribeAvailabilityZones(gomock.Any()).
 		Return(&ec2.DescribeAvailabilityZonesOutput{AvailabilityZones: []*ec2.AvailabilityZone{{ZoneName: aws.String("us-honk-1a")}, {ZoneName: aws.String("us-honk-1b")}}}, nil).
@@ -105,13 +84,9 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterCreatedWithSGError() {
 		Return(nil, errors.New("db cluster does not exist")).
 		Times(1)
 
-	a.Mocks.Log.Logger.EXPECT().
-		WithField("security-group-ids", []string{a.GroupID}).
-		Return(testlib.NewLoggerEntry()).
-		Times(1).
-		After(a.Mocks.API.EC2.EXPECT().
-			DescribeSecurityGroups(gomock.Any()).
-			Return(nil, errors.New("invalid group id")))
+	a.Mocks.API.EC2.EXPECT().
+		DescribeSecurityGroups(gomock.Any()).
+		Return(nil, errors.New("invalid group id"))
 
 	err := a.Mocks.AWS.rdsEnsureDBClusterCreated(CloudID(a.InstallationA.ID), a.VPCa, a.DBUser, a.DBPassword, a.RDSEncryptionKeyID, a.RDSEngineType, a.Mocks.Log.Logger)
 	a.Assert().Error(err)
@@ -130,15 +105,11 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterCreatedSubnetError() {
 				SecurityGroups: []*ec2.SecurityGroup{{GroupId: &a.GroupID}},
 			}, nil))
 
-	a.Mocks.Log.Logger.EXPECT().
-		WithField("db-subnet-group-name", DBSubnetGroupName(a.VPCa)).
-		Return(testlib.NewLoggerEntry()).
-		Times(1).
-		After(a.Mocks.API.RDS.EXPECT().
-			DescribeDBSubnetGroups(gomock.Any()).
-			Return(&rds.DescribeDBSubnetGroupsOutput{
-				DBSubnetGroups: []*rds.DBSubnetGroup{},
-			}, errors.New("invalid cluster id")))
+	a.Mocks.API.RDS.EXPECT().
+		DescribeDBSubnetGroups(gomock.Any()).
+		Return(&rds.DescribeDBSubnetGroupsOutput{
+			DBSubnetGroups: []*rds.DBSubnetGroup{},
+		}, errors.New("invalid cluster id"))
 
 	err := a.Mocks.AWS.rdsEnsureDBClusterCreated(CloudID(a.InstallationA.ID), a.VPCa, a.DBUser, a.DBPassword, a.RDSEncryptionKeyID, a.RDSEngineType, a.Mocks.Log.Logger)
 
@@ -188,11 +159,6 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterCreatedError() {
 }
 
 func (a *AWSTestSuite) TestRDSEnsureDBClusterInstanceCreated() {
-	a.Mocks.Log.Logger.EXPECT().
-		Infof("Provisioning AWS RDS database with ID %s", CloudID(a.InstallationA.ID)).
-		Return().
-		Times(1)
-
 	a.Mocks.API.RDS.EXPECT().
 		DescribeDBInstances(gomock.Any()).
 		Return(nil, errors.New("db cluster instance does not exist")).
@@ -216,11 +182,6 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterInstanceCreated() {
 }
 
 func (a *AWSTestSuite) TestRDSEnsureDBClusterInstanceAlreadyExistError() {
-	a.Mocks.Log.Logger.EXPECT().
-		Infof("Provisioning AWS RDS database with ID %s", CloudID(a.InstallationA.ID)).
-		Return().
-		Times(1)
-
 	a.Mocks.API.RDS.EXPECT().
 		DescribeDBInstances(gomock.Any()).
 		Return(nil, nil).
@@ -237,11 +198,6 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterInstanceAlreadyExistError() {
 }
 
 func (a *AWSTestSuite) TestRDSEnsureDBClusterInstanceCreateError() {
-	a.Mocks.Log.Logger.EXPECT().
-		Infof("Provisioning AWS RDS database with ID %s", CloudID(a.InstallationA.ID)).
-		Return().
-		Times(1)
-
 	a.Mocks.API.RDS.EXPECT().
 		DescribeDBInstances(gomock.Any()).
 		Return(nil, errors.New("db cluster instance does not exist")).
@@ -249,16 +205,13 @@ func (a *AWSTestSuite) TestRDSEnsureDBClusterInstanceCreateError() {
 			a.Assert().Equal(*input.DBInstanceIdentifier, RDSMasterInstanceID(a.InstallationA.ID))
 		})
 
-	a.Mocks.Log.Logger.EXPECT().WithField("db-instance-name", RDSMasterInstanceID(a.InstallationA.ID)).
-		Return(testlib.NewLoggerEntry()).
-		Times(1).
-		After(a.Mocks.API.RDS.EXPECT().
-			CreateDBInstance(gomock.Any()).Return(nil, errors.New("instance creation failure")).
-			Do(func(input *rds.CreateDBInstanceInput) {
-				a.Assert().Equal(*input.DBClusterIdentifier, CloudID(a.InstallationA.ID))
-				a.Assert().Equal(*input.DBInstanceIdentifier, RDSMasterInstanceID(a.InstallationA.ID))
-			}).
-			Times(1))
+	a.Mocks.API.RDS.EXPECT().
+		CreateDBInstance(gomock.Any()).Return(nil, errors.New("instance creation failure")).
+		Do(func(input *rds.CreateDBInstanceInput) {
+			a.Assert().Equal(*input.DBClusterIdentifier, CloudID(a.InstallationA.ID))
+			a.Assert().Equal(*input.DBInstanceIdentifier, RDSMasterInstanceID(a.InstallationA.ID))
+		}).
+		Times(1)
 
 	err := a.Mocks.AWS.rdsEnsureDBClusterInstanceCreated(CloudID(a.InstallationA.ID), RDSMasterInstanceID(a.InstallationA.ID), a.RDSEngineType, "db.r5.large", a.Mocks.Log.Logger)
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Some calls expected by the tests were no longer performed (mostly logs) this caused new version of `gomock` mark tests as failed.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-39469

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Make AWS tests compatible with gomock 1.6.0
```
