### PR TITLE
Support multiple public hosted zones

### DIFF
--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -185,7 +185,7 @@ func (c *Client) buildCache() error {
 	c.logger.WithFields(log.Fields{
 		"environment":            c.cache.environment,
 		"private-hosted-zone-id": c.cache.route53.privateHostedZoneID,
-		"public-hosted-zone-ids":  c.cache.route53.publicHostedZones,
+		"public-hosted-zone-ids": c.cache.route53.publicHostedZones,
 	}).Info("AWS client cache initialized")
 
 	return nil

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -185,7 +185,7 @@ func (c *Client) buildCache() error {
 	c.logger.WithFields(log.Fields{
 		"environment":            c.cache.environment,
 		"private-hosted-zone-id": c.cache.route53.privateHostedZoneID,
-		"public-hosted-zone-id":  c.cache.route53.publicHostedZoneID,
+		"public-hosted-zone-ids":  c.cache.route53.publicHostedZones,
 	}).Info("AWS client cache initialized")
 
 	return nil
@@ -201,8 +201,8 @@ func (c *Client) validateCache() error {
 	if len(c.cache.route53.privateHostedZoneID) == 0 {
 		return errors.New("private hosted zone ID cache value is empty")
 	}
-	if len(c.cache.route53.publicHostedZoneID) == 0 {
-		return errors.New("public hosted zone ID cache value is empty")
+	if len(c.cache.route53.publicHostedZones) == 0 {
+		return errors.New("public hosted zone IDs cache is empty")
 	}
 
 	return nil

--- a/internal/tools/aws/client_test.go
+++ b/internal/tools/aws/client_test.go
@@ -205,7 +205,9 @@ func newClientDummyCache() *cache {
 		environment: "dev",
 		route53: &route53Cache{
 			privateHostedZoneID: "HZONE1",
-			publicHostedZoneID:  "HZONE2",
+			publicHostedZones: map[string]awsHostedZone{
+				"mattermost.com": {ID: "HZONE2"},
+			},
 		},
 	}
 }

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -23,56 +23,92 @@ const (
 	hostedZonePrefix       = "/hostedzone/"
 )
 
+type awsHostedZone struct {
+	ID string
+}
+
 type route53Cache struct {
 	privateHostedZoneID string
-	publicHostedZoneID  string
+	publicHostedZones   map[string]awsHostedZone
 }
 
 func (a *Client) buildRoute53Cache() error {
 	privateID, err := a.getHostedZoneIDWithTag(Tag{
 		Key:   DefaultCloudDNSTagKey,
 		Value: DefaultPrivateCloudDNSTagValue,
-	}, a.logger)
+	})
 	if err != nil {
 		return errors.Wrap(err, "failed to get private hosted zone ID")
 	}
 
-	publicID, err := a.getHostedZoneIDWithTag(Tag{
+	publicTag := Tag{
 		Key:   DefaultCloudDNSTagKey,
 		Value: DefaultPublicCloudDNSTagValue,
-	}, a.logger)
+	}
+
+	zones, err := a.GetHostedZonesWithTag(publicTag)
 	if err != nil {
 		return errors.Wrap(err, "failed to get public hosted zone ID")
+	}
+	if len(zones) == 0 {
+		return errors.Errorf("no hosted zone associated with tag: %s", publicTag.String())
+	}
+
+	zoneMap := map[string]awsHostedZone{}
+
+	for _, zone := range zones {
+		zoneID, err := parseHostedZoneResourceID(zone)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse hosted zone ID")
+		}
+
+		zoneMap[strings.TrimSuffix(getString(zone.Name), ".")] = awsHostedZone{ID: zoneID}
 	}
 
 	a.cache.route53 = &route53Cache{
 		privateHostedZoneID: privateID,
-		publicHostedZoneID:  publicID,
+		publicHostedZones:   zoneMap,
 	}
 
 	return nil
 }
 
