### PR TITLE
[fix] Detach velero node policy on cluster deletion

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -954,6 +954,10 @@ func (provisioner *KopsProvisioner) cleanupKopsCluster(cluster *model.Cluster, a
 	if err != nil {
 		return errors.Wrap(err, "unable to detach custom node policy")
 	}
+	err = awsClient.DetachPolicyFromRole(iamRole, aws.VeleroNodePolicyName, logger)
+	if err != nil {
+		return errors.Wrap(err, "unable to detach custom node policy")
+	}
 
 	_, err = kopsClient.GetCluster(kopsMetadata.Name)
 	if err != nil {

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -956,7 +956,7 @@ func (provisioner *KopsProvisioner) cleanupKopsCluster(cluster *model.Cluster, a
 	}
 	err = awsClient.DetachPolicyFromRole(iamRole, aws.VeleroNodePolicyName, logger)
 	if err != nil {
-		return errors.Wrap(err, "unable to detach custom node policy")
+		return errors.Wrap(err, "unable to detach velero node policy")
 	}
 
 	_, err = kopsClient.GetCluster(kopsMetadata.Name)


### PR DESCRIPTION
#### Summary
If we won't detach the IAM policy then it's not possible to delete the cluster.

#### Ticket Link
 https://mattermost.atlassian.net/browse/CLD-2450

#### Release Note
```release-note
Fix cluster deletion and detaching IAM policy from nodes
```
