### PR TITLE
Use mmctl for getting and setting Mattermost config

### DIFF
--- a/internal/api/cluster_installation.go
+++ b/internal/api/cluster_installation.go
@@ -126,7 +126,7 @@ func handleGetClusterInstallationConfig(c *Context, w http.ResponseWriter, r *ht
 		return
 	}
 
-	output, err := c.Provisioner.ExecMattermostCLI(cluster, clusterInstallation, "config", "show", "--json")
+	output, err := c.Provisioner.ExecClusterInstallationCLI(cluster, clusterInstallation, "mmctl", "--local", "config", "show", "--json")
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to execute mattermost cli")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -211,7 +211,7 @@ func handleSetClusterInstallationConfig(c *Context, w http.ResponseWriter, r *ht
 
 			valueStr, ok := value.(string)
 			if ok {
-				_, err := c.Provisioner.ExecMattermostCLI(cluster, clusterInstallation, "config", "set", fullKey, valueStr)
+				_, err := c.Provisioner.ExecClusterInstallationCLI(cluster, clusterInstallation, "mmctl", "--local", "config", "set", fullKey, valueStr)
 				if err != nil {
 					c.Logger.WithError(err).Errorf("failed to set key %s to value %s", fullKey, valueStr)
 					return err


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Due to removal of `mattermost config` command we need to switch to use `mmctl` for config related operations.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-40054

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Use mmctl for getting and setting Mattermost config
```
