### PR TITLE
Enable Provisioner events for Installation, Cluster and Cluster Installation

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -356,17 +356,17 @@ var serverCmd = &cobra.Command{
 
 		var multiDoer supervisor.MultiDoer
 		if clusterSupervisor {
-			multiDoer = append(multiDoer, supervisor.NewClusterSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, logger))
+			multiDoer = append(multiDoer, supervisor.NewClusterSupervisor(sqlStore, kopsProvisioner, awsClient, eventsProducer, instanceID, logger))
 		}
 		if groupSupervisor {
-			multiDoer = append(multiDoer, supervisor.NewGroupSupervisor(sqlStore, instanceID, logger))
+			multiDoer = append(multiDoer, supervisor.NewGroupSupervisor(sqlStore, eventsProducer, instanceID, logger))
 		}
 		if installationSupervisor {
 			scheduling := supervisor.NewInstallationSupervisorSchedulingOptions(balancedInstallationScheduling, clusterResourceThreshold, clusterResourceThresholdScaleValue)
-			multiDoer = append(multiDoer, supervisor.NewInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, keepDatabaseData, keepFilestoreData, scheduling, resourceUtil, logger, cloudMetrics, forceCRUpgrade))
+			multiDoer = append(multiDoer, supervisor.NewInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, keepDatabaseData, keepFilestoreData, scheduling, resourceUtil, logger, cloudMetrics, eventsProducer, forceCRUpgrade))
 		}
 		if clusterInstallationSupervisor {
-			multiDoer = append(multiDoer, supervisor.NewClusterInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, logger))
+			multiDoer = append(multiDoer, supervisor.NewClusterInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, eventsProducer, instanceID, logger))
 		}
 		if backupSupervisor {
 			multiDoer = append(multiDoer, supervisor.NewBackupSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, logger))
@@ -376,13 +376,13 @@ var serverCmd = &cobra.Command{
 			if awatAddress == "" {
 				return errors.New("--awat flag must be provided when --import-supervisor flag is provided")
 			}
-			multiDoer = append(multiDoer, supervisor.NewImportSupervisor(awsClient, awat.NewClient(awatAddress), sqlStore, kopsProvisioner, logger))
+			multiDoer = append(multiDoer, supervisor.NewImportSupervisor(awsClient, awat.NewClient(awatAddress), sqlStore, kopsProvisioner, eventsProducer, logger))
 		}
 		if installationDBRestorationSupervisor {
-			multiDoer = append(multiDoer, supervisor.NewInstallationDBRestorationSupervisor(sqlStore, awsClient, kopsProvisioner, instanceID, logger))
+			multiDoer = append(multiDoer, supervisor.NewInstallationDBRestorationSupervisor(sqlStore, awsClient, kopsProvisioner, eventsProducer, instanceID, logger))
 		}
 		if installationDBMigrationSupervisor {
-			multiDoer = append(multiDoer, supervisor.NewInstallationDBMigrationSupervisor(sqlStore, awsClient, resourceUtil, instanceID, kopsProvisioner, logger))
+			multiDoer = append(multiDoer, supervisor.NewInstallationDBMigrationSupervisor(sqlStore, awsClient, resourceUtil, instanceID, kopsProvisioner, eventsProducer, logger))
 		}
 
 		// Setup the supervisor to effect any requested changes. It is wrapped in a

--- a/internal/api/cluster_installation_test.go
+++ b/internal/api/cluster_installation_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/api"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,9 +29,10 @@ func TestGetClusterInstallations(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -562,9 +564,10 @@ func TestMigrateClusterInstallations(t *testing.T) {
 
 	router := mux.NewRouter()
 	context := &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	}
 	api.Register(router, context)
 	ts := httptest.NewServer(router)
