### PR TITLE
Add velero in our kops cluster

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -657,5 +657,8 @@ func processUtilityFlags(command *cobra.Command) map[string]*model.HelmUtilityVe
 		model.MetricsServerCanonicalName: {
 			Chart:      MustGetString("metrics-server-version", command),
 			ValuesPath: MustGetString("metrics-server-values", command)},
+		model.VeleroCanonicalName: {
+			Chart:      MustGetString("velero-version", command),
+			ValuesPath: MustGetString("velero-values", command)},
 	}
 }

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -42,6 +42,7 @@ func init() {
 	clusterCreateCmd.Flags().String("kubecost-version", "", "The version of Kubecost. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("node-problem-detector-version", "", "The version of Node Problem Detector. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("metrics-server-version", "", "The version of Metrics Server. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().String("velero-version", "", "The version of Velero. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("prometheus-operator-values", "", "The full Git URL of the desired chart value file's version for Prometheus Operator")
 	clusterCreateCmd.Flags().String("thanos-values", "", "The full Git URL of the desired chart value file's version for Thanos")
 	clusterCreateCmd.Flags().String("fluentbit-values", "", "The full Git URL of the desired chart value file's version for Fluent-Bit")
@@ -53,6 +54,7 @@ func init() {
 	clusterCreateCmd.Flags().String("kubecost-values", "", "The full Git URL of the desired chart value file's version for Kubecost")
 	clusterCreateCmd.Flags().String("node-problem-detector-values", "", "The full Git URL of the desired chart value file's version for Node Problem Detector")
 	clusterCreateCmd.Flags().String("metrics-server-values", "", "The full Git URL of the desired chart value file's version for Metrics Server")
+	clusterCreateCmd.Flags().String("velero-values", "", "The full Git URL of the desired chart value file's version for Velero")
 	clusterCreateCmd.Flags().String("networking", "amazon-vpc-routed-eni", "Networking mode to use, for example: weave, calico, canal, amazon-vpc-routed-eni")
 	clusterCreateCmd.Flags().String("vpc", "", "Set to use a shared VPC")
 	clusterCreateCmd.Flags().String("cluster", "", "The id of the cluster. If provided and the cluster exists the creation will be retried ignoring other parameters.")
@@ -71,6 +73,7 @@ func init() {
 	clusterProvisionCmd.Flags().String("kubecost-version", "", "The version of the Kubecost Helm chart")
 	clusterProvisionCmd.Flags().String("node-problem-detector-version", "", "The version of the Node Problem Detector Helm chart")
 	clusterProvisionCmd.Flags().String("metrics-server-version", "", "The version of the Metrics Server Helm chart")
+	clusterProvisionCmd.Flags().String("velero-version", "", "The version of Velero. Use 'stable' to provision the latest stable version published upstream.")
 
 	clusterProvisionCmd.Flags().String("prometheus-operator-values", "", "The full Git URL of the desired chart values for Prometheus Operator")
 	clusterProvisionCmd.Flags().String("thanos-values", "", "The full Git URL of the desired chart values for Thanos")
@@ -83,6 +86,7 @@ func init() {
 	clusterProvisionCmd.Flags().String("kubecost-values", "", "The full Git URL of the desired Kubecost chart")
 	clusterProvisionCmd.Flags().String("node-problem-detector-values", "", "The full Git URL of the desired chart values for the Node Problem Detector")
 	clusterProvisionCmd.Flags().String("metrics-server-values", "", "The full Git URL of the desired chart values for the Metrics Server")
+	clusterProvisionCmd.Flags().String("velero-values", "", "The full Git URL of the desired chart value file's version for Velero")
 	clusterProvisionCmd.Flags().Bool("reprovision-all-utilities", false, "Set to true if all utilities should be reprovisioned and not just ones with new versions")
 
 	clusterProvisionCmd.MarkFlagRequired("cluster")

--- a/helm-charts/velero_values.yaml
+++ b/helm-charts/velero_values.yaml
@@ -1,0 +1,1 @@
+### Set the values for local Velero utility testing

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -37,6 +37,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"kubecost":              {Chart: "1.88.1", ValuesPath: ""},
 				"node-problem-detector": {Chart: "2.0.5", ValuesPath: ""},
 				"metrics-server":        {Chart: "3.8.2", ValuesPath: ""},
+				"velero":                {Chart: "2.29.4", ValuesPath: ""},
 			},
 		}
 	}
@@ -103,6 +104,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"kubecost":              {Chart: "1.88.1", ValuesPath: ""},
 				"node-problem-detector": {Chart: "2.0.5", ValuesPath: ""},
 				"metrics-server":        {Chart: "3.8.2", ValuesPath: ""},
+				"velero":                {Chart: "2.29.4", ValuesPath: ""},
 			},
 		}, clusterRequest)
 	})

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -146,12 +146,17 @@ func newUtilityGroupHandle(kops *kops.Cmd, provisioner *KopsProvisioner, cluster
 		cluster, provisioner, kops, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get handle for Metrics Server")
+	velero, err := newVeleroHandle(
+		cluster.DesiredUtilityVersion(model.VeleroCanonicalName), cluster,
+		provisioner, kops, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get handle for Node Problem Detector")
 	}
 
 	// the order of utilities here matters; the utilities are deployed
 	// in order to resolve dependencies between them
 	return &utilityGroup{
-		utilities:   []Utility{nginx, nginxInternal, prometheusOperator, thanos, fluentbit, teleport, pgbouncer, promtail, kubecost, nodeProblemDetector, metricsServer},
+		utilities:   []Utility{nginx, nginxInternal, prometheusOperator, thanos, fluentbit, teleport, pgbouncer, promtail, kubecost, nodeProblemDetector, metricsServer, velero},
 		kops:        kops,
 		provisioner: provisioner,
 		cluster:     cluster,

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -150,7 +150,7 @@ func newUtilityGroupHandle(kops *kops.Cmd, provisioner *KopsProvisioner, cluster
 		cluster.DesiredUtilityVersion(model.VeleroCanonicalName), cluster,
 		provisioner, kops, logger)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get handle for Node Problem Detector")
+		return nil, errors.Wrap(err, "failed to get handle for Velero")
 	}
 
 	// the order of utilities here matters; the utilities are deployed

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -146,6 +146,8 @@ func newUtilityGroupHandle(kops *kops.Cmd, provisioner *KopsProvisioner, cluster
 		cluster, provisioner, kops, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get handle for Metrics Server")
+	}
+
 	velero, err := newVeleroHandle(
 		cluster.DesiredUtilityVersion(model.VeleroCanonicalName), cluster,
 		provisioner, kops, logger)

--- a/internal/provisioner/velero.go
+++ b/internal/provisioner/velero.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type velero struct {
+	cluster        *model.Cluster
+	kops           *kops.Cmd
+	logger         log.FieldLogger
+	provisioner    *KopsProvisioner
+	actualVersion  *model.HelmUtilityVersion
+	desiredVersion *model.HelmUtilityVersion
+}
+
+func newVeleroHandle(desiredVersion *model.HelmUtilityVersion, cluster *model.Cluster, provisioner *KopsProvisioner, kops *kops.Cmd, logger log.FieldLogger) (*velero, error) {
+	if logger == nil {
+		return nil, fmt.Errorf("cannot instantiate Velero handle with nil logger")
+	}
+
+	if cluster == nil {
+		return nil, errors.New("cannot create a connection to Velero if the cluster provided is nil")
+	}
+
+	if provisioner == nil {
+		return nil, errors.New("cannot create a connection to Velero if the provisioner provided is nil")
+	}
+	if kops == nil {
+		return nil, errors.New("cannot create a connection to Velero if the Kops command provided is nil")
+	}
+	return &velero{
+		cluster:        cluster,
+		kops:           kops,
+		logger:         logger.WithField("cluster-utility", model.VeleroCanonicalName),
+		provisioner:    provisioner,
+		desiredVersion: desiredVersion,
+		actualVersion:  cluster.UtilityMetadata.ActualVersions.Velero,
+	}, nil
+}
+
+func (f *velero) Destroy() error {
+	return nil
+}
+
+func (f *velero) Migrate() error {
+	return nil
+}
+
+func (f *velero) CreateOrUpgrade() error {
+	logger := f.logger.WithField("velero-action", "upgrade")
+	h := f.NewHelmDeployment(logger)
+
+	err := h.Update()
+	if err != nil {
+		return err
+	}
+
+	err = f.updateVersion(h)
+	return err
+}
+
+func (f *velero) DesiredVersion() *model.HelmUtilityVersion {
+	return f.desiredVersion
+}
+
+func (f *velero) ActualVersion() *model.HelmUtilityVersion {
+	if f.actualVersion == nil {
+		return nil
+	}
+	return &model.HelmUtilityVersion{
+		Chart:      strings.TrimPrefix(f.actualVersion.Version(), "velero-"),
+		ValuesPath: f.actualVersion.Values(),
+	}
+}
+
+func (f *velero) Name() string {
+	return model.VeleroCanonicalName
+}
+
+func (f *velero) NewHelmDeployment(logger log.FieldLogger) *helmDeployment {
+	return &helmDeployment{
+		chartDeploymentName: "velero",
+		chartName:           "vmware-tanzu/velero",
+		namespace:           "velero",
+		kopsProvisioner:     f.provisioner,
+		kops:                f.kops,
+		logger:              logger,
+		desiredVersion:      f.desiredVersion,
+	}
+}
+
+func (f *velero) ValuesPath() string {
+	if f.desiredVersion == nil {
+		return ""
+	}
+	return f.desiredVersion.Values()
+}
+
+func (f *velero) updateVersion(h *helmDeployment) error {
+	actualVersion, err := h.Version()
+	if err != nil {
+		return err
+	}
+
+	f.actualVersion = actualVersion
+	return nil
+}

--- a/internal/provisioner/velero.go
+++ b/internal/provisioner/velero.go
@@ -48,14 +48,6 @@ func newVeleroHandle(desiredVersion *model.HelmUtilityVersion, cluster *model.Cl
 	}, nil
 }
 
