### PR TITLE
fix bug with rtcd helm chart prefix

### DIFF
--- a/internal/provisioner/rtcd.go
+++ b/internal/provisioner/rtcd.go
@@ -94,7 +94,7 @@ func (r *rtcd) ActualVersion() *model.HelmUtilityVersion {
 		return nil
 	}
 	return &model.HelmUtilityVersion{
-		Chart:      strings.TrimPrefix(r.actualVersion.Version(), "rtcd-"),
+		Chart:      strings.TrimPrefix(r.actualVersion.Version(), "mattermost-rtcd-"),
 		ValuesPath: r.actualVersion.Values(),
 	}
 }


### PR DESCRIPTION
#### Summary
Reprovisioning fails due to this bug as the prefix does not match the already deployed


#### Release Note

```release-note
fix bug with rtcd helm chart prefix
```
