### PR TITLE
Increase S3 import chunk size

### DIFF
--- a/internal/tools/aws/s3.go
+++ b/internal/tools/aws/s3.go
@@ -136,7 +136,7 @@ func (a *Client) S3LargeCopy(srcBucketName, srcBucketKey, destBucketName, destBu
 
 	objectSize := *objectMetadata.ContentLength
 	var (
-		partSize     int64 = 5 * 1024 * 1024 // 5 MB parts
+		partSize     int64 = 256 * 1024 * 1024 // 256 MB parts
 		bytePosition int64 = 0
 		partNum      int64 = 1
 	)


### PR DESCRIPTION
This allows for S3 file transfers from one bucket to another to
run in a more performant manner and to avoid issues where the
import bundle is too large to fit into 10000 chunks which is the
current limit.

https://mattermost.atlassian.net/browse/MM-42205

```release-note
Increase S3 import chunk size
```
