### PR TITLE
Cleanup Teleport utility destruction

### DIFF
--- a/internal/provisioner/teleport.go
+++ b/internal/provisioner/teleport.go
@@ -103,15 +103,6 @@ func (n *teleport) Destroy() error {
 		return errors.Wrap(err, "unable to delete Teleport bucket")
 	}
 
-	err = n.awsClient.DynamoDBEnsureTableDeleted(teleportClusterName, n.logger)
-	if err != nil {
-		return errors.Wrap(err, "unable to delete Teleport dynamodb table")
-	}
-
-	err = n.awsClient.DynamoDBEnsureTableDeleted(fmt.Sprintf("%s-events", teleportClusterName), n.logger)
-	if err != nil {
-		return errors.Wrap(err, "unable to delete Teleport dynamodb events table")
-	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Cleanup destruction of resources that are no longer created.

Due to missing permission Provisioner fails to delete cluster. For all clusters created prior to migration to new Teleport we should cleanup resources manually.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-41199

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Cleanup Teleport utility destruction
```
