### PR TITLE
[MM-42288] - Org name from portal is not reflected in team name

### DIFF
--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/mattermost/mattermost-cloud/internal/events"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 
 	"github.com/gorilla/mux"
@@ -214,7 +215,12 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	err = c.EventProducer.ProduceInstallationStateChangeEvent(&installation, model.NonApplicableState)
+	extraFields := events.DataField{
+		Key:   "FirstTeamName",
+		Value: createInstallationRequest.FirstTeamName,
+	}
+
+	err = c.EventProducer.ProduceInstallationStateChangeEvent(&installation, model.NonApplicableState, extraFields)
 	if err != nil {
 		c.Logger.WithError(err).Error("Failed to create installation state change event")
 	}

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -43,6 +43,7 @@ type CreateInstallationRequest struct {
 	Version         string
 	Image           string
 	DNS             string
+	FirstTeamName   string
 	License         string
 	Size            string
 	Affinity        string


### PR DESCRIPTION
#### Summary
This PR adds changes to enable modification of the first team name based on org name from the portal

#### Ticket Link
[MM-42288](https://mattermost.atlassian.net/browse/MM-42288)

#### Related PRs
https://github.com/mattermost/customer-web-server/pull/694

#### Release Note

```release-note
NONE

```
