### PR TITLE
Allow events to appear in switched order

### DIFF
--- a/e2e/pkg/eventstest/handler.go
+++ b/e2e/pkg/eventstest/handler.go
@@ -172,8 +172,15 @@ func (ev *EventsRecorder) VerifyInOrder(expectedEvents []EventOccurrence) error 
 		}
 		expected := expectedEvents[0]
 
+		// The order of some events might be different depending on which
+		// supervisor run earlier therefore we check first 2 events.
 		if expected.MatchPayload(e) {
 			expectedEvents = expectedEvents[1:]
+		} else if len(expectedEvents) > 1 {
+			expected = expectedEvents[1]
+			if expected.MatchPayload(e) {
+				expectedEvents = append(expectedEvents[:1], expectedEvents[2:]...)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Allow switched order of events in e2e.

Sometimes depending on Provisioner's activity some Installation and Cluster Installation state transitions can appear in a different order, which causes e2e to fail. With this change, we accept the two neighboring events to appear in switched order.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Allow events to appear in switched order
```
