### PR TITLE
Skip DB cleanup if database is marked as deleted

### DIFF
--- a/internal/tools/aws/database_multitenant.go
+++ b/internal/tools/aws/database_multitenant.go
@@ -338,6 +338,10 @@ func (d *RDSMultitenantDatabase) TeardownMigrated(store model.InstallationDataba
 		logger.Info("Source database does not exist, skipping removal")
 		return nil
 	}
+	if db.DeleteAt > 0 {
+		logger.Info("Source database marked as deleted, skipping removal")
+		return nil
+	}
 
 	unlockFn, err := lockMultitenantDatabase(migrationOp.SourceMultiTenant.DatabaseID, d.instanceID, store, logger)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When deleting DB migration we ensure the old database is deleted.
We should additionally skip the check if the multitenant database is marked as deleted.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-41286

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Skip DB cleanup if database is marked as deleted
```
