### PR TITLE
Add checks for Provisioner events to e2e cluster tests

### DIFF
--- a/e2e/pkg/cluster.go
+++ b/e2e/pkg/cluster.go
@@ -14,6 +14,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var (
+	ClusterProvisioningFailedStates = []string{model.ClusterStateCreationFailed, model.ClusterStateProvisioningFailed}
+)
+
+
 // WaitForClusterToBeStable waits until Cluster reaches Stable state.
 func WaitForClusterToBeStable(ctx context.Context, clusterID string, whChan <-chan *model.WebhookPayload, log logrus.FieldLogger) error {
 	waitCtx, cancel := context.WithTimeout(ctx, 20*time.Minute)
@@ -21,9 +26,9 @@ func WaitForClusterToBeStable(ctx context.Context, clusterID string, whChan <-ch
 
 	whWaiter := webhookWaiter{
 		whChan:        whChan,
-		resourceType:  model.TypeCluster,
+		resourceType:  model.TypeCluster.String(),
 		desiredState:  model.ClusterStateStable,
-		failureStates: []string{model.ClusterStateCreationFailed, model.ClusterStateProvisioningFailed},
+		failureStates: ClusterProvisioningFailedStates,
 		logger: log.WithFields(map[string]interface{}{
 			"cluster":       clusterID,
 			"desired-state": model.ClusterStateStable,
@@ -40,7 +45,7 @@ func WaitForClusterDeletion(ctx context.Context, clusterID string, whChan <-chan
 
 	whWaiter := webhookWaiter{
 		whChan:        whChan,
-		resourceType:  model.TypeCluster,
+		resourceType:  model.TypeCluster.String(),
 		desiredState:  model.ClusterStateDeleted,
 		failureStates: []string{model.ClusterStateDeletionFailed},
 		logger: log.WithFields(map[string]interface{}{

--- a/e2e/pkg/cluster.go
+++ b/e2e/pkg/cluster.go
@@ -21,7 +21,7 @@ var (
 
 // WaitForClusterToBeStable waits until Cluster reaches Stable state.
 func WaitForClusterToBeStable(ctx context.Context, clusterID string, whChan <-chan *model.WebhookPayload, log logrus.FieldLogger) error {
-	waitCtx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 
 	whWaiter := webhookWaiter{

--- a/e2e/pkg/eventstest/handler.go
+++ b/e2e/pkg/eventstest/handler.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package eventstest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type RecordType int
+
+const (
+	RecordInstallation RecordType = 1 << iota
+	RecordCluster
+	RecordClusterInstallation
+)
+
+const (
+	RecordAll RecordType = RecordInstallation | RecordCluster | RecordClusterInstallation
+)
+
+type EventsRecorder struct {
+	client          *model.Client
+	owner           string
+	listenerAddress string
+	logger          log.FieldLogger
+
+	server       *http.Server
+	subscription *model.Subscription
+
+	recordResources RecordType
+
+	sync.Mutex
+	RecordedEvents []model.StateChangeEventPayload
+}
+
+func NewEventsRecorder(owner, listenAddr string, logger log.FieldLogger, recordRes RecordType) *EventsRecorder {
+	return &EventsRecorder{
+		owner:           owner,
+		listenerAddress: listenAddr,
+		logger:          logger,
+		recordResources: recordRes,
+		Mutex:           sync.Mutex{},
+		RecordedEvents:  []model.StateChangeEventPayload{},
+	}
+}
+
+func (ev *EventsRecorder) Start(client *model.Client) error {
+	err := ev.runServer()
+	if err != nil {
+		return err
+	}
+
+	sub, err := RegisterStateChangeSubscription(client, ev.owner, ev.listenerAddress)
+	if err != nil {
+		return errors.Wrap(err, "failed to register subscription")
+	}
+	ev.subscription = sub
+	ev.logger.WithField("subscriptionID", sub.ID).Info("Created subscription")
+
+	return nil
+}
+
+func (ev *EventsRecorder) runServer() error {
+	eventsURL, err := url.Parse(ev.listenerAddress)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse listener address")
+	}
+
+	handler := http.NewServeMux()
+	handler.HandleFunc("/", ev.eventsHandler)
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", eventsURL.Port()),
+		Handler: handler,
+	}
+	ev.server = server
+
+	go func() {
+		ev.logger.WithField("port", eventsURL.Port()).Info("Starting events listener...")
+		err := ev.server.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			log.WithError(err).Errorf("Error listening")
+			return
+		}
+	}()
+	return nil
+}
+
+func (ev *EventsRecorder) ShutDown(client *model.Client) {
+	err := ev.server.Close()
+	if err != nil {
+		ev.logger.WithError(err).Error("Error while closing events server")
+	}
+
+	err = client.DeleteSubscription(ev.subscription.ID)
+	if err != nil {
+		ev.logger.WithError(err).Error("Error while deleting subscription")
+	}
+
+	return
+}
+
+func (ev *EventsRecorder) eventsHandler(w http.ResponseWriter, r *http.Request) {
+	payload := model.StateChangeEventPayload{}
+	err := json.NewDecoder(r.Body).Decode(&payload)
+	if err != nil {
+		ev.logger.WithError(err).Error("Failed to decode event payload")
+		return
+	}
+
+	if maskType(payload.ResourceType)&ev.recordResources == 0 {
+		ev.logger.Debugf("Event ignored: %s, %s", payload.ResourceType, payload.ResourceID)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	ev.Lock()
+	ev.RecordedEvents = append(ev.RecordedEvents, payload)
+	ev.Unlock()
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func maskType(resourceType model.ResourceType) RecordType {
+	switch resourceType {
+	case model.TypeInstallation:
+		return RecordInstallation
+	case model.TypeCluster:
+		return RecordCluster
+	case model.TypeClusterInstallation:
+		return RecordClusterInstallation
+	}
+	return 0
+}
+
+type EventOccurrence struct {
+	ResourceType string
+	ResourceID   string
+	OldState     string
+	NewState     string
+}
+
+func (eo EventOccurrence) MatchPayload(payload model.StateChangeEventPayload) bool {
+	return eo.ResourceID == payload.ResourceID &&
+		eo.ResourceType == payload.ResourceType.String() &&
+		eo.NewState == payload.NewState &&
+		eo.OldState == payload.OldState
+}
+
+func (ev *EventsRecorder) VerifyInOrder(expectedEvents []EventOccurrence) error {
+	expEvLen := len(expectedEvents)
+
+	// This might be a little hard to troubleshoot in case of error,
+	// so we leave here some Debug logs for such scenarios.
+	for i, e := range ev.RecordedEvents {
+		ev.logger.WithField("event", e).Debugf("Recorderd event %d", i)
+		if len(expectedEvents) == 0 {
+			break
+		}
+		expected := expectedEvents[0]
+
+		if expected.MatchPayload(e) {
+			expectedEvents = expectedEvents[1:]
+		}
+	}
+
+	if len(expectedEvents) > 0 {
+		return fmt.Errorf("not all expected events appeared in correct order, "+
+			"%d expected events occured, "+
+			"stuck at expected event: %v", expEvLen-len(expectedEvents), expectedEvents[0])
+	}
+
+	return nil
+}
+
+func RegisterStateChangeSubscription(client *model.Client, owner, subURL string) (*model.Subscription, error) {
+	createSubReq := model.CreateSubscriptionRequest{
+		Name:             "E2e Event Listener",
+		URL:              subURL,
+		OwnerID:          owner,
+		EventType:        model.ResourceStateChangeEventType,
+		FailureThreshold: 30 * time.Second, // Should guarantee one retry
+	}
+
+	return client.CreateSubscription(&createSubReq)
+}

--- a/e2e/pkg/eventstest/handler_test.go
+++ b/e2e/pkg/eventstest/handler_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+//+build e2e
+
+package eventstest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventsRecorder(t *testing.T) {
+
+	mockEvents := []*model.StateChangeEventPayload{
+		{ResourceType: model.TypeCluster, ResourceID: "cluster1"},
+		{ResourceType: model.TypeInstallation, ResourceID: "installation"},
+		{ResourceType: model.TypeClusterInstallation, ResourceID: "clusterInstallation1"},
+	}
+
+	clusterEventOcc := EventOccurrence{ResourceType: model.TypeCluster.String(), ResourceID: "cluster1"}
+	installationEventOcc := EventOccurrence{ResourceType: model.TypeInstallation.String(), ResourceID: "installation"}
+	clusterInstallationEventOcc := EventOccurrence{ResourceType: model.TypeClusterInstallation.String(), ResourceID: "clusterInstallation1"}
+
+	recorderURL := "http://localhost:11112"
+
+	for _, testCase := range []struct {
+		description    string
+		recorder       *EventsRecorder
+		recordedEvents []EventOccurrence
+	}{
+		{
+			description: "record all and verify",
+			recorder:    NewEventsRecorder("test", recorderURL, logrus.New(), RecordAll),
+			recordedEvents: []EventOccurrence{
+				clusterEventOcc, installationEventOcc, clusterInstallationEventOcc,
+			},
+		},
+		{
+			description: "record installation only",
+			recorder:    NewEventsRecorder("test", recorderURL, logrus.New(), RecordInstallation),
+			recordedEvents: []EventOccurrence{
+				installationEventOcc,
+			},
+		},
+		{
+			description: "record cluster only",
+			recorder:    NewEventsRecorder("test", recorderURL, logrus.New(), RecordCluster),
+			recordedEvents: []EventOccurrence{
+				clusterEventOcc,
+			},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			err := testCase.recorder.runServer()
+			require.NoError(t, err)
+			defer testCase.recorder.server.Close()
+
+			for _, mockEve := range mockEvents {
+				mockEvent(t, recorderURL, mockEve)
+			}
+
+			assert.Equal(t, len(testCase.recordedEvents), len(testCase.recorder.RecordedEvents))
+
+			err = testCase.recorder.VerifyInOrder(testCase.recordedEvents)
+			require.NoError(t, err)
+		})
+	}
+
+	t.Run("verification fail", func(t *testing.T) {
+		recorder := NewEventsRecorder("test", recorderURL, logrus.New(), RecordAll)
+		err := recorder.runServer()
+		require.NoError(t, err)
+		defer recorder.server.Close()
+
+		for _, mockEve := range mockEvents {
+			mockEvent(t, recorderURL, mockEve)
+		}
+
+		incorectOrderOccurences := []EventOccurrence{
+			clusterEventOcc, clusterInstallationEventOcc, installationEventOcc,
+		}
+
+		err = recorder.VerifyInOrder(incorectOrderOccurences)
+		require.Error(t, err)
+	})
+}
+
+func mockEvent(t *testing.T, url string, eventPayload *model.StateChangeEventPayload) {
+	payload, err := json.Marshal(eventPayload)
+	require.NoError(t, err)
+
+	_, err = http.Post(url, "application/json", bytes.NewBuffer(payload))
+	require.NoError(t, err)
+}

--- a/e2e/tests/cluster/steps.go
+++ b/e2e/tests/cluster/steps.go
@@ -13,14 +13,16 @@ import (
 func clusterLifecycleSteps(clusterSuite *workflow.ClusterSuite, installationSuite *workflow.InstallationSuite) []*workflow.Step {
 	return []*workflow.Step{
 		{
-			Name:      "CreateCluster",
-			Func:      clusterSuite.CreateCluster,
-			DependsOn: []string{},
+			Name:              "CreateCluster",
+			Func:              clusterSuite.CreateCluster,
+			DependsOn:         []string{},
+			GetExpectedEvents: clusterSuite.ClusterCreationEvents,
 		},
 		{
-			Name:      "CreateInstallation",
-			Func:      installationSuite.CreateInstallation,
-			DependsOn: []string{"CreateCluster"},
+			Name:              "CreateInstallation",
+			Func:              installationSuite.CreateInstallation,
+			DependsOn:         []string{"CreateCluster"},
+			GetExpectedEvents: installationSuite.InstallationCreationEvents,
 		},
 		{
 			Name:      "GetCI",
@@ -33,9 +35,10 @@ func clusterLifecycleSteps(clusterSuite *workflow.ClusterSuite, installationSuit
 			DependsOn: []string{"GetCI"},
 		},
 		{
-			Name:      "ProvisionCluster",
-			Func:      clusterSuite.ProvisionCluster,
-			DependsOn: []string{"PopulateSampleData"},
+			Name:              "ProvisionCluster",
+			Func:              clusterSuite.ProvisionCluster,
+			DependsOn:         []string{"PopulateSampleData"},
+			GetExpectedEvents: clusterSuite.ClusterReprovisionEvents,
 		},
 		{
 			Name:      "CheckInstallation",
@@ -43,14 +46,16 @@ func clusterLifecycleSteps(clusterSuite *workflow.ClusterSuite, installationSuit
 			DependsOn: []string{"ProvisionCluster"},
 		},
 		{
-			Name:      "DeleteInstallation",
-			Func:      installationSuite.Cleanup,
-			DependsOn: []string{"CheckInstallation"},
+			Name:              "DeleteInstallation",
+			Func:              installationSuite.Cleanup,
+			DependsOn:         []string{"CheckInstallation"},
+			GetExpectedEvents: installationSuite.InstallationDeletionEvents,
 		},
 		{
-			Name:      "DeleteCluster",
-			Func:      clusterSuite.DeleteCluster,
-			DependsOn: []string{"DeleteInstallation"},
+			Name:              "DeleteCluster",
+			Func:              clusterSuite.DeleteCluster,
+			DependsOn:         []string{"DeleteInstallation"},
+			GetExpectedEvents: clusterSuite.ClusterDeletionEvents,
 		},
 	}
 }

--- a/e2e/workflow/db_migration.go
+++ b/e2e/workflow/db_migration.go
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 //
 
-//+build e2e
+// +build e2e
 
 package workflow
 

--- a/e2e/workflow/events.go
+++ b/e2e/workflow/events.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+// +build e2e
+
+package workflow
+
+import "github.com/mattermost/mattermost-cloud/e2e/pkg/eventstest"
+
+func GetExpectedEvents(workflow []*Step) []eventstest.EventOccurrence {
+	var events []eventstest.EventOccurrence
+
+	for _, step := range workflow {
+		if step.GetExpectedEvents != nil {
+			events = append(events, step.GetExpectedEvents()...)
+		}
+	}
+
+	return events
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds a check for events that occurred in the provisioner as part of the e2e test.

Each step of the e2e test defines events that should occur after it was run. The test registers a subscription and records all events that were emitted by the Provisioner.
Events are expected to appear in the correct order. Events that were not tied to the test are ignored.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-40741

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add checks for events to e2e
```
