### PR TITLE
Add metrics for installation changes

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -18,13 +18,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/mattermost/mattermost-cloud/internal/events"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	sdkAWS "github.com/aws/aws-sdk-go/aws"
 	"github.com/gorilla/mux"
 	awat "github.com/mattermost/awat/model"
 	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/mattermost/mattermost-cloud/internal/events"
 	"github.com/mattermost/mattermost-cloud/internal/metrics"
 	"github.com/mattermost/mattermost-cloud/internal/provisioner"
 	"github.com/mattermost/mattermost-cloud/internal/store"

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -9,10 +9,19 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const (
+	provisionerNamespace    = "provisioner"
+	provisionerSubsystemApp = "app"
+)
+
 // CloudMetrics holds all of the metrics needed to properly instrument
 // the Provisioning server
 type CloudMetrics struct {
-	InstallationCreationDurationHist prometheus.Histogram
+	InstallationCreationDurationHist    prometheus.Histogram
+	InstallationUpdateDurationHist      prometheus.Histogram
+	InstallationHibernationDurationHist prometheus.Histogram
+	InstallationWakeUpDurationHist      prometheus.Histogram
+	InstallationDeletionDurationHist    prometheus.Histogram
 }
 
 // New creates a new Prometheus-based Metrics object to be used
@@ -22,10 +31,57 @@ func New() *CloudMetrics {
 	return &CloudMetrics{
 		InstallationCreationDurationHist: promauto.NewHistogram(
 			prometheus.HistogramOpts{
-				Name:    "mm_cloud_create_installation_duration_seconds",
-				Help:    "The duration of Installation creation tasks",
-				Buckets: prometheus.LinearBuckets(0, 30, 20),
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "installation_creation_duration_seconds",
+				Help:      "The duration of installation creation tasks",
+				Buckets:   standardDurationBuckets(),
+			},
+		),
+
+		InstallationUpdateDurationHist: promauto.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "installation_update_duration_seconds",
+				Help:      "The duration of installation update tasks",
+				Buckets:   standardDurationBuckets(),
+			},
+		),
+
+		InstallationHibernationDurationHist: promauto.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "installation_hibernation_duration_seconds",
+				Help:      "The duration of installation hibernation tasks",
+				Buckets:   standardDurationBuckets(),
+			},
+		),
+
+		InstallationWakeUpDurationHist: promauto.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "installation_wakeup_duration_seconds",
+				Help:      "The duration of installation wake up tasks",
+				Buckets:   standardDurationBuckets(),
+			},
+		),
+
+		InstallationDeletionDurationHist: promauto.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "installation_deletion_duration_seconds",
+				Help:      "The duration of installation deletion tasks",
+				Buckets:   standardDurationBuckets(),
 			},
 		),
 	}
