### PR TITLE
Implement event Producer and Deliverer

### DIFF
--- a/internal/events/delivery.go
+++ b/internal/events/delivery.go
@@ -1,0 +1,328 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package events
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	contentTypeApplicationJSON = "application/json"
+
+	processingDelay = 5 * time.Second
+
+	retryDelay = 20 * time.Second
+)
+
+type delivererStore interface {
+	ClaimUpToDateSubscription(instanceID string) (*model.Subscription, error)
+	ClaimRetryingSubscription(instanceID string, cooldown time.Duration) (*model.Subscription, error)
+	UpdateSubscriptionStatus(sub *model.Subscription) error
+	UnlockSubscription(subID, lockerID string, force bool) (bool, error)
+	CountSubscriptionsForEvent(eventType model.EventType) (int64, error)
+	GetStateChangeEventsToProcess(subID string) ([]*model.StateChangeEventDeliveryData, error)
+	UpdateEventDeliveryStatus(delivery *model.EventDelivery) error
+}
+
+// EventDeliverer is responsible for delivering events.
+type EventDeliverer struct {
+	ctx        context.Context
+	store      delivererStore
+	client     *http.Client
+	instanceID string
+	config     DelivererConfig
+	logger     logrus.FieldLogger
+	// TODO: Make retry delay exponential. This will require storing the last delay on Subscription.
+	// For now we just use const.
+	retryDelay time.Duration
+}
+
+// DelivererConfig is config of EventDeliverer component.
+type DelivererConfig struct {
+	IdleRetryWorkers int
+	IdleNewWorkers   int
+	MaxBurstWorkers  int
+}
+
+// NewDeliverer creates new EventDeliverer component.
+func NewDeliverer(ctx context.Context, store delivererStore, instanceID string, log logrus.FieldLogger, cfg DelivererConfig) *EventDeliverer {
+	delivery := &EventDeliverer{
+		ctx:        ctx,
+		store:      store,
+		client:     &http.Client{Timeout: 15 * time.Second},
+		instanceID: instanceID,
+		config:     cfg,
+		logger:     log.WithField("component", "eventsDelivery"),
+		retryDelay: retryDelay,
+	}
+
+	for i := 0; i < delivery.config.IdleRetryWorkers; i++ {
+		go delivery.newWorker().ProcessRetrying(ctx)
+	}
+
+	for i := 0; i < delivery.config.IdleNewWorkers; i++ {
+		go delivery.newWorker().ProcessUpToDate(ctx)
+	}
+
+	return delivery
+}
+
+type token struct{}
+
+// SignalNewEvents attempts to try/retry to send to all subscriptions for particular type of event.
+// It will throttle concurrent deliveries.
+func (d *EventDeliverer) SignalNewEvents(eventType model.EventType) {
+	if d.config.MaxBurstWorkers == 0 {
+		return
+	}
+
+	burst, err := d.store.CountSubscriptionsForEvent(eventType)
+	if err != nil {
+		d.logger.WithField("eventType", eventType).WithError(err).Error("Failed to count subscriptions for event")
+		burst = int64(d.config.MaxBurstWorkers)
+	}
+
+	// This will attempt to send to at most MaxBurstWorkers at a time
+	// until all subscriptions subscribed to the event where attempted
+	// or a worker did not find any subscription to process.
+	semaphore := make(chan token, d.config.MaxBurstWorkers)
+	done := make(chan struct{})
+	wg := &sync.WaitGroup{}
+
+	for i := int64(0); i < burst; i++ {
+		// In case any of burst workers did not find any more work stop early.
+		select {
+		case <-done:
+			d.logger.Debug("No more subscriptions to process, stopping burst early")
+			break
+		default:
+			semaphore <- token{}
+		}
+
+		wg.Add(1)
+		go func() {
+			defer func() {
+				<-semaphore
+				wg.Done()
+			}()
+
+			if !d.newWorker().ProcessUpToDateOnce() {
+				closeIfOpen(done)
+			}
+		}()
+	}
+	wg.Wait()
+	close(semaphore)
+
+	// Make sure done channel was closed
+	closeIfOpen(done)
+}
+
+func closeIfOpen(c chan struct{}) {
+	select {
+	case <-c:
+	default:
+		close(c)
+	}
+}
+
+// sender is a helper struct for separation of logic.
+// It uses HTTP client of EventDeliverer.
+type sender struct {
+	store      delivererStore
+	client     *http.Client
+	instanceID string
+	logger     logrus.FieldLogger
+}
+
+func (d *EventDeliverer) newWorker() *sender {
+	return &sender{
+		store:      d.store,
+		client:     d.client,
+		instanceID: d.instanceID,
+		logger:     d.logger.WithField("worker", model.NewID()),
+	}
+}
+
+// ProcessUpToDateOnce attempts to process single up-to-date subscription once.
+func (s *sender) ProcessUpToDateOnce() bool {
+	return s.processSubscriptionEvents(s.store.ClaimUpToDateSubscription)
+}
+
+// ProcessUpToDate starts a worker processing up-to-date subscriptions.
+func (s *sender) ProcessUpToDate(ctx context.Context) {
+	s.process(ctx, s.store.ClaimUpToDateSubscription)
+}
+
+// ProcessRetrying starts a worker processing retrying subscriptions.
+func (s *sender) ProcessRetrying(ctx context.Context) {
+	s.process(ctx, func(instanceID string) (*model.Subscription, error) {
+		return s.store.ClaimRetryingSubscription(instanceID, retryDelay)
+	})
+}
+
+func (s *sender) process(ctx context.Context, claimFunc func(instanceID string) (*model.Subscription, error)) {
+	s.logger.Info("Worker is starting processing")
+
+	subscriptionProcessed := true
+	for {
+		select {
+		case <-ctx.Done():
+		default:
+			// If last time we did not get subscription to process, wait before trying again.
+			if !subscriptionProcessed {
+				time.Sleep(processingDelay)
+			}
+			subscriptionProcessed = s.processSubscriptionEvents(claimFunc)
+		}
+	}
+}
+
+// processSubscriptionEvents attempts to claim subscription and process its events.
+// Returns true if the subscription was claimed, false if there are no more
+// subscriptions awaiting delivery or failed to claim.
+func (s *sender) processSubscriptionEvents(claimFunc func(instanceID string) (*model.Subscription, error)) bool {
+	subscription, err := claimFunc(s.instanceID)
+	if err != nil {
+		if err == store.ErrNoSubscriptionsToProcess {
+			return false
+		}
+		s.logger.WithError(err).Error("Failed to claim subscription to process")
+		return false
+	}
+	log := s.logger.WithField("subscription", subscription.ID)
+	defer s.unlockSubscription(subscription.ID, log)
+
+	log.Debug("Processing events delivery for subscription")
+
+	// If amount of events will grow substantially we might consider
+	// fetching in batches. For now fetching all should be good.
+	eventDeliveries, err := s.store.GetStateChangeEventsToProcess(subscription.ID)
+	if err != nil {
+		s.logger.WithError(err).Error("Failed to get events to process")
+		return true
+	}
+
+	s.processDeliveries(subscription, eventDeliveries, log)
+	return true
+}
+
+func (s *sender) processDeliveries(sub *model.Subscription, deliveries []*model.StateChangeEventDeliveryData, log logrus.FieldLogger) {
+	var subDeliveryStatus model.SubscriptionDeliveryStatus
+	var continueSending bool
+	for _, d := range deliveries {
+		subDeliveryStatus, continueSending = s.processDelivery(sub, d, log)
+		if !continueSending {
+			break
+		}
+	}
+	sub.LastDeliveryStatus = subDeliveryStatus
+	sub.LastDeliveryAttemptAt = model.GetMillis()
+
+	err := s.store.UpdateSubscriptionStatus(sub)
+	if err != nil {
+		log.WithError(err).Error("Failed to update subscription status after delivery")
+		return
+	}
+	return
+}
+
+func (s *sender) processDelivery(sub *model.Subscription, delivery *model.StateChangeEventDeliveryData, logger logrus.FieldLogger) (model.SubscriptionDeliveryStatus, bool) {
+	delivery.EventDelivery.Attempts++
+	delivery.EventDelivery.LastAttempt = model.GetMillis()
+
+	log := logger.WithFields(map[string]interface{}{
+		"event":         delivery.EventData.Event.ID,
+		"eventDelivery": delivery.EventDelivery.ID,
+	})
+
+	log.Debug("Attempting to deliver event...")
+
+	var subDeliveryStatus model.SubscriptionDeliveryStatus
+
+	err := s.sendEvent(sub.URL, delivery, log)
+	if err != nil {
+		log.WithError(err).Error("Failed to deliver event")
+
+		// We abort delivery on the subscription only if the event will be retried
+		// otherwise we mark event as failed and continue.
+		if delivery.EventData.Event.Timestamp+sub.FailureThreshold.Milliseconds() < delivery.EventDelivery.LastAttempt {
+			delivery.EventDelivery.Status = model.EventDeliveryFailed
+		} else {
+			subDeliveryStatus = model.SubscriptionDeliveryFailed
+			delivery.EventDelivery.Status = model.EventDeliveryRetrying
+		}
+	} else {
+		delivery.EventDelivery.Status = model.EventDeliveryDelivered
+	}
+
+	err = s.store.UpdateEventDeliveryStatus(&delivery.EventDelivery)
+	if err != nil {
+		log.WithError(err).Error("Failed to update event delivery state")
+		return subDeliveryStatus, false
+	}
+
+	return subDeliveryStatus, subDeliveryStatus != model.SubscriptionDeliveryFailed
+}
+
+func (s *sender) sendEvent(url string, data *model.StateChangeEventDeliveryData, log logrus.FieldLogger) error {
+	payload, err := json.Marshal(data.EventData.ToEventPayload())
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal event payload")
+	}
+
+	resp, err := s.client.Post(url, contentTypeApplicationJSON, bytes.NewBuffer(payload))
+	if err != nil {
+		return errors.Wrap(err, "failed to deliver event")
+	}
+	defer drainBody(resp.Body)
+	if resp.StatusCode >= 500 {
+		return errors.Errorf(
+			"consumer failed to receive event, got %d response code, body: %s",
+			resp.StatusCode, attemptToReadBody(resp.Body),
+		)
+	}
+	if resp.StatusCode != http.StatusOK {
+		log.Errorf("Event delivery resulted in status %d. Treating it as consumer error, delivery will not be retried",
+			resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (s *sender) unlockSubscription(subID string, log logrus.FieldLogger) {
+	unlocked, err := s.store.UnlockSubscription(subID, s.instanceID, false)
+	if err != nil {
+		log.WithError(err).Error("failed to unlock subscription")
+	} else if !unlocked {
+		log.Error("failed to release lock for subscription")
+	}
+}
+
+func attemptToReadBody(reader io.Reader) string {
+	body, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return fmt.Sprintf("failed to read body: %s", err.Error())
+	}
+	return string(body)
+}
+
+func drainBody(readCloser io.ReadCloser) {
+	_, _ = ioutil.ReadAll(readCloser)
+	_ = readCloser.Close()
+}

--- a/internal/events/delivery_test.go
+++ b/internal/events/delivery_test.go
@@ -28,7 +28,7 @@ func TestDelivery_Workers(t *testing.T) {
 	defer cancel()
 
 	cfg := DelivererConfig{
-		IdleNewWorkers: 4,
+		UpToDateWorkers: 4,
 	}
 	_ = NewDeliverer(ctx, sqlStore, instanceID, logger, cfg)
 
@@ -53,8 +53,8 @@ func TestDelivery_WorkersRetrying(t *testing.T) {
 	defer cancel()
 
 	cfg := DelivererConfig{
-		IdleRetryWorkers: 4,
-		MaxBurstWorkers:  50,
+		RetryWorkers:    4,
+		MaxBurstWorkers: 50,
 	}
 	eventsDeliverer := NewDeliverer(ctx, sqlStore, instanceID, logger, cfg)
 	// Adjust for the purpose of tests.
@@ -142,8 +142,8 @@ func TestDelivery_GiveUpWhenThresholdReached(t *testing.T) {
 	defer cancel()
 
 	cfg := DelivererConfig{
-		IdleRetryWorkers: 4,
-		MaxBurstWorkers:  50,
+		RetryWorkers:    4,
+		MaxBurstWorkers: 50,
 	}
 	eventsDeliverer := NewDeliverer(ctx, sqlStore, instanceID, logger, cfg)
 

--- a/internal/events/delivery_test.go
+++ b/internal/events/delivery_test.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package events
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelivery_Workers(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	instanceID := model.NewID()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := DelivererConfig{
+		IdleNewWorkers: 4,
+	}
+	_ = NewDeliverer(ctx, sqlStore, instanceID, logger, cfg)
+
+	subscriptions := 10
+	deliveredEvents := make(chan *model.StateChangeEventPayload, subscriptions)
+
+	r := mux.NewRouter()
+	r.HandleFunc("/event", successEventHandler(t, deliveredEvents))
+	consumerSever := httptest.NewServer(r)
+
+	createFixedSubscriptions(t, sqlStore, subscriptions, consumerSever.URL)
+	eventData := createFixedEventData(t, sqlStore)
+
+	awaitEvents(t, deliveredEvents, eventData.Event.ID, subscriptions)
+}
+
+func TestDelivery_WorkersRetrying(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	instanceID := model.NewID()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := DelivererConfig{
+		IdleRetryWorkers: 4,
+		MaxBurstWorkers:  50,
+	}
+	eventsDeliverer := NewDeliverer(ctx, sqlStore, instanceID, logger, cfg)
+	// Adjust for the purpose of tests.
+	eventsDeliverer.retryDelay = 5 * time.Second
+
+	subscriptions := 10
+	deliveredEvents := make(chan *model.StateChangeEventPayload, subscriptions)
+
+	r := mux.NewRouter()
+	r.HandleFunc("/event", failureEventHandler(t, deliveredEvents))
+	consumerSever := httptest.NewServer(r)
+
+	createFixedSubscriptions(t, sqlStore, subscriptions, consumerSever.URL)
+	eventData := createFixedEventData(t, sqlStore)
+
+	// Fail delivery
+	eventsDeliverer.SignalNewEvents(model.ResourceStateChangeEventType)
+
+	awaitEvents(t, deliveredEvents, eventData.Event.ID, subscriptions)
+
+	// Events should be retried after a couple of seconds
+	awaitEvents(t, deliveredEvents, eventData.Event.ID, subscriptions)
+}
+
+func TestDelivery_SignalNewEvents(t *testing.T) {
+
+	for _, testCase := range []struct {
+		description   string
+		subscriptions int
+	}{
+		{
+			description:   "300 subscriptions",
+			subscriptions: 300,
+		},
+		{
+			description:   "101 subscriptions",
+			subscriptions: 101,
+		},
+		{
+			description:   "5 subscriptions",
+			subscriptions: 5,
+		},
+		{
+			description:   "123 subscriptions",
+			subscriptions: 123,
+		},
+		{
+			description:   "0 subscriptions",
+			subscriptions: 0,
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			logger := testlib.MakeLogger(t)
+			sqlStore := store.MakeTestSQLStore(t, logger)
+			instanceID := model.NewID()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			cfg := DelivererConfig{
+				MaxBurstWorkers: 50,
+			}
+			eventsDeliverer := NewDeliverer(ctx, sqlStore, instanceID, logger, cfg)
+
+			deliveredEvents := make(chan *model.StateChangeEventPayload, testCase.subscriptions)
+
+			r := mux.NewRouter()
+			r.HandleFunc("/event", successEventHandler(t, deliveredEvents))
+			consumerSever := httptest.NewServer(r)
+
+			createFixedSubscriptions(t, sqlStore, testCase.subscriptions, consumerSever.URL)
+			eventData := createFixedEventData(t, sqlStore)
+
+			eventsDeliverer.SignalNewEvents(model.ResourceStateChangeEventType)
+
+			awaitEvents(t, deliveredEvents, eventData.Event.ID, testCase.subscriptions)
+		})
+	}
+}
+
+func TestDelivery_GiveUpWhenThresholdReached(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	instanceID := model.NewID()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := DelivererConfig{
+		IdleRetryWorkers: 4,
+		MaxBurstWorkers:  50,
+	}
+	eventsDeliverer := NewDeliverer(ctx, sqlStore, instanceID, logger, cfg)
+
+	deliveredEvents := make(chan *model.StateChangeEventPayload, 1)
+
+	r := mux.NewRouter()
+	r.HandleFunc("/event", failureEventHandler(t, deliveredEvents))
+	consumerSever := httptest.NewServer(r)
+
+	subscription := &model.Subscription{
+		URL:                fmt.Sprintf("%s/event", consumerSever.URL),
+		EventType:          model.ResourceStateChangeEventType,
+		LastDeliveryStatus: model.SubscriptionDeliveryNone,
+		FailureThreshold:   0, // This will guarantee only one try
+	}
+	err := sqlStore.CreateSubscription(subscription)
+	require.NoError(t, err)
+
+	eventData := createFixedEventData(t, sqlStore)
+
+	// Make sure last delivery attempt is not equal event timestamp.
+	time.Sleep(1 * time.Millisecond)
+
+	// Init and wait for delivery
+	eventsDeliverer.SignalNewEvents(model.ResourceStateChangeEventType)
+	<-deliveredEvents
+
+	// Assert that EventDelivery was marked as failed.
+	deliveries, err := sqlStore.GetDeliveriesForSubscription(subscription.ID)
+	require.NoError(t, err)
+	assert.Len(t, deliveries, 1, "expected one delivery")
+	assert.Equal(t, eventData.Event.ID, deliveries[0].EventID)
+	assert.Equal(t, model.EventDeliveryFailed, deliveries[0].Status)
+}
+
+func successEventHandler(t *testing.T, deliveryChan chan<- *model.StateChangeEventPayload) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		payload, err := model.NewStateChangeEventPayloadFromReader(r.Body)
+		require.NoError(t, err)
+		deliveryChan <- payload
+	}
+}
+
+func failureEventHandler(t *testing.T, deliveryChan chan<- *model.StateChangeEventPayload) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		payload, err := model.NewStateChangeEventPayloadFromReader(r.Body)
+		require.NoError(t, err)
+		deliveryChan <- payload
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func awaitEvents(t *testing.T, deliveryChan <-chan *model.StateChangeEventPayload, expectedID string, eventsCount int) {
+	timeout := time.After(25 * time.Second)
+	delivered := 0
+
+	for delivered < eventsCount {
+		select {
+		case event := <-deliveryChan:
+			delivered++
+			assert.Equal(t, expectedID, event.EventID)
+		case <-timeout:
+			t.Fatalf("timeout while waiting for events, delivered: %d", delivered)
+		}
+	}
+}
+
+func createFixedSubscriptions(t *testing.T, sqlStore *store.SQLStore, subsCount int, subBaseURL string) {
+	for i := 0; i < subsCount; i++ {
+		subscription := &model.Subscription{
+			URL:                fmt.Sprintf("%s/event", subBaseURL),
+			EventType:          model.ResourceStateChangeEventType,
+			LastDeliveryStatus: model.SubscriptionDeliveryNone,
+			FailureThreshold:   1 * time.Minute,
+		}
+		err := sqlStore.CreateSubscription(subscription)
+		require.NoError(t, err)
+	}
+}
+
+func createFixedEventData(t *testing.T, sqlStore *store.SQLStore) model.StateChangeEventData {
+	eventData := model.StateChangeEventData{
+		Event: model.Event{
+			EventType: model.ResourceStateChangeEventType,
+			Timestamp: model.GetMillis(),
+		},
+		StateChange: model.StateChangeEvent{
+			OldState:     "old",
+			NewState:     "new",
+			ResourceID:   "abcd",
+			ResourceType: "installation",
+		},
+	}
+
+	err := sqlStore.CreateStateChangeEvent(&eventData)
+	require.NoError(t, err)
+
+	return eventData
+}

--- a/internal/events/producer.go
+++ b/internal/events/producer.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package events
+
+import (
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/webhook"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type producerStore interface {
+	CreateStateChangeEvent(event *model.StateChangeEventData) error
+	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)
+}
+
+type deliverySignaler interface {
+	SignalNewEvents(eventType model.EventType)
+}
+
+// DataField represents strings key value pair used for events extra data.
+type DataField struct {
+	Key   string
+	Value string
+}
+
+// EventProducer produces Provisioners' state change events.
+type EventProducer struct {
+	store       producerStore
+	signaler    deliverySignaler
+	environment string
+	logger      logrus.FieldLogger
+}
+
+// TODO: ideally we should produce state change events in the same transaction that is updating the state.
+// Given that this would require huge refactor, we do not do it for the initial implementation.
+
+// NewProducer creates new EventProducer.
+func NewProducer(store producerStore, signaler deliverySignaler, env string, log logrus.FieldLogger) *EventProducer {
+	return &EventProducer{
+		store:       store,
+		signaler:    signaler,
+		environment: env,
+		logger:      log.WithField("component", "eventsProducer"),
+	}
+}
+
+// ProduceInstallationStateChangeEvent produces state change event for a given Installation.
+func (e *EventProducer) ProduceInstallationStateChangeEvent(installation *model.Installation, oldState string, extraDataFields ...DataField) error {
+	stateChangeEvent := model.StateChangeEvent{
+		OldState:     oldState,
+		NewState:     installation.State,
+		ResourceID:   installation.ID,
+		ResourceType: model.TypeInstallation,
+	}
+
+	extraData := e.initExtraData(extraDataFields)
+	extraData["DNS"] = installation.DNS
+
+	return e.produceStateChangeEvent(stateChangeEvent, extraData)
+}
+
+// ProduceClusterStateChangeEvent produces state change event for a given Cluster.
+func (e *EventProducer) ProduceClusterStateChangeEvent(cluster *model.Cluster, oldState string, extraDataFields ...DataField) error {
+	stateChangeEvent := model.StateChangeEvent{
+		OldState:     oldState,
+		NewState:     cluster.State,
+		ResourceID:   cluster.ID,
+		ResourceType: model.TypeCluster,
+	}
+
+	extraData := e.initExtraData(extraDataFields)
+
+	return e.produceStateChangeEvent(stateChangeEvent, extraData)
+}
+
+// ProduceClusterInstallationStateChangeEvent produces state change event for a given ClusterInstallation.
+func (e *EventProducer) ProduceClusterInstallationStateChangeEvent(clusterInstallation *model.ClusterInstallation, oldState string, extraDataFields ...DataField) error {
+	stateChangeEvent := model.StateChangeEvent{
+		OldState:     oldState,
+		NewState:     clusterInstallation.State,
+		ResourceID:   clusterInstallation.ID,
+		ResourceType: model.TypeClusterInstallation,
+	}
+
+	extraData := e.initExtraData(extraDataFields)
+	extraData["ClusterID"] = clusterInstallation.ClusterID
+
+	return e.produceStateChangeEvent(stateChangeEvent, extraData)
+}
+
+func (e *EventProducer) produceStateChangeEvent(stateChangeEvent model.StateChangeEvent, extraData map[string]string) error {
+	event := model.Event{
+		EventType: model.ResourceStateChangeEventType,
+		Timestamp: model.GetMillis(),
+		ExtraData: model.EventExtraData{Fields: extraData},
+	}
+
+	eventData := model.StateChangeEventData{
+		Event:       event,
+		StateChange: stateChangeEvent,
+	}
+
+	err := e.store.CreateStateChangeEvent(&eventData)
+	if err != nil {
+		return errors.Wrap(err, "failed to create state change event")
+	}
+
+	log := e.logger.WithField("event", eventData.Event.ID)
+
+	e.signaler.SignalNewEvents(model.ResourceStateChangeEventType)
+
+	webhookPayload := eventData.ToWebhookPayload()
+
+	e.sendWebhook(&webhookPayload, log)
+	return nil
+}
+
+func (e *EventProducer) sendWebhook(payload *model.WebhookPayload, log logrus.FieldLogger) {
+	// TODO: currently webhooks timestamp is in nano seconds instead of milliseconds as all the other timestamps.
+	// We do not want to break compatibility now, but we should align in the future when critical services switch to Events.
+	payload.Timestamp = time.Now().UnixNano()
+
+	err := webhook.SendToAllWebhooks(e.store, payload, log.WithField("webhookEvent", payload.NewState))
+	if err != nil {
+		log.WithError(err).Error("Failed to send webhook")
+	}
+}
+
+func (e *EventProducer) initExtraData(extraData []DataField) map[string]string {
+	base := map[string]string{
+		"Environment": e.environment,
+	}
+	for _, d := range extraData {
+		base[d.Key] = d.Value
+	}
+	return base
+}

