### PR TITLE
Group selection based on annotations

### DIFF
--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -24,6 +24,7 @@ func init() {
 	groupCreateCmd.Flags().String("image", "", "The Mattermost container image to use.")
 	groupCreateCmd.Flags().Int64("max-rolling", 1, "The maximum number of installations that can be updated at one time when a group is updated")
 	groupCreateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
+	groupCreateCmd.Flags().StringArray("annotation", []string{}, "Annotations for a group used for automatic group selection. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 	groupCreateCmd.MarkFlagRequired("name")
 
 	groupUpdateCmd.Flags().String("group", "", "The id of the group to be updated.")
@@ -89,6 +90,7 @@ var groupCreateCmd = &cobra.Command{
 		version, _ := command.Flags().GetString("version")
 		maxRolling, _ := command.Flags().GetInt64("max-rolling")
 		mattermostEnv, _ := command.Flags().GetStringArray("mattermost-env")
+		annotations, _ := command.Flags().GetStringArray("annotation")
 
 		envVarMap, err := parseEnvVarInput(mattermostEnv, false)
 		if err != nil {
@@ -102,6 +104,7 @@ var groupCreateCmd = &cobra.Command{
 			Version:       version,
 			Image:         image,
 			MattermostEnv: envVarMap,
+			Annotations:   annotations,
 		}
 
 		dryRun, _ := command.Flags().GetBool("dry-run")

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -38,6 +38,7 @@ func init() {
 	installationCreateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	installationCreateCmd.Flags().StringArray("priority-env", []string{}, "Env vars to add to the Mattermost App that take priority over group config. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	installationCreateCmd.Flags().StringArray("annotation", []string{}, "Additional annotations for the installation. Accepts multiple values, for example: '... --annotation abc --annotation def'")
+	installationCreateCmd.Flags().StringArray("group-selection-annotation", []string{}, "Annotations for automatic group selection. Accepts multiple values, for example: '... --group-selection-annotation abc --group-selection-annotation def'")
 	installationCreateCmd.Flags().String("rds-primary-instance", "", "The machine instance type used for primary replica of database cluster. Works only with single tenant RDS databases.")
 	installationCreateCmd.Flags().String("rds-replica-instance", "", "The machine instance type used for reader replicas of database cluster. Works only with single tenant RDS databases.")
 	installationCreateCmd.Flags().Int("rds-replicas-count", 0, "The number of reader replicas of database cluster. Min: 0, Max: 15. Works only with single tenant RDS databases.")
@@ -143,6 +144,7 @@ var installationCreateCmd = &cobra.Command{
 		mattermostEnv, _ := command.Flags().GetStringArray("mattermost-env")
 		priorityEnv, _ := command.Flags().GetStringArray("priority-env")
 		annotations, _ := command.Flags().GetStringArray("annotation")
+		groupSelectionAnnotations, _ := command.Flags().GetStringArray("group-selection-annotation")
 
 		envVarMap, err := parseEnvVarInput(mattermostEnv, false)
 		if err != nil {
@@ -154,19 +156,20 @@ var installationCreateCmd = &cobra.Command{
 		}
 
 		request := &model.CreateInstallationRequest{
-			Name:          name,
-			OwnerID:       ownerID,
-			GroupID:       groupID,
-			Version:       version,
-			Image:         image,
-			Size:          size,
-			License:       license,
-			Affinity:      affinity,
-			Database:      database,
-			Filestore:     filestore,
-			MattermostEnv: envVarMap,
-			PriorityEnv:   priorityEnvVarMap,
-			Annotations:   annotations,
+			Name:                      name,
+			OwnerID:                   ownerID,
+			GroupID:                   groupID,
+			Version:                   version,
+			Image:                     image,
+			Size:                      size,
+			License:                   license,
+			Affinity:                  affinity,
+			Database:                  database,
+			Filestore:                 filestore,
+			MattermostEnv:             envVarMap,
+			PriorityEnv:               priorityEnvVarMap,
+			Annotations:               annotations,
+			GroupSelectionAnnotations: groupSelectionAnnotations,
 		}
 		// For CLI to be backward compatible, if only one DNS is passed we use
 		// the old field.

--- a/cmd/tools/cloudburst/cloudburst.go
+++ b/cmd/tools/cloudburst/cloudburst.go
@@ -306,7 +306,7 @@ func (b *Blaster) serialBatchInstall(count int) (installations []*cloud.Installa
 // createGroup creates a group for all of the Installations in the
 // test to belong to
 func (b *Blaster) createGroup() error {
-	group, err := b.client.CreateGroup(
+	groupDTO, err := b.client.CreateGroup(
 		&cloud.CreateGroupRequest{
 			Name:            b.testID,
 			Description:     fmt.Sprintf("Load Test Group for Test %s", b.testID),
@@ -315,7 +315,7 @@ func (b *Blaster) createGroup() error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to create a group for test %s", b.testID)
 	}
-	b.group = group
+	b.group = groupDTO.Group
 	return nil
 }
 

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -54,9 +54,11 @@ type Store interface {
 	LockClusterInstallationAPI(clusterInstallationID string) error
 	UnlockClusterInstallationAPI(clusterInstallationID string) error
 
-	CreateGroup(group *model.Group) error
+	CreateGroup(group *model.Group, annotations []*model.Annotation) error
 	GetGroup(groupID string) (*model.Group, error)
+	GetGroupDTO(groupID string) (*model.GroupDTO, error)
 	GetGroups(filter *model.GroupFilter) ([]*model.Group, error)
+	GetGroupDTOs(filter *model.GroupFilter) ([]*model.GroupDTO, error)
 	UpdateGroup(group *model.Group, forceSequenceUpdate bool) error
 	LockGroup(groupID, lockerID string) (bool, error)
 	UnlockGroup(groupID, lockerID string, force bool) (bool, error)
@@ -71,6 +73,7 @@ type Store interface {
 	DeleteWebhook(webhookID string) error
 
 	GetOrCreateAnnotations(annotations []*model.Annotation) ([]*model.Annotation, error)
+	GetAnnotationsByName(names []string) ([]*model.Annotation, error)
 
 	CreateClusterAnnotations(clusterID string, annotations []*model.Annotation) ([]*model.Annotation, error)
 	DeleteClusterAnnotation(clusterID string, annotationName string) error

--- a/internal/api/lock.go
+++ b/internal/api/lock.go
@@ -48,8 +48,8 @@ func lockCluster(c *Context, clusterID string) (*model.ClusterDTO, int, func()) 
 
 // lockGroup synchronizes access to the given group across potentially multiple
 // provisioning servers.
-func lockGroup(c *Context, groupID string) (*model.Group, int, func()) {
-	group, err := c.Store.GetGroup(groupID)
+func lockGroup(c *Context, groupID string) (*model.GroupDTO, int, func()) {
+	group, err := c.Store.GetGroupDTO(groupID)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to query group")
 		return nil, http.StatusInternalServerError, nil

--- a/internal/store/cluster_installation_test.go
+++ b/internal/store/cluster_installation_test.go
@@ -655,7 +655,7 @@ func TestSwitchDNS(t *testing.T) {
 			"Key1": model.EnvVar{Value: "Value1"},
 		},
 	}
-	err := sqlStore.CreateGroup(group1)
+	err := sqlStore.CreateGroup(group1, nil)
 	require.NoError(t, err)
 	groupID1 := group1.ID
 

--- a/internal/store/group_dto.go
+++ b/internal/store/group_dto.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+// GetGroupDTO fetches the given group by id with data from connected tables.
+func (sqlStore *SQLStore) GetGroupDTO(id string) (*model.GroupDTO, error) {
+	group, err := sqlStore.GetGroup(id)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get group")
+	}
+	if group == nil {
+		return nil, nil
+	}
+
+	annotations, err := sqlStore.getAnnotationsForGroup(sqlStore.db, id)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get annotations for installation")
+	}
+	return group.ToDTO(annotations), nil
+}
+
+// GetGroupDTOs fetches the given page of groups with data from connected tables. The first page is 0.
+func (sqlStore *SQLStore) GetGroupDTOs(filter *model.GroupFilter) ([]*model.GroupDTO, error) {
+	groups, err := sqlStore.GetGroups(filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get installations")
+	}
+
+	ids := make([]string, 0, len(groups))
+	for _, g := range groups {
+		ids = append(ids, g.ID)
+	}
+
+	annotations, err := sqlStore.getAnnotationsForGroups(ids)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get annotations for groups")
+	}
+
+	dtos := make([]*model.GroupDTO, 0, len(groups))
+	for _, g := range groups {
+		dtos = append(dtos, g.ToDTO(annotations[g.ID]))
+	}
+
+	return dtos, nil
+}

--- a/internal/store/group_dto_test.go
+++ b/internal/store/group_dto_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package store
+
+import (
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_GroupDTO(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := MakeTestSQLStore(t, logger)
+
+	group1 := &model.Group{
+		Name: "group1",
+	}
+	annotations1 := []*model.Annotation{
+		{Name: "ann-group1"},
+		{Name: "ann-group2"},
+	}
+	createAnnotations(t, sqlStore, annotations1)
+	err := sqlStore.CreateGroup(group1, annotations1)
+	require.NoError(t, err)
+
+	group2 := &model.Group{
+		Name: "group2",
+	}
+	annotations2 := []*model.Annotation{
+		{Name: "ann-group3"},
+	}
+	createAnnotations(t, sqlStore, annotations2)
+	err = sqlStore.CreateGroup(group2, annotations2)
+	require.NoError(t, err)
+
+	group3 := &model.Group{
+		Name: "group3",
+	}
+	err = sqlStore.CreateGroup(group3, nil)
+	require.NoError(t, err)
+
+	group4 := &model.Group{
+		Name: "group4",
+	}
+	err = sqlStore.CreateGroup(group4, annotations1[:1])
+	require.NoError(t, err)
+
+	t.Run("get group1 DTO", func(t *testing.T) {
+		group1DTO, err := sqlStore.GetGroupDTO(group1.ID)
+		require.NoError(t, err)
+		assert.Equal(t, group1, group1DTO.Group)
+		assert.Equal(t, 2, len(group1DTO.Annotations))
+		model.SortAnnotations(group1DTO.Annotations)
+		assert.Equal(t, group1.ToDTO(annotations1), group1DTO)
+	})
+
+	t.Run("get group3 DTO", func(t *testing.T) {
+		group3DTO, err := sqlStore.GetGroupDTO(group3.ID)
+		require.NoError(t, err)
+		assert.Equal(t, group3, group3DTO.Group)
+		assert.Equal(t, 0, len(group3DTO.Annotations))
+		assert.Equal(t, group3.ToDTO(nil), group3DTO)
+	})
+
+	t.Run("get group DTOs", func(t *testing.T) {
+		testCases := []struct {
+			Description string
+			Filter      *model.GroupFilter
+			Expected    []*model.GroupDTO
+		}{
+			{
+				"page 0, perPage 0",
+				&model.GroupFilter{
+					Paging: model.Paging{
+						Page:           0,
+						PerPage:        0,
+						IncludeDeleted: false,
+					},
+				},
+				[]*model.GroupDTO{},
+			},
+			{
+				"page 0, perPage 1",
+				&model.GroupFilter{
+					Paging: model.Paging{
+						Page:           0,
+						PerPage:        1,
+						IncludeDeleted: false,
+					},
+				},
+				[]*model.GroupDTO{group1.ToDTO(annotations1)},
+			},
+			{
+				"with multiple annotations",
+				&model.GroupFilter{
+					Paging: model.AllPagesNotDeleted(),
+					Annotations: &model.AnnotationsFilter{
+						MatchAllIDs: []string{annotations1[0].ID, annotations1[1].ID},
+					},
+				},
+				[]*model.GroupDTO{group1.ToDTO(annotations1)},
+			},
+			{
+				"with single annotation",
+				&model.GroupFilter{
+					Paging: model.AllPagesNotDeleted(),
+					Annotations: &model.AnnotationsFilter{
+						MatchAllIDs: []string{annotations1[0].ID},
+					},
+				},
+				[]*model.GroupDTO{group1.ToDTO(annotations1), group4.ToDTO(annotations1[:1])},
+			},
+		}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.Description, func(t *testing.T) {
+				actual, err := sqlStore.GetGroupDTOs(testCase.Filter)
+				require.NoError(t, err)
+				assert.Equal(t, testCase.Expected, actual)
+			})
+		}
+	})
+}
+
+func createAnnotations(t *testing.T, sqlStore *SQLStore, anns []*model.Annotation) {
+	for _, ann := range anns {
+		err := sqlStore.CreateAnnotation(ann)
+		require.NoError(t, err)
+	}
+}

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -36,7 +36,7 @@ func TestInstallations(t *testing.T) {
 			"Key1": model.EnvVar{Value: "Value1"},
 		},
 	}
-	err := sqlStore.CreateGroup(group1)
+	err := sqlStore.CreateGroup(group1, nil)
 	require.NoError(t, err)
 	groupID1 := group1.ID
 
@@ -611,7 +611,7 @@ func TestUpdateInstallation(t *testing.T) {
 			"Key1": model.EnvVar{Value: "Value1"},
 		},
 	}
-	err := sqlStore.CreateGroup(group1)
+	err := sqlStore.CreateGroup(group1, nil)
 	require.NoError(t, err)
 	groupID1 := group1.ID
 
@@ -755,7 +755,7 @@ func TestUpdateInstallationSequence(t *testing.T) {
 			"Key1": model.EnvVar{Value: "Value1"},
 		},
 	}
-	err := sqlStore.CreateGroup(group1)
+	err := sqlStore.CreateGroup(group1, nil)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Millisecond)

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1932,4 +1932,20 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.35.0"), semver.MustParse("0.36.0"), func(e execer) error {
+		// Add GroupAnnotation table.
+
+		_, err := e.Exec(`
+			CREATE TABLE GroupAnnotation (
+				ID TEXT PRIMARY KEY,
+				GroupID TEXT NOT NULL,
+				AnnotationID TEXT NOT NULL
+			);
+		`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/internal/supervisor/group_test.go
+++ b/internal/supervisor/group_test.go
@@ -175,7 +175,7 @@ func TestGroupSupervisor(t *testing.T) {
 		)
 
 		group := standardGroup()
-		err := sqlStore.CreateGroup(group)
+		err := sqlStore.CreateGroup(group, nil)
 		require.NoError(t, err)
 
 		supervisor.Supervise(group)
@@ -194,7 +194,7 @@ func TestGroupSupervisor(t *testing.T) {
 		)
 
 		group := standardGroup()
-		err := sqlStore.CreateGroup(group)
+		err := sqlStore.CreateGroup(group, nil)
 		require.NoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
@@ -229,7 +229,7 @@ func TestGroupSupervisor(t *testing.T) {
 
 		group := standardGroup()
 		group.MaxRolling = 10
-		err := sqlStore.CreateGroup(group)
+		err := sqlStore.CreateGroup(group, nil)
 		require.NoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
@@ -289,7 +289,7 @@ func TestGroupSupervisor(t *testing.T) {
 		)
 
 		group := standardGroup()
-		err := sqlStore.CreateGroup(group)
+		err := sqlStore.CreateGroup(group, nil)
 		require.NoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
@@ -324,7 +324,7 @@ func TestGroupSupervisor(t *testing.T) {
 			)
 
 			group := standardGroup()
-			err := sqlStore.CreateGroup(group)
+			err := sqlStore.CreateGroup(group, nil)
 			require.NoError(t, err)
 
 			time.Sleep(1 * time.Millisecond)
@@ -373,7 +373,7 @@ func TestGroupSupervisor(t *testing.T) {
 			)
 
 			group := standardGroup()
-			err := sqlStore.CreateGroup(group)
+			err := sqlStore.CreateGroup(group, nil)
 			require.NoError(t, err)
 
 			time.Sleep(1 * time.Millisecond)

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -382,7 +382,7 @@ func (s *InstallationSupervisor) createInstallation(installation *model.Installa
 		return model.InstallationStateCreationRequested
 	}
 	if len(annotations) > 0 {
-		clusterFilter.Annotations = &model.AnnotationsFilter{MatchAllIDs: getAnnotationsIDs(annotations)}
+		clusterFilter.Annotations = &model.AnnotationsFilter{MatchAllIDs: model.GetAnnotationsIDs(annotations)}
 	}
 
 	// Proceed to requesting cluster installation creation on any available clusters.
@@ -1554,14 +1554,6 @@ func getInstallationDBMigrationOperationIDs(operations []*model.InstallationDBMi
 	ids := make([]string, 0, len(operations))
 	for _, op := range operations {
 		ids = append(ids, op.ID)
-	}
-	return ids
-}
-
-func getAnnotationsIDs(annotations []*model.Annotation) []string {
-	ids := make([]string, 0, len(annotations))
-	for _, ann := range annotations {
-		ids = append(ids, ann.ID)
 	}
 	return ids
 }

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -1111,7 +1111,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			Image:    "gImage",
 		}
 
-		err = sqlStore.CreateGroup(group)
+		err = sqlStore.CreateGroup(group, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1388,7 +1388,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			Image:   "gImage",
 		}
 
-		err = sqlStore.CreateGroup(group)
+		err = sqlStore.CreateGroup(group, nil)
 		require.NoError(t, err)
 		// Group Sequence always set to 0 when created so we need to update it.
 		err = sqlStore.UpdateGroup(group, true)
@@ -1758,7 +1758,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			Image:    "gImage",
 		}
 
-		err = sqlStore.CreateGroup(group)
+		err = sqlStore.CreateGroup(group, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1877,7 +1877,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			Image:    "gImage",
 		}
 
-		err = sqlStore.CreateGroup(group)
+		err = sqlStore.CreateGroup(group, nil)
 		require.NoError(t, err)
 
 		owner := model.NewID()
@@ -1995,7 +1995,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			Image:   "gImage",
 		}
 
-		err = sqlStore.CreateGroup(group)
+		err = sqlStore.CreateGroup(group, nil)
 		require.NoError(t, err)
 		// Group Sequence always set to 0 when created so we need to update it
 		// by calling group update once.

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -41,16 +41,24 @@ func AnnotationsFromStringSlice(names []string) ([]*Annotation, error) {
 
 	annotations := make([]*Annotation, 0, len(names))
 	for _, n := range names {
-		if len(n) < annotationMinLen || len(n) > annotationMaxLen {
-			return nil, fmt.Errorf("annotation '%s' is invalid: annotations must be between %d and %d characters long", n, annotationMinLen, annotationMaxLen)
-		}
-		if !annotationRegex.MatchString(n) {
-			return nil, fmt.Errorf("annotation '%s' is invalid: %s", n, annotationAllowedFormat)
+		err := validateAnnotationName(n)
+		if err != nil {
+			return nil, err
 		}
 		annotations = append(annotations, &Annotation{Name: n})
 	}
 
 	return annotations, nil
+}
+
+func validateAnnotationName(name string) error {
+	if len(name) < annotationMinLen || len(name) > annotationMaxLen {
+		return fmt.Errorf("annotation '%s' is invalid: annotations must be between %d and %d characters long", name, annotationMinLen, annotationMaxLen)
+	}
+	if !annotationRegex.MatchString(name) {
+		return fmt.Errorf("annotation '%s' is invalid: %s", name, annotationAllowedFormat)
+	}
+	return nil
 }
 
 // SortAnnotations sorts annotations by name alphabetically.
@@ -59,6 +67,15 @@ func SortAnnotations(annotations []*Annotation) []*Annotation {
 		return annotations[i].Name < annotations[j].Name
 	})
 	return annotations
+}
+
+// GetAnnotationsIDs gets IDs of annotations.
+func GetAnnotationsIDs(annotations []*Annotation) []string {
+	ids := make([]string, 0, len(annotations))
+	for _, ann := range annotations {
+		ids = append(ids, ann.ID)
+	}
+	return ids
 }
 
 // NewAddAnnotationsRequestFromReader will create a AddAnnotationsRequest from an

--- a/model/client.go
+++ b/model/client.go
@@ -932,7 +932,7 @@ func (c *Client) ExecClusterInstallationCLI(clusterInstallationID, command strin
 }
 
 // CreateGroup requests the creation of a group from the configured provisioning server.
-func (c *Client) CreateGroup(request *CreateGroupRequest) (*Group, error) {
+func (c *Client) CreateGroup(request *CreateGroupRequest) (*GroupDTO, error) {
 	resp, err := c.doPost(c.buildURL("/api/groups"), request)
 	if err != nil {
 		return nil, err
@@ -941,7 +941,7 @@ func (c *Client) CreateGroup(request *CreateGroupRequest) (*Group, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return GroupFromReader(resp.Body)
+		return GroupDTOFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -949,7 +949,7 @@ func (c *Client) CreateGroup(request *CreateGroupRequest) (*Group, error) {
 }
 
 // UpdateGroup updates the installation group.
-func (c *Client) UpdateGroup(request *PatchGroupRequest) (*Group, error) {
+func (c *Client) UpdateGroup(request *PatchGroupRequest) (*GroupDTO, error) {
 	resp, err := c.doPut(c.buildURL("/api/group/%s", request.ID), request)
 	if err != nil {
 		return nil, err
@@ -958,7 +958,7 @@ func (c *Client) UpdateGroup(request *PatchGroupRequest) (*Group, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return GroupFromReader(resp.Body)
+		return GroupDTOFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -983,7 +983,7 @@ func (c *Client) DeleteGroup(groupID string) error {
 }
 
 // GetGroup fetches the specified group from the configured provisioning server.
-func (c *Client) GetGroup(groupID string) (*Group, error) {
+func (c *Client) GetGroup(groupID string) (*GroupDTO, error) {
 	resp, err := c.doGet(c.buildURL("/api/group/%s", groupID))
 	if err != nil {
 		return nil, err
@@ -992,7 +992,7 @@ func (c *Client) GetGroup(groupID string) (*Group, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return GroupFromReader(resp.Body)
+		return GroupDTOFromReader(resp.Body)
 
 	case http.StatusNotFound:
 		return nil, nil
@@ -1003,7 +1003,7 @@ func (c *Client) GetGroup(groupID string) (*Group, error) {
 }
 
 // GetGroups fetches the list of groups from the configured provisioning server.
-func (c *Client) GetGroups(request *GetGroupsRequest) ([]*Group, error) {
+func (c *Client) GetGroups(request *GetGroupsRequest) ([]*GroupDTO, error) {
 	u, err := url.Parse(c.buildURL("/api/groups"))
 	if err != nil {
 		return nil, err
@@ -1019,7 +1019,7 @@ func (c *Client) GetGroups(request *GetGroupsRequest) ([]*Group, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return GroupsFromReader(resp.Body)
+		return GroupDTOsFromReader(resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)

--- a/model/group.go
+++ b/model/group.go
@@ -29,6 +29,15 @@ type Group struct {
 // GroupFilter describes the parameters used to constrain a set of groups.
 type GroupFilter struct {
 	Paging
+	Annotations *AnnotationsFilter
+}
+
+// ToDTO returns Group joined with Annotations.
+func (g *Group) ToDTO(annotations []*Annotation) *GroupDTO {
+	return &GroupDTO{
+		Group:       g,
+		Annotations: annotations,
+	}
 }
 
 // Clone returns a deep copy the group.

--- a/model/group_dto.go
+++ b/model/group_dto.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// GroupDTO is a group with Annotations.
+type GroupDTO struct {
+	*Group
+	Annotations []*Annotation `json:"annotations"`
+}
+
+// GroupDTOFromReader decodes a json-encoded group DTO from the given io.Reader.
+func GroupDTOFromReader(reader io.Reader) (*GroupDTO, error) {
+	groupDTO := GroupDTO{}
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&groupDTO)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &groupDTO, nil
+}
+
+// GroupDTOsFromReader decodes a json-encoded list of group DTOs from the given io.Reader.
+func GroupDTOsFromReader(reader io.Reader) ([]*GroupDTO, error) {
+	groupDTOs := []*GroupDTO{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&groupDTOs)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return groupDTOs, nil
+}

--- a/model/group_dto_test.go
+++ b/model/group_dto_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGroupDTOFromReader(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		groupDTO, err := GroupDTOFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &GroupDTO{}, groupDTO)
+	})
+
+	t.Run("invalid request", func(t *testing.T) {
+		groupDTO, err := GroupDTOFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, groupDTO)
+	})
+
+	t.Run("request", func(t *testing.T) {
+		groupDTO, err := GroupDTOFromReader(bytes.NewReader([]byte(`{
+			"ID":"id",
+			"Sequence":10,
+			"Name": "group1",
+			"Version": "12",
+			"Annotations": [
+				{"ID": "abc", "Name": "efg"}
+			]
+		}`)))
+		require.NoError(t, err)
+		require.Equal(t, &GroupDTO{
+			Group: &Group{
+				ID:              "id",
+				Sequence:        10,
+				Name:            "group1",
+				Version:         "12",
+				APISecurityLock: false,
+				LockAcquiredBy:  nil,
+				LockAcquiredAt:  int64(0),
+			},
+			Annotations: []*Annotation{{ID: "abc", Name: "efg"}},
+		}, groupDTO)
+	})
+}
+
+func TestGroupDTOsFromReader(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		groupDTOs, err := GroupDTOsFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, []*GroupDTO{}, groupDTOs)
+	})
+
+	t.Run("invalid request", func(t *testing.T) {
+		groupDTOs, err := GroupDTOsFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, groupDTOs)
+	})
+
+	t.Run("request", func(t *testing.T) {
+		groupDTOs, err := GroupDTOsFromReader(bytes.NewReader([]byte(`[
+			{
+				"ID":"id",
+				"Sequence":10,
+				"Name": "group1",
+				"Version": "12",
+				"Annotations": [
+					{"ID": "abc", "Name": "efg"}
+				]
+			},
+			{
+				"ID":"id2",
+				"Sequence":11,
+				"Name": "group2",
+				"Version": "13"
+			}
+		]`)))
+		require.NoError(t, err)
+		require.Equal(t, []*GroupDTO{
+			{
+				Group: &Group{
+					ID:              "id",
+					Sequence:        10,
+					Name:            "group1",
+					Version:         "12",
+					APISecurityLock: false,
+					LockAcquiredBy:  nil,
+					LockAcquiredAt:  int64(0),
+				},
+				Annotations: []*Annotation{{ID: "abc", Name: "efg"}},
+			},
+			{
+				Group: &Group{
+					ID:              "id2",
+					Sequence:        11,
+					Name:            "group2",
+					Version:         "13",
+					APISecurityLock: false,
+					LockAcquiredBy:  nil,
+					LockAcquiredAt:  int64(0),
+				},
+			},
+		}, groupDTOs)
+	})
+}

--- a/model/group_request.go
+++ b/model/group_request.go
@@ -21,6 +21,7 @@ type CreateGroupRequest struct {
 	MaxRolling      int64
 	APISecurityLock bool
 	MattermostEnv   EnvVarMap
+	Annotations     []string
 }
 
 // Validate validates the values of a group create request.

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -44,17 +44,18 @@ type CreateInstallationRequest struct {
 	Version string
 	Image   string
 	// Deprecated: Use DNSNames instead.
-	DNS             string
-	DNSNames        []string
-	License         string
-	Size            string
-	Affinity        string
-	Database        string
-	Filestore       string
-	APISecurityLock bool
-	MattermostEnv   EnvVarMap
-	PriorityEnv     EnvVarMap
-	Annotations     []string
+	DNS                       string
+	DNSNames                  []string
+	License                   string
+	Size                      string
+	Affinity                  string
+	Database                  string
+	Filestore                 string
+	APISecurityLock           bool
+	MattermostEnv             EnvVarMap
+	PriorityEnv               EnvVarMap
+	Annotations               []string
+	GroupSelectionAnnotations []string
 	// SingleTenantDatabaseConfig is ignored if Database is not single tenant mysql or postgres.
 	SingleTenantDatabaseConfig SingleTenantDatabaseRequest
 }
@@ -144,6 +145,13 @@ func (request *CreateInstallationRequest) Validate() error {
 	if requireAnnotatedInstallations {
 		if len(request.Annotations) == 0 {
 			return errors.Errorf("at least one annotation is required")
+		}
+	}
+
+	for _, ann := range request.GroupSelectionAnnotations {
+		err := validateAnnotationName(ann)
+		if err != nil {
+			return errors.Wrap(err, "invalid group selection annotation")
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Changes:
- Add annotations to Group.
- Add Group Selection Annotation for Installation.
- If `GroupSelectionAnnotations` are provided and `Group` is not set, assign a group automatically.

The selection works in the same way as for Cluster annotations, meaning:
- All annotations specified as `GroupSelectionAnnotation` need to be set on the Group in order for a Group to be selected. 
- Group can have additional annotations.
- If multiple groups satisfy Installation annotations, the random one is selected.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add group selection based on annotations
```
