### PR TITLE
Add cluster installation duration metrics

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -369,7 +369,7 @@ var serverCmd = &cobra.Command{
 			multiDoer = append(multiDoer, supervisor.NewInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, keepDatabaseData, keepFilestoreData, scheduling, resourceUtil, logger, cloudMetrics, eventsProducer, forceCRUpgrade))
 		}
 		if clusterInstallationSupervisor {
-			multiDoer = append(multiDoer, supervisor.NewClusterInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, eventsProducer, instanceID, logger))
+			multiDoer = append(multiDoer, supervisor.NewClusterInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, eventsProducer, instanceID, logger, cloudMetrics))
 		}
 		if backupSupervisor {
 			multiDoer = append(multiDoer, supervisor.NewBackupSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, logger))

--- a/e2e/workflow/installation.go
+++ b/e2e/workflow/installation.go
@@ -279,12 +279,17 @@ func (w *InstallationSuite) InstallationDeletionEvents() []eventstest.EventOccur
 			NewState:     model.InstallationStateDeletionRequested,
 		},
 		{
+			ResourceType: model.TypeClusterInstallation.String(),
+			ResourceID:   w.Meta.ClusterInstallationID,
+			OldState:     model.ClusterInstallationStateStable,
+			NewState:     model.ClusterInstallationStateDeletionRequested,
+		},
+		{
 			ResourceType: model.TypeInstallation.String(),
 			ResourceID:   w.Meta.InstallationID,
 			OldState:     model.InstallationStateDeletionRequested,
 			NewState:     model.InstallationStateDeletionInProgress,
 		},
-		// TODO: Provisioner does not send webhook for CI - Stable -> DeletionRequested
 		{
 			ResourceType: model.TypeClusterInstallation.String(),
 			ResourceID:   w.Meta.ClusterInstallationID,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -17,11 +17,16 @@ const (
 // CloudMetrics holds all of the metrics needed to properly instrument
 // the Provisioning server
 type CloudMetrics struct {
+	// Installation
 	InstallationCreationDurationHist    prometheus.Histogram
 	InstallationUpdateDurationHist      prometheus.Histogram
 	InstallationHibernationDurationHist prometheus.Histogram
 	InstallationWakeUpDurationHist      prometheus.Histogram
 	InstallationDeletionDurationHist    prometheus.Histogram
+
+	// ClusterInstallation
+	ClusterInstallationReconcilingDurationHist prometheus.Histogram
+	ClusterInstallationDeletionDurationHist    prometheus.Histogram
 }
 
 // New creates a new Prometheus-based Metrics object to be used
@@ -75,6 +80,26 @@ func New() *CloudMetrics {
 				Subsystem: provisionerSubsystemApp,
 				Name:      "installation_deletion_duration_seconds",
 				Help:      "The duration of installation deletion tasks",
+				Buckets:   standardDurationBuckets(),
+			},
+		),
+
+		ClusterInstallationReconcilingDurationHist: promauto.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "cluster_installation_reconciling_duration_seconds",
+				Help:      "The duration of cluster installation reconciliation tasks",
+				Buckets:   standardDurationBuckets(),
+			},
+		),
+
+		ClusterInstallationDeletionDurationHist: promauto.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "cluster_installation_deletion_duration_seconds",
+				Help:      "The duration of cluster installation deletion tasks",
 				Buckets:   standardDurationBuckets(),
 			},
 		),

--- a/internal/supervisor/cluster_installation_test.go
+++ b/internal/supervisor/cluster_installation_test.go
@@ -74,6 +74,10 @@ func (s *mockClusterInstallationStore) GetWebhooks(filter *model.WebhookFilter) 
 	return nil, nil
 }
 
+func (s *mockClusterInstallationStore) GetStateChangeEvents(filter *model.StateChangeEventFilter) ([]*model.StateChangeEventData, error) {
+	return nil, nil
+}
+
 type mockClusterInstallationProvisioner struct{}
 
 func (p *mockClusterInstallationProvisioner) ClusterInstallationProvisioner(version string) provisioner.ClusterInstallationProvisioner {
@@ -92,6 +96,7 @@ func TestClusterInstallationSupervisorDo(t *testing.T) {
 			&mockEventProducer{},
 			"instanceID",
 			logger,
+			cloudMetrics,
 		)
 		err := supervisor.Do()
 		require.NoError(t, err)
@@ -124,6 +129,7 @@ func TestClusterInstallationSupervisorDo(t *testing.T) {
 			&mockEventProducer{},
 			"instanceID",
 			logger,
+			cloudMetrics,
 		)
 		err := supervisor.Do()
 		require.NoError(t, err)
@@ -164,6 +170,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 					testutil.SetupTestEventsProducer(sqlStore, logger),
 					"instanceID",
 					logger,
+					cloudMetrics,
 				)
 
 				installation := &model.Installation{}
@@ -207,6 +214,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 					testutil.SetupTestEventsProducer(sqlStore, logger),
 					"instanceID",
 					logger,
+					cloudMetrics,
 				)
 
 				cluster := &model.Cluster{}
@@ -239,6 +247,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			"instanceID",
 			logger,
+			cloudMetrics,
 		)
 
 		cluster := &model.Cluster{}
@@ -293,6 +302,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 					testutil.SetupTestEventsProducer(sqlStore, logger),
 					"instanceID",
 					logger,
+					cloudMetrics,
 				)
 
 				cluster := &model.Cluster{}
@@ -329,6 +339,7 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			"instanceID",
 			logger,
+			cloudMetrics,
 		)
 
 		cluster := &model.Cluster{}

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -928,11 +928,17 @@ func (s *InstallationSupervisor) hibernateInstallation(installation *model.Insta
 			return installation.State
 		}
 
+		oldState := clusterInstallation.State
 		clusterInstallation.State = model.ClusterInstallationStateReconciling
 		err = s.store.UpdateClusterInstallation(clusterInstallation)
 		if err != nil {
 			logger.WithError(err).Errorf("Failed to change cluster installation state to %s", model.ClusterInstallationStateReconciling)
 			return installation.State
+		}
+
+		err = s.eventsProducer.ProduceClusterInstallationStateChangeEvent(clusterInstallation, oldState)
+		if err != nil {
+			logger.WithError(err).Error("Failed to create cluster installation state change event")
 		}
 	}
 
@@ -1037,11 +1043,17 @@ func (s *InstallationSupervisor) deleteInstallation(installation *model.Installa
 			return model.InstallationStateDeletionFailed
 		}
 
+		oldState := clusterInstallation.State
 		clusterInstallation.State = model.ClusterInstallationStateDeletionRequested
 		err = s.store.UpdateClusterInstallation(clusterInstallation)
 		if err != nil {
 			logger.WithError(err).Warnf("Failed to mark cluster installation %s for deletion", clusterInstallation.ID)
 			return installation.State
+		}
+
+		err = s.eventsProducer.ProduceClusterInstallationStateChangeEvent(clusterInstallation, oldState)
+		if err != nil {
+			logger.WithError(err).Error("Failed to create cluster installation state change event")
 		}
 
 		deletingClusterInstallations++


### PR DESCRIPTION
This adds duration metrics for cluster installation processing. It
also corrects a few cases where cluster installation events were
not created on state change.

Fixes https://mattermost.atlassian.net/browse/MM-41915

```release-note
Add cluster installation duration metrics
```
