### PR TITLE
Expose base prometheus metrics on separate port

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -42,5 +42,6 @@ WORKDIR /mattermost-cloud/
 USER ${USER_UID}
 
 EXPOSE 8075
+EXPOSE 8076
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-cloud/internal/events"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	sdkAWS "github.com/aws/aws-sdk-go/aws"
 	"github.com/gorilla/mux"
@@ -48,6 +50,7 @@ func init() {
 	// General
 	serverCmd.PersistentFlags().String("database", "sqlite://cloud.db", "The database backing the provisioning server.")
 	serverCmd.PersistentFlags().String("listen", ":8075", "The interface and port on which to listen.")
+	serverCmd.PersistentFlags().Int("metrics-port", 8076, "Port on which the metrics server should be listening.")
 	serverCmd.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
 	serverCmd.PersistentFlags().StringSlice("allow-list-cidr-range", []string{"0.0.0.0/0"}, "The list of CIDRs to allow communication with the private ingress.")
 	serverCmd.PersistentFlags().StringSlice("vpn-list-cidr", []string{"0.0.0.0/0"}, "The list of VPN CIDRs to allow communication with the clusters.")
@@ -396,6 +399,28 @@ var serverCmd = &cobra.Command{
 		supervisor := supervisor.NewScheduler(multiDoer, time.Duration(poll)*time.Second)
 		defer supervisor.Close()
 
+		metricsPort, _ := command.Flags().GetInt("metrics-port")
+		metricsRouter := mux.NewRouter()
+		metricsRouter.Handle("/metrics", promhttp.Handler())
+
+		metricsServer := &http.Server{
+			Addr:           fmt.Sprintf(":%d", metricsPort),
+			Handler:        metricsRouter,
+			ReadTimeout:    180 * time.Second,
+			WriteTimeout:   180 * time.Second,
+			IdleTimeout:    time.Second * 180,
+			MaxHeaderBytes: 1 << 20,
+			ErrorLog:       log.New(&logrusWriter{logger: logger}, "", 0),
+		}
+
+		go func() {
+			logger.WithField("addr", metricsServer.Addr).Info("Metrics server listening")
+			err := metricsServer.ListenAndServe()
+			if err != nil && err != http.ErrServerClosed {
+				logger.WithError(err).Error("Failed to listen and serve metrics")
+			}
+		}()
+
 		router := mux.NewRouter()
 
 		api.Register(router, &api.Context{
@@ -421,7 +446,7 @@ var serverCmd = &cobra.Command{
 		}
 
 		go func() {
-			logger.WithField("addr", srv.Addr).Info("Listening")
+			logger.WithField("addr", srv.Addr).Info("API server listening")
 			err := srv.ListenAndServe()
 			if err != nil && err != http.ErrServerClosed {
 				logger.WithError(err).Error("Failed to listen and serve")

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -6,14 +6,10 @@ package api
 
 import (
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Register registers the API endpoints on the given router.
 func Register(rootRouter *mux.Router, context *Context) {
-	// metrics handler at /metrics
-	rootRouter.Handle("/metrics", promhttp.Handler())
-
 	// api handler at /api
 	apiRouter := rootRouter.PathPrefix("/api").Subrouter()
 	initCluster(apiRouter, context)

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -43,6 +43,8 @@ spec:
         ports:
         - containerPort: 8075
           name: api
+        - containerPort: 8076
+          name: metrics
         resources:
           {}
         env:


### PR DESCRIPTION
Metrics will be handled separately from standard API calls to
ensure maximum flexibility and security.

Fixes https://mattermost.atlassian.net/browse/MM-41794

```release-note
Expose base prometheus metrics on separate port
```