@@ -708,9 +711,10 @@ func TestMigrateDNS(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -866,9 +870,10 @@ func TestMigrateDNSForHibernatingInstallation(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -1013,9 +1018,10 @@ func TestMigrateDNSForNonHibernatingInstallation(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/api"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,9 +29,10 @@ func TestClusters(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -295,9 +297,10 @@ func TestCreateCluster(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -387,9 +390,10 @@ func TestRetryCreateCluster(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -472,9 +476,10 @@ func TestProvisionCluster(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -616,9 +621,10 @@ func TestUpgradeCluster(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -790,9 +796,10 @@ func TestUpdateClusterConfiguration(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -874,9 +881,10 @@ func TestResizeCluster(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -1030,9 +1038,10 @@ func TestDeleteCluster(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -1152,9 +1161,10 @@ func TestGetAllUtilityMetadata(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 
 	ts := httptest.NewServer(router)
@@ -1187,9 +1197,10 @@ func TestClusterAnnotations(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 
 	ts := httptest.NewServer(router)

--- a/internal/api/events_test.go
+++ b/internal/api/events_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListStateChangeEvents(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
+	})
+
+	ts := httptest.NewServer(router)
+	client := model.NewClient(ts.URL)
+	model.SetDeployOperators(true, true)
+
+	// Create Installation and Cluster
+	installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
+		OwnerID: "test",
+		DNS:     "test.com",
+	})
+	require.NoError(t, err)
+	time.Sleep(1 * time.Millisecond)
+	cluster, err := client.CreateCluster(&model.CreateClusterRequest{})
+	require.NoError(t, err)
+
+	// List Events
+	eventsData, err := client.ListStateChangeEvents(&model.ListStateChangeEventsRequest{Paging: model.AllPagesNotDeleted()})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, len(eventsData))
+	assert.Equal(t, cluster.ID, eventsData[0].StateChange.ResourceID)
+	assert.Equal(t, model.TypeCluster, eventsData[0].StateChange.ResourceType)
+	assert.Equal(t, "n/a", eventsData[0].StateChange.OldState)
+	assert.Equal(t, cluster.State, eventsData[0].StateChange.NewState)
+	assert.Equal(t, model.ResourceStateChangeEventType, eventsData[0].Event.EventType)
+
+	assert.Equal(t, installation.ID, eventsData[1].StateChange.ResourceID)
+	assert.Equal(t, model.TypeInstallation, eventsData[1].StateChange.ResourceType)
+	assert.Equal(t, "n/a", eventsData[1].StateChange.OldState)
+	assert.Equal(t, installation.State, eventsData[1].StateChange.NewState)
+	assert.Equal(t, model.ResourceStateChangeEventType, eventsData[1].Event.EventType)
+
+	// List by resource ID
+	eventsData, err = client.ListStateChangeEvents(&model.ListStateChangeEventsRequest{ResourceID: installation.ID, Paging: model.AllPagesNotDeleted()})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(eventsData))
+	assert.Equal(t, installation.ID, eventsData[0].StateChange.ResourceID)
+	assert.Equal(t, model.TypeInstallation, eventsData[0].StateChange.ResourceType)
+
+	// List by resource type
+	eventsData, err = client.ListStateChangeEvents(&model.ListStateChangeEventsRequest{ResourceType: model.TypeCluster, Paging: model.AllPagesNotDeleted()})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(eventsData))
+	assert.Equal(t, cluster.ID, eventsData[0].StateChange.ResourceID)
+	assert.Equal(t, model.TypeCluster, eventsData[0].StateChange.ResourceType)
+}

--- a/internal/api/group_test.go
+++ b/internal/api/group_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/api"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -392,9 +393,10 @@ func TestDeleteGroup(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -481,9 +483,10 @@ func TestGroupStatus(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -597,9 +600,10 @@ func TestGroupsStatus(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()

