### PR TITLE
Bump alpine to 3.14 and golang to 1.17.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ executors:
 aliases:
 - &restore_cache
   restore_cache:
-    key: go-mod-v1-{{ checksum "go.sum" }}
+    key: go-mod-v2-{{ checksum "go.sum" }}
 - &save_cache
   save_cache:
-    key: go-mod-v1-{{ checksum "go.sum" }}
+    key: go-mod-v2-{{ checksum "go.sum" }}
     paths:
       - "/go/pkg/mod"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   default:
     docker:
-    - image: circleci/golang:1.16.2
+    - image: cimg/go:1.17.4
 
 aliases:
 - &restore_cache
@@ -71,7 +71,7 @@ jobs:
 
   test-postgres:
     docker:
-    - image: circleci/golang:1.16.2
+    - image: cimg/go:1.17.4
       environment:
         CLOUD_DATABASE=postgres://cloud_test@localhost:5432/cloud_test?sslmode=disable
     - image: circleci/postgres:11.2-alpine

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@
 ################################################################################
 
 ## Docker Build Versions
-DOCKER_BUILD_IMAGE = golang:1.16.8
-DOCKER_BASE_IMAGE = alpine:3.14.2
+DOCKER_BUILD_IMAGE = golang:1.17.4
+DOCKER_BASE_IMAGE = alpine:3.14
 
 ## Tool Versions
 TERRAFORM_VERSION=0.12.31

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 # See LICENSE.txt for license information.
 
 # Build the mattermost cloud
-ARG DOCKER_BUILD_IMAGE=golang:1.16
+ARG DOCKER_BUILD_IMAGE=golang:1.17
 ARG DOCKER_BASE_IMAGE=alpine:3.14
 
 FROM ${DOCKER_BUILD_IMAGE} AS build


### PR DESCRIPTION
Fixes known vulnerabilities

Issue: MM-40588

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Bump alpine to 3.14 and golang to 1.17.4

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40558

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Bump alpine to 3.14 and golang to 1.17.4.
```