-func (f *velero) Destroy() error {
-	return nil
-}
-
-func (f *velero) Migrate() error {
-	return nil
-}
-
 func (f *velero) CreateOrUpgrade() error {
 	logger := f.logger.WithField("velero-action", "upgrade")
 	h := f.NewHelmDeployment(logger)
@@ -67,6 +59,18 @@ func (f *velero) CreateOrUpgrade() error {
 
 	err = f.updateVersion(h)
 	return err
+}
+
+func (f *velero) Name() string {
+	return model.VeleroCanonicalName
+}
+
+func (f *velero) Destroy() error {
+	return nil
+}
+
+func (f *velero) Migrate() error {
+	return nil
 }
 
 func (f *velero) DesiredVersion() *model.HelmUtilityVersion {
@@ -83,11 +87,9 @@ func (f *velero) ActualVersion() *model.HelmUtilityVersion {
 	}
 }
 
-func (f *velero) Name() string {
-	return model.VeleroCanonicalName
-}
-
 func (f *velero) NewHelmDeployment(logger log.FieldLogger) *helmDeployment {
+	helmValueArguments := fmt.Sprintf("configuration.backupStorageLocation.prefix=%s", f.cluster.ID)
+
 	return &helmDeployment{
 		chartDeploymentName: "velero",
 		chartName:           "vmware-tanzu/velero",
@@ -95,6 +97,7 @@ func (f *velero) NewHelmDeployment(logger log.FieldLogger) *helmDeployment {
 		kopsProvisioner:     f.provisioner,
 		kops:                f.kops,
 		logger:              logger,
+		setArgument:         helmValueArguments,
 		desiredVersion:      f.desiredVersion,
 	}
 }

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -33,6 +33,8 @@ const (
 	NodeProblemDetectorCanonicalName = "node-problem-detector"
 	// MetricsServerCanonicalName is the canonical string representation of metrics server
 	MetricsServerCanonicalName = "metrics-server"
+	// VeleroCanonicalName is the canonical string representation of velero
+	VeleroCanonicalName = "velero"
 	// GitlabOAuthTokenKey is the name of the Environment Variable which
 	// may contain an OAuth token for accessing GitLab repositories over
 	// HTTPS, used for fetching values files
@@ -77,6 +79,8 @@ var DefaultUtilityVersions map[string]*HelmUtilityVersion = map[string]*HelmUtil
 	NodeProblemDetectorCanonicalName: {Chart: "2.0.5", ValuesPath: ""},
 	// MetricsServerCanonicalName defines the default version and values path for the Helm chart
 	MetricsServerCanonicalName: {Chart: "3.8.2", ValuesPath: ""},
+	// VeleroCanonicalName defines the default version for the Helm chart
+	VeleroCanonicalName: {Chart: "2.29.4", ValuesPath: ""},
 }
 
 var defaultUtilityValuesFileNames map[string]string = map[string]string{
@@ -91,6 +95,7 @@ var defaultUtilityValuesFileNames map[string]string = map[string]string{
 	KubecostCanonicalName:            "kubecost_values.yaml",
 	NodeProblemDetectorCanonicalName: "node_problem_detector_values.yaml",
 	MetricsServerCanonicalName:       "metrics_server_values.yaml",
+	VeleroCanonicalName:              "velero_values.yaml",
 }
 
 var (
@@ -134,6 +139,7 @@ type UtilityGroupVersions struct {
 	Kubecost            *HelmUtilityVersion
 	NodeProblemDetector *HelmUtilityVersion
 	MetricsServer       *HelmUtilityVersion
+	Velero              *HelmUtilityVersion
 }
 
 // AsMap returns the UtilityGroupVersion represented as a map with the
@@ -152,6 +158,7 @@ func (h *UtilityGroupVersions) AsMap() map[string]*HelmUtilityVersion {
 		KubecostCanonicalName:            h.Kubecost,
 		NodeProblemDetectorCanonicalName: h.NodeProblemDetector,
 		MetricsServerCanonicalName:       h.MetricsServer,
+		VeleroCanonicalName:              h.Velero,
 	}
 }
 
@@ -284,6 +291,8 @@ func setUtilityVersion(versions *UtilityGroupVersions, utility string, desiredVe
 		versions.NodeProblemDetector = desiredVersion
 	case MetricsServerCanonicalName:
 		versions.MetricsServer = desiredVersion
+	case VeleroCanonicalName:
+		versions.Velero = desiredVersion
 	}
 }
 

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -35,6 +35,7 @@ func TestGetUtilityVersion(t *testing.T) {
 		Fluentbit:           &HelmUtilityVersion{Chart: "6"},
 		NodeProblemDetector: &HelmUtilityVersion{Chart: "7"},
 		MetricsServer:       &HelmUtilityVersion{Chart: "8"},
+		Velero:              &HelmUtilityVersion{Chart: "9"},
 	}
 
 	assert.Equal(t, &HelmUtilityVersion{Chart: "3"}, getUtilityVersion(u, PrometheusOperatorCanonicalName))
@@ -43,6 +44,7 @@ func TestGetUtilityVersion(t *testing.T) {
 	assert.Equal(t, &HelmUtilityVersion{Chart: "6"}, getUtilityVersion(u, FluentbitCanonicalName))
 	assert.Equal(t, &HelmUtilityVersion{Chart: "7"}, getUtilityVersion(u, NodeProblemDetectorCanonicalName))
 	assert.Equal(t, &HelmUtilityVersion{Chart: "8"}, getUtilityVersion(u, MetricsServerCanonicalName))
+	assert.Equal(t, &HelmUtilityVersion{Chart: "9"}, getUtilityVersion(u, VeleroCanonicalName))
 	assert.Equal(t, nilHuv, getUtilityVersion(u, "anything else"))
 }
 
@@ -135,6 +137,7 @@ func TestGetActualVersion(t *testing.T) {
 				Kubecost:            &HelmUtilityVersion{Chart: "12345678"},
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "123456789"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "1234567899"},
+				Velero:              &HelmUtilityVersion{Chart: "12345678910"},
 			},
 			ActualVersions: UtilityGroupVersions{
 				PrometheusOperator:  &HelmUtilityVersion{Chart: "kube-prometheus-stack-9.4"},
@@ -147,6 +150,7 @@ func TestGetActualVersion(t *testing.T) {
 				Kubecost:            &HelmUtilityVersion{Chart: "cost-analyzer-1.88.1"},
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "node-problem-detector-2.0.5"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "metrics-server-3.8.2"},
+				Velero:              &HelmUtilityVersion{Chart: "velero-2.29.4"},
 			},
 		},
 	}
