### PR TITLE
Add `PriorityEnv` support to Installations

### DIFF
--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -194,6 +194,7 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		Affinity:                   createInstallationRequest.Affinity,
 		APISecurityLock:            createInstallationRequest.APISecurityLock,
 		MattermostEnv:              createInstallationRequest.MattermostEnv,
+		PriorityEnv:                createInstallationRequest.PriorityEnv,
 		SingleTenantDatabaseConfig: createInstallationRequest.SingleTenantDatabaseConfig.ToDBConfig(createInstallationRequest.Database),
 		CRVersion:                  model.DefaultCRVersion,
 		State:                      model.InstallationStateCreationRequested,

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -953,7 +953,7 @@ func clusterInstallationBaseLabels(installation *model.Installation, clusterInst
 // NOTE: this should be called whenever the Mattermost custom resource is created
 // or updated.
 func getMattermostEnvWithOverrides(installation *model.Installation) model.EnvVarMap {
-	mattermostEnv := installation.MattermostEnv
+	mattermostEnv := installation.GetEnvVars()
 	if mattermostEnv == nil {
 		mattermostEnv = map[string]model.EnvVar{}
 	}

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1722,8 +1722,19 @@ var migrations = []migration{
 				Status TEXT NOT NULL,
 				LastAttempt BIGINT NOT NULL,
 				Attempts INT NOT NULL
-
 			);
+		`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
+	{semver.MustParse("0.33.0"), semver.MustParse("0.34.0"), func(e execer) error {
+		// Add PriorityEnv column to Installation
+		_, err := e.Exec(`
+				ALTER TABLE Installation
+				ADD COLUMN PriorityEnvRaw BYTEA NULL;
 		`)
 		if err != nil {
 			return err

--- a/model/env.go
+++ b/model/env.go
@@ -62,10 +62,10 @@ func (em *EnvVarMap) ClearOrPatch(new *EnvVarMap) bool {
 	}
 
 	if len(*new) == 0 {
-		orginalEmpty := len(*em) != 0
+		originalEmpty := len(*em) != 0
 		*em = nil
 
-		return orginalEmpty
+		return originalEmpty
 	}
 
 	return em.Patch(*new)

--- a/model/installation.go
+++ b/model/installation.go
@@ -37,6 +37,7 @@ type Installation struct {
 	Filestore                  string
 	License                    string
 	MattermostEnv              EnvVarMap
+	PriorityEnv                EnvVarMap
 	Size                       string
 	Affinity                   string
 	State                      string
@@ -194,6 +195,22 @@ func (i *Installation) MergeWithGroup(group *Group, includeOverrides bool) {
 		}
 		i.MattermostEnv[key] = value
 	}
+}
+
+// GetEnvVars returns Mattermost environment variables that will be applied to the installation.
+// If the installation was not merged with group, group env vars may impact the actual result.
+func (i Installation) GetEnvVars() EnvVarMap {
+	envs := make(map[string]EnvVar, len(i.MattermostEnv))
+
+	// First apply standard env, then override PriorityEnv.
+	for k, v := range i.MattermostEnv {
+		envs[k] = v
+	}
+	for k, v := range i.PriorityEnv {
+		envs[k] = v
+	}
+
+	return envs
 }
 
 // InstallationFromReader decodes a json-encoded installation from the given io.Reader.

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -130,6 +130,17 @@ func TestCreateInstallationRequestValid(t *testing.T) {
 			},
 		},
 		{
+			"invalid priority mattermost env",
+			true,
+			&model.CreateInstallationRequest{
+				OwnerID: "owner1",
+				DNS:     "domain4321.com",
+				PriorityEnv: model.EnvVarMap{
+					"key1": {Value: ""},
+				},
+			},
+		},
+		{
 			"invalid single tenant db replicas",
 			true,
 			&model.CreateInstallationRequest{


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds support for priority environment variables to Provisioner.

When environtment variable is set in `PriorityEnv` it will take precedence over `MattermostEnv`and over group configuration, allowing for customization of certain things without need of removing installation from the group.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add `PriorityEnv` support to Installations
```
