### PR TITLE
Improve CI exec error handling

### DIFF
--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -19,10 +19,19 @@ func (s *mockSupervisor) Do() error {
 
 type mockProvisioner struct {
 	Output       []byte
+	ExecError    error
 	CommandError error
 }
 
-func (s *mockProvisioner) ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error) {
+func (s *mockProvisioner) ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error, error) {
+	if len(s.Output) == 0 {
+		s.Output = []byte(`{"ServiceSettings":{"SiteURL":"http://test.example.com"}}`)
+	}
+
+	return s.Output, s.ExecError, s.CommandError
+}
+
+func (s *mockProvisioner) ExecMMCTL(*model.Cluster, *model.ClusterInstallation, ...string) ([]byte, error) {
 	if len(s.Output) == 0 {
 		s.Output = []byte(`{"ServiceSettings":{"SiteURL":"http://test.example.com"}}`)
 	}

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -118,7 +118,8 @@ type Store interface {
 
 // Provisioner describes the interface required to communicate with the Kubernetes cluster.
 type Provisioner interface {
-	ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
+	ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error, error)
+	ExecMMCTL(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
 	ExecMattermostCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
 	GetClusterResources(*model.Cluster, bool, log.FieldLogger) (*k8s.ClusterResources, error)
 }

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -58,7 +58,7 @@ type importStore interface {
 }
 
 type importProvisioner interface {
-	ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
+	ExecMMCTL(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
 }
 
 type mmctl struct {
@@ -70,8 +70,8 @@ type mmctl struct {
 }
 
 func (m *mmctl) Run(args ...string) ([]byte, error) {
-	args = append([]string{"mmctl", "--format", "json", "--local"}, args...)
-	return m.provisioner.ExecClusterInstallationCLI(m.cluster, m.clusterInstallation, args...)
+	args = append([]string{"--format", "json", "--local"}, args...)
+	return m.provisioner.ExecMMCTL(m.cluster, m.clusterInstallation, args...)
 }
 
 type team struct {
@@ -307,8 +307,11 @@ func (s *ImportSupervisor) ensureTeamSettings(mmctl *mmctl, imprt *awat.ImportSt
 		}
 	}
 
-	// ensure that there will be enough new user slots for this import
+	if imprt.Users == 0 {
+		return nil
+	}
 
+	// ensure that there will be enough new user slots for this import
 	output, err := mmctl.Run("config", "get", "TeamSettings.MaxUsersPerTeam")
 	if err != nil {
 		return errors.Wrapf(err, "failed to get max user limit")
@@ -401,7 +404,7 @@ func (s *ImportSupervisor) waitForImportToComplete(mmctl *mmctl, logger logrus.F
 	for !complete {
 		output, err := mmctl.Run("import", "job", "show", mattermostJobID)
 		if err != nil {
-			logger.WithError(err).Warn("failed to check job")
+			logger.WithError(err).Warn("failed to check import job")
 			time.Sleep(5 * time.Second)
 			continue
 		}

--- a/internal/supervisor/import_test.go
+++ b/internal/supervisor/import_test.go
@@ -262,7 +262,7 @@ type mockImportProvisioner struct {
 	Fail bool
 }
 
-func (m *mockImportProvisioner) ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error) {
+func (m *mockImportProvisioner) ExecMMCTL(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error) {
 	switch args[len(args)-1] {
 	case "TeamSettings.MaxUsersPerTeam":
 		return []byte("10"), nil

--- a/model/client.go
+++ b/model/client.go
@@ -895,21 +895,7 @@ func (c *Client) SetClusterInstallationConfig(clusterInstallationID string, conf
 
 // RunMattermostCLICommandOnClusterInstallation runs a Mattermost CLI command against a cluster installation.
 func (c *Client) RunMattermostCLICommandOnClusterInstallation(clusterInstallationID string, subcommand []string) ([]byte, error) {
-	resp, err := c.doPost(c.buildURL("/api/cluster_installation/%s/mattermost_cli", clusterInstallationID), subcommand)
-	if err != nil {
-		return nil, err
-	}
-	defer closeBody(resp)
-
-	bytes, _ := ioutil.ReadAll(resp.Body)
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		return bytes, nil
-
-	default:
-		return bytes, errors.Errorf("failed with status code %d", resp.StatusCode)
-	}
+	return c.ExecClusterInstallationCLI(clusterInstallationID, "mattermost", subcommand)
 }
 
 // ExecClusterInstallationCLI runs a valid exec command against a cluster installation.

--- a/model/exec.go
+++ b/model/exec.go
@@ -4,9 +4,17 @@
 
 package model
 
-const execMMCTL = "mmctl"
+const (
+	execMMCTL         = "mmctl"
+	execMattermostCLI = "mattermost"
+)
 
 // IsValidExecCommand returns wheather the provided command is valid or not.
 func IsValidExecCommand(command string) bool {
-	return command == execMMCTL
+	switch command {
+	case execMMCTL, execMattermostCLI:
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
This changes how errors are exposed when running exec commands
against a cluster installation. A separate error is now exposed
for issues that relate to the execution of the provided command
which allows for more granular logic when needed.

Fixes https://mattermost.atlassian.net/browse/MM-44104

```release-note
Improve CI exec error handling
```
