### PR TITLE
Close database connections in some unit tests

### DIFF
--- a/internal/events/delivery_test.go
+++ b/internal/events/delivery_test.go
@@ -23,6 +23,8 @@ import (
 func TestDelivery_Workers(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
 	instanceID := model.NewID()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -48,6 +50,8 @@ func TestDelivery_Workers(t *testing.T) {
 func TestDelivery_WorkersRetrying(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
 	instanceID := model.NewID()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -109,6 +113,8 @@ func TestDelivery_SignalNewEvents(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
+			defer store.CloseConnection(t, sqlStore)
+
 			instanceID := model.NewID()
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -137,6 +143,8 @@ func TestDelivery_SignalNewEvents(t *testing.T) {
 func TestDelivery_GiveUpWhenThresholdReached(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
 	instanceID := model.NewID()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/events/producer_test.go
+++ b/internal/events/producer_test.go
@@ -24,6 +24,8 @@ import (
 func Test_ProduceAndDeliverEvents(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
 	instanceID := model.NewID()
 
 	installation := &model.Installation{

--- a/internal/supervisor/backup_test.go
+++ b/internal/supervisor/backup_test.go
@@ -173,6 +173,7 @@ func TestBackupMetadataSupervisorSupervise(t *testing.T) {
 	t.Run("trigger backup", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		mockBackupOp := &mockBackupProvisioner{}
 
 		installation, clusterInstallation := setupBackupRequiredResources(t, sqlStore)
@@ -198,6 +199,7 @@ func TestBackupMetadataSupervisorSupervise(t *testing.T) {
 	t.Run("do not trigger backup if installation not hibernated", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		mockBackupOp := &mockBackupProvisioner{}
 
 		installation, _ := setupBackupRequiredResources(t, sqlStore)
@@ -224,6 +226,7 @@ func TestBackupMetadataSupervisorSupervise(t *testing.T) {
 	t.Run("set backup as failed if installation deleted", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		mockBackupOp := &mockBackupProvisioner{}
 
 		backupMeta := &model.InstallationBackup{
@@ -272,6 +275,7 @@ func TestBackupMetadataSupervisorSupervise(t *testing.T) {
 			t.Run(testCase.description, func(t *testing.T) {
 				logger := testlib.MakeLogger(t)
 				sqlStore := store.MakeTestSQLStore(t, logger)
+				defer store.CloseConnection(t, sqlStore)
 
 				installation, clusterInstallation := setupBackupRequiredResources(t, sqlStore)
 
@@ -301,6 +305,7 @@ func TestBackupMetadataSupervisorSupervise(t *testing.T) {
 	t.Run("cleanup backup", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		mockBackupOp := &mockBackupProvisioner{}
 
 		installation, clusterInstallation := setupBackupRequiredResources(t, sqlStore)
@@ -336,6 +341,7 @@ func TestBackupMetadataSupervisorSupervise(t *testing.T) {
 	t.Run("full backup lifecycle", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		mockBackupOp := &mockBackupProvisioner{}
 
 		installation, clusterInstallation := setupBackupRequiredResources(t, sqlStore)

--- a/internal/supervisor/cluster_installation_test.go
+++ b/internal/supervisor/cluster_installation_test.go
@@ -156,6 +156,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 			t.Run(tc.Description, func(t *testing.T) {
 				logger := testlib.MakeLogger(t)
 				sqlStore := store.MakeTestSQLStore(t, logger)
+				defer store.CloseConnection(t, sqlStore)
 				supervisor := supervisor.NewClusterInstallationSupervisor(
 					sqlStore,
 					&mockClusterInstallationProvisioner{},
@@ -198,6 +199,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 			t.Run(tc.Description, func(t *testing.T) {
 				logger := testlib.MakeLogger(t)
 				sqlStore := store.MakeTestSQLStore(t, logger)
+				defer store.CloseConnection(t, sqlStore)
 				supervisor := supervisor.NewClusterInstallationSupervisor(
 					sqlStore,
 					&mockClusterInstallationProvisioner{},
@@ -229,6 +231,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 	t.Run("cannot delete when backup is running", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewClusterInstallationSupervisor(
 			sqlStore,
 			&mockClusterInstallationProvisioner{},
@@ -282,6 +285,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 			t.Run(tc.Description, func(t *testing.T) {
 				logger := testlib.MakeLogger(t)
 				sqlStore := store.MakeTestSQLStore(t, logger)
+				defer store.CloseConnection(t, sqlStore)
 				supervisor := supervisor.NewClusterInstallationSupervisor(
 					sqlStore,
 					&mockClusterInstallationProvisioner{},
@@ -317,6 +321,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 	t.Run("state has changed since cluster installation was selected to be worked on", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewClusterInstallationSupervisor(
 			sqlStore,
 			&mockClusterInstallationProvisioner{},

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -157,6 +157,7 @@ func TestClusterSupervisorSupervise(t *testing.T) {
 		t.Run(tc.Description, func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
+			defer store.CloseConnection(t, sqlStore)
 			supervisor := supervisor.NewClusterSupervisor(
 				sqlStore,
 				&mockClusterProvisioner{},
@@ -185,6 +186,7 @@ func TestClusterSupervisorSupervise(t *testing.T) {
 	t.Run("state has changed since cluster was selected to be worked on", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewClusterSupervisor(
 			sqlStore,
 			&mockClusterProvisioner{},

--- a/internal/supervisor/group_test.go
+++ b/internal/supervisor/group_test.go
@@ -165,6 +165,7 @@ func TestGroupSupervisor(t *testing.T) {
 	t.Run("no installations", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewGroupSupervisor(
 			sqlStore,
 			&mockEventProducer{},
@@ -183,6 +184,7 @@ func TestGroupSupervisor(t *testing.T) {
 	t.Run("one installation, stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewGroupSupervisor(
 			sqlStore,
 			&mockEventProducer{},
@@ -216,6 +218,7 @@ func TestGroupSupervisor(t *testing.T) {
 	t.Run("three installations, stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewGroupSupervisor(
 			sqlStore,
 			&mockEventProducer{},
@@ -276,6 +279,7 @@ func TestGroupSupervisor(t *testing.T) {
 	t.Run("one installation, not stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewGroupSupervisor(
 			sqlStore,
 			&mockEventProducer{},
@@ -310,6 +314,7 @@ func TestGroupSupervisor(t *testing.T) {
 		t.Run("two installations, stable", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
+			defer store.CloseConnection(t, sqlStore)
 			supervisor := supervisor.NewGroupSupervisor(
 				sqlStore,
 				&mockEventProducer{},
@@ -358,6 +363,7 @@ func TestGroupSupervisor(t *testing.T) {
 		t.Run("two installations, one stable", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
+			defer store.CloseConnection(t, sqlStore)
 			supervisor := supervisor.NewGroupSupervisor(
 				sqlStore,
 				&mockEventProducer{},

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -590,6 +590,8 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("unexpected state", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -640,6 +642,8 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("state has changed since installation was selected to be worked on", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -686,6 +690,8 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations not yet created, no clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -724,6 +730,8 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations not yet created, cluster doesn't allow scheduling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -767,6 +775,8 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations not yet created, no empty clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -818,6 +828,8 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -869,6 +881,8 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -920,6 +934,8 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation DNS, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -971,6 +987,8 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1022,6 +1040,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations stable, in group with different sequence", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1086,6 +1105,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("pre provisioning requested, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1137,6 +1157,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations failed", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1188,6 +1209,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation in progress, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1239,6 +1261,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation in progress, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1290,6 +1313,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation in progress, cluster installations stable, in group with same sequence", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1361,6 +1385,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation in progress, cluster installations failed", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1412,6 +1437,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation final tasks, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1463,6 +1489,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("no compatible clusters, cluster installations not yet created, no clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1501,6 +1528,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("no compatible clusters, cluster installations not yet created, no available clusters", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1552,6 +1580,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("no compatible clusters, cluster installations not yet created, available cluster", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1594,6 +1623,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1645,6 +1675,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update requested, cluster installations stable, in group with different sequence", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1709,6 +1740,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update in progress, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1760,6 +1792,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update requested, cluster installations reconciling, in group with different sequence", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1824,6 +1857,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update in progress, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1875,6 +1909,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("update requested, cluster installations stable, in group with same sequence", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -1949,6 +1984,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("hibernation requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -2000,6 +2036,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("hibernation in progress, cluster installations reconciling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -2051,6 +2088,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("hibernation in progress, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -2102,6 +2140,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("wake up requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -2153,6 +2192,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion requested, cluster installations stable", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -2204,6 +2244,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion requested, cluster installations deleting", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -2255,6 +2296,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion in progress, cluster installations failed", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -2306,6 +2348,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion requested, cluster installations failed, so retry", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -2357,6 +2400,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion requested, delete backups", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -2418,6 +2462,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("deletion requested, delete migrations and restorations", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -2489,6 +2534,7 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations deleted", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},
@@ -2541,6 +2587,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		t.Run("creation requested, cluster installations not yet created, available cluster", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
+			defer store.CloseConnection(t, sqlStore)
 			supervisor := supervisor.NewInstallationSupervisor(
 				sqlStore,
 				&mockInstallationProvisioner{},
@@ -2584,6 +2631,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		t.Run("creation requested, cluster installations not yet created, 3 installations, available cluster", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
+			defer store.CloseConnection(t, sqlStore)
 			supervisor := supervisor.NewInstallationSupervisor(
 				sqlStore,
 				&mockInstallationProvisioner{},
@@ -2631,6 +2679,7 @@ func TestInstallationSupervisor(t *testing.T) {
 		t.Run("creation requested, cluster installations not yet created, 1 isolated and 1 multitenant, available cluster", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
+			defer store.CloseConnection(t, sqlStore)
 			supervisor := supervisor.NewInstallationSupervisor(
 				sqlStore,
 				&mockInstallationProvisioner{},
@@ -2694,6 +2743,8 @@ func TestInstallationSupervisor(t *testing.T) {
 		t.Run("creation requested, cluster installations not yet created, insufficient cluster resources", func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
 			sqlStore := store.MakeTestSQLStore(t, logger)
+			defer store.CloseConnection(t, sqlStore)
+
 			mockInstallationProvisioner := &mockInstallationProvisioner{
 				UseCustomClusterResources: true,
 				CustomClusterResources: &k8s.ClusterResources{
@@ -2747,6 +2798,8 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations not yet created, insufficient cluster resources, but scale", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
 		mockInstallationProvisioner := &mockInstallationProvisioner{
 			UseCustomClusterResources: true,
 			CustomClusterResources: &k8s.ClusterResources{
@@ -2800,6 +2853,8 @@ func TestInstallationSupervisor(t *testing.T) {
 	t.Run("creation requested, cluster installations not yet created, use balanced installation scheduling", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
 		schedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 0)
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Provisioner unit tests fail occasionally on CI when running against the Postgres database.

After some investigation, I found that the issue is (again) with too many open connections as connections are not closed immediately when the tests finish.

This PR defers closing DB connections in some of the tests which should fix the issue.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-40999

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Close database connections in some unit tests
```
