### PR TITLE
Build cluster e2e tests image as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
     - checkout
     - setup_remote_docker
     - run: make build-image
+    - run: make build-image-e2e
     - run: ./scripts/push-docker-pr.sh
     - run:
         name: Re-run Docker Push if fail
@@ -118,6 +119,7 @@ jobs:
     - checkout
     - setup_remote_docker
     - run: make build-image
+    - run: make build-image-e2e
     - run: ./scripts/push-docker.sh
     - run:
         name: Re-run Docker Push if fail

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ KUBECTL_VERSION=v1.21.2
 GO ?= $(shell command -v go 2> /dev/null)
 PACKAGES=$(shell go list ./... | grep -v internal/mocks)
 MATTERMOST_CLOUD_IMAGE ?= mattermost/mattermost-cloud:test
+MATTERMOST_CLOUD_E2E_IMAGE ?= mattermost/mattermost-cloud-e2e:test
 MACHINE = $(shell uname -m)
 GOFLAGS ?= $(GOFLAGS:)
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M%S)
@@ -194,6 +195,14 @@ verify-mocks:  $(MOCKGEN) mocks
 	@if !(git diff --quiet HEAD); then \
 		echo "generated files are out of date, run make mocks"; exit 1; \
 	fi
+
+.PHONY: build-image-e2e
+build-image-e2e:
+	@echo Building e2e image
+	docker build \
+	--build-arg DOCKER_BUILD_IMAGE=$(DOCKER_BUILD_IMAGE) \
+	--build-arg DOCKER_BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
+	. -f build/Dockerfile.e2e -t $(MATTERMOST_CLOUD_E2E_IMAGE)
 
 .PHONY: e2e-db-migration
 e2e-db-migration:

--- a/build/Dockerfile.e2e
+++ b/build/Dockerfile.e2e
@@ -1,0 +1,36 @@
+# Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+# See LICENSE.txt for license information.
+
+# Build the mattermost cloud e2e
+ARG DOCKER_BUILD_IMAGE=golang:1.17
+ARG DOCKER_BASE_IMAGE=alpine:3.14
+
+FROM ${DOCKER_BUILD_IMAGE} AS build
+WORKDIR /mattermost-cloud-e2e/
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+
+## TODO: We should also build other tests with either this or other dockerfiles,
+## when they are ready to be run without infra dependencies
+
+RUN CGO_ENABLED=0 go test -tags=e2e -c -ldflags="-s -w" -o mattermost-cloud-e2e-tests ./e2e/tests/cluster
+
+# Final Image
+FROM ${DOCKER_BASE_IMAGE}
+
+RUN addgroup -S app-group && adduser -S app-user -G app-group
+USER app-user
+
+LABEL name="Mattermost Cloud E2e" \
+  maintainer="cloud-team@mattermost.com" \
+  vendor="Mattermost" \
+  distribution-scope="public" \
+  architecture="x86_64" \
+  url="https://mattermost.com"
+
+WORKDIR /mattermost-cloud-e2e/
+COPY --from=build /mattermost-cloud-e2e/mattermost-cloud-e2e-tests /mattermost-cloud-e2e
+
+ENTRYPOINT ["/mattermost-cloud-e2e/mattermost-cloud-e2e-tests"]

--- a/scripts/push-docker-pr.sh
+++ b/scripts/push-docker-pr.sh
@@ -11,5 +11,7 @@ export TAG="${CIRCLE_SHA1:0:7}"
 echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
 
 docker tag mattermost/mattermost-cloud:test mattermost/mattermost-cloud:$TAG
+docker tag mattermost/mattermost-cloud-e2e:test mattermost/mattermost-cloud-e2e:$TAG
 
 docker push mattermost/mattermost-cloud:$TAG
+docker push mattermost/mattermost-cloud-e2e:$TAG

--- a/scripts/push-docker.sh
+++ b/scripts/push-docker.sh
@@ -17,5 +17,7 @@ fi
 echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
 
 docker tag mattermost/mattermost-cloud:test mattermost/mattermost-cloud:$TAG
+docker tag mattermost/mattermost-cloud-e2e:test mattermost/mattermost-cloud-e2e:$TAG
 
 docker push mattermost/mattermost-cloud:$TAG
+docker push mattermost/mattermost-cloud-e2e:$TAG


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds a step of building the image of cluster e2e to CI.
The image is built and pushed for every PR as well as master commits together with Provisioner image.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-41179

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Build cluster e2e tests image as part of CI
```