@@ -181,6 +185,9 @@ func TestGetActualVersion(t *testing.T) {
 	version = c.ActualUtilityVersion(MetricsServerCanonicalName)
 	assert.Equal(t, &HelmUtilityVersion{Chart: "metrics-server-3.8.2"}, version)
 
+	version = c.ActualUtilityVersion(VeleroCanonicalName)
+	assert.Equal(t, &HelmUtilityVersion{Chart: "velero-2.29.4"}, version)
+
 	version = c.ActualUtilityVersion("something else that doesn't exist")
 	assert.Equal(t, version, nilHuv)
 }
@@ -199,6 +206,7 @@ func TestGetDesiredVersion(t *testing.T) {
 				Kubecost:            &HelmUtilityVersion{Chart: "12345678"},
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "123456789"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "1234567899"},
+				Velero:              &HelmUtilityVersion{Chart: "12345678910"},
 			},
 			ActualVersions: UtilityGroupVersions{
 				PrometheusOperator:  &HelmUtilityVersion{Chart: "kube-prometheus-stack-9.4"},
@@ -211,6 +219,7 @@ func TestGetDesiredVersion(t *testing.T) {
 				Kubecost:            &HelmUtilityVersion{Chart: "cost-analyzer-1.88.1"},
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "node-problem-detector-2.0.5"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "metrics-server-3.8.2"},
+				Velero:              &HelmUtilityVersion{Chart: "velero-2.29.4"},
 			},
 		},
 	}
@@ -244,6 +253,9 @@ func TestGetDesiredVersion(t *testing.T) {
 
 	version = c.DesiredUtilityVersion(MetricsServerCanonicalName)
 	assert.Equal(t, &HelmUtilityVersion{Chart: "1234567899"}, version)
+
+	version = c.DesiredUtilityVersion(VeleroCanonicalName)
+	assert.Equal(t, &HelmUtilityVersion{Chart: "12345678910"}, version)
 
 	version = c.DesiredUtilityVersion("something else that doesn't exist")
 	assert.Equal(t, nilHuv, version)


### PR DESCRIPTION
#### Summary
We are adding velero as a utility tool for start setting up the disaster recovery plan
goals. In case of a k8s cluster cannot be fully functional for any reason we have a backup
which we can use to create a k8s cluster with the last backup.

#### Ticket Link

Ticket: https://mattermost.atlassian.net/browse/MM-43762

#### Release Note
```release-note
Add velero as utility in the clusters for backing up k8s
```
