### PR TITLE
Fix helm repos list for utilities

### DIFF
--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -69,6 +69,7 @@ var helmRepos = map[string]string{
 	"kubecost":             "https://kubecost.github.io/cost-analyzer/",
 	"deliveryhero":         "https://charts.deliveryhero.io/",
 	"metrics-server":       "https://kubernetes-sigs.github.io/metrics-server/",
+	"vmware-tanzu":         "https://vmware-tanzu.github.io/helm-charts/",
 }
 
 func newUtilityGroupHandle(kops *kops.Cmd, provisioner *KopsProvisioner, cluster *model.Cluster, awsClient aws.AWS, parentLogger log.FieldLogger) (*utilityGroup, error) {


### PR DESCRIPTION
#### Summary
The velero helm repository was missing from the whitelist provisioner has and it's breaking.

#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/MM-43762

#### Release Note
```release-note
Fix missing helm repository for utilities
```