--- a/internal/events/producer_test.go
+++ b/internal/events/producer_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package events
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ProduceAndDeliverEvents(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	instanceID := model.NewID()
+
+	installation := &model.Installation{
+		DNS:   "test.installation.com",
+		State: model.InstallationStateStable,
+	}
+	err := sqlStore.CreateInstallation(installation, nil)
+	require.NoError(t, err)
+
+	eventChan := make(chan *model.StateChangeEventPayload)
+	webhookChan := make(chan *model.WebhookPayload)
+
+	r := mux.NewRouter()
+	r.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
+		payload, err := model.WebhookPayloadFromReader(r.Body)
+		require.NoError(t, err)
+		webhookChan <- payload
+	})
+	r.HandleFunc("/event", func(w http.ResponseWriter, r *http.Request) {
+		payload, err := model.NewStateChangeEventPayloadFromReader(r.Body)
+		require.NoError(t, err)
+		eventChan <- payload
+	})
+
+	consumerSever := httptest.NewServer(r)
+	webhook := &model.Webhook{
+		URL: fmt.Sprintf("%s/webhook", consumerSever.URL),
+	}
+	err = sqlStore.CreateWebhook(webhook)
+	require.NoError(t, err)
+
+	subscription := &model.Subscription{
+		URL:                fmt.Sprintf("%s/event", consumerSever.URL),
+		EventType:          model.ResourceStateChangeEventType,
+		LastDeliveryStatus: model.SubscriptionDeliveryNone,
+	}
+	err = sqlStore.CreateSubscription(subscription)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := DelivererConfig{
+		MaxBurstWorkers: 5,
+	}
+	eventsDeliverer := NewDeliverer(ctx, sqlStore, instanceID, logger, cfg)
+
+	eventProducer := NewProducer(sqlStore, eventsDeliverer, "test", logger)
+
+	err = eventProducer.ProduceInstallationStateChangeEvent(installation, model.InstallationStateUpdateInProgress)
+	require.NoError(t, err)
+
+	webhookPayload, eventPayload, err := awaitWebhookAndEvent(webhookChan, eventChan)
+	require.NoError(t, err)
+	assert.Equal(t, eventPayload.EventID, webhookPayload.EventID)
+
+	// Assert Event
+	assert.Equal(t, installation.ID, eventPayload.ResourceID)
+	assert.Equal(t, model.TypeInstallation, eventPayload.ResourceType)
+	assert.Equal(t, model.InstallationStateStable, eventPayload.NewState)
+	assert.Equal(t, model.InstallationStateUpdateInProgress, eventPayload.OldState)
+	assert.NotEmpty(t, eventPayload.EventID)
+	assert.NotEmpty(t, eventPayload.Timestamp)
+	assert.Equal(t, "test", eventPayload.ExtraData["Environment"])
+	assert.Equal(t, installation.DNS, eventPayload.ExtraData["DNS"])
+
+	// Asset Webhook
+	assert.Equal(t, installation.ID, webhookPayload.ID)
+	assert.Equal(t, model.TypeInstallation, webhookPayload.Type)
+	assert.Equal(t, model.InstallationStateStable, webhookPayload.NewState)
+	assert.Equal(t, model.InstallationStateUpdateInProgress, webhookPayload.OldState)
+	assert.NotEmpty(t, webhookPayload.EventID)
+	assert.NotEmpty(t, webhookPayload.Timestamp)
+	assert.Equal(t, "test", webhookPayload.ExtraData["Environment"])
+	assert.Equal(t, installation.DNS, webhookPayload.ExtraData["DNS"])
+}
+
+func awaitWebhookAndEvent(webhookChan <-chan *model.WebhookPayload, eventChan <-chan *model.StateChangeEventPayload) (*model.WebhookPayload, *model.StateChangeEventPayload, error) {
+	gotWebhook := false
+	gotEvent := false
+
+	var eventPayload *model.StateChangeEventPayload
+	var webhookPayload *model.WebhookPayload
+
+	timeout := time.After(3 * time.Second)
+
+	for !gotWebhook || !gotEvent {
+		select {
+		case eventPayload = <-eventChan:
+			gotEvent = true
+		case webhookPayload = <-webhookChan:
+			gotWebhook = true
+
+		case <-timeout:
+			return nil, nil, errors.New("timeout waiting for event and webhook")
+		}
+	}
+	return webhookPayload, eventPayload, nil
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR introduces events Producer and Deliverer as two main components responsible for creating and delivering events.

When an event is produced the old-fashioned webhook will be sent too for now. This should ensure compatibility between the two mechanisms as well as will reduce the impact on other parts of the code.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-40427

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Implement event Producer and Deliverer
```
