### PR TITLE
Use HistogramVec to collect metrics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -18,15 +18,15 @@ const (
 // the Provisioning server
 type CloudMetrics struct {
 	// Installation
-	InstallationCreationDurationHist    prometheus.Histogram
-	InstallationUpdateDurationHist      prometheus.Histogram
-	InstallationHibernationDurationHist prometheus.Histogram
-	InstallationWakeUpDurationHist      prometheus.Histogram
-	InstallationDeletionDurationHist    prometheus.Histogram
+	InstallationCreationDurationHist    *prometheus.HistogramVec
+	InstallationUpdateDurationHist      *prometheus.HistogramVec
+	InstallationHibernationDurationHist *prometheus.HistogramVec
+	InstallationWakeUpDurationHist      *prometheus.HistogramVec
+	InstallationDeletionDurationHist    *prometheus.HistogramVec
 
 	// ClusterInstallation
-	ClusterInstallationReconcilingDurationHist prometheus.Histogram
-	ClusterInstallationDeletionDurationHist    prometheus.Histogram
+	ClusterInstallationReconcilingDurationHist *prometheus.HistogramVec
+	ClusterInstallationDeletionDurationHist    *prometheus.HistogramVec
 }
 
 // New creates a new Prometheus-based Metrics object to be used
@@ -34,7 +34,7 @@ type CloudMetrics struct {
 // metrics
 func New() *CloudMetrics {
 	return &CloudMetrics{
-		InstallationCreationDurationHist: promauto.NewHistogram(
+		InstallationCreationDurationHist: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: provisionerNamespace,
 				Subsystem: provisionerSubsystemApp,
@@ -42,9 +42,10 @@ func New() *CloudMetrics {
 				Help:      "The duration of installation creation tasks",
 				Buckets:   standardDurationBuckets(),
 			},
+			[]string{"group"},
 		),
 
-		InstallationUpdateDurationHist: promauto.NewHistogram(
+		InstallationUpdateDurationHist: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: provisionerNamespace,
 				Subsystem: provisionerSubsystemApp,
@@ -52,9 +53,10 @@ func New() *CloudMetrics {
 				Help:      "The duration of installation update tasks",
 				Buckets:   standardDurationBuckets(),
 			},
+			[]string{"group"},
 		),
 
-		InstallationHibernationDurationHist: promauto.NewHistogram(
+		InstallationHibernationDurationHist: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: provisionerNamespace,
 				Subsystem: provisionerSubsystemApp,
@@ -62,9 +64,10 @@ func New() *CloudMetrics {
 				Help:      "The duration of installation hibernation tasks",
 				Buckets:   standardDurationBuckets(),
 			},
+			[]string{"group"},
 		),
 
-		InstallationWakeUpDurationHist: promauto.NewHistogram(
+		InstallationWakeUpDurationHist: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: provisionerNamespace,
 				Subsystem: provisionerSubsystemApp,
@@ -72,9 +75,10 @@ func New() *CloudMetrics {
 				Help:      "The duration of installation wake up tasks",
 				Buckets:   standardDurationBuckets(),
 			},
+			[]string{"group"},
 		),
 
-		InstallationDeletionDurationHist: promauto.NewHistogram(
+		InstallationDeletionDurationHist: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: provisionerNamespace,
 				Subsystem: provisionerSubsystemApp,
@@ -82,9 +86,10 @@ func New() *CloudMetrics {
 				Help:      "The duration of installation deletion tasks",
 				Buckets:   standardDurationBuckets(),
 			},
+			[]string{"group"},
 		),
 
-		ClusterInstallationReconcilingDurationHist: promauto.NewHistogram(
+		ClusterInstallationReconcilingDurationHist: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: provisionerNamespace,
 				Subsystem: provisionerSubsystemApp,
@@ -92,9 +97,10 @@ func New() *CloudMetrics {
 				Help:      "The duration of cluster installation reconciliation tasks",
 				Buckets:   standardDurationBuckets(),
 			},
+			[]string{"cluster"},
 		),
 
-		ClusterInstallationDeletionDurationHist: promauto.NewHistogram(
+		ClusterInstallationDeletionDurationHist: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: provisionerNamespace,
 				Subsystem: provisionerSubsystemApp,
@@ -102,6 +108,7 @@ func New() *CloudMetrics {
 				Help:      "The duration of cluster installation deletion tasks",
 				Buckets:   standardDurationBuckets(),
 			},
+			[]string{"cluster"},
 		),
 	}
 }

--- a/internal/supervisor/cluster_installation.go
+++ b/internal/supervisor/cluster_installation.go
@@ -306,10 +306,10 @@ func (s *ClusterInstallationSupervisor) processClusterInstallationMetrics(cluste
 
 	switch event.StateChange.NewState {
 	case model.ClusterInstallationStateReconciling:
-		s.metrics.ClusterInstallationReconcilingDurationHist.Observe(elapsedSeconds)
+		s.metrics.ClusterInstallationReconcilingDurationHist.WithLabelValues(clusterInstallation.ClusterID).Observe(elapsedSeconds)
 		logger.Debugf("Cluster installation was reconciled in %d seconds", int(elapsedSeconds))
 	case model.ClusterInstallationStateDeletionRequested:
-		s.metrics.ClusterInstallationDeletionDurationHist.Observe(elapsedSeconds)
+		s.metrics.ClusterInstallationDeletionDurationHist.WithLabelValues(clusterInstallation.ClusterID).Observe(elapsedSeconds)
 		logger.Debugf("Cluster installation was deleted in %d seconds", int(elapsedSeconds))
 	default:
 		return errors.Errorf("failed to handle event %s with new state %s", event.Event.ID, event.StateChange.NewState)

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -1496,24 +1496,28 @@ func (s *InstallationSupervisor) processInstallationMetrics(installation *model.
 		return errors.Errorf("expected 1 state change event, but got %d", len(events))
 	}
 
+	groupID := "none"
+	if installation.GroupID != nil && len(*installation.GroupID) != 0 {
+		groupID = *installation.GroupID
+	}
 	event := events[0]
 	elapsedSeconds := model.ElapsedTimeInSeconds(event.Event.Timestamp)
 
 	switch event.StateChange.NewState {
 	case model.InstallationStateCreationRequested:
-		s.metrics.InstallationCreationDurationHist.Observe(elapsedSeconds)
+		s.metrics.InstallationCreationDurationHist.WithLabelValues(groupID).Observe(elapsedSeconds)
 		logger.Debugf("Installation was created in %d seconds", int(elapsedSeconds))
 	case model.InstallationStateUpdateRequested:
-		s.metrics.InstallationUpdateDurationHist.Observe(elapsedSeconds)
+		s.metrics.InstallationUpdateDurationHist.WithLabelValues(groupID).Observe(elapsedSeconds)
 		logger.Debugf("Installation was updated in %d seconds", int(elapsedSeconds))
 	case model.InstallationStateHibernationRequested:
-		s.metrics.InstallationHibernationDurationHist.Observe(elapsedSeconds)
+		s.metrics.InstallationHibernationDurationHist.WithLabelValues(groupID).Observe(elapsedSeconds)
 		logger.Debugf("Installation was hibernated in %d seconds", int(elapsedSeconds))
 	case model.InstallationStateWakeUpRequested:
-		s.metrics.InstallationWakeUpDurationHist.Observe(elapsedSeconds)
+		s.metrics.InstallationWakeUpDurationHist.WithLabelValues(groupID).Observe(elapsedSeconds)
 		logger.Debugf("Installation was woken up in %d seconds", int(elapsedSeconds))
 	case model.InstallationStateDeletionRequested:
-		s.metrics.InstallationDeletionDurationHist.Observe(elapsedSeconds)
+		s.metrics.InstallationDeletionDurationHist.WithLabelValues(groupID).Observe(elapsedSeconds)
 		logger.Debugf("Installation was deleted in %d seconds", int(elapsedSeconds))
 	default:
 		return errors.Errorf("failed to handle event %s with new state %s", event.Event.ID, event.StateChange.NewState)


### PR DESCRIPTION
This allows for labels such as cluster and group IDs to be
associated with metrics for enhanced observability.

Fixes https://mattermost.atlassian.net/browse/MM-42211

```release-note
Use HistogramVec to collect metrics
```