-// GetPublicHostedZoneID returns the public R53 hosted zone ID for the AWS
-// account.
-func (a *Client) GetPublicHostedZoneID() string {
-	return a.cache.route53.publicHostedZoneID
+func (a *Client) getDNSZoneID(dns string) (string, bool) {
+	for domainName, zone := range a.cache.route53.publicHostedZones {
+		if strings.HasSuffix(dns, domainName) {
+			return zone.ID, true
+		}
+	}
+
+	return "", false
 }
 
 // CreatePublicCNAME creates a record in Route53 for a public domain name.
 func (a *Client) CreatePublicCNAME(dnsName string, dnsEndpoints []string, dnsIdentifier string, logger log.FieldLogger) error {
-	return a.createCNAME(a.GetPublicHostedZoneID(), dnsName, dnsEndpoints, dnsIdentifier, logger)
+	zoneID, found := a.getDNSZoneID(dnsName)
+	if !found {
+		return errors.Errorf("hosted zone for %q domain name not found", dnsName)
+	}
+	return a.createCNAME(zoneID, dnsName, dnsEndpoints, dnsIdentifier, logger)
 }
 
 // UpdatePublicRecordIDForCNAME updates the record ID for the record corresponding
 // to a DNS value in the public hosted zone.
 func (a *Client) UpdatePublicRecordIDForCNAME(dnsName, newID string, logger log.FieldLogger) error {
-	return a.updateResourceRecordIDs(a.GetPublicHostedZoneID(), dnsName, newID, logger)
+	zoneID, found := a.getDNSZoneID(dnsName)
+	if !found {
+		return errors.Errorf("hosted zone for %q domain name not found", dnsName)
+	}
+	return a.updateResourceRecordIDs(zoneID, dnsName, newID, logger)
 }
 
 // DeletePublicCNAME deletes a AWS route53 record for a public domain name.
 func (a *Client) DeletePublicCNAME(dnsName string, logger log.FieldLogger) error {
-	return a.deleteCNAME(a.GetPublicHostedZoneID(), dnsName, logger)
+	zoneID, found := a.getDNSZoneID(dnsName)
+	if !found {
+		return errors.Errorf("hosted zone for %q domain name not found", dnsName)
+	}
+	return a.deleteCNAME(zoneID, dnsName, logger)
 }
 
 // GetPrivateHostedZoneID returns the private R53 hosted zone ID for the AWS
@@ -345,18 +381,40 @@ func (a *Client) getRecordSetsForDNS(hostedZoneID, dnsName string, logger log.Fi
 }
 
 // getHostedZoneIDWithTag returns R53 hosted zone ID for a given tag
-func (a *Client) getHostedZoneIDWithTag(tag Tag, logger log.FieldLogger) (string, error) {
+func (a *Client) getHostedZoneIDWithTag(tag Tag) (string, error) {
+	zones, err := a.getHostedZonesWithTag(tag, true)
+	if err != nil {
+		return "", err
+	}
+	if len(zones) == 0 {
+		return "", errors.Errorf("no hosted zone ID associated with tag: %s", tag.String())
+	}
+	return getString(zones[0].Name), nil
+}
+
+// GetHostedZonesWithTag returns R53 hosted zone for a given tag
+func (a *Client) GetHostedZonesWithTag(tag Tag) ([]*route53.HostedZone, error) {
+	zones, err := a.getHostedZonesWithTag(tag, true)
+	if err != nil {
+		return nil, err
+	}
+	return zones, nil
+}
+
+func (a *Client) getHostedZonesWithTag(tag Tag, firstOnly bool) ([]*route53.HostedZone, error) {
+	var zones []*route53.HostedZone
 	var next *string
+
 	for {
 		zoneList, err := a.Service().route53.ListHostedZones(&route53.ListHostedZonesInput{Marker: next})
 		if err != nil {
-			return "", errors.Wrapf(err, "failed to list all hosted zones")
+			return nil, errors.Wrapf(err, "failed to list all hosted zones")
 		}
 
 		for _, zone := range zoneList.HostedZones {
 			id, err := parseHostedZoneResourceID(zone)
 			if err != nil {
-				return "", errors.Wrapf(err, "failed to parse hosted zone ID: %s", zone.String())
+				return nil, errors.Wrapf(err, "failed to parse hosted zone ID: %s", zone.String())
 			}
 
 			tagList, err := a.Service().route53.ListTagsForResource(&route53.ListTagsForResourceInput{
@@ -364,13 +422,17 @@ func (a *Client) getHostedZoneIDWithTag(tag Tag, logger log.FieldLogger) (string
 				ResourceType: aws.String(hostedZoneResourceType),
 			})
 			if err != nil {
-				return "", errors.Wrap(err, "failed to get tag list for hosted zone")
+				return nil, errors.Wrap(err, "failed to get tag list for hosted zone")
 			}
 
 			for _, resourceTag := range tagList.ResourceTagSet.Tags {
 				if tag.Compare(resourceTag) {
-					return id, nil
+					zones = append(zones, zone)
+					break
 				}
+			}
+			if firstOnly && len(zones) > 0 {
+				return zones, nil
 			}
 		}
 
@@ -380,7 +442,7 @@ func (a *Client) getHostedZoneIDWithTag(tag Tag, logger log.FieldLogger) (string
 		next = zoneList.Marker
 	}
 
-	return "", errors.Errorf("no hosted zone ID associated with tag: %s", tag.String())
+	return zones, nil
 }
 
 func prettyRoute53Response(resp *route53.ChangeResourceRecordSetsOutput) string {
@@ -392,6 +454,7 @@ func prettyRoute53Response(resp *route53.ChangeResourceRecordSetsOutput) string 
 	return string(prettyResp)
 }
 
+// parseHostedZoneResourceID removes prefix from hosted zone ID.
 func parseHostedZoneResourceID(hostedZone *route53.HostedZone) (string, error) {
 	id := strings.TrimLeft(*hostedZone.Id, hostedZonePrefix)
 	if len(id) < hostedZoneIDLength {
@@ -431,4 +494,11 @@ func (t *Tag) String() string {
 // hosted zone domain names.
 func trimTrailingDomainDot(domain string) string {
 	return strings.TrimRight(domain, ".")
+}
+
+func getString(str *string) string {
+	if str != nil {
+		return *str
+	}
+	return ""
 }

--- a/internal/tools/aws/route53_test.go
+++ b/internal/tools/aws/route53_test.go
@@ -19,14 +19,13 @@ func (a *AWSTestSuite) TestRoute53CreatePublicCNAME() {
 			Do(func(input *route53.ChangeResourceRecordSetsInput) {
 				a.Assert().Equal("mattermost.com", *input.ChangeBatch.Changes[0].ResourceRecordSet.Name)
 				a.Assert().Equal("example.mattermost.com", *input.ChangeBatch.Changes[0].ResourceRecordSet.ResourceRecords[0].Value)
-				a.Assert().Equal(a.Mocks.AWS.GetPublicHostedZoneID(), *input.HostedZoneId)
 			}).
 			Return(&route53.ChangeResourceRecordSetsOutput{}, nil),
 
 		a.Mocks.Log.Logger.EXPECT().WithFields(log.Fields{
 			"route53-dns-value":      "mattermost.com",
 			"route53-dns-endpoints":  []string{"example.mattermost.com"},
-			"route53-hosted-zone-id": a.Mocks.AWS.GetPublicHostedZoneID(),
+			"route53-hosted-zone-id": "HZONE2",
 		}).
 			Return(testlib.NewLoggerEntry()).
 			Times(1),
@@ -67,7 +66,6 @@ func (a *AWSTestSuite) TestRoute53CreatePublicCNAMEChangeRecordSetsError() {
 			Do(func(input *route53.ChangeResourceRecordSetsInput) {
 				a.Assert().Equal("mattermost.com", *input.ChangeBatch.Changes[0].ResourceRecordSet.Name)
 				a.Assert().Equal("example.mattermost.com", *input.ChangeBatch.Changes[0].ResourceRecordSet.ResourceRecords[0].Value)
-				a.Assert().Equal(a.Mocks.AWS.GetPublicHostedZoneID(), *input.HostedZoneId)
 			}).
 			Return(nil, errors.New("unable to change recordsets")).
 			Times(1),


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This adds support for multiple public-hosted zones to Provisioner.  
Provisioner will discover all public zones on startup.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Support multiple public hosted zones
```
