### PR TITLE
Improve e2e test edge cases, fix populate sample data command

### DIFF
--- a/e2e/tests/cluster/cluster_test.go
+++ b/e2e/tests/cluster/cluster_test.go
@@ -41,7 +41,7 @@ func Test_ClusterLifecycle(t *testing.T) {
 			}
 		}()
 	}
-	err = test.EventsRecorder.Start(test.ProvisionerClient)
+	err = test.EventsRecorder.Start(test.ProvisionerClient, test.Logger)
 	require.NoError(t, err)
 	defer test.EventsRecorder.ShutDown(test.ProvisionerClient)
 

--- a/e2e/tests/cluster/suite.go
+++ b/e2e/tests/cluster/suite.go
@@ -86,7 +86,7 @@ func SetupClusterLifecycleTest() (*Test, error) {
 		return nil, err
 	}
 
-	subOwner := fmt.Sprintf("e2e-test-%s", testID)
+	subOwner := "e2e-test"
 
 	// We need to be cautious with introducing some parallelism for tests especially on step level
 	// as webhook event will be delivered to only one channel.

--- a/e2e/workflow/installation.go
+++ b/e2e/workflow/installation.go
@@ -121,7 +121,7 @@ func (w *InstallationSuite) GetConnectionStrAndExport(ctx context.Context) error
 func (w *InstallationSuite) PopulateSampleData(ctx context.Context) error {
 	// Do not generate guest user as by default guest accounts are disabled,
 	// which results in guest users being deactivated when Mattermost restarts.
-	_, err := w.client.RunMattermostCLICommandOnClusterInstallation(w.Meta.ClusterInstallationID, []string{"sampledata", "--teams", "4", "--channels-per-team", "15", "--guests", "0"})
+	_, err := w.client.ExecClusterInstallationCLI(w.Meta.ClusterInstallationID, "mmctl", []string{"--local", "sampledata", "--teams", "4", "--channels-per-team", "15", "--guests", "0"})
 	if err != nil {
 		return errors.Wrap(err, "while populating sample data for CI")
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
PR changes:
- Improve edge cases in e2e test webhook registration.
- Fix `sampleData` command that is no longer in `mattermost` command.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Improve e2e test edge cases, fix populate sample data command
```
