### PR TITLE
Fetch AMI from existing clusters in e2e

### DIFF
--- a/e2e/pkg/cluster.go
+++ b/e2e/pkg/cluster.go
@@ -40,7 +40,7 @@ func WaitForClusterToBeStable(ctx context.Context, clusterID string, whChan <-ch
 
 // WaitForClusterDeletion waits until Cluster is deleted.
 func WaitForClusterDeletion(ctx context.Context, clusterID string, whChan <-chan *model.WebhookPayload, log logrus.FieldLogger) error {
-	waitCtx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 
 	whWaiter := webhookWaiter{


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
- Allow enabling fetching AMI from existing clusters when creating cluster as part of e2e.
- Increase cluster deletion timeout.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fetch AMI from existing clusters in e2e
```
