### PR TITLE
Cleanup database migration backups

### DIFF
--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1648,4 +1648,17 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.32.0"), semver.MustParse("0.32.1"), func(e execer) error {
+		_, err := e.Exec(`DROP TABLE MultitenantDatabaseBackup;`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`DROP TABLE MultitenantDatabaseBackup2;`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }


### PR DESCRIPTION
Removes the backups from before the pgbouncer refactor.

```release-note
Cleanup database migration backups
```
