### PR TITLE
Add Provisioner Events model and store

### DIFF
--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -117,9 +117,8 @@ func (sqlStore *SQLStore) createEventDeliveries(db dbInterface, event *model.Eve
 	// Although we do not expect huge number of subscriptions
 	// max number of prepared statement tokens is 999, so we batch
 	// for sake of future proofing.
-	batchStart := 0
 	batchSize := 50
-	for batchStart < len(subscriptions) {
+	for batchStart := 0; batchStart < len(subscriptions); batchStart += batchSize {
 		end := batchStart + batchSize
 		if end > len(subscriptions) {
 			end = len(subscriptions)
@@ -128,7 +127,6 @@ func (sqlStore *SQLStore) createEventDeliveries(db dbInterface, event *model.Eve
 		if err != nil {
 			return err
 		}
-		batchStart += batchSize
 	}
 
 	return nil

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -308,7 +308,7 @@ func (sqlStore *SQLStore) GetDeliveriesForSubscription(subID string) ([]*model.E
 	deliveries := []*model.EventDelivery{}
 	err := sqlStore.selectBuilder(sqlStore.db, &deliveries, query)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get event delivery")
+		return nil, errors.Wrap(err, "failed to get event deliveries")
 	}
 
 	return deliveries, nil

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -48,7 +48,8 @@ func (sqlStore *SQLStore) CreateStateChangeEvent(event *model.StateChangeEventDa
 		return errors.Wrap(err, "failed to create state change event")
 	}
 
-	subscriptions, err := sqlStore.getSubscriptions(tx, &model.SubscriptionsFilter{EventType: event.Event.EventType, Paging: model.AllPagesNotDeleted()})
+	subFilter := model.SubscriptionsFilter{EventType: event.Event.EventType, Paging: model.AllPagesNotDeleted()}
+	subscriptions, err := sqlStore.getSubscriptions(tx, &subFilter)
 	if err != nil {
 		return errors.Wrap(err, "failed to get subscriptions")
 	}
@@ -307,7 +308,7 @@ func (sqlStore *SQLStore) GetDeliveriesForSubscription(subID string) ([]*model.E
 	deliveries := []*model.EventDelivery{}
 	err := sqlStore.selectBuilder(sqlStore.db, &deliveries, query)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to update event delivery status")
+		return nil, errors.Wrap(err, "failed to get event delivery")
 	}
 
 	return deliveries, nil

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -1,0 +1,324 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+const (
+	subscriptionsTable    = "Subscription"
+	eventTable            = "Event"
+	eventDeliveryTable    = "EventDelivery"
+	stateChangeEventTable = "StateChangeEvent"
+)
+
+var (
+	eventDeliveryColumns = []string{"ID", "EventID", "SubscriptionID", "Status", "LastAttempt", "Attempts"}
+
+	stateChangeEventSelect = sq.Select("sc.ID, sc.ResourceID, sc.ResourceType, sc.OldState, sc.NewState, sc.EventID, e.Timestamp, e.EventType, e.ExtraData").
+				From("StateChangeEvent as sc").
+				Join("Event as e on sc.EventID = e.ID")
+)
+
+// CreateStateChangeEvent creates new StateChangeEvent and initializes EventDeliveries.
+func (sqlStore *SQLStore) CreateStateChangeEvent(event *model.StateChangeEventData) error {
+	tx, err := sqlStore.beginTransaction(sqlStore.db)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	err = sqlStore.createEvent(tx, &event.Event)
+	if err != nil {
+		return errors.Wrap(err, "failed to create event")
+	}
+
+	event.StateChange.EventID = event.Event.ID
+
+	err = sqlStore.createStateChangeEvent(tx, &event.StateChange)
+	if err != nil {
+		return errors.Wrap(err, "failed to create state change event")
+	}
+
+	subscriptions, err := sqlStore.getSubscriptions(tx, &model.SubscriptionsFilter{EventType: event.Event.EventType, Paging: model.AllPagesNotDeleted()})
+	if err != nil {
+		return errors.Wrap(err, "failed to get subscriptions")
+	}
+
+	err = sqlStore.createEventDeliveries(tx, &event.Event, subscriptions)
+	if err != nil {
+		return errors.Wrap(err, "failed to create event deliveries")
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return errors.Wrap(err, "failed to commit transaction")
+	}
+	return nil
+}
+
+func (sqlStore *SQLStore) createEvent(db execer, event *model.Event) error {
+	event.ID = model.NewID()
+
+	extraData, err := json.Marshal(event.ExtraData)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal events' extra data")
+	}
+
+	_, err = sqlStore.execBuilder(db, sq.
+		Insert(eventTable).
+		SetMap(map[string]interface{}{
+			"ID":        event.ID,
+			"EventType": event.EventType,
+			"Timestamp": event.Timestamp,
+			"ExtraData": extraData,
+		}),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to create event")
+	}
+	return nil
+}
+
+func (sqlStore *SQLStore) createStateChangeEvent(db execer, event *model.StateChangeEvent) error {
+	event.ID = model.NewID()
+
+	_, err := sqlStore.execBuilder(db, sq.
+		Insert(stateChangeEventTable).
+		SetMap(map[string]interface{}{
+			"ID":           event.ID,
+			"EventID":      event.EventID,
+			"ResourceID":   event.ResourceID,
+			"ResourceType": event.ResourceType,
+			"OldState":     event.OldState,
+			"NewState":     event.NewState,
+		}),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to create state change event")
+	}
+	return nil
+}
+
+func (sqlStore *SQLStore) createEventDeliveries(db dbInterface, event *model.Event, subscriptions []*model.Subscription) error {
+	if len(subscriptions) == 0 {
+		return nil
+	}
+
+	// Although we do not expect huge number of subscriptions
+	// max number of prepared statement tokens is 999, so we batch
+	// for sake of future proofing.
+	batchStart := 0
+	batchSize := 50
+	for batchStart < len(subscriptions) {
+		end := batchStart + batchSize
+		if end > len(subscriptions) {
+			end = len(subscriptions)
+		}
+		err := sqlStore.insertEventDeliveries(db, event, subscriptions[batchStart:end])
+		if err != nil {
+			return err
+		}
+		batchStart += batchSize
+	}
+
+	return nil
+}
+
+func (sqlStore *SQLStore) insertEventDeliveries(db dbInterface, event *model.Event, subscriptions []*model.Subscription) error {
+	builder := sq.Insert("EventDelivery").Columns(eventDeliveryColumns...)
+	for _, sub := range subscriptions {
+		builder = builder.Values(model.NewID(), event.ID, sub.ID, model.EventDeliveryNotAttempted, 0, 0)
+	}
+
+	_, err := sqlStore.execBuilder(db, builder)
+	if err != nil {
+		return errors.Wrap(err, "failed to create event deliveries")
+	}
+	return nil
+}
+
+// stateChangeEventData is a helper struct for querying joined data of Event and StateChangeEvent.
+type stateChangeEventData struct {
+	EventType model.EventType
+	Timestamp int64
+	ExtraData []byte
+	model.StateChangeEvent
+}
+
+func (s stateChangeEventData) toStateChangeEventData() (model.StateChangeEventData, error) {
+	extraData := model.EventExtraData{}
+	err := json.Unmarshal(s.ExtraData, &extraData)
+	if err != nil {
+		return model.StateChangeEventData{}, errors.Wrapf(err, "failed to unmarshal events' extra data, eventID: %q", s.EventID)
+	}
+
+	return model.StateChangeEventData{
+		Event: model.Event{
+			ID:        s.EventID,
+			EventType: s.EventType,
+			Timestamp: s.Timestamp,
+			ExtraData: extraData,
+		},
+		StateChange: s.StateChangeEvent,
+	}, nil
+}
+
+// GetStateChangeEventsToProcess returns StateChangeEventDeliveryData for given subscription in order of occurrence.
+func (sqlStore *SQLStore) GetStateChangeEventsToProcess(subID string) ([]*model.StateChangeEventDeliveryData, error) {
+	var eventDeliveries []*model.EventDelivery
+	err := sqlStore.selectBuilder(sqlStore.db, &eventDeliveries,
+		sq.Select(eventDeliveryColumns...).
+			From(eventDeliveryTable).
+			Where("SubscriptionID = ?", subID).
+			Where(sq.Eq{"Status": []model.EventDeliveryStatus{model.EventDeliveryNotAttempted, model.EventDeliveryRetrying}}),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query event deliveries for subscription")
+	}
+
+	eventIDs := make([]string, 0, len(eventDeliveries))
+	for _, e := range eventDeliveries {
+		eventIDs = append(eventIDs, e.EventID)
+	}
+
+	var eventsData []stateChangeEventData
+	err = sqlStore.selectBuilder(sqlStore.db, &eventsData,
+		stateChangeEventSelect.
+			Where(sq.Eq{"sc.EventID": eventIDs}).
+			OrderBy("e.Timestamp ASC"),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query state change events for subscription")
+	}
+
+	if len(eventsData) != len(eventDeliveries) {
+		return nil, errors.Errorf("number of found events does not match number of deliveries, events: %d, deliveries: %d",
+			len(eventsData), len(eventDeliveries))
+	}
+
+	deliveryData := make([]*model.StateChangeEventDeliveryData, len(eventsData))
+	for i, event := range eventsData {
+		delivery, found := model.EventDeliveryForEvent(event.EventID, eventDeliveries)
+		if !found {
+			return nil, errors.Wrap(err, "failed to find event delivery for the event")
+		}
+
+		eventData, err := event.toStateChangeEventData()
+		if err != nil {
+			return nil, err
+		}
+
+		deliveryData[i] = &model.StateChangeEventDeliveryData{
+			EventDelivery: *delivery,
+			EventData:     eventData,
+		}
+	}
+
+	return deliveryData, nil
+}
+
+// GetStateChangeEvent fetches StateChangeEventData based on specified event ID.
+func (sqlStore *SQLStore) GetStateChangeEvent(eventID string) (*model.StateChangeEventData, error) {
+	var event stateChangeEventData
+	err := sqlStore.getBuilder(sqlStore.db, &event,
+		stateChangeEventSelect.Where("e.ID = ?", eventID),
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get event")
+	}
+
+	eventData, err := event.toStateChangeEventData()
+	if err != nil {
+		return nil, err
+	}
+	return &eventData, nil
+}
+
+// GetStateChangeEvents fetches StateChangeEventData based on the filter.
+func (sqlStore *SQLStore) GetStateChangeEvents(filter *model.StateChangeEventFilter) ([]*model.StateChangeEventData, error) {
+	query := stateChangeEventSelect.OrderBy("e.Timestamp DESC")
+
+	if filter.Paging.PerPage != model.AllPerPage {
+		query = query.
+			Limit(uint64(filter.Paging.PerPage)).
+			Offset(uint64(filter.Paging.Page * filter.Paging.PerPage))
+	}
+
+	if filter.ResourceType != "" {
+		query = query.Where("sc.ResourceType = ?", filter.ResourceType)
+	}
+	if filter.ResourceID != "" {
+		query = query.Where("sc.ResourceID = ?", filter.ResourceID)
+	}
+
+	var eventsData []stateChangeEventData
+	err := sqlStore.selectBuilder(sqlStore.db, &eventsData, query)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query state change events")
+	}
+
+	out := make([]*model.StateChangeEventData, len(eventsData))
+	for i, ed := range eventsData {
+		data, err := ed.toStateChangeEventData()
+		if err != nil {
+			return nil, err
+		}
+
+		out[i] = &data
+	}
+
+	return out, nil
+}
+
+// UpdateEventDeliveryStatus updates status fields of EventDelivery.
+func (sqlStore *SQLStore) UpdateEventDeliveryStatus(delivery *model.EventDelivery) error {
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.Update(eventDeliveryTable).
+		SetMap(map[string]interface{}{
+			"Status":      delivery.Status,
+			"Attempts":    delivery.Attempts,
+			"LastAttempt": delivery.LastAttempt,
+		}).
+		Where("ID = ?", delivery.ID),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to update event delivery status")
+	}
+
+	return nil
+}
+
+// GetDeliveriesForSubscription is a helper function used for some tests.
+func (sqlStore *SQLStore) GetDeliveriesForSubscription(subID string) ([]*model.EventDelivery, error) {
+	query := sq.Select("*").From(eventDeliveryTable).
+		Where("SubscriptionID = ?", subID)
+
+	deliveries := []*model.EventDelivery{}
+	err := sqlStore.selectBuilder(sqlStore.db, &deliveries, query)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update event delivery status")
+	}
+
+	return deliveries, nil
+}
+
+// lockSubscription marks the subscription as locked for exclusive use by the caller.
+func (sqlStore *SQLStore) lockSubscription(db execer, subID, lockerID string) (bool, error) {
+	return sqlStore.lockRowsTx(db, subscriptionsTable, []string{subID}, lockerID)
+}
+
+// UnlockSubscription releases a lock previously acquired against a caller.
+func (sqlStore *SQLStore) UnlockSubscription(subID, lockerID string, force bool) (bool, error) {
+	return sqlStore.unlockRows(subscriptionsTable, []string{subID}, lockerID, force)
+}

