### PR TITLE
Add cluster resource cache

### DIFF
--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -7,6 +7,7 @@ package api_test
 import (
 	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/mattermost/mattermost-cloud/model"
+	log "github.com/sirupsen/logrus"
 )
 
 type mockSupervisor struct {
@@ -37,7 +38,7 @@ func (s *mockProvisioner) ExecMattermostCLI(*model.Cluster, *model.ClusterInstal
 	return s.Output, s.CommandError
 }
 
-func (s *mockProvisioner) GetClusterResources(*model.Cluster, bool) (*k8s.ClusterResources, error) {
+func (s *mockProvisioner) GetClusterResources(*model.Cluster, bool, log.FieldLogger) (*k8s.ClusterResources, error) {
 	return nil, nil
 }
 

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // Supervisor describes the interface to notify the background jobs of an actionable change.
@@ -119,7 +120,7 @@ type Store interface {
 type Provisioner interface {
 	ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
 	ExecMattermostCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
-	GetClusterResources(*model.Cluster, bool) (*k8s.ClusterResources, error)
+	GetClusterResources(*model.Cluster, bool, log.FieldLogger) (*k8s.ClusterResources, error)
 }
 
 // AwsClient describes the interface required to communicate with the AWS

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -14,18 +14,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
-	"github.com/mattermost/mattermost-cloud/internal/tools/terraform"
-
-	"github.com/sirupsen/logrus"
-
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/internal/tools/terraform"
 	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/mattermost/mattermost-cloud/model"
 	rotatorModel "github.com/mattermost/rotator/model"
@@ -956,8 +954,8 @@ func (provisioner *KopsProvisioner) cleanupKopsCluster(cluster *model.Cluster, a
 }
 
 // GetClusterResources returns a snapshot of resources of a given cluster.
-func (provisioner *KopsProvisioner) GetClusterResources(cluster *model.Cluster, onlySchedulable bool) (*k8s.ClusterResources, error) {
-	logger := provisioner.logger.WithField("cluster", cluster.ID)
+func (provisioner *KopsProvisioner) GetClusterResources(cluster *model.Cluster, onlySchedulable bool, logger logrus.FieldLogger) (*k8s.ClusterResources, error) {
+	logger = logger.WithField("cluster", cluster.ID)
 
 	configLocation, err := provisioner.getCachedKopsClusterKubecfg(cluster.ProvisionerMetadataKops.Name, logger)
 	if err != nil {

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -339,7 +339,7 @@ func (p *mockInstallationProvisioner) VerifyClusterInstallationMatchesConfig(clu
 	return true, nil
 }
 
-func (p *mockInstallationProvisioner) GetClusterResources(cluster *model.Cluster, onlySchedulable bool) (*k8s.ClusterResources, error) {
+func (p *mockInstallationProvisioner) GetClusterResources(cluster *model.Cluster, onlySchedulable bool, logger log.FieldLogger) (*k8s.ClusterResources, error) {
 	if p.UseCustomClusterResources {
 		return p.CustomClusterResources, nil
 	}


### PR DESCRIPTION
This new cache speeds up cluster selection when installations are
scheduled with the balanced scheduling server option.

Fixes https://mattermost.atlassian.net/browse/MM-43190

```release-note
Add cluster resource cache
```
