### PR TITLE
Add delete multi-tenant database endpoint

### DIFF
--- a/cmd/cloud/databases.go
+++ b/cmd/cloud/databases.go
@@ -32,9 +32,14 @@ func init() {
 	multitenantDatabaseUpdateCmd.Flags().Int64("max-installations-per-logical-db", 10, "The maximum number of installations permitted in a single logical database (only applies to proxy databases).")
 	multitenantDatabaseUpdateCmd.MarkFlagRequired("multitenant-database")
 
+	multitenantDatabaseDeleteCmd.Flags().String("multitenant-database", "", "The id of the mulitenant database to delete.")
+	multitenantDatabaseDeleteCmd.Flags().Bool("force", false, "Specifies whether to delete record even if database cluster exists.")
+	multitenantDatabaseDeleteCmd.MarkFlagRequired("multitenant-database")
+
 	multitenantDatabaseCmd.AddCommand(multitenantDatabaseListCmd)
 	multitenantDatabaseCmd.AddCommand(multitenantDatabaseGetCmd)
 	multitenantDatabaseCmd.AddCommand(multitenantDatabaseUpdateCmd)
+	multitenantDatabaseCmd.AddCommand(multitenantDatabaseDeleteCmd)
 
 	// Logical Databases
 	logicalDatabaseListCmd.Flags().String("multitenant-database-id", "", "The multitenant database ID by which to filter logical databases.")
@@ -188,6 +193,26 @@ var multitenantDatabaseUpdateCmd = &cobra.Command{
 		}
 
 		return printJSON(multitenantDatabase)
+	},
+}
+
+var multitenantDatabaseDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete an multitenant database's configuration",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		multitenantDatabaseID, _ := command.Flags().GetString("multitenant-database")
+		force, _ := command.Flags().GetBool("force")
+
+		err := client.DeleteMultitenantDatabase(multitenantDatabaseID, force)
+		if err != nil {
+			return errors.Wrap(err, "failed to update multitenant database")
+		}
+		return nil
 	},
 }
 

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -19,6 +19,7 @@ type Supervisor interface {
 // Store describes the interface required to persist changes made via API requests.
 type Store interface {
 	model.InstallationDatabaseStoreInterface
+	DeleteMultitenantDatabase(multitenantDatabaseID string) error
 
 	CreateCluster(cluster *model.Cluster, annotations []*model.Annotation) error
 	GetCluster(clusterID string) (*model.Cluster, error)
@@ -124,6 +125,7 @@ type Provisioner interface {
 // AwsClient describes the interface required to communicate with the AWS
 type AwsClient interface {
 	SwitchClusterTags(clusterID string, targetClusterID string, logger logrus.FieldLogger) error
+	RDSDBCLusterExists(awsID string) (bool, error)
 }
 
 // DBProvider describes the interface required to get database for specific installation and specified type.

--- a/internal/store/db_multitenant_database.go
+++ b/internal/store/db_multitenant_database.go
@@ -236,6 +236,21 @@ func (sqlStore *SQLStore) updateMultitenantDatabase(db execer, multitenantDataba
 	return nil
 }
 
+// DeleteMultitenantDatabase marks multitenant database as deleted.
+func (sqlStore *SQLStore) DeleteMultitenantDatabase(multitenantDatabaseID string) error {
+	_, err := sqlStore.execBuilder(sqlStore.db, sq.
+		Update("MultitenantDatabase").
+		Set("DeleteAt", model.GetMillis()).
+		Where("ID = ?", multitenantDatabaseID).
+		Where("DeleteAt = 0"),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to mark multitenant database as deleted")
+	}
+
+	return nil
+}
+
 // LockMultitenantDatabase marks the database cluster as locked for exclusive use by the caller.
 func (sqlStore *SQLStore) LockMultitenantDatabase(multitenantDatabaseID, lockerID string) (bool, error) {
 	return sqlStore.lockRows("MultitenantDatabase", []string{multitenantDatabaseID}, lockerID)

--- a/internal/store/db_multitenant_database_test.go
+++ b/internal/store/db_multitenant_database_test.go
@@ -351,3 +351,23 @@ func TestGetMultitenantDatabases_WeightCalculation(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteMultitenantDatabase(t *testing.T) {
+	sqlStore := MakeTestSQLStore(t, testlib.MakeLogger(t))
+	defer CloseConnection(t, sqlStore)
+
+	database1 := &model.MultitenantDatabase{
+		RdsClusterID:  "database_id0",
+		VpcID:         "vpc_id0",
+	}
+
+	err := sqlStore.CreateMultitenantDatabase(database1)
+	require.NoError(t, err)
+
+	err = sqlStore.DeleteMultitenantDatabase(database1.ID)
+	require.NoError(t, err)
+
+	db, err := sqlStore.GetMultitenantDatabase(database1.ID)
+	require.NoError(t, err)
+	assert.NotEqual(t, int64(0), db.DeleteAt)
+}

--- a/internal/tools/aws/rds.go
+++ b/internal/tools/aws/rds.go
@@ -18,6 +18,22 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// RDSDBCLusterExists check whether RDS cluster with specified ID exists.
+func (a *Client) RDSDBCLusterExists(awsID string) (bool, error) {
+	_, err := a.Service().rds.DescribeDBClusters(&rds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String(awsID),
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == rds.ErrCodeDBClusterNotFoundFault {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func (a *Client) rdsGetDBSecurityGroupIDs(vpcID, tagValue string, logger log.FieldLogger) ([]string, error) {
 	result, err := a.Service().ec2.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{

--- a/model/client.go
+++ b/model/client.go
@@ -1168,6 +1168,24 @@ func (c *Client) UpdateMultitenantDatabase(databaseID string, request *PatchMult
 	}
 }
 
+// DeleteMultitenantDatabase marks multitenant database as deleted.
+func (c *Client) DeleteMultitenantDatabase(databaseID string, force bool) error {
+	u := c.buildURL("/api/databases/multitenant_database/%s?force=%t", databaseID, force)
+	resp, err := c.doDelete(u)
+	if err != nil {
+		return err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+
+	default:
+		return errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // GetLogicalDatabases fetches the list of logical databases from the configured provisioning server.
 func (c *Client) GetLogicalDatabases(request *GetLogicalDatabasesRequest) ([]*LogicalDatabase, error) {
 	u, err := url.Parse(c.buildURL("/api/databases/logical_databases"))


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds a new endpoint to mark the multitenant database as deleted.
Currently there is no endpoint to do that therefore deleting database needs 
to be done from DB level.

When deleting multitenant database, Provisioner will check if cluster does not
exist and will fail to mark DB as deleted unless `force` query param is set to `true`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add delete multi-tenant database endpoint
```
