### PR TITLE
Make better Installation DNS configuration in e2e

### DIFF
--- a/e2e/pkg/dns.go
+++ b/e2e/pkg/dns.go
@@ -12,12 +12,12 @@ import (
 )
 
 const (
-	installationDNSFormat = "e2e-test-%s.%s.cloud.mattermost.com"
+	installationDNSFormat = "e2e-test-%s.%s"
 )
 
 // GetDNS returns e2e test dns with random suffix.
-func GetDNS(env string) string {
-	return fmt.Sprintf(installationDNSFormat, randStringBytes(4), env)
+func GetDNS(domain string) string {
+	return fmt.Sprintf(installationDNSFormat, randStringBytes(4), domain)
 }
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyz"

--- a/e2e/tests/cluster/suite.go
+++ b/e2e/tests/cluster/suite.go
@@ -29,7 +29,7 @@ type TestConfig struct {
 	CloudURL                  string `envconfig:"default=http://localhost:8075"`
 	InstallationDBType        string `envconfig:"default=mysql-operator"`
 	InstallationFileStoreType string `envconfig:"default=minio-operator"`
-	Environment               string `envconfig:"default=dev"`
+	DNSSubdomain              string `envconfig:"default=dev.cloud.mattermost.com"`
 	WebhookAddress            string `envconfig:"default=http://localhost:11111"`
 	EventListenerAddress      string `envconfig:"default=http://localhost:11112"`
 	Cleanup                   bool   `envconfig:"default=true"`
@@ -95,8 +95,8 @@ func SetupClusterLifecycleTest() (*Test, error) {
 		return nil, errors.Wrap(err, "failed to setup webhook")
 	}
 
-	clusterSuite := workflow.NewClusterSuite(clusterParams, config.Environment, client, webhookChan, logger)
-	installationSuite := workflow.NewInstallationSuite(installationParams, config.Environment, client, kubeClient, logger)
+	clusterSuite := workflow.NewClusterSuite(clusterParams, client, webhookChan, logger)
+	installationSuite := workflow.NewInstallationSuite(installationParams, config.DNSSubdomain, client, kubeClient, logger)
 
 	eventsRecorder := eventstest.NewEventsRecorder(subOwner, config.EventListenerAddress, logger.WithField("component", "event-recorder"), eventstest.RecordAll)
 

--- a/e2e/tests/dbmigration/suite.go
+++ b/e2e/tests/dbmigration/suite.go
@@ -23,7 +23,7 @@ type TestConfig struct {
 	DestinationDB             string
 	InstallationDBType        string `envconfig:"default=aws-multitenant-rds-postgres"`
 	InstallationFileStoreType string `envconfig:"default=bifrost"`
-	Environment               string `envconfig:"default=dev"`
+	DNSSubdomain              string `envconfig:"default=dev.cloud.mattermost.com"`
 	Cleanup                   bool   `envconfig:"default=true"`
 }
 
@@ -114,7 +114,7 @@ func setupDBMigrationTestSuite(config TestConfig, logger logrus.FieldLogger) (*w
 		return nil, err
 	}
 
-	return workflow.NewDBMigrationSuite(params, config.Environment, client, kubeClient, logger), nil
+	return workflow.NewDBMigrationSuite(params, config.DNSSubdomain, client, kubeClient, logger), nil
 }
 
 // Run runs the test workflow.

--- a/e2e/workflow/cluster.go
+++ b/e2e/workflow/cluster.go
@@ -18,12 +18,11 @@ import (
 )
 
 // NewClusterSuite creates new Cluster testing suite.
-func NewClusterSuite(params ClusterSuiteParams, env string, client *model.Client, whChan <-chan *model.WebhookPayload, logger logrus.FieldLogger) *ClusterSuite {
+func NewClusterSuite(params ClusterSuiteParams, client *model.Client, whChan <-chan *model.WebhookPayload, logger logrus.FieldLogger) *ClusterSuite {
 	return &ClusterSuite{
 		client: client,
 		whChan: whChan,
 		logger: logger.WithField("suite", "cluster"),
-		env:    env,
 		Params: params,
 		Meta:   ClusterSuiteMeta{},
 	}
@@ -34,7 +33,6 @@ type ClusterSuite struct {
 	client *model.Client
 	whChan <-chan *model.WebhookPayload
 	logger logrus.FieldLogger
-	env    string
 
 	Params ClusterSuiteParams
 	Meta   ClusterSuiteMeta

--- a/e2e/workflow/db_migration.go
+++ b/e2e/workflow/db_migration.go
@@ -19,8 +19,8 @@ import (
 )
 
 // NewDBMigrationSuite creates new DBMigrationSuite.
-func NewDBMigrationSuite(params DBMigrationSuiteParams, env string, client *model.Client, kubeClient kubernetes.Interface, logger logrus.FieldLogger) *DBMigrationSuite {
-	installationSuite := NewInstallationSuite(params.InstallationSuiteParams, env, client, kubeClient, logger)
+func NewDBMigrationSuite(params DBMigrationSuiteParams, dnsSubdomain string, client *model.Client, kubeClient kubernetes.Interface, logger logrus.FieldLogger) *DBMigrationSuite {
+	installationSuite := NewInstallationSuite(params.InstallationSuiteParams, dnsSubdomain, client, kubeClient, logger)
 
 	return &DBMigrationSuite{
 		InstallationSuite: installationSuite,

--- a/e2e/workflow/installation.go
+++ b/e2e/workflow/installation.go
@@ -19,23 +19,23 @@ import (
 )
 
 // NewInstallationSuite creates new Installation testing suite.
-func NewInstallationSuite(params InstallationSuiteParams, env string, client *model.Client, kubeClient kubernetes.Interface, logger logrus.FieldLogger) *InstallationSuite {
+func NewInstallationSuite(params InstallationSuiteParams, dnsSubdomain string, client *model.Client, kubeClient kubernetes.Interface, logger logrus.FieldLogger) *InstallationSuite {
 	return &InstallationSuite{
-		client:     client,
-		kubeClient: kubeClient,
-		logger:     logger.WithField("suite", "installation"),
-		env:        env,
-		Params:     params,
-		Meta:       InstallationSuiteMeta{},
+		client:       client,
+		kubeClient:   kubeClient,
+		logger:       logger.WithField("suite", "installation"),
+		dnsSubdomain: dnsSubdomain,
+		Params:       params,
+		Meta:         InstallationSuiteMeta{},
 	}
 }
 
 // InstallationSuite is testing suite for Installations.
 type InstallationSuite struct {
-	client     *model.Client
-	kubeClient kubernetes.Interface
-	logger     logrus.FieldLogger
-	env        string
+	client       *model.Client
+	kubeClient   kubernetes.Interface
+	logger       logrus.FieldLogger
+	dnsSubdomain string
 
 	Params InstallationSuiteParams
 	Meta   InstallationSuiteMeta
@@ -61,7 +61,7 @@ type InstallationSuiteMeta struct {
 func (w *InstallationSuite) CreateInstallation(ctx context.Context) error {
 	if w.Meta.InstallationID == "" {
 		installationBuilder := pkg.NewInstallationBuilderWithDefaults().
-			DNS(pkg.GetDNS(w.env)).
+			DNS(pkg.GetDNS(w.dnsSubdomain)).
 			DB(w.Params.DBType).
 			FileStore(w.Params.FileStoreType).
 			Annotations(w.Params.Annotations)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR makes it possible to configure the whole DNS subdomain used for creating the Installation instead of creating DNS based on the environment. This is required as domains used in different environments vary more than just env name.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-41262

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Make better Installation DNS configuration in e2e
```
