### PR TITLE
[MM-41366] Fix wrong Teleport kube agent default name

### DIFF
--- a/internal/provisioner/teleport.go
+++ b/internal/provisioner/teleport.go
@@ -91,7 +91,7 @@ func (n *teleport) ActualVersion() *model.HelmUtilityVersion {
 		return nil
 	}
 	return &model.HelmUtilityVersion{
-		Chart:      strings.TrimPrefix(n.actualVersion.Version(), "teleport-"),
+		Chart:      strings.TrimPrefix(n.actualVersion.Version(), "kube-agent-"),
 		ValuesPath: n.actualVersion.Values(),
 	}
 }


### PR DESCRIPTION
#### Summary
- Fix wrong Teleport kube agent default name


#### Release Note
```release-note
- Fix wrong Teleport kube agent default name
```
