### PR TITLE
[CLD-2448] Revert calls node group skip AMI rotation

### DIFF
--- a/internal/provisioner/kops_utils.go
+++ b/internal/provisioner/kops_utils.go
@@ -174,12 +174,6 @@ func updateKopsInstanceGroupAMIs(kops *kops.Cmd, kopsMetadata *model.KopsMetadat
 
 	var ami string
 	for _, ig := range instanceGroups {
-		// TODO: temporary skip logic for calls instance group.
-		if ig.Metadata.Name == "calls" {
-			logger.Debug("Skipping AMI update for calls instance group")
-			continue
-		}
-
 		if ig.Spec.Image != kopsMetadata.ChangeRequest.AMI {
 			if kopsMetadata.ChangeRequest.AMI == "latest" {
 				// Setting the image value to "" leads kops to autoreplace it with


### PR DESCRIPTION
#### Summary
- Revert calls node group skip AMI rotation

#### Ticket Link
- https://mattermost.atlassian.net/browse/CLD-2448

#### Release Note
```release-note
- Revert calls node group skip AMI rotation
```