--- a/internal/store/events_subscription.go
+++ b/internal/store/events_subscription.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+var (
+	subscriptionsColumns = []string{
+		"ID",
+		"URL",
+		"Name",
+		"OwnerID",
+		"EventType",
+		"FailureThreshold",
+		"LastDeliveryStatus",
+		"LastDeliveryAttemptAt",
+		"CreateAt",
+		"DeleteAt",
+		"LockAcquiredBy",
+		"LockAcquiredAt",
+	}
+
+	subscriptionsSelect = sq.Select(subscriptionsColumns...).
+				From(subscriptionsTable)
+
+	claimSubscriptionSelect = sq.Select(prefixAll("sub.", subscriptionsColumns)...).
+				From(fmt.Sprintf("%s as sub", subscriptionsTable)).
+				Join("EventDelivery ON sub.ID=EventDelivery.SubscriptionID").
+				Where("DeleteAt = 0").
+		// Take only not claimed subscriptions.
+		Where("sub.LockAcquiredAt = 0").
+		Where(sq.Eq{"LockAcquiredBy": nil}).
+		// Start with subscriptions that were not processed recently.
+		OrderBy("sub.LastDeliveryAttemptAt ASC").
+		Limit(1)
+)
+
+// ErrNoSubscriptionsToProcess indicates that there is no subscription to claim.
+var ErrNoSubscriptionsToProcess error = fmt.Errorf("no subscriptions to process")
+
+// ClaimUpToDateSubscription fetches and locks first subscription which last delivery did not fail and has events to process.
+func (sqlStore *SQLStore) ClaimUpToDateSubscription(instanceID string) (*model.Subscription, error) {
+	query := claimSubscriptionSelect.
+		// Only new and succeeded on last attempt.
+		Where(sq.Eq{"sub.LastDeliveryStatus": []model.SubscriptionDeliveryStatus{model.SubscriptionDeliverySucceeded, model.SubscriptionDeliveryNone}}).
+		// Have new, not delivered events.
+		Where("EventDelivery.status = ?", model.EventDeliveryNotAttempted)
+
+	return sqlStore.claimSubscription(instanceID, query)
+}
+
+// ClaimRetryingSubscription fetches and locks first subscription which last delivery failed and has events to process.
+func (sqlStore *SQLStore) ClaimRetryingSubscription(instanceID string, cooldown time.Duration) (*model.Subscription, error) {
+	minTime := model.GetMillis() - cooldown.Milliseconds()
+
+	query := claimSubscriptionSelect.
+		// Failed on last delivery.
+		Where("sub.LastDeliveryStatus = ?", model.SubscriptionDeliveryFailed).
+		// More than some time ago.
+		Where("sub.LastDeliveryAttemptAt < ?", minTime).
+		// And have retrying or new events.
+		Where(sq.Eq{"EventDelivery.status": []model.EventDeliveryStatus{model.EventDeliveryRetrying, model.EventDeliveryNotAttempted}})
+
+	return sqlStore.claimSubscription(instanceID, query)
+}
+
+func (sqlStore *SQLStore) claimSubscription(instanceID string, query sq.SelectBuilder) (*model.Subscription, error) {
+	tx, err := sqlStore.beginTransaction(sqlStore.db)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	if sqlStore.db.DriverName() == "postgres" {
+		// To avoid conflicts on custom lock, we make Postgres lock the row
+		// for the time of transaction with `FOR UPDATE`.
+		// For multiple calls to not block when asking for the same row,
+		// we use `SKIP LOCKED` as we only need one row that matches our expectations.
+		// SQLite does not understand this query as it is not needed there,
+		// due to SQLite using single connection.
+		query = query.Suffix("FOR UPDATE SKIP LOCKED")
+	}
+
+	subscriptions := []*model.Subscription{}
+	err = sqlStore.selectBuilder(tx, &subscriptions, query)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to claim subscription")
+	}
+
+	if len(subscriptions) == 0 {
+		return nil, ErrNoSubscriptionsToProcess
+	}
+	if len(subscriptions) > 1 {
+		return nil, errors.Errorf("expected only one subscription")
+	}
+
+	sub := subscriptions[0]
+
+	locked, err := sqlStore.lockSubscription(tx, sub.ID, instanceID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to lock subscription")
+	}
+	if !locked {
+		return nil, errors.New("failed to lock subscription")
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to commit transaction")
+	}
+	return sub, nil
+}
+
+// CountSubscriptionsForEvent count number of subscriptions for the specified event type.
+func (sqlStore *SQLStore) CountSubscriptionsForEvent(eventType model.EventType) (int64, error) {
+	query := sq.Select("Count (*)").From(subscriptionsTable).
+		Where("eventType = ?", eventType).
+		Where("DeleteAt = 0")
+
+	count, err := sqlStore.getCount(query)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get subscriptions count")
+	}
+	return count, nil
+}
+
+// CreateSubscription creates new subscription.
+func (sqlStore *SQLStore) CreateSubscription(sub *model.Subscription) error {
+	sub.ID = model.NewID()
+	sub.CreateAt = model.GetMillis()
+
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.Insert(subscriptionsTable).
+		SetMap(map[string]interface{}{
+			"ID":                    sub.ID,
+			"Name":                  sub.Name,
+			"URL":                   sub.URL,
+			"OwnerID":               sub.OwnerID,
+			"EventType":             sub.EventType,
+			"LastDeliveryAttemptAt": sub.LastDeliveryAttemptAt,
+			"LastDeliveryStatus":    sub.LastDeliveryStatus,
+			"FailureThreshold":      sub.FailureThreshold,
+			"CreateAt":              sub.CreateAt,
+			"DeleteAt":              sub.DeleteAt,
+			"LockAcquiredAt":        sub.LockAcquiredAt,
+			"LockAcquiredBy":        sub.LockAcquiredBy,
+		}))
+	if err != nil {
+		return errors.Wrap(err, "failed to create subscription")
+	}
+
+	return nil
+}
+
+// UpdateSubscriptionStatus updates subscription status.
+func (sqlStore *SQLStore) UpdateSubscriptionStatus(sub *model.Subscription) error {
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.Update(subscriptionsTable).
+		SetMap(map[string]interface{}{
+			"LastDeliveryStatus":    sub.LastDeliveryStatus,
+			"LastDeliveryAttemptAt": sub.LastDeliveryAttemptAt,
+		}).
+		Where("ID = ?", sub.ID).
+		Where("DeleteAt = 0"),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to update event delivery status")
+	}
+
+	return nil
+}
+
+// GetSubscriptions fetches subscriptions specified by the filter.
+func (sqlStore *SQLStore) GetSubscriptions(filter *model.SubscriptionsFilter) ([]*model.Subscription, error) {
+	return sqlStore.getSubscriptions(sqlStore.db, filter)
+}
+
+func (sqlStore *SQLStore) getSubscriptions(db queryer, filter *model.SubscriptionsFilter) ([]*model.Subscription, error) {
+	query := subscriptionsSelect.
+		OrderBy("CreateAt DESC")
+	query = applyPagingFilter(query, filter.Paging)
+
+	if filter.EventType != "" {
+		query = query.Where("eventType = ?", filter.EventType)
+	}
+	if filter.Owner != "" {
+		query = query.Where("ownerID = ?", filter.Owner)
+	}
+
+	subs := []*model.Subscription{}
+	err := sqlStore.selectBuilder(db, &subs, query)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get subscription")
+	}
+
+	return subs, nil
+}
+
+// GetSubscription fetches a subscription by ID.
+func (sqlStore *SQLStore) GetSubscription(subID string) (*model.Subscription, error) {
+	sub := model.Subscription{}
+	err := sqlStore.getBuilder(sqlStore.db, &sub, subscriptionsSelect.Where("ID = ?", subID))
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get subscription")
+	}
+
+	return &sub, nil
+}
+
+// DeleteSubscription marks the given subscription as deleted.
+func (sqlStore *SQLStore) DeleteSubscription(id string) error {
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Update(subscriptionsTable).
+		Set("DeleteAt", model.GetMillis()).
+		Where("ID = ?", id).
+		Where("DeleteAt = 0"),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to mark subscription as deleted")
+	}
+
+	return nil
+}
+
+func prefixAll(prefix string, strs []string) []string {
+	out := make([]string, len(strs))
+	for i := range strs {
+		out[i] = fmt.Sprintf("%s%s", prefix, strs[i])
+	}
+	return out
+}