+}
+
+// 15 second buckets up to 5 minutes.
+func standardDurationBuckets() []float64 {
+	return prometheus.LinearBuckets(0, 15, 20)
 }

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -261,6 +261,12 @@ func (sqlStore *SQLStore) GetStateChangeEvents(filter *model.StateChangeEventFil
 	if filter.ResourceID != "" {
 		query = query.Where("sc.ResourceID = ?", filter.ResourceID)
 	}
+	if filter.OldStates != nil {
+		query = query.Where(sq.Eq{"sc.OldState": filter.OldStates})
+	}
+	if filter.NewStates != nil {
+		query = query.Where(sq.Eq{"sc.NewState": filter.NewStates})
+	}
 
 	var eventsData []stateChangeEventData
 	err := sqlStore.selectBuilder(sqlStore.db, &eventsData, query)

--- a/internal/store/events_test.go
+++ b/internal/store/events_test.go
@@ -222,16 +222,19 @@ func TestGetStateChangeEvents(t *testing.T) {
 
 	events := []*model.StateChangeEventData{
 		{
-			Event:       model.Event{EventType: "test", Timestamp: 1000},
-			StateChange: model.StateChangeEvent{ResourceType: model.TypeInstallation, ResourceID: "inst1"},
+			Event: model.Event{EventType: "test", Timestamp: 1000},
+			StateChange: model.StateChangeEvent{ResourceType: model.TypeInstallation, ResourceID: "inst1",
+				OldState: model.InstallationStateHibernationInProgress, NewState: model.InstallationStateHibernating},
 		},
 		{
-			Event:       model.Event{EventType: "test", Timestamp: 2000},
-			StateChange: model.StateChangeEvent{ResourceType: model.TypeInstallation, ResourceID: "inst2"},
+			Event: model.Event{EventType: "test", Timestamp: 2000},
+			StateChange: model.StateChangeEvent{ResourceType: model.TypeInstallation, ResourceID: "inst2",
+				OldState: model.InstallationStateDeletionInProgress, NewState: model.InstallationStateDeleted},
 		},
 		{
-			Event:       model.Event{EventType: "test", Timestamp: 3000},
-			StateChange: model.StateChangeEvent{ResourceType: model.TypeCluster, ResourceID: "cluster1"},
+			Event: model.Event{EventType: "test", Timestamp: 3000},
+			StateChange: model.StateChangeEvent{ResourceType: model.TypeCluster, ResourceID: "cluster1",
+				OldState: model.ClusterStateCreationRequested, NewState: model.ClusterStateStable},
 		},
 	}
 
@@ -252,9 +255,19 @@ func TestGetStateChangeEvents(t *testing.T) {
 			fetched:     2,
 		},
 		{
-			description: "fetch all fon specific ID",
+			description: "fetch all for specific ID",
 			filter:      &model.StateChangeEventFilter{ResourceID: "inst2", Paging: model.AllPagesNotDeleted()},
 			fetched:     1,
+		},
+		{
+			description: "fetch all installations with old state of deletion-in-progress",
+			filter:      &model.StateChangeEventFilter{OldStates: []string{model.InstallationStateDeletionInProgress}, Paging: model.AllPagesNotDeleted()},
+			fetched:     1,
+		},
+		{
+			description: "fetch all installations with new state of deletion-in-progress",
+			filter:      &model.StateChangeEventFilter{NewStates: []string{model.InstallationStateDeletionInProgress}, Paging: model.AllPagesNotDeleted()},
+			fetched:     0,
 		},
 	} {
 		t.Run(testCase.description, func(t *testing.T) {

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -220,6 +220,10 @@ func (s *mockInstallationStore) UnlockInstallationDBRestorationOperations(backup
 	return true, nil
 }
 
+func (s *mockInstallationStore) GetStateChangeEvents(filter *model.StateChangeEventFilter) ([]*model.StateChangeEventData, error) {
+	return nil, nil
+}
+
 type mockMultitenantDBStore struct{}
 
 func (m *mockMultitenantDBStore) GetMultitenantDatabase(multitenantdatabaseID string) (*model.MultitenantDatabase, error) {

--- a/model/events_state_change.go
+++ b/model/events_state_change.go
@@ -100,6 +100,8 @@ type StateChangeEventFilter struct {
 	Paging
 	ResourceType ResourceType
 	ResourceID   string
+	OldStates    []string
+	NewStates    []string
 }
 
 // ListStateChangeEventsRequest represents request for state change events query.

--- a/model/time.go
+++ b/model/time.go
@@ -15,3 +15,8 @@ func GetMillis() int64 {
 func TimeFromMillis(millis int64) time.Time {
 	return time.Unix(0, millis*int64(time.Millisecond))
 }
+
+// ElapsedTimeInSeconds returns time in seconds since the provided millis.
+func ElapsedTimeInSeconds(millis int64) float64 {
+	return float64(GetMillis()-millis) / 1000
+}


### PR DESCRIPTION
This change captures the time taken for the primary installation
state change flows and exposes them as metrics.

Fixes https://mattermost.atlassian.net/browse/MM-35834

```release-note
Add metrics for installation changes
```
