### PR TITLE
Add max pods per worker node configuration option

### DIFF
--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -121,11 +121,11 @@ func handleCreateCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 				NodeInstanceType:   createClusterRequest.NodeInstanceType,
 				NodeMinCount:       createClusterRequest.NodeMinCount,
 				NodeMaxCount:       createClusterRequest.NodeMaxCount,
+				MaxPodsPerNode:     createClusterRequest.MaxPodsPerNode,
 				Networking:         createClusterRequest.Networking,
 				VPC:                createClusterRequest.VPC,
 			},
 		},
-
 		AllowInstallations: createClusterRequest.AllowInstallations,
 		APISecurityLock:    createClusterRequest.APISecurityLock,
 		State:              model.ClusterStateCreationRequested,

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -23,6 +23,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			NodeInstanceType:   "m5.large",
 			NodeMinCount:       2,
 			NodeMaxCount:       2,
+			MaxPodsPerNode:     200,
 			Zones:              []string{"us-east-1a"},
 			Networking:         model.NetworkingCalico,
 			DesiredUtilityVersions: map[string]*model.HelmUtilityVersion{
@@ -88,6 +89,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 			NodeInstanceType:   "m5.large",
 			NodeMinCount:       2,
 			NodeMaxCount:       2,
+			MaxPodsPerNode:     200,
 			Zones:              []string{"zone1", "zone2"},
 			Networking:         model.NetworkingCalico,
 			DesiredUtilityVersions: map[string]*model.HelmUtilityVersion{

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -160,11 +160,13 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 	if err != nil {
 		return errors.Wrapf(err, "failed to set %s", setValue)
 	}
-	logger.Infof("Updating max pods per node to %d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
-	setValue = fmt.Sprintf("spec.kubelet.maxPods=%d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
-	err = kops.SetCluster(kopsMetadata.Name, setValue)
-	if err != nil {
-		return errors.Wrapf(err, "failed to set %s", setValue)
+	if kopsMetadata.ChangeRequest.MaxPodsPerNode != 0 {
+		logger.Infof("Updating max pods per node to %d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
+		setValue = fmt.Sprintf("spec.kubelet.maxPods=%d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
+		err = kops.SetCluster(kopsMetadata.Name, setValue)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set %s", setValue)
+		}
 	}
 
 	err = kops.UpdateCluster(kopsMetadata.Name, kops.GetOutputDirectory())
@@ -641,11 +643,13 @@ func (provisioner *KopsProvisioner) UpgradeCluster(cluster *model.Cluster, awsCl
 	if err != nil {
 		return errors.Wrapf(err, "failed to set %s", setValue)
 	}
-	logger.Infof("Updating max pods per node to %d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
-	setValue = fmt.Sprintf("spec.kubelet.maxPods=%d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
-	err = kops.SetCluster(kopsMetadata.Name, setValue)
-	if err != nil {
-		return errors.Wrapf(err, "failed to set %s", setValue)
+	if kopsMetadata.ChangeRequest.MaxPodsPerNode != 0 {
+		logger.Infof("Updating max pods per node to %d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
+		setValue = fmt.Sprintf("spec.kubelet.maxPods=%d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
+		err = kops.SetCluster(kopsMetadata.Name, setValue)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set %s", setValue)
+		}
 	}
 
 	err = kops.UpdateCluster(kopsMetadata.Name, kops.GetOutputDirectory())

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -149,15 +149,22 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 
 	// TODO: read from config file
 	logger.Info("Updating kubelet options")
+
 	setValue := "spec.kubelet.authenticationTokenWebhook=true"
 	err = kops.SetCluster(kopsMetadata.Name, setValue)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to set %s", setValue)
 	}
 	setValue = "spec.kubelet.authorizationMode=Webhook"
 	err = kops.SetCluster(kopsMetadata.Name, setValue)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to set %s", setValue)
+	}
+	logger.Infof("Updating max pods per node to %d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
+	setValue = fmt.Sprintf("spec.kubelet.maxPods=%d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
+	err = kops.SetCluster(kopsMetadata.Name, setValue)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set %s", setValue)
 	}
 
 	err = kops.UpdateCluster(kopsMetadata.Name, kops.GetOutputDirectory())
@@ -623,15 +630,22 @@ func (provisioner *KopsProvisioner) UpgradeCluster(cluster *model.Cluster, awsCl
 	// TODO: read from config file
 	// TODO: check if those configs are already or remove this when we update all clusters
 	logger.Info("Updating kubelet options")
+
 	setValue := "spec.kubelet.authenticationTokenWebhook=true"
 	err = kops.SetCluster(kopsMetadata.Name, setValue)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to set %s", setValue)
 	}
 	setValue = "spec.kubelet.authorizationMode=Webhook"
 	err = kops.SetCluster(kopsMetadata.Name, setValue)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to set %s", setValue)
+	}
+	logger.Infof("Updating max pods per node to %d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
+	setValue = fmt.Sprintf("spec.kubelet.maxPods=%d", kopsMetadata.ChangeRequest.MaxPodsPerNode)
+	err = kops.SetCluster(kopsMetadata.Name, setValue)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set %s", setValue)
 	}
 
 	err = kops.UpdateCluster(kopsMetadata.Name, kops.GetOutputDirectory())

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -30,13 +30,13 @@ type CreateClusterRequest struct {
 	NodeInstanceType       string                         `json:"node-instance-type,omitempty"`
 	NodeMinCount           int64                          `json:"node-min-count,omitempty"`
 	NodeMaxCount           int64                          `json:"node-max-count,omitempty"`
-	MaxPodsPerNode         int64                          `json:"max-pods-per-node,omitempty"`
 	AllowInstallations     bool                           `json:"allow-installations,omitempty"`
 	APISecurityLock        bool                           `json:"api-security-lock,omitempty"`
 	DesiredUtilityVersions map[string]*HelmUtilityVersion `json:"utility-versions,omitempty"`
 	Annotations            []string                       `json:"annotations,omitempty"`
 	Networking             string                         `json:"networking,omitempty"`
 	VPC                    string                         `json:"vpc,omitempty"`
+	MaxPodsPerNode         int64
 }
 
 func (request *CreateClusterRequest) setUtilityDefaults(utilityName string) {
@@ -190,8 +190,8 @@ func NewUpdateClusterRequestFromReader(reader io.Reader) (*UpdateClusterRequest,
 type PatchUpgradeClusterRequest struct {
 	Version        *string        `json:"version,omitempty"`
 	KopsAMI        *string        `json:"kops-ami,omitempty"`
-	MaxPodsPerNode *int64         `json:"max-pods-per-node,omitempty"`
 	RotatorConfig  *RotatorConfig `json:"rotatorConfig,omitempty"`
+	MaxPodsPerNode *int64
 }
 
 // Validate validates the values of a cluster upgrade request.

--- a/model/cluster_request_test.go
+++ b/model/cluster_request_test.go
@@ -23,6 +23,7 @@ func TestCreateClusterRequestValid(t *testing.T) {
 		{"negative node counts", &model.CreateClusterRequest{NodeMinCount: -1, NodeMaxCount: -1}, true},
 		{"negative master count", &model.CreateClusterRequest{MasterCount: -1}, true},
 		{"mismatched node count", &model.CreateClusterRequest{NodeMinCount: 2, NodeMaxCount: 3}, true},
+		{"max pods too low", &model.CreateClusterRequest{MaxPodsPerNode: 1}, true},
 	}
 
 	for _, tc := range testCases {
@@ -48,6 +49,7 @@ func TestUpgradeClusterRequestValid(t *testing.T) {
 		{"valid version", &model.PatchUpgradeClusterRequest{Version: sToP("1.15.2")}, false},
 		{"invalid version", &model.PatchUpgradeClusterRequest{Version: sToP("invalid")}, true},
 		{"blank version", &model.PatchUpgradeClusterRequest{Version: sToP("")}, true},
+		{"max pods too low", &model.PatchUpgradeClusterRequest{MaxPodsPerNode: i64oP(1)}, true},
 	}
 
 	for _, tc := range testCases {
@@ -109,6 +111,22 @@ func TestUpgradeClusterRequestApply(t *testing.T) {
 			&model.KopsMetadata{
 				ChangeRequest: &model.KopsMetadataRequestedState{
 					AMI: "image1",
+				},
+				RotatorRequest: &model.RotatorMetadata{},
+			},
+		},
+		{
+			"max pods only",
+			true,
+			&model.PatchUpgradeClusterRequest{
+				MaxPodsPerNode: i64oP(200),
+			},
+			&model.KopsMetadata{
+				ChangeRequest: &model.KopsMetadataRequestedState{},
+			},
+			&model.KopsMetadata{
+				ChangeRequest: &model.KopsMetadataRequestedState{
+					MaxPodsPerNode: 200,
 				},
 				RotatorRequest: &model.RotatorMetadata{},
 			},

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -22,6 +22,7 @@ type KopsMetadata struct {
 	NodeInstanceType     string
 	NodeMinCount         int64
 	NodeMaxCount         int64
+	MaxPodsPerNode       int64
 	VPC                  string
 	Networking           string
 	MasterInstanceGroups KopsInstanceGroupsMetadata
@@ -51,6 +52,7 @@ type KopsMetadataRequestedState struct {
 	NodeInstanceType   string `json:"NodeInstanceType,omitempty"`
 	NodeMinCount       int64  `json:"NodeMinCount,omitempty"`
 	NodeMaxCount       int64  `json:"NodeMaxCount,omitempty"`
+	MaxPodsPerNode     int64  `json:"MaxPodsPerNode,omitempty"`
 	Networking         string `json:"Networking,omitempty"`
 	VPC                string `json:"VPC,omitempty"`
 }


### PR DESCRIPTION
This can be used to set the max number of pods that will run on
a kubernetes cluster node.

Fixes https://mattermost.atlassian.net/browse/MM-31253

```release-note
Add max pods per worker node configuration option
```