--- a/internal/store/events_subscription_test.go
+++ b/internal/store/events_subscription_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountSubscriptionsForEvent(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	sub1 := &model.Subscription{
+		EventType: model.ResourceStateChangeEventType,
+	}
+	err := sqlStore.CreateSubscription(sub1)
+	require.NoError(t, err)
+	sub2 := &model.Subscription{
+		EventType: model.ResourceStateChangeEventType,
+	}
+	err = sqlStore.CreateSubscription(sub2)
+	require.NoError(t, err)
+	sub3 := &model.Subscription{
+		EventType: "different",
+	}
+	err = sqlStore.CreateSubscription(sub3)
+	require.NoError(t, err)
+
+	subsCount, err := sqlStore.CountSubscriptionsForEvent(model.ResourceStateChangeEventType)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), subsCount)
+}
+
+func TestGetCreateUpdateSubscription(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	sub := &model.Subscription{
+		Name:                  "test",
+		URL:                   "http://test",
+		OwnerID:               "tester",
+		EventType:             model.ResourceStateChangeEventType,
+		LastDeliveryStatus:    model.SubscriptionDeliverySucceeded,
+		LastDeliveryAttemptAt: 100,
+		FailureThreshold:      2 * time.Minute,
+	}
+	err := sqlStore.CreateSubscription(sub)
+	require.NoError(t, err)
+	assert.NotEmpty(t, sub.ID)
+
+	fetchedSub, err := sqlStore.GetSubscription(sub.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test", fetchedSub.Name)
+	assert.Equal(t, "http://test", fetchedSub.URL)
+	assert.Equal(t, "tester", fetchedSub.OwnerID)
+	assert.Equal(t, model.ResourceStateChangeEventType, fetchedSub.EventType)
+	assert.Equal(t, model.SubscriptionDeliverySucceeded, fetchedSub.LastDeliveryStatus)
+	assert.Equal(t, int64(100), fetchedSub.LastDeliveryAttemptAt)
+	assert.Equal(t, 2*time.Minute, fetchedSub.FailureThreshold)
+
+	t.Run("unknown ID", func(t *testing.T) {
+		s, err := sqlStore.GetSubscription(model.NewID())
+		require.NoError(t, err)
+		assert.Nil(t, s)
+	})
+
+	sub.LastDeliveryStatus = model.SubscriptionDeliveryFailed
+	sub.LastDeliveryAttemptAt = 10000
+	sub.Name = "should not change"
+
+	err = sqlStore.UpdateSubscriptionStatus(sub)
+	require.NoError(t, err)
+
+	fetchedSub, err = sqlStore.GetSubscription(sub.ID)
+	require.NoError(t, err)
+	assert.Equal(t, model.SubscriptionDeliveryFailed, fetchedSub.LastDeliveryStatus)
+	assert.Equal(t, int64(10000), fetchedSub.LastDeliveryAttemptAt)
+	assert.Equal(t, "test", fetchedSub.Name)
+
+	err = sqlStore.DeleteSubscription(sub.ID)
+	require.NoError(t, err)
+
+	fetchedSub, err = sqlStore.GetSubscription(sub.ID)
+	require.NoError(t, err)
+	assert.True(t, fetchedSub.DeleteAt > 0)
+}
+
+func TestGetSubscriptions(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	subs := []*model.Subscription{
+		{OwnerID: "tester1", EventType: model.ResourceStateChangeEventType},
+		{OwnerID: "tester1", EventType: "test"},
+		{OwnerID: "tester2", EventType: model.ResourceStateChangeEventType},
+		{OwnerID: "tester3", EventType: "test2"},
+	}
+
+	for i := range subs {
+		err := sqlStore.CreateSubscription(subs[i])
+		require.NoError(t, err)
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	err := sqlStore.DeleteSubscription(subs[3].ID)
+	require.NoError(t, err)
+
+	for _, testCase := range []struct {
+		description string
+		filter      *model.SubscriptionsFilter
+		fetchedIds  []string
+	}{
+		{
+			description: "fetch all not deleted",
+			filter:      &model.SubscriptionsFilter{Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{subs[2].ID, subs[1].ID, subs[0].ID},
+		},
+		{
+			description: "fetch all with deleted",
+			filter:      &model.SubscriptionsFilter{Paging: model.AllPagesWithDeleted()},
+			fetchedIds:  []string{subs[3].ID, subs[2].ID, subs[1].ID, subs[0].ID},
+		},
+		{
+			description: "fetch by owner",
+			filter:      &model.SubscriptionsFilter{Owner: "tester1", Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{subs[1].ID, subs[0].ID},
+		},
+		{
+			description: "fetch by event type",
+			filter:      &model.SubscriptionsFilter{EventType: model.ResourceStateChangeEventType, Paging: model.AllPagesNotDeleted()},
+			fetchedIds:  []string{subs[2].ID, subs[0].ID},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			fetchedSubs, err := sqlStore.GetSubscriptions(testCase.filter)
+			require.NoError(t, err)
+			assert.Equal(t, len(testCase.fetchedIds), len(fetchedSubs))
+
+			for i, b := range fetchedSubs {
+				assert.Equal(t, testCase.fetchedIds[i], b.ID)
+			}
+		})
+	}
+}

--- a/internal/store/events_test.go
+++ b/internal/store/events_test.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ClaimSubscriptionsAndGetDeliveries(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+	instanceID := model.NewID()
+
+	sub1 := &model.Subscription{
+		URL:                   "test1",
+		EventType:             model.ResourceStateChangeEventType,
+		LastDeliveryStatus:    model.SubscriptionDeliverySucceeded,
+		LastDeliveryAttemptAt: 100,
+	}
+	sub2 := &model.Subscription{
+		URL:                   "test2",
+		EventType:             model.ResourceStateChangeEventType,
+		LastDeliveryStatus:    model.SubscriptionDeliverySucceeded,
+		LastDeliveryAttemptAt: 101,
+	}
+	sub3 := &model.Subscription{
+		URL:                   "test3",
+		EventType:             "unknown event type",
+		LastDeliveryStatus:    model.SubscriptionDeliverySucceeded,
+		LastDeliveryAttemptAt: 103,
+	}
+	sub4 := &model.Subscription{
+		URL:                   "test4",
+		EventType:             model.ResourceStateChangeEventType,
+		LastDeliveryStatus:    model.SubscriptionDeliverySucceeded,
+		LastDeliveryAttemptAt: 104,
+	}
+
+	err := sqlStore.CreateSubscription(sub1)
+	require.NoError(t, err)
+	err = sqlStore.CreateSubscription(sub2)
+	require.NoError(t, err)
+	err = sqlStore.CreateSubscription(sub3)
+	require.NoError(t, err)
+	err = sqlStore.CreateSubscription(sub4)
+	require.NoError(t, err)
+
+	// Deleted subscription should not be picked.
+	err = sqlStore.DeleteSubscription(sub4.ID)
+	require.NoError(t, err)
+
+	eventData1 := &model.StateChangeEventData{
+		Event: model.Event{
+			EventType: model.ResourceStateChangeEventType,
+			Timestamp: model.GetMillis(),
+		},
+		StateChange: model.StateChangeEvent{
+			OldState:     "old",
+			NewState:     "new",
+			ResourceID:   "installation1",
+			ResourceType: "installation",
+		},
+	}
+	time.Sleep(1 * time.Millisecond) // Make sure timestamps differ
+	eventData2 := &model.StateChangeEventData{
+		Event: model.Event{
+			EventType: model.ResourceStateChangeEventType,
+			Timestamp: model.GetMillis(),
+		},
+		StateChange: model.StateChangeEvent{
+			OldState:     "old",
+			NewState:     "new",
+			ResourceID:   "installation1",
+			ResourceType: "installation",
+		},
+	}
+	err = sqlStore.CreateStateChangeEvent(eventData1)
+	require.NoError(t, err)
+	err = sqlStore.CreateStateChangeEvent(eventData2)
+	require.NoError(t, err)
+
+	// Claim first subscription
+	subscription, err := sqlStore.ClaimUpToDateSubscription(instanceID)
+	require.NoError(t, err)
+	assert.Equal(t, sub1.ID, subscription.ID)
+
+	subscription, err = sqlStore.GetSubscription(subscription.ID)
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.True(t, subscription.LockAcquiredAt > 0)
+	assert.Equal(t, instanceID, *subscription.LockAcquiredBy)
+
+	// Claim second subscription
+	subscription2, err := sqlStore.ClaimUpToDateSubscription(instanceID)
+	require.NoError(t, err)
+	assert.Equal(t, sub2.ID, subscription2.ID)
+
+	subscription2, err = sqlStore.GetSubscription(subscription2.ID)
+	require.NoError(t, err)
+	require.NotNil(t, subscription2)
+	assert.True(t, subscription2.LockAcquiredAt > 0)
+	assert.Equal(t, instanceID, *subscription2.LockAcquiredBy)
+
+	// Do not claim any if all are already claimed
+	_, err = sqlStore.ClaimUpToDateSubscription(instanceID)
+	require.Error(t, err)
+	assert.Equal(t, ErrNoSubscriptionsToProcess, err)
+
+	// Mark event deliveries for firs subscription as success and release lock
+	deliveries, err := sqlStore.GetStateChangeEventsToProcess(sub1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(deliveries))
+
+	// Assert event IDs are set properly and events order is correct
+	assert.Equal(t, eventData1.Event.ID, deliveries[0].EventData.Event.ID)
+	assert.Equal(t, eventData1.StateChange.ID, deliveries[0].EventData.StateChange.ID)
+	assert.NotEqual(t, deliveries[0].EventData.Event.ID, deliveries[0].EventData.StateChange.ID)
+	assert.True(t, deliveries[0].EventData.Event.Timestamp < deliveries[1].EventData.Event.Timestamp)
+
+	deliveries[0].EventDelivery.LastAttempt = model.GetMillis()
+	deliveries[0].EventDelivery.Attempts = 1
+	deliveries[0].EventDelivery.Status = model.EventDeliveryDelivered
+	deliveries[1].EventDelivery.Status = model.EventDeliveryRetrying
+
+	err = sqlStore.UpdateEventDeliveryStatus(&deliveries[0].EventDelivery)
+	require.NoError(t, err)
+	err = sqlStore.UpdateEventDeliveryStatus(&deliveries[1].EventDelivery)
+	require.NoError(t, err)
+
+	sub1.LastDeliveryStatus = model.SubscriptionDeliveryFailed
+	err = sqlStore.UpdateSubscriptionStatus(sub1)
+	require.NoError(t, err)
+
+	unlocked, err := sqlStore.UnlockSubscription(sub1.ID, instanceID, false)
+	require.NoError(t, err)
+	assert.True(t, unlocked)
+
+	// Claim first subscription again and get retrying delivery to process
+	sub1, err = sqlStore.ClaimRetryingSubscription(instanceID, 10)
+	require.NoError(t, err)
+	assert.Equal(t, subscription.ID, sub1.ID)
+
+	deliveries, err = sqlStore.GetStateChangeEventsToProcess(sub1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(deliveries))
+
+	deliveries[0].EventDelivery.Status = model.EventDeliveryDelivered
+	err = sqlStore.UpdateEventDeliveryStatus(&deliveries[0].EventDelivery)
+	require.NoError(t, err)
+
+	unlocked, err = sqlStore.UnlockSubscription(sub1.ID, instanceID, false)
+	require.NoError(t, err)
+	assert.True(t, unlocked)
+
+	// Claim no subscription as no events to process
+	_, err = sqlStore.ClaimUpToDateSubscription(instanceID)
+	require.Error(t, err)
+	assert.Equal(t, ErrNoSubscriptionsToProcess, err)
+	_, err = sqlStore.ClaimRetryingSubscription(instanceID, 10)
+	require.Error(t, err)
+	assert.Equal(t, ErrNoSubscriptionsToProcess, err)
+}
+
+func TestGetStateChangeEvent(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	eventData1 := &model.StateChangeEventData{
+		Event: model.Event{
+			EventType: model.ResourceStateChangeEventType,
+			Timestamp: model.GetMillis(),
+			ExtraData: model.EventExtraData{Fields: map[string]string{
+				"key1": "val1",
+				"key2": "val2",
+			}},
+		},
+		StateChange: model.StateChangeEvent{
+			OldState:     "old",
+			NewState:     "new",
+			ResourceID:   "installation1",
+			ResourceType: "installation",
+		},
+	}
+	err := sqlStore.CreateStateChangeEvent(eventData1)
+	require.NoError(t, err)
+
+	event, err := sqlStore.GetStateChangeEvent(eventData1.Event.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, eventData1.Event.ID, event.Event.ID)
+	assert.Equal(t, eventData1.Event.EventType, event.Event.EventType)
+	assert.Equal(t, eventData1.Event.Timestamp, event.Event.Timestamp)
+	assert.Equal(t, eventData1.Event.ExtraData, event.Event.ExtraData)
+	assert.Equal(t, eventData1.StateChange.ID, event.StateChange.ID)
+	assert.Equal(t, eventData1.StateChange.EventID, event.StateChange.EventID)
+	assert.Equal(t, eventData1.StateChange.OldState, event.StateChange.OldState)
+	assert.Equal(t, eventData1.StateChange.NewState, event.StateChange.NewState)
+	assert.Equal(t, eventData1.StateChange.ResourceID, event.StateChange.ResourceID)
+	assert.Equal(t, eventData1.StateChange.ResourceType, event.StateChange.ResourceType)
+
+	t.Run("should not found", func(t *testing.T) {
+		event, err := sqlStore.GetStateChangeEvent(model.NewID())
+		require.NoError(t, err)
+		assert.Nil(t, event)
+	})
+}
+
+func TestGetStateChangeEvents(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+	defer CloseConnection(t, sqlStore)
+
+	events := []*model.StateChangeEventData{
+		{
+			Event:       model.Event{EventType: "test", Timestamp: 1000},
+			StateChange: model.StateChangeEvent{ResourceType: model.TypeInstallation, ResourceID: "inst1"},
+		},
+		{
+			Event:       model.Event{EventType: "test", Timestamp: 2000},
+			StateChange: model.StateChangeEvent{ResourceType: model.TypeInstallation, ResourceID: "inst2"},
+		},
+		{
+			Event:       model.Event{EventType: "test", Timestamp: 3000},
+			StateChange: model.StateChangeEvent{ResourceType: model.TypeCluster, ResourceID: "cluster1"},
+		},
+	}
+
+	for i := range events {
+		err := sqlStore.CreateStateChangeEvent(events[i])
+		require.NoError(t, err)
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	for _, testCase := range []struct {
+		description string
+		filter      *model.StateChangeEventFilter
+		fetched     int
+	}{
+		{
+			description: "fetch all for installations",
+			filter:      &model.StateChangeEventFilter{ResourceType: model.TypeInstallation, Paging: model.AllPagesNotDeleted()},
+			fetched:     2,
+		},
+		{
+			description: "fetch all fon specific ID",
+			filter:      &model.StateChangeEventFilter{ResourceID: "inst2", Paging: model.AllPagesNotDeleted()},
+			fetched:     1,
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			fetchedSubs, err := sqlStore.GetStateChangeEvents(testCase.filter)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.fetched, len(fetchedSubs))
+		})
+	}
+}

--- a/internal/store/lock.go
+++ b/internal/store/lock.go
@@ -12,7 +12,11 @@ import (
 
 // lockRow marks the row in the given table as locked for exclusive use by the caller.
 func (sqlStore *SQLStore) lockRows(table string, ids []string, lockerID string) (bool, error) {
-	result, err := sqlStore.execBuilder(sqlStore.db, sq.
+	return sqlStore.lockRowsTx(sqlStore.db, table, ids, lockerID)
+}
+
+func (sqlStore *SQLStore) lockRowsTx(db execer, table string, ids []string, lockerID string) (bool, error) {
+	result, err := sqlStore.execBuilder(db, sq.
 		Update(table).
 		SetMap(map[string]interface{}{
 			"LockAcquiredBy": lockerID,

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1648,7 +1648,20 @@ var migrations = []migration{
 
 		return nil
 	}},
-	{semver.MustParse("0.32.0"), semver.MustParse("0.33.0"), func(e execer) error {
+	{semver.MustParse("0.32.0"), semver.MustParse("0.32.1"), func(e execer) error {
+		_, err := e.Exec(`DROP TABLE MultitenantDatabaseBackup;`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`DROP TABLE MultitenantDatabaseBackup2;`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
+	{semver.MustParse("0.32.1"), semver.MustParse("0.33.0"), func(e execer) error {
 		// Add new tables for Provisioner Events:
 		// - Event
 		// - StateChangeEvent

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1648,13 +1648,70 @@ var migrations = []migration{
 
 		return nil
 	}},
-	{semver.MustParse("0.32.0"), semver.MustParse("0.32.1"), func(e execer) error {
-		_, err := e.Exec(`DROP TABLE MultitenantDatabaseBackup;`)
+	{semver.MustParse("0.32.0"), semver.MustParse("0.33.0"), func(e execer) error {
+		// Add new tables for Provisioner Events:
+		// - Event
+		// - StateChangeEvent
+		// - Subscription
+		// - EventDelivery
+
+		_, err := e.Exec(`
+			CREATE TABLE Event (
+				ID TEXT PRIMARY KEY,
+				Timestamp BIGINT NOT NULL,
+				EventType TEXT NOT NULL,
+				ExtraData BYTEA NOT NULL
+			);
+		`)
 		if err != nil {
 			return err
 		}
 
-		_, err = e.Exec(`DROP TABLE MultitenantDatabaseBackup2;`)
+		_, err = e.Exec(`
+			CREATE TABLE StateChangeEvent (
+				ID TEXT PRIMARY KEY,
+				EventID TEXT NOT NULL,
+				ResourceID TEXT NOT NULL,
+				ResourceType TEXT NOT NULL,
+				OldState TEXT NOT NULL,
+				NewState TEXT NOT NULL
+			);
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+			CREATE TABLE Subscription (
+				ID TEXT PRIMARY KEY,
+				Name TEXT NOT NULL,
+				URL TEXT NOT NULL,
+				OwnerID TEXT NOT NULL,
+				EventType TEXT NOT NULL,
+				LastDeliveryAttemptAt BIGINT NOT NULL,
+				LastDeliveryStatus TEXT NOT NULL,
+				FailureThreshold BIGINT NOT NULL,
+				CreateAt BIGINT NOT NULL,
+				DeleteAt BIGINT NOT NULL,
+				LockAcquiredBy TEXT NULL,
+				LockAcquiredAt BIGINT NOT NULL
+			);
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`
+			CREATE TABLE EventDelivery (
+				ID TEXT PRIMARY KEY,
+				EventID TEXT NOT NULL,
+				SubscriptionID TEXT NOT NULL,
+				Status TEXT NOT NULL,
+				LastAttempt BIGINT NOT NULL,
+				Attempts INT NOT NULL
+
+			);
+		`)
 		if err != nil {
 			return err
 		}

--- a/model/events.go
+++ b/model/events.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+// EventType represents the Provisioners' event type.
+type EventType string
+
+const (
+	// ResourceStateChangeEventType is event type representing resource state change.
+	ResourceStateChangeEventType EventType = "resourceStateChange"
+)
+
+// Event represent event produced by Provisioner.
+type Event struct {
+	ID        string
+	EventType EventType
+	Timestamp int64
+	ExtraData EventExtraData
+}
+
+// EventExtraData represents extra data of an Event.
+type EventExtraData struct {
+	Fields map[string]string `json:"fields"`
+}
+
+// EventDeliveryStatus represents status of EventDelivery
+type EventDeliveryStatus string
+
+const (
+	// EventDeliveryNotAttempted indicates that delivery was not yet tried.
+	EventDeliveryNotAttempted EventDeliveryStatus = "not-attempted"
+	// EventDeliveryDelivered indicates that delivery was successful.
+	EventDeliveryDelivered EventDeliveryStatus = "delivered"
+	// EventDeliveryRetrying indicates that delivery failed but will be retired.
+	EventDeliveryRetrying EventDeliveryStatus = "retrying"
+	// EventDeliveryFailed indicates that delivery failed and will not be retried.
+	EventDeliveryFailed EventDeliveryStatus = "failed"
+)
+
+// EventDelivery represents delivery status of particular Event to particular Subscription.
+type EventDelivery struct {
+	ID             string
+	Status         EventDeliveryStatus
+	LastAttempt    int64
+	Attempts       int
+	EventID        string
+	SubscriptionID string
+}
+
+// EventDeliveryForEvent finds first EventDelivery for a particular eventID in collection.
+func EventDeliveryForEvent(eventID string, deliveries []*EventDelivery) (*EventDelivery, bool) {
+	for _, ed := range deliveries {
+		if ed.EventID == eventID {
+			return ed, true
+		}
+	}
+	return nil, false
+}

--- a/model/events_state_change.go
+++ b/model/events_state_change.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+	"net/url"
+)
+
+// StateChangeEvent contains data specific to StateChangeEvent.
+type StateChangeEvent struct {
+	ID           string
+	EventID      string
+	OldState     string
+	NewState     string
+	ResourceID   string
+	ResourceType ResourceType
+}
+
+// StateChangeEventData is a combination of StateChangeEvent and Event data.
+type StateChangeEventData struct {
+	Event       Event
+	StateChange StateChangeEvent
+}
+
+// StateChangeEventDeliveryData is a combination of StateChangeEventData and EventDelivery.
+type StateChangeEventDeliveryData struct {
+	EventDelivery EventDelivery
+	EventData     StateChangeEventData
+}
+
+// StateChangeEventPayload represents payload that is sent to consumers.
+type StateChangeEventPayload struct {
+	EventID      string       `json:"eventId"`
+	Timestamp    int64        `json:"timestamp"`
+	ResourceID   string       `json:"resourceId"`
+	ResourceType ResourceType `json:"resourceType"`
+	NewState     string       `json:"newState"`
+	OldState     string       `json:"oldState"`
+	ExtraData    map[string]string
+}
+
+// ToEventPayload converts StateChangeEventData to StateChangeEventPayload.
+func (e *StateChangeEventData) ToEventPayload() StateChangeEventPayload {
+	return StateChangeEventPayload{
+		EventID:      e.Event.ID,
+		Timestamp:    e.Event.Timestamp,
+		ResourceID:   e.StateChange.ResourceID,
+		ResourceType: e.StateChange.ResourceType,
+		NewState:     e.StateChange.NewState,
+		OldState:     e.StateChange.OldState,
+		ExtraData:    e.Event.ExtraData.Fields,
+	}
+}
+
+// ToWebhookPayload converts StateChangeEventData to WebhookPayload.
+func (e *StateChangeEventData) ToWebhookPayload() WebhookPayload {
+	return WebhookPayload{
+		EventID:   e.Event.ID,
+		Timestamp: e.Event.Timestamp,
+		ID:        e.StateChange.ResourceID,
+		Type:      e.StateChange.ResourceType,
+		NewState:  e.StateChange.NewState,
+		OldState:  e.StateChange.OldState,
+		ExtraData: e.Event.ExtraData.Fields,
+	}
+}
+
+// NewStateChangeEventPayloadFromReader will create a StateChangeEventPayload from an
+// io.Reader with JSON data.
+func NewStateChangeEventPayloadFromReader(reader io.Reader) (*StateChangeEventPayload, error) {
+	eventPayload := StateChangeEventPayload{}
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&eventPayload)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &eventPayload, nil
+}
+
+// NewStateChangeEventsDataFromReader will create an array of StateChangeEventData from an
+// io.Reader with JSON data.
+func NewStateChangeEventsDataFromReader(reader io.Reader) ([]*StateChangeEventData, error) {
+	data := []*StateChangeEventData{}
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&data)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// StateChangeEventFilter is a filter for state change event queries.
+type StateChangeEventFilter struct {
+	Paging
+	ResourceType ResourceType
+	ResourceID   string
+}
+
+// ListStateChangeEventsRequest represents request for state change events query.
+type ListStateChangeEventsRequest struct {
+	Paging
+	ResourceType ResourceType
+	ResourceID   string
+}
+
+// ApplyToURL modifies the given url to include query string parameters for the request.
+func (request *ListStateChangeEventsRequest) ApplyToURL(u *url.URL) {
+	q := u.Query()
+	q.Add("resource_type", string(request.ResourceType))
+	q.Add("resource_id", request.ResourceID)
+	request.Paging.AddToQuery(q)
+
+	u.RawQuery = q.Encode()
+}

--- a/model/events_state_change_test.go
+++ b/model/events_state_change_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStateChangeEventPayloadFromReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		stateChangeEventPayload, err := NewStateChangeEventPayloadFromReader(bytes.NewReader([]byte(
+			"",
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &StateChangeEventPayload{}, stateChangeEventPayload)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		stateChangeEventPayload, err := NewStateChangeEventPayloadFromReader(bytes.NewReader([]byte(
+			"{test",
+		)))
+		require.Error(t, err)
+		require.Nil(t, stateChangeEventPayload)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		stateChangeEventPayload, err := NewStateChangeEventPayloadFromReader(bytes.NewReader([]byte(
+			`{"eventID":"event-1", "timestamp":1000}`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &StateChangeEventPayload{
+			EventID:   "event-1",
+			Timestamp: 1000,
+		}, stateChangeEventPayload)
+	})
+}
+
+func TestNewStateChangeEventsDataFromReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		stateChangeEventDatas, err := NewStateChangeEventsDataFromReader(bytes.NewReader([]byte(
+			"",
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*StateChangeEventData{}, stateChangeEventDatas)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		stateChangeEventDatas, err := NewStateChangeEventsDataFromReader(bytes.NewReader([]byte(
+			"{test",
+		)))
+		require.Error(t, err)
+		require.Nil(t, stateChangeEventDatas)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		stateChangeEventDatas, err := NewStateChangeEventsDataFromReader(bytes.NewReader([]byte(
+			`[
+				{"event":{"id":"event-1","timestamp":1000},"stateChange":{"id":"state-change-1","eventID":"event-1"}},
+				{"event":{"id":"event-2","timestamp":1000},"stateChange":{"id":"state-change-2","eventID":"event-2"}}
+			]`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*StateChangeEventData{
+			{
+				Event: Event{
+					ID:        "event-1",
+					Timestamp: 1000,
+				},
+				StateChange: StateChangeEvent{
+					ID:      "state-change-1",
+					EventID: "event-1",
+				},
+			},
+			{
+				Event: Event{
+					ID:        "event-2",
+					Timestamp: 1000,
+				},
+				StateChange: StateChangeEvent{
+					ID:      "state-change-2",
+					EventID: "event-2",
+				},
+			},
+		}, stateChangeEventDatas)
+	})
+}
+
+func TestStateChangeEventDataToPayload(t *testing.T) {
+	stateChangeEvent := StateChangeEventData{
+		Event: Event{
+			ID:        "eid",
+			EventType: ResourceStateChangeEventType,
+			Timestamp: 100,
+			ExtraData: EventExtraData{
+				Fields: map[string]string{"test": "test"},
+			},
+		},
+		StateChange: StateChangeEvent{
+			ID:           "scid",
+			EventID:      "eid",
+			OldState:     "old",
+			NewState:     "new",
+			ResourceID:   "resid",
+			ResourceType: TypeInstallation,
+		},
+	}
+
+	eventPayload := stateChangeEvent.ToEventPayload()
+	assert.Equal(t, stateChangeEvent.Event.ID, eventPayload.EventID)
+	assert.Equal(t, stateChangeEvent.Event.Timestamp, eventPayload.Timestamp)
+	assert.Equal(t, stateChangeEvent.Event.ExtraData.Fields, eventPayload.ExtraData)
+	assert.Equal(t, stateChangeEvent.StateChange.ResourceType, eventPayload.ResourceType)
+	assert.Equal(t, stateChangeEvent.StateChange.ResourceID, eventPayload.ResourceID)
+	assert.Equal(t, stateChangeEvent.StateChange.NewState, eventPayload.NewState)
+	assert.Equal(t, stateChangeEvent.StateChange.OldState, eventPayload.OldState)
+
+	webhookPayload := stateChangeEvent.ToWebhookPayload()
+	assert.Equal(t, stateChangeEvent.Event.ID, webhookPayload.EventID)
+	assert.Equal(t, stateChangeEvent.Event.Timestamp, webhookPayload.Timestamp)
+	assert.Equal(t, stateChangeEvent.Event.ExtraData.Fields, webhookPayload.ExtraData)
+	assert.Equal(t, stateChangeEvent.StateChange.ResourceType, webhookPayload.Type)
+	assert.Equal(t, stateChangeEvent.StateChange.ResourceID, webhookPayload.ID)
+	assert.Equal(t, stateChangeEvent.StateChange.NewState, webhookPayload.NewState)
+	assert.Equal(t, stateChangeEvent.StateChange.OldState, webhookPayload.OldState)
+}

--- a/model/events_subscription.go
+++ b/model/events_subscription.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// SubscriptionDeliveryStatus represents delivery status for subscription.
+type SubscriptionDeliveryStatus string
+
+const (
+	// SubscriptionDeliveryNone indicates no prior delivery for the subscription.
+	SubscriptionDeliveryNone SubscriptionDeliveryStatus = ""
+	// SubscriptionDeliverySucceeded indicates that last delivery for subscription succeeded.
+	SubscriptionDeliverySucceeded SubscriptionDeliveryStatus = "succeeded"
+	// SubscriptionDeliveryFailed indicates that last delivery for subscription failed.
+	SubscriptionDeliveryFailed SubscriptionDeliveryStatus = "failed"
+)
+
+// Subscription is a subscription for Provisioner events.
+type Subscription struct {
+	ID                    string
+	Name                  string
+	URL                   string
+	OwnerID               string
+	EventType             EventType
+	LastDeliveryStatus    SubscriptionDeliveryStatus
+	LastDeliveryAttemptAt int64
+	// FailureThreshold specifies the time, after which undelivered event will be considered failed.
+	FailureThreshold time.Duration
+	CreateAt         int64
+	DeleteAt         int64
+	LockAcquiredBy   *string
+	LockAcquiredAt   int64
+}
+
+// IsDeleted returns true if subscription is deleted.
+func (s Subscription) IsDeleted() bool {
+	return s.DeleteAt > 0
+}
+
+// SubscriptionsFilter is a filter for subscription queries.
+type SubscriptionsFilter struct {
+	Paging
+	Owner     string
+	EventType EventType
+}
+
+// NewSubscriptionFromReader will create a Subscription from an
+// io.Reader with JSON data.
+func NewSubscriptionFromReader(reader io.Reader) (*Subscription, error) {
+	var subscription Subscription
+	err := json.NewDecoder(reader).Decode(&subscription)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode Subscription")
+	}
+
+	return &subscription, nil
+}
+
+// NewSubscriptionsFromReader will create a slice of Subscriptions from an
+// io.Reader with JSON data.
+func NewSubscriptionsFromReader(reader io.Reader) ([]*Subscription, error) {
+	subscriptions := []*Subscription{}
+	err := json.NewDecoder(reader).Decode(&subscriptions)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode Subscriptions")
+	}
+
+	return subscriptions, nil
+}

--- a/model/events_subscription_request.go
+++ b/model/events_subscription_request.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// CreateSubscriptionRequest represents a request to create Subscription.
+type CreateSubscriptionRequest struct {
+	Name             string
+	URL              string
+	OwnerID          string
+	EventType        EventType
+	FailureThreshold time.Duration
+}
+
+// ToSubscription validates request and converts it to subscription
+func (r CreateSubscriptionRequest) ToSubscription() (Subscription, error) {
+	_, err := url.Parse(r.URL)
+	if err != nil {
+		return Subscription{}, errors.Wrap(err, "failed to parse subscription URL")
+	}
+
+	if r.EventType == "" {
+		return Subscription{}, errors.New("event type is required when registering subscription")
+	}
+	if r.OwnerID == "" {
+		return Subscription{}, errors.New("owner ID is required when registering subscription")
+	}
+	if r.FailureThreshold < 0 || r.FailureThreshold > 72*time.Hour {
+		return Subscription{}, errors.New("failure threshold need to be between 0 and 72 hours")
+	}
+
+	return Subscription{
+		Name:                  r.Name,
+		URL:                   r.URL,
+		OwnerID:               r.OwnerID,
+		EventType:             r.EventType,
+		LastDeliveryStatus:    SubscriptionDeliveryNone,
+		LastDeliveryAttemptAt: 0,
+		FailureThreshold:      r.FailureThreshold,
+	}, nil
+}
+
+// NewCreateSubscriptionRequestFromReader will create a CreateSubscriptionRequest from an
+// io.Reader with JSON data.
+func NewCreateSubscriptionRequestFromReader(reader io.Reader) (*CreateSubscriptionRequest, error) {
+	subRequest := CreateSubscriptionRequest{}
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&subRequest)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &subRequest, nil
+}
+
+// ListSubscriptionsRequest represents a request data for querying subscriptions.
+type ListSubscriptionsRequest struct {
+	Paging
+	Owner     string
+	EventType EventType
+}
+
+// ApplyToURL modifies the given url to include query string parameters for the request.
+func (request *ListSubscriptionsRequest) ApplyToURL(u *url.URL) {
+	q := u.Query()
+	q.Add("owner", request.Owner)
+	q.Add("event_type", string(request.EventType))
+	request.Paging.AddToQuery(q)
+
+	u.RawQuery = q.Encode()
+}

--- a/model/events_subscription_request_test.go
+++ b/model/events_subscription_request_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCreateSubscriptionRequestFromReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		createSubscriptionRequest, err := NewCreateSubscriptionRequestFromReader(bytes.NewReader([]byte(
+			"",
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &CreateSubscriptionRequest{}, createSubscriptionRequest)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		createSubscriptionRequest, err := NewCreateSubscriptionRequestFromReader(bytes.NewReader([]byte(
+			"{test",
+		)))
+		require.Error(t, err)
+		require.Nil(t, createSubscriptionRequest)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		createSubscriptionRequest, err := NewCreateSubscriptionRequestFromReader(bytes.NewReader([]byte(
+			`{"name":"test","url":"http://test", "ownerID":"owner","failureThreshold":100}`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &CreateSubscriptionRequest{
+			Name:             "test",
+			URL:              "http://test",
+			OwnerID:          "owner",
+			FailureThreshold: 100,
+		}, createSubscriptionRequest)
+	})
+}

--- a/model/events_subscription_test.go
+++ b/model/events_subscription_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSubscriptionFromReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		subscription, err := NewSubscriptionFromReader(bytes.NewReader([]byte(
+			"",
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &Subscription{}, subscription)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		subscription, err := NewSubscriptionFromReader(bytes.NewReader([]byte(
+			"{test",
+		)))
+		require.Error(t, err)
+		require.Nil(t, subscription)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		subscription, err := NewSubscriptionFromReader(bytes.NewReader([]byte(
+			`{"id":"abcd", "name":"test", "url":"http://events", "ownerid":"owner", "eventType":"event", "lastDeliveryStatus":"fail", "lastDeliveryAttemptAt":100, "failureThreshold":200, "createAt":300, "deleteAt":400}`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &Subscription{
+			ID:                    "abcd",
+			Name:                  "test",
+			URL:                   "http://events",
+			OwnerID:               "owner",
+			EventType:             "event",
+			LastDeliveryStatus:    "fail",
+			LastDeliveryAttemptAt: 100,
+			FailureThreshold:      200,
+			CreateAt:              300,
+			DeleteAt:              400,
+		}, subscription)
+	})
+}
+
+func TestNewSubscriptionsFromReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		subscriptions, err := NewSubscriptionsFromReader(bytes.NewReader([]byte(
+			"",
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*Subscription{}, subscriptions)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		subscriptions, err := NewSubscriptionsFromReader(bytes.NewReader([]byte(
+			"{test",
+		)))
+		require.Error(t, err)
+		require.Nil(t, subscriptions)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		subscriptions, err := NewSubscriptionsFromReader(bytes.NewReader([]byte(
+			`[{"id":"abcd"},{"id":"efgh"}]`,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*Subscription{
+			{ID: "abcd"},
+			{ID: "efgh"},
+		}, subscriptions)
+	})
+}

--- a/model/events_test.go
+++ b/model/events_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventDeliveryForEvent(t *testing.T) {
+	eventID := "event1"
+	desiredDelivery := &EventDelivery{
+		ID:      "desired-ed",
+		EventID: eventID,
+	}
+
+	for _, testCase := range []struct {
+		description      string
+		deliveries       []*EventDelivery
+		expectedDelivery *EventDelivery
+		found            bool
+	}{
+		{
+			description: "find first",
+			deliveries: []*EventDelivery{
+				{ID: "ed1", EventID: "some event"},
+				{ID: "ed2", EventID: "other event"},
+				desiredDelivery,
+				{ID: "ed3", EventID: eventID},
+			},
+			expectedDelivery: desiredDelivery,
+			found:            true,
+		},
+		{
+			description: "do not find",
+			deliveries: []*EventDelivery{
+				{ID: "ed1", EventID: "some event"},
+				{ID: "ed2", EventID: "other event"},
+				{ID: "ed3", EventID: "third event"},
+			},
+			expectedDelivery: nil,
+			found:            false,
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			delivery, found := EventDeliveryForEvent(eventID, testCase.deliveries)
+			assert.Equal(t, testCase.found, found)
+			assert.Equal(t, testCase.expectedDelivery, delivery)
+		})
+	}
+
+}

--- a/model/general.go
+++ b/model/general.go
@@ -11,4 +11,7 @@ const (
 	// NoInstallationsLimit signals the store to return all multitenant database instances independently
 	// of the number of installations using each instance.
 	NoInstallationsLimit = -1
+
+	// NonApplicableState represents constant use for StateChangeEvents when resource did not have a previous state.
+	NonApplicableState = "n/a"
 )

--- a/model/webhook.go
+++ b/model/webhook.go
@@ -9,21 +9,29 @@ import (
 	"io"
 )
 
+// ResourceType specifies a type of Provisioners' resource.
+type ResourceType string
+
 const (
 	// TypeCluster is the string value that represents a cluster.
-	TypeCluster = "cluster"
+	TypeCluster ResourceType = "cluster"
 	// TypeInstallation is the string value that represents an installation.
-	TypeInstallation = "installation"
+	TypeInstallation ResourceType = "installation"
 	// TypeClusterInstallation is the string value that represents a cluster
 	// installation.
-	TypeClusterInstallation = "cluster_installaton"
+	TypeClusterInstallation ResourceType = "cluster_installation"
 	// TypeInstallationBackup is the string value that represents an installation backup.
-	TypeInstallationBackup = "installation_backup"
+	TypeInstallationBackup ResourceType = "installation_backup"
 	// TypeInstallationDBRestoration is the string value that represents an installation db restoration operation.
-	TypeInstallationDBRestoration = "installation_db_restoration_operation"
+	TypeInstallationDBRestoration ResourceType = "installation_db_restoration_operation"
 	// TypeInstallationDBMigration is the string value that represents an installation db migration operation.
-	TypeInstallationDBMigration = "installation_db_migration_operation"
+	TypeInstallationDBMigration ResourceType = "installation_db_migration_operation"
 )
+
+// String converts ResourceType to string.
+func (t ResourceType) String() string {
+	return string(t)
+}
 
 // Webhook is
 type Webhook struct {
@@ -42,9 +50,10 @@ type WebhookFilter struct {
 
 // WebhookPayload is the payload sent in every webhook.
 type WebhookPayload struct {
+	EventID   string            `json:"event_id"`
 	Timestamp int64             `json:"timestamp"`
 	ID        string            `json:"id"`
-	Type      string            `json:"type"`
+	Type      ResourceType      `json:"type"`
 	NewState  string            `json:"new_state"`
 	OldState  string            `json:"old_state"`
 	ExtraData map[string]string `json:"extra_data,omitempty"`

--- a/model/webhook_test.go
+++ b/model/webhook_test.go
@@ -29,6 +29,7 @@ func TestWebhookIsDeleted(t *testing.T) {
 
 func TestWebhookPayloadToJSON(t *testing.T) {
 	payload := &WebhookPayload{
+		EventID:   "test-event",
 		Timestamp: 123456789,
 		ID:        "id",
 		Type:      "type",
@@ -36,7 +37,7 @@ func TestWebhookPayloadToJSON(t *testing.T) {
 		OldState:  "state2",
 	}
 
-	expectedStr := `{"timestamp":123456789,"id":"id","type":"type","new_state":"state1","old_state":"state2"}`
+	expectedStr := `{"event_id":"test-event","timestamp":123456789,"id":"id","type":"type","new_state":"state1","old_state":"state2"}`
 
 	payloadStr, err := payload.ToJSON()
 	require.NoError(t, err)
@@ -152,6 +153,7 @@ func TestWebhookPayloadFromReader(t *testing.T) {
 
 	t.Run("request", func(t *testing.T) {
 		payload, err := WebhookPayloadFromReader(strings.NewReader(`{
+			"event_id":"test-event",
 			"timestamp":1234,
 			"id":"id",
 			"type":"installation",
@@ -160,6 +162,7 @@ func TestWebhookPayloadFromReader(t *testing.T) {
 		}`))
 		require.NoError(t, err)
 		require.Equal(t, &WebhookPayload{
+			EventID:   "test-event",
 			Timestamp: 1234,
 			ID:        "id",
 			Type:      "installation",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds the Provisioner Events model and store logic.

Apologies for the big PR but there is no real good way to split it, a lot of the code is boilerplate tho.
To highlight some important parts:
- Models.
- Subscription claiming logic
- Event producing logic

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-40129

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add Provisioner Events model and store
```