--- a/internal/api/installation_backup_test.go
+++ b/internal/api/installation_backup_test.go
@@ -26,9 +26,10 @@ func TestRequestInstallationBackup(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 
 	ts := httptest.NewServer(router)

--- a/internal/api/installation_db_migration_test.go
+++ b/internal/api/installation_db_migration_test.go
@@ -29,9 +29,10 @@ func TestTriggerInstallationDBMigration(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 
 	ts := httptest.NewServer(router)

--- a/internal/api/installation_db_restoration_operation.go
+++ b/internal/api/installation_db_restoration_operation.go
@@ -64,7 +64,7 @@ func handleTriggerInstallationDBRestoration(c *Context, w http.ResponseWriter, r
 		return
 	}
 
-	dbRestoration, err := common.TriggerInstallationDBRestoration(c.Store, installationDTO.Installation, backup, c.Environment, c.Logger)
+	dbRestoration, err := common.TriggerInstallationDBRestoration(c.Store, installationDTO.Installation, backup, c.EventProducer, c.Environment, c.Logger)
 	if err != nil {
 		c.Logger.WithError(err).Error("Failed to trigger installation db restoration")
 		w.WriteHeader(common.ErrToStatus(err))

--- a/internal/api/installation_db_restoration_operation_test.go
+++ b/internal/api/installation_db_restoration_operation_test.go
@@ -26,9 +26,10 @@ func TestTriggerInstallationDBRestoration(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 
 	ts := httptest.NewServer(router)

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/api"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -350,9 +351,10 @@ func TestCreateInstallation(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -624,9 +626,10 @@ func TestRetryCreateInstallation(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -711,9 +714,10 @@ func TestUpdateInstallation(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -958,9 +962,10 @@ func TestJoinGroup(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -1079,9 +1084,10 @@ func TestWakeUpInstallation(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -1196,9 +1202,10 @@ func TestLeaveGroup(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -1313,9 +1320,10 @@ func TestDeleteInstallation(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -1427,9 +1435,10 @@ func TestInstallationAnnotations(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:      sqlStore,
-		Supervisor: &mockSupervisor{},
-		Logger:     logger,
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
 	})
 
 	ts := httptest.NewServer(router)

--- a/internal/supervisor/cluster_installation_test.go
+++ b/internal/supervisor/cluster_installation_test.go
@@ -7,6 +7,8 @@ package supervisor_test
 import (
 	"testing"
 
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
+
 	"github.com/mattermost/mattermost-cloud/internal/provisioner"
 
 	"github.com/mattermost/mattermost-cloud/internal/store"
@@ -83,7 +85,14 @@ func TestClusterInstallationSupervisorDo(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		mockStore := &mockClusterInstallationStore{}
 
-		supervisor := supervisor.NewClusterInstallationSupervisor(mockStore, &mockClusterInstallationProvisioner{}, &mockAWS{}, "instanceID", logger)
+		supervisor := supervisor.NewClusterInstallationSupervisor(
+			mockStore,
+			&mockClusterInstallationProvisioner{},
+			&mockAWS{},
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 		err := supervisor.Do()
 		require.NoError(t, err)
 
@@ -108,7 +117,14 @@ func TestClusterInstallationSupervisorDo(t *testing.T) {
 		}
 		mockStore.ClusterInstallation = mockStore.UnlockedClusterInstallationsPendingWork[0]
 
-		supervisor := supervisor.NewClusterInstallationSupervisor(mockStore, &mockClusterInstallationProvisioner{}, &mockAWS{}, "instanceID", logger)
+		supervisor := supervisor.NewClusterInstallationSupervisor(
+			mockStore,
+			&mockClusterInstallationProvisioner{},
+			&mockAWS{},
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 		err := supervisor.Do()
 		require.NoError(t, err)
 
@@ -140,7 +156,14 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 			t.Run(tc.Description, func(t *testing.T) {
 				logger := testlib.MakeLogger(t)
 				sqlStore := store.MakeTestSQLStore(t, logger)
-				supervisor := supervisor.NewClusterInstallationSupervisor(sqlStore, &mockClusterInstallationProvisioner{}, &mockAWS{}, "instanceID", logger)
+				supervisor := supervisor.NewClusterInstallationSupervisor(
+					sqlStore,
+					&mockClusterInstallationProvisioner{},
+					&mockAWS{},
+					testutil.SetupTestEventsProducer(sqlStore, logger),
+					"instanceID",
+					logger,
+				)
 
 				installation := &model.Installation{}
 				err := sqlStore.CreateInstallation(installation, nil)
@@ -175,7 +198,14 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 			t.Run(tc.Description, func(t *testing.T) {
 				logger := testlib.MakeLogger(t)
 				sqlStore := store.MakeTestSQLStore(t, logger)
-				supervisor := supervisor.NewClusterInstallationSupervisor(sqlStore, &mockClusterInstallationProvisioner{}, &mockAWS{}, "instanceID", logger)
+				supervisor := supervisor.NewClusterInstallationSupervisor(
+					sqlStore,
+					&mockClusterInstallationProvisioner{},
+					&mockAWS{},
+					testutil.SetupTestEventsProducer(sqlStore, logger),
+					"instanceID",
+					logger,
+				)
 
 				cluster := &model.Cluster{}
 				err := sqlStore.CreateCluster(cluster, nil)
@@ -199,7 +229,14 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 	t.Run("cannot delete when backup is running", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewClusterInstallationSupervisor(sqlStore, &mockClusterInstallationProvisioner{}, &mockAWS{}, "instanceID", logger)
+		supervisor := supervisor.NewClusterInstallationSupervisor(
+			sqlStore,
+			&mockClusterInstallationProvisioner{},
+			&mockAWS{},
+			testutil.SetupTestEventsProducer(sqlStore, logger),
+			"instanceID",
+			logger,
+		)
 
 		cluster := &model.Cluster{}
 		err := sqlStore.CreateCluster(cluster, nil)
@@ -245,7 +282,14 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 			t.Run(tc.Description, func(t *testing.T) {
 				logger := testlib.MakeLogger(t)
 				sqlStore := store.MakeTestSQLStore(t, logger)
-				supervisor := supervisor.NewClusterInstallationSupervisor(sqlStore, &mockClusterInstallationProvisioner{}, &mockAWS{}, "instanceID", logger)
+				supervisor := supervisor.NewClusterInstallationSupervisor(
+					sqlStore,
+					&mockClusterInstallationProvisioner{},
+					&mockAWS{},
+					testutil.SetupTestEventsProducer(sqlStore, logger),
+					"instanceID",
+					logger,
+				)
 
 				cluster := &model.Cluster{}
 				err := sqlStore.CreateCluster(cluster, nil)
@@ -273,7 +317,14 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 	t.Run("state has changed since cluster installation was selected to be worked on", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewClusterInstallationSupervisor(sqlStore, &mockClusterInstallationProvisioner{}, &mockAWS{}, "instanceID", logger)
+		supervisor := supervisor.NewClusterInstallationSupervisor(
+			sqlStore,
+			&mockClusterInstallationProvisioner{},
+			&mockAWS{},
+			testutil.SetupTestEventsProducer(sqlStore, logger),
+			"instanceID",
+			logger,
+		)
 
 		cluster := &model.Cluster{}
 		err := sqlStore.CreateCluster(cluster, nil)

--- a/internal/supervisor/db_migration_test.go
+++ b/internal/supervisor/db_migration_test.go
@@ -206,7 +206,7 @@ func TestDBMigrationSupervisor_Do(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		mockStore := &mockDBMigrationStore{}
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(mockStore, &mockAWS{}, &utils.ResourceUtil{}, "instanceID", nil, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(mockStore, &mockAWS{}, &utils.ResourceUtil{}, "instanceID", nil, nil, logger)
 		err := dbMigrationSupervisor.Do()
 		require.NoError(t, err)
 
@@ -231,7 +231,15 @@ func TestDBMigrationSupervisor_Do(t *testing.T) {
 			UnlockChan:           make(chan interface{}),
 		}
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(mockStore, &mockAWS{}, &utils.ResourceUtil{}, "instanceID", nil, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+			mockStore,
+			&mockAWS{},
+			&utils.ResourceUtil{},
+			"instanceID",
+			nil,
+			&mockEventProducer{},
+			logger,
+		)
 		err := dbMigrationSupervisor.Do()
 		require.NoError(t, err)
 
@@ -256,7 +264,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 		require.NoError(t, err)
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &utils.ResourceUtil{}, "instanceID", nil, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			&utils.ResourceUtil{},
+			"instanceID",
+			nil,
+			&mockEventProducer{},
+			logger,
+		)
 		dbMigrationSupervisor.Supervise(migrationOp)
 
 		// Assert
@@ -323,7 +339,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 				err = sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 				require.NoError(t, err)
 
-				dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &utils.ResourceUtil{}, "instanceID", nil, logger)
+				dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+					sqlStore,
+					&mockAWS{},
+					&utils.ResourceUtil{},
+					"instanceID",
+					nil,
+					&mockEventProducer{},
+					logger,
+				)
 				dbMigrationSupervisor.Supervise(migrationOp)
 
 				// Assert
@@ -353,7 +377,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 		require.NoError(t, err)
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &mockResourceUtil{}, "instanceID", nil, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			&mockResourceUtil{},
+			"instanceID",
+			nil,
+			&mockEventProducer{},
+			logger,
+		)
 		dbMigrationSupervisor.Supervise(migrationOp)
 
 		// Assert
@@ -381,7 +413,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 		require.NoError(t, err)
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &mockResourceUtil{}, "instanceID", &mockMigrationProvisioner{}, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			&mockResourceUtil{},
+			"instanceID",
+			&mockMigrationProvisioner{},
+			&mockEventProducer{},
+			logger,
+		)
 		dbMigrationSupervisor.Supervise(migrationOp)
 
 		// Assert
@@ -413,7 +453,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 		err = sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 		require.NoError(t, err)
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &mockResourceUtil{}, "instanceID", nil, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			&mockResourceUtil{},
+			"instanceID",
+			nil,
+			&mockEventProducer{},
+			logger,
+		)
 		dbMigrationSupervisor.Supervise(migrationOp)
 
 		// Assert
@@ -444,7 +492,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 		require.NoError(t, err)
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &mockResourceUtil{}, "instanceID", nil, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			&mockResourceUtil{},
+			"instanceID",
+			nil,
+			&mockEventProducer{},
+			logger,
+		)
 		dbMigrationSupervisor.Supervise(migrationOp)
 
 		// Assert
@@ -513,7 +569,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 				err = sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 				require.NoError(t, err)
 
-				dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &utils.ResourceUtil{}, "instanceID", nil, logger)
+				dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+					sqlStore,
+					&mockAWS{},
+					&utils.ResourceUtil{},
+					"instanceID",
+					nil,
+					&mockEventProducer{},
+					logger,
+				)
 				dbMigrationSupervisor.Supervise(migrationOp)
 
 				// Assert
@@ -539,7 +603,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 		require.NoError(t, err)
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &mockResourceUtil{}, "instanceID", &mockMigrationProvisioner{}, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			&mockResourceUtil{},
+			"instanceID",
+			&mockMigrationProvisioner{},
+			&mockEventProducer{},
+			logger,
+		)
 		dbMigrationSupervisor.Supervise(migrationOp)
 
 		// Assert
@@ -563,7 +635,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 		require.NoError(t, err)
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &mockResourceUtil{}, "instanceID", nil, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			&mockResourceUtil{},
+			"instanceID",
+			nil,
+			&mockEventProducer{},
+			logger,
+		)
 		dbMigrationSupervisor.Supervise(migrationOp)
 
 		// Assert
@@ -592,7 +672,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 		require.NoError(t, err)
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &mockResourceUtil{}, "instanceID", nil, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			&mockResourceUtil{},
+			"instanceID",
+			nil,
+			&mockEventProducer{},
+			logger,
+		)
 		dbMigrationSupervisor.Supervise(migrationOp)
 
 		// Assert
@@ -620,7 +708,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 		require.NoError(t, err)
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &mockResourceUtil{}, "instanceID", &mockMigrationProvisioner{}, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			&mockResourceUtil{},
+			"instanceID",
+			&mockMigrationProvisioner{},
+			&mockEventProducer{},
+			logger,
+		)
 		dbMigrationSupervisor.Supervise(migrationOp)
 
 		// Assert
@@ -648,7 +744,15 @@ func TestDBMigrationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBMigrationOperation(migrationOp)
 		require.NoError(t, err)
 
-		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(sqlStore, &mockAWS{}, &mockResourceUtil{}, "instanceID", &mockMigrationProvisioner{}, logger)
+		dbMigrationSupervisor := supervisor.NewInstallationDBMigrationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			&mockResourceUtil{},
+			"instanceID",
+			&mockMigrationProvisioner{},
+			&mockEventProducer{},
+			logger,
+		)
 		dbMigrationSupervisor.Supervise(migrationOp)
 
 		// Assert

--- a/internal/supervisor/group_test.go
+++ b/internal/supervisor/group_test.go
@@ -80,7 +80,7 @@ func TestGroupSupervisorDo(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		mockStore := &mockGroupStore{}
 
-		supervisor := supervisor.NewGroupSupervisor(mockStore, "instanceID", logger)
+		supervisor := supervisor.NewGroupSupervisor(mockStore, nil, "instanceID", logger)
 		err := supervisor.Do()
 		require.NoError(t, err)
 
@@ -106,7 +106,12 @@ func TestGroupSupervisorDo(t *testing.T) {
 		}
 		mockStore.UnlockChan = make(chan interface{})
 
-		supervisor := supervisor.NewGroupSupervisor(mockStore, "instanceID", logger)
+		supervisor := supervisor.NewGroupSupervisor(
+			mockStore,
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 		err := supervisor.Do()
 		require.NoError(t, err)
 
@@ -160,7 +165,12 @@ func TestGroupSupervisor(t *testing.T) {
 	t.Run("no installations", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewGroupSupervisor(sqlStore, "instanceID", logger)
+		supervisor := supervisor.NewGroupSupervisor(
+			sqlStore,
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 
 		group := standardGroup()
 		err := sqlStore.CreateGroup(group)
@@ -173,7 +183,12 @@ func TestGroupSupervisor(t *testing.T) {
 	t.Run("one installation, stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewGroupSupervisor(sqlStore, "instanceID", logger)
+		supervisor := supervisor.NewGroupSupervisor(
+			sqlStore,
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 
 		group := standardGroup()
 		err := sqlStore.CreateGroup(group)
@@ -201,7 +216,12 @@ func TestGroupSupervisor(t *testing.T) {
 	t.Run("three installations, stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewGroupSupervisor(sqlStore, "instanceID", logger)
+		supervisor := supervisor.NewGroupSupervisor(
+			sqlStore,
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 
 		group := standardGroup()
 		group.MaxRolling = 10
@@ -256,7 +276,12 @@ func TestGroupSupervisor(t *testing.T) {
 	t.Run("one installation, not stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
-		supervisor := supervisor.NewGroupSupervisor(sqlStore, "instanceID", logger)
+		supervisor := supervisor.NewGroupSupervisor(
+			sqlStore,
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 
 		group := standardGroup()
 		err := sqlStore.CreateGroup(group)
@@ -285,7 +310,12 @@ func TestGroupSupervisor(t *testing.T) {
 		t.Run("two installations, stable", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
-			supervisor := supervisor.NewGroupSupervisor(sqlStore, "instanceID", logger)
+			supervisor := supervisor.NewGroupSupervisor(
+				sqlStore,
+				&mockEventProducer{},
+				"instanceID",
+				logger,
+			)
 
 			group := standardGroup()
 			err := sqlStore.CreateGroup(group)
@@ -328,7 +358,12 @@ func TestGroupSupervisor(t *testing.T) {
 		t.Run("two installations, one stable", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
-			supervisor := supervisor.NewGroupSupervisor(sqlStore, "instanceID", logger)
+			supervisor := supervisor.NewGroupSupervisor(
+				sqlStore,
+				&mockEventProducer{},
+				"instanceID",
+				logger,
+			)
 
 			group := standardGroup()
 			err := sqlStore.CreateGroup(group)

--- a/internal/supervisor/import_test.go
+++ b/internal/supervisor/import_test.go
@@ -44,6 +44,7 @@ func TestImportSupervisor(t *testing.T) {
 			awatClient,
 			store,
 			&mockImportProvisioner{Fail: false},
+			&mockEventProducer{},
 			logger)
 
 		awatClient.EXPECT().
@@ -96,6 +97,7 @@ func TestImportSupervisor(t *testing.T) {
 			awatClient,
 			store,
 			&mockImportProvisioner{Fail: true},
+			&mockEventProducer{},
 			logger)
 
 		awatClient.EXPECT().
@@ -152,6 +154,7 @@ func TestImportSupervisor(t *testing.T) {
 			awatClient,
 			store,
 			&mockImportProvisioner{Fail: false},
+			&mockEventProducer{},
 			logger)
 
 		awatClient.EXPECT().
@@ -176,6 +179,7 @@ func TestImportSupervisor(t *testing.T) {
 			awatClient,
 			store,
 			&mockImportProvisioner{Fail: false},
+			&mockEventProducer{},
 			logger)
 
 		awatClient.EXPECT().
@@ -200,6 +204,7 @@ func TestImportSupervisor(t *testing.T) {
 			awatClient,
 			store,
 			&mockImportProvisioner{Fail: false},
+			&mockEventProducer{},
 			logger)
 
 		awatClient.EXPECT().

--- a/internal/supervisor/installation_db_restoration_test.go
+++ b/internal/supervisor/installation_db_restoration_test.go
@@ -135,7 +135,7 @@ func TestInstallationDBRestorationSupervisor_Do(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		mockStore := &mockRestorationStore{}
 
-		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(mockStore, &mockAWS{}, &mockRestoreProvisioner{}, "instanceID", logger)
+		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(mockStore, &mockAWS{}, &mockRestoreProvisioner{}, nil, "instanceID", logger)
 		err := restorationSupervisor.Do()
 		require.NoError(t, err)
 
@@ -160,7 +160,14 @@ func TestInstallationDBRestorationSupervisor_Do(t *testing.T) {
 			UnlockChan:                       make(chan interface{}),
 		}
 
-		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(mockStore, &mockAWS{}, &mockRestoreProvisioner{}, "instanceID", logger)
+		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(
+			mockStore,
+			&mockAWS{},
+			&mockRestoreProvisioner{},
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 		err := restorationSupervisor.Do()
 		require.NoError(t, err)
 
@@ -189,7 +196,14 @@ func TestInstallationDBRestorationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBRestorationOperation(restorationOp)
 		require.NoError(t, err)
 
-		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(sqlStore, &mockAWS{}, mockRestoreOp, "instanceID", logger)
+		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			mockRestoreOp,
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 		restorationSupervisor.Supervise(restorationOp)
 
 		// Assert
@@ -246,7 +260,14 @@ func TestInstallationDBRestorationSupervisor_Supervise(t *testing.T) {
 				err := sqlStore.CreateInstallationDBRestorationOperation(restorationOp)
 				require.NoError(t, err)
 
-				restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(sqlStore, &mockAWS{}, testCase.mockRestoreOp, "instanceID", logger)
+				restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(
+					sqlStore,
+					&mockAWS{},
+					testCase.mockRestoreOp,
+					&mockEventProducer{},
+					"instanceID",
+					logger,
+				)
 				restorationSupervisor.Supervise(restorationOp)
 
 				// Assert
@@ -277,7 +298,14 @@ func TestInstallationDBRestorationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBRestorationOperation(restorationOp)
 		require.NoError(t, err)
 
-		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(sqlStore, &mockAWS{}, mockRestoreOp, "instanceID", logger)
+		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			mockRestoreOp,
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 		restorationSupervisor.Supervise(restorationOp)
 
 		// Assert
@@ -309,7 +337,14 @@ func TestInstallationDBRestorationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBRestorationOperation(restorationOp)
 		require.NoError(t, err)
 
-		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(sqlStore, &mockAWS{}, mockRestoreOp, "instanceID", logger)
+		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			mockRestoreOp,
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 		restorationSupervisor.Supervise(restorationOp)
 
 		// Assert
@@ -340,7 +375,14 @@ func TestInstallationDBRestorationSupervisor_Supervise(t *testing.T) {
 		err := sqlStore.CreateInstallationDBRestorationOperation(restorationOp)
 		require.NoError(t, err)
 
-		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(sqlStore, &mockAWS{}, mockRestoreOp, "instanceID", logger)
+		restorationSupervisor := supervisor.NewInstallationDBRestorationSupervisor(
+			sqlStore,
+			&mockAWS{},
+			mockRestoreOp,
+			&mockEventProducer{},
+			"instanceID",
+			logger,
+		)
 		restorationSupervisor.Supervise(restorationOp)
 
 		// Assert

--- a/internal/testutil/events.go
+++ b/internal/testutil/events.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package testutil
+
+import (
+	"context"
+
+	"github.com/mattermost/mattermost-cloud/internal/events"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/sirupsen/logrus"
+)
+
+// SetupTestEventsProducer sets up testing event produced that does not deliver events.
+func SetupTestEventsProducer(sqlStore *store.SQLStore, logger logrus.FieldLogger) *events.EventProducer {
+	cfg := events.DelivererConfig{
+		RetryWorkers:    0,
+		UpToDateWorkers: 0,
+		MaxBurstWorkers: 0,
+	}
+	deliverer := events.NewDeliverer(context.Background(), sqlStore, model.NewID(), logger, cfg)
+
+	return events.NewProducer(sqlStore, deliverer, "test", logger)
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR enables the creation of state change events for Clusters, Installations, and Cluster Installations.
After merging, the events will be stored and emitted together with sending webhooks.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-40628

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Enable Provisioner events for Installation, Cluster and Cluster Installation
```
