### PR TITLE
Add mmctl endpoint to run mmctl commands from the Cloud plugin

### DIFF
--- a/internal/api/cluster_installation.go
+++ b/internal/api/cluster_installation.go
@@ -35,6 +35,7 @@ func initClusterInstallation(apiRouter *mux.Router, context *Context) {
 	clusterInstallationRouter.Handle("/config", addContext(handleSetClusterInstallationConfig)).Methods("PUT")
 	clusterInstallationRouter.Handle("/exec/{command}", addContext(handleRunClusterInstallationExecCommand)).Methods("POST")
 	clusterInstallationRouter.Handle("/mattermost_cli", addContext(handleRunClusterInstallationMattermostCLI)).Methods("POST")
+	clusterInstallationRouter.Handle("/mmctl", addContext(handleRunClusterInstallationMmctl)).Methods("POST")
 }
 
 // handleGetClusterInstallations responds to GET /api/cluster_installations, returning the specified page of cluster installations.
@@ -361,6 +362,65 @@ func handleRunClusterInstallationMattermostCLI(c *Context, w http.ResponseWriter
 	output, err := c.Provisioner.ExecMattermostCLI(cluster, clusterInstallation, clusterInstallationMattermostCLISubcommandRequest...)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to execute mattermost cli")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write(output)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(output)
+}
+
+func handleRunClusterInstallationMmctl(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	clusterInstallationID := vars["cluster_installation"]
+	c.Logger = c.Logger.WithField("cluster_installation", clusterInstallationID)
+
+	clusterInstallationMmctlSubcommandRequest, err := model.NewClusterInstallationMmctlSubcommandFromReader(r.Body)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to decode request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	clusterInstallation, err := c.Store.GetClusterInstallation(clusterInstallationID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query cluster installation")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if clusterInstallation == nil {
+		c.Logger.Error("cluster installation not found")
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	if clusterInstallation.IsDeleted() {
+		c.Logger.Error("cluster installation is deleted")
+		w.WriteHeader(http.StatusGone)
+		return
+	}
+
+	if clusterInstallation.APISecurityLock {
+		logSecurityLockConflict("cluster-installation", c.Logger)
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	cluster, err := c.Store.GetCluster(clusterInstallation.ClusterID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to query cluster")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if cluster == nil {
+		c.Logger.Errorf("failed to find cluster %s associated with cluster installations", clusterInstallation.ClusterID)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	output, err := c.Provisioner.ExecMmctl(cluster, clusterInstallation, clusterInstallationMmctlSubcommandRequest...)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to execute mmctl command")
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write(output)
 		return

--- a/internal/api/cluster_installation_test.go
+++ b/internal/api/cluster_installation_test.go
@@ -556,6 +556,91 @@ func TestRunClusterInstallationMattermostCLI(t *testing.T) {
 	})
 }
 
+func TestRunClusterInstallationMmctl(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+
+	mProvisioner := &mockProvisioner{}
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:       sqlStore,
+		Supervisor:  &mockSupervisor{},
+		Provisioner: mProvisioner,
+		Logger:      logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	cluster := &model.Cluster{}
+	err := sqlStore.CreateCluster(cluster, nil)
+	require.NoError(t, err)
+
+	clusterInstallation1 := &model.ClusterInstallation{
+		ClusterID:      cluster.ID,
+		InstallationID: model.NewID(),
+	}
+	err = sqlStore.CreateClusterInstallation(clusterInstallation1)
+	require.NoError(t, err)
+
+	subcommand := model.ClusterInstallationMmctlSubcommand{"config", "get", "ServiceSettings.SiteURL"}
+
+	t.Run("unknown cluster installation", func(t *testing.T) {
+		bytes, err := client.RunMmctlCommandOnClusterInstallation(model.NewID(), subcommand)
+		require.EqualError(t, err, "failed with status code 404")
+		require.Empty(t, bytes)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		bytes, err := client.RunMmctlCommandOnClusterInstallation(clusterInstallation1.ID, subcommand)
+		require.NoError(t, err)
+		require.NotEmpty(t, bytes)
+	})
+
+	t.Run("invalid payload", func(t *testing.T) {
+		httpRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/cluster_installation/%s/mmctl", ts.URL, clusterInstallation1.ID), bytes.NewReader([]byte("invalid")))
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(httpRequest)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("while api-security-locked", func(t *testing.T) {
+		err = sqlStore.LockClusterInstallationAPI(clusterInstallation1.ID)
+		require.NoError(t, err)
+
+		bytes, err := client.RunMmctlCommandOnClusterInstallation(clusterInstallation1.ID, subcommand)
+		require.EqualError(t, err, "failed with status code 403")
+		require.Empty(t, bytes)
+
+		err = sqlStore.UnlockClusterInstallationAPI(clusterInstallation1.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-zero exit command", func(t *testing.T) {
+		mProvisioner.CommandError = errors.New("encountered a command error")
+
+		httpRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/cluster_installation/%s/mmctl", ts.URL, clusterInstallation1.ID), bytes.NewReader([]byte("[]")))
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(httpRequest)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	})
+
+	t.Run("cluster installation deleted", func(t *testing.T) {
+		err = sqlStore.DeleteClusterInstallation(clusterInstallation1.ID)
+		require.NoError(t, err)
+
+		bytes, err := client.RunMmctlCommandOnClusterInstallation(clusterInstallation1.ID, subcommand)
+		require.Error(t, err)
+		require.Empty(t, bytes)
+	})
+}
+
 func TestMigrateClusterInstallations(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)

--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -37,6 +37,14 @@ func (s *mockProvisioner) ExecMattermostCLI(*model.Cluster, *model.ClusterInstal
 	return s.Output, s.CommandError
 }
 
+func (s *mockProvisioner) ExecMmctl(*model.Cluster, *model.ClusterInstallation, ...string) ([]byte, error) {
+	if len(s.Output) == 0 {
+		s.Output = []byte(`{"ServiceSettings":{"SiteURL":"http://test.example.com"}}`)
+	}
+
+	return s.Output, s.CommandError
+}
+
 func (s *mockProvisioner) GetClusterResources(*model.Cluster, bool) (*k8s.ClusterResources, error) {
 	return nil, nil
 }

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -118,6 +118,7 @@ type Store interface {
 type Provisioner interface {
 	ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
 	ExecMattermostCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
+	ExecMmctl(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
 	GetClusterResources(*model.Cluster, bool) (*k8s.ClusterResources, error)
 }
 

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -617,7 +617,7 @@ func (provisioner *KopsProvisioner) ExecMattermostCLI(cluster *model.Cluster, cl
 	return provisioner.ExecClusterInstallationCLI(cluster, clusterInstallation, append([]string{"./bin/mattermost"}, args...)...)
 }
 
-// ExecMattermostCLI invokes the Mattermost CLI for the given cluster installation with the given args.
+// ExecMmctl invokes the mmctl command for the given cluster installation with the given args.
 func (provisioner *KopsProvisioner) ExecMmctl(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error) {
 	args = append(args, "--local")
 	return provisioner.ExecClusterInstallationCLI(cluster, clusterInstallation, append([]string{"./bin/mmctl"}, args...)...)

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -617,6 +617,12 @@ func (provisioner *KopsProvisioner) ExecMattermostCLI(cluster *model.Cluster, cl
 	return provisioner.ExecClusterInstallationCLI(cluster, clusterInstallation, append([]string{"./bin/mattermost"}, args...)...)
 }
 
+// ExecMattermostCLI invokes the Mattermost CLI for the given cluster installation with the given args.
+func (provisioner *KopsProvisioner) ExecMmctl(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error) {
+	args = append(args, "--local")
+	return provisioner.ExecClusterInstallationCLI(cluster, clusterInstallation, append([]string{"./bin/mmctl"}, args...)...)
+}
+
 // ExecClusterInstallationCLI execs the provided command on the defined cluster installation.
 func (provisioner *KopsProvisioner) ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error) {
 	logger := provisioner.logger.WithFields(log.Fields{

--- a/model/client.go
+++ b/model/client.go
@@ -912,6 +912,25 @@ func (c *Client) RunMattermostCLICommandOnClusterInstallation(clusterInstallatio
 	}
 }
 
+// RunMmctlCommandOnClusterInstallation runs a Mattermost CLI command against a cluster installation.
+func (c *Client) RunMmctlCommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error) {
+	resp, err := c.doPost(c.buildURL("/api/cluster_installation/%s/mmctl", clusterInstallationID), subcommand)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	bytes, _ := ioutil.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return bytes, nil
+
+	default:
+		return bytes, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // ExecClusterInstallationCLI runs a valid exec command against a cluster installation.
 func (c *Client) ExecClusterInstallationCLI(clusterInstallationID, command string, subcommand []string) ([]byte, error) {
 	resp, err := c.doPost(c.buildURL("/api/cluster_installation/%s/exec/%s", clusterInstallationID, command), subcommand)

--- a/model/cluster_installation_request.go
+++ b/model/cluster_installation_request.go
@@ -57,6 +57,20 @@ func NewClusterInstallationMattermostCLISubcommandFromReader(reader io.Reader) (
 	return clusterInstallationMattermostCLISubcommand, nil
 }
 
+// ClusterInstallationMmctlSubcommand describes the payload necessary to run the mmctl command line tool on a cluster installation.
+type ClusterInstallationMmctlSubcommand []string
+
+// NewClusterInstallationMmctlSubcommandFromReader will create a ClusterInstallationMmctlSubcommand from an io.Reader.
+func NewClusterInstallationMmctlSubcommandFromReader(reader io.Reader) (ClusterInstallationMmctlSubcommand, error) {
+	var clusterInstallationMmctlSubcommand ClusterInstallationMmctlSubcommand
+	err := json.NewDecoder(reader).Decode(&clusterInstallationMmctlSubcommand)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode cluster installation mmctl request")
+	}
+
+	return clusterInstallationMmctlSubcommand, nil
+}
+
 // ClusterInstallationExecSubcommand describes the payload necessary to run container exec commands on a cluster installation.
 type ClusterInstallationExecSubcommand []string
 


### PR DESCRIPTION
#### Summary

This PR makes it so the Cloud plugin has access to run `mmctl` commands in local mode.

I'm not sure how I can test this code without setting up the infrastructure described in this project's README.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-40727

#### Related Pull Requests

https://github.com/mattermost/mattermost-plugin-cloud/pull/86

#### Release Note


```release-note
Add support for running mmctl commands from the Cloud plugin.
```
