### PR TITLE
[MM-42455] Fix a bug where teleport applies wrong version during reprovisioning

### DIFF
--- a/internal/provisioner/teleport.go
+++ b/internal/provisioner/teleport.go
@@ -91,7 +91,7 @@ func (n *teleport) ActualVersion() *model.HelmUtilityVersion {
 		return nil
 	}
 	return &model.HelmUtilityVersion{
-		Chart:      strings.TrimPrefix(n.actualVersion.Version(), "kube-agent-"),
+		Chart:      strings.TrimPrefix(n.actualVersion.Version(), "teleport-kube-agent-"),
 		ValuesPath: n.actualVersion.Values(),
 	}
 }


### PR DESCRIPTION
#### Summary
- Fix a bug where teleport applies wrong version during reprovisioning

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-42455

#### Release Note
```release-note
- Fix a bug where teleport applies wrong version during reprovisioning
```
