### PR TITLE
Add ability to add domains to existing Installations and switch primary domain

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -114,6 +114,7 @@ func init() {
 	installationCmd.AddCommand(backupCmd)
 	installationCmd.AddCommand(installationOperationCmd)
 	installationCmd.AddCommand(installationDeploymentReportCmd)
+	installationCmd.AddCommand(installationDNSCmd)
 }
 
 var installationCmd = &cobra.Command{

--- a/cmd/cloud/installation_dns.go
+++ b/cmd/cloud/installation_dns.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+
+	installationDNSAddCmd.Flags().String("installation", "", "The id of the installation to add domain to.")
+	installationDNSAddCmd.MarkFlagRequired("installation")
+	installationDNSAddCmd.Flags().String("domain", "", "Domain name to map to the installation.")
+	installationDNSAddCmd.MarkFlagRequired("domain")
+
+	installationDNSSetPrimaryCmd.Flags().String("installation", "", "The id of the installation for domain switch.")
+	installationDNSSetPrimaryCmd.MarkFlagRequired("installation")
+	installationDNSSetPrimaryCmd.Flags().String("domain-id", "", "The id of domain name to set as primary.")
+	installationDNSSetPrimaryCmd.MarkFlagRequired("domain-id")
+
+	installationDNSCmd.AddCommand(installationDNSAddCmd)
+	installationDNSCmd.AddCommand(installationDNSSetPrimaryCmd)
+}
+
+var installationDNSCmd = &cobra.Command{
+	Use:   "dns",
+	Short: "Manipulate installation DNS records.",
+}
+
+var installationDNSAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Adds domain name for the installation.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		installationID, _ := command.Flags().GetString("installation")
+		dnsName, _ := command.Flags().GetString("domain")
+
+		request := &model.AddDNSRecordRequest{
+			DNS: dnsName,
+		}
+
+		dryRun, _ := command.Flags().GetBool("dry-run")
+		if dryRun {
+			err := printJSON(request)
+			if err != nil {
+				return errors.Wrap(err, "failed to print API request")
+			}
+
+			return nil
+		}
+
+		installation, err := client.AddInstallationDNS(installationID, request)
+		if err != nil {
+			return errors.Wrap(err, "failed to add installation dns")
+		}
+
+		err = printJSON(installation)
+		if err != nil {
+			return errors.Wrap(err, "failed to print response")
+		}
+
+		return nil
+	},
+}
+
+var installationDNSSetPrimaryCmd = &cobra.Command{
+	Use:   "set-primary",
+	Short: "Sets installation domain name as primary.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		installationID, _ := command.Flags().GetString("installation")
+		domainNameID, _ := command.Flags().GetString("domain-id")
+
+		installation, err := client.SetInstallationDomainPrimary(installationID, domainNameID)
+		if err != nil {
+			return errors.Wrap(err, "failed to set installation domain primary")
+		}
+
+		err = printJSON(installation)
+		if err != nil {
+			return errors.Wrap(err, "failed to print response")
+		}
+
+		return nil
+	},
+}

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -118,6 +118,11 @@ type Store interface {
 	DeleteSubscription(subID string) error
 
 	GetStateChangeEvents(filter *model.StateChangeEventFilter) ([]*model.StateChangeEventData, error)
+
+	AddInstallationDomain(installation *model.Installation, dnsRecord *model.InstallationDNS) error
+	GetInstallationDNS(id string) (*model.InstallationDNS, error)
+	SwitchPrimaryInstallationDomain(installationID string, installationDNSID string) error
+	GetDNSRecordsForInstallation(installationID string) ([]*model.InstallationDNS, error)
 }
 
 // Provisioner describes the interface required to communicate with the Kubernetes cluster.

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -45,6 +45,10 @@ func initInstallation(apiRouter *mux.Router, context *Context) {
 	installationRouter.Handle("", addContext(handleDeleteInstallation)).Methods("DELETE")
 	installationRouter.Handle("/annotations", addContext(handleAddInstallationAnnotations)).Methods("POST")
 	installationRouter.Handle("/annotation/{annotation-name}", addContext(handleDeleteInstallationAnnotation)).Methods("DELETE")
+
+	// DNS manipulation
+	installationRouter.Handle("/dns", addContext(handleAddDNSRecord)).Methods("POST")
+	installationRouter.Handle("/dns/{installationDNS}/set-primary", addContext(handleSetDomainNamePrimary)).Methods("POST")
 }
 
 // handleGetInstallation responds to GET /api/installation/{installation}, returning the installation in question.

--- a/internal/api/installation_dns.go
+++ b/internal/api/installation_dns.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+func handleAddDNSRecord(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	installationID := vars["installation"]
+
+	c.Logger = c.Logger.
+		WithField("installation", installationID).
+		WithField("action", "add-installation-dns")
+
+	addDNSRecordRequest, err := model.NewAddDNSRecordRequestFromReader(r.Body)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed decode add DNS request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	newState := model.InstallationStateUpdateRequested
+	installationDTO, status, unlockOnce := getInstallationForTransition(c, installationID, newState)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	err = addDNSRecordRequest.Validate(installationDTO.Name)
+	if err != nil {
+		c.Logger.WithError(err).Error("Invalid request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	oldState := installationDTO.State
+	installationDTO.State = newState
+
+	dnsRecord := &model.InstallationDNS{
+		DomainName:     addDNSRecordRequest.DNS,
+		InstallationID: installationID,
+	}
+
+	err = c.Store.AddInstallationDomain(installationDTO.Installation, dnsRecord)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to add installation domain")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	err = c.Store.UpdateInstallationState(installationDTO.Installation)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to update installation state when adding domain name")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	err = c.EventProducer.ProduceInstallationStateChangeEvent(installationDTO.Installation, oldState)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to create installation state change event")
+	}
+	installationDTO.DNSRecords = append(installationDTO.DNSRecords, dnsRecord)
+
+	unlockOnce()
+	c.Supervisor.Do()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	outputJSON(c, w, installationDTO)
+}
+
+func handleSetDomainNamePrimary(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	installationID := vars["installation"]
+	installationDNSID := vars["installationDNS"]
+
+	c.Logger = c.Logger.
+		WithField("installation", installationID).
+		WithField("installationDNS", installationDNSID).
+		WithField("action", "set-domain-name-primary")
+
+	// Make sure the domain name with provided ID exists, otherwise we would
+	// just set all 'IsPrimary' to false.
+	installationDNS, err := c.Store.GetInstallationDNS(installationDNSID)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to get installation domain")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if installationDNS == nil {
+		c.Logger.WithError(err).Error("Installation domain not found")
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	newState := model.InstallationStateUpdateRequested
+	installationDTO, status, unlockOnce := getInstallationForTransition(c, installationID, newState)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	oldState := installationDTO.State
+	installationDTO.State = newState
+
+	err = c.Store.SwitchPrimaryInstallationDomain(installationDTO.ID, installationDNSID)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to add installation domain")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	err = c.Store.UpdateInstallationState(installationDTO.Installation)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to update installation state when adding domain name")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	err = c.EventProducer.ProduceInstallationStateChangeEvent(installationDTO.Installation, oldState)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to create installation state change event")
+	}
+	// Refresh DNS records after switch
+	installationDTO.DNSRecords, err = c.Store.GetDNSRecordsForInstallation(installationDTO.ID)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to get DNS records after primary switch")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	unlockOnce()
+	c.Supervisor.Do()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	outputJSON(c, w, installationDTO)
+}

--- a/internal/api/installation_dns_test.go
+++ b/internal/api/installation_dns_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-cloud/internal/api"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AddInstallationDNS(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+	model.SetDeployOperators(true, true)
+
+	client := model.NewClient(ts.URL)
+
+	// Create installation with multiple DNS right away.
+	multiDNSInstallationReq := &model.CreateInstallationRequest{
+		Name:     "multi-dns",
+		DNSNames: []string{"multi-dns.example.com", "multi-dns.dns.com"},
+		OwnerID:  "test",
+	}
+	installation1, err := client.CreateInstallation(multiDNSInstallationReq)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(installation1.DNSRecords))
+	assert.Equal(t, "multi-dns.example.com", installation1.DNS)
+	assert.Equal(t, true, installation1.DNSRecords[0].IsPrimary)
+
+	// Assert one record set as primary.
+	dnsRecords, err := sqlStore.GetDNSRecordsForInstallation(installation1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, true, dnsRecords[0].IsPrimary)
+	assert.Equal(t, "multi-dns.example.com", dnsRecords[0].DomainName)
+	assert.Equal(t, false, dnsRecords[1].IsPrimary)
+
+	t.Run("cannot create Installation with name not matching DNS", func(t *testing.T) {
+		_, err = client.CreateInstallation(&model.CreateInstallationRequest{
+			Name:    "test",
+			DNS:     "not-test.dns.com",
+			OwnerID: "test",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("cannot add already existing DNS", func(t *testing.T) {
+		_, err = client.AddInstallationDNS(installation1.ID, &model.AddDNSRecordRequest{
+			DNS: "multi-dns.example.com",
+		})
+		require.Error(t, err)
+	})
+
+	// Create installation using old API.
+	oldAPIInstallation := &model.CreateInstallationRequest{
+		DNS:     "old-api-dns.example.com",
+		OwnerID: "test",
+	}
+	installation2, err := client.CreateInstallation(oldAPIInstallation)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(installation2.DNSRecords))
+	assert.Equal(t, "old-api-dns.example.com", installation2.DNS)
+	assert.Equal(t, "old-api-dns", installation2.Name)
+
+	// Set installation to stable so we can add DNS.
+	installation2.State = model.InstallationStateStable
+	err = sqlStore.UpdateInstallation(installation2.Installation)
+	require.NoError(t, err)
+
+	installation2, err = client.AddInstallationDNS(installation2.ID, &model.AddDNSRecordRequest{
+		DNS: "old-api-dns.dns.com",
+	})
+	require.NoError(t, err)
+	installation2Fetched, err := client.GetInstallation(installation2.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, installation2, installation2Fetched)
+
+	t.Run("query installation by any DNS", func(t *testing.T) {
+		for _, testCase := range []struct {
+			dns          string
+			installation *model.InstallationDTO
+		}{
+			{
+				dns:          "multi-dns.example.com",
+				installation: installation1,
+			},
+			{
+				dns:          "multi-dns.dns.com",
+				installation: installation1,
+			},
+			{
+				dns:          "old-api-dns.example.com",
+				installation: installation2,
+			},
+			{
+				dns:          "old-api-dns.dns.com",
+				installation: installation2,
+			},
+		} {
+			t.Run(testCase.dns, func(t *testing.T) {
+				fetched, err := client.GetInstallationByDNS(testCase.dns, nil)
+				require.NoError(t, err)
+				assert.Equal(t, testCase.installation, fetched)
+			})
+		}
+	})
+}
+
+func Test_SetDomainNamePrimary(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:         sqlStore,
+		Supervisor:    &mockSupervisor{},
+		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
+		Logger:        logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+	model.SetDeployOperators(true, true)
+
+	client := model.NewClient(ts.URL)
+
+	// Create installation with multiple DNS right away.
+	multiDNSInstallationReq := &model.CreateInstallationRequest{
+		Name:     "dns",
+		DNSNames: []string{"dns.example.com", "dns.dns.com"},
+		OwnerID:  "test",
+	}
+	installation, err := client.CreateInstallation(multiDNSInstallationReq)
+	require.NoError(t, err)
+	installation.State = model.InstallationStateStable
+	err = sqlStore.UpdateInstallationState(installation.Installation)
+	require.NoError(t, err)
+
+	installation, err = client.AddInstallationDNS(installation.ID, &model.AddDNSRecordRequest{
+		DNS: "dns.dns3.com",
+	})
+	require.NoError(t, err)
+	// New domain name should not be primary.
+	assert.Equal(t, false, installation.DNSRecords[2].IsPrimary)
+
+	t.Run("cannot set non existing record as primary", func(t *testing.T) {
+		_, err = client.SetInstallationDomainPrimary(installation.ID, "not-existing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "404")
+	})
+
+	installation, err = client.SetInstallationDomainPrimary(installation.ID, installation.DNSRecords[2].ID)
+	require.NoError(t, err)
+	assert.Equal(t, true, installation.DNSRecords[2].IsPrimary)
+
+	installationFetched, err := client.GetInstallation(installation.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, installationFetched, installation)
+}

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -879,6 +879,13 @@ func (s *InstallationSupervisor) waitForUpdateStable(installation *model.Install
 		logger.WithError(err).Warn("Failed to update the installation route53 records")
 		return installation.State
 	}
+	// Given that new DNS record can be added on update, we need to update
+	// Cloudflare as well.
+	err = s.cloudflareClient.CreateDNSRecords(dnsNames, endpoints, logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed to upsert DNS CNAME record in Cloudflare")
+		return installation.State
+	}
 
 	logger.Info("Finished updating installation")
 

--- a/internal/tools/cloudflare/dns.go
+++ b/internal/tools/cloudflare/dns.go
@@ -169,7 +169,8 @@ func (c *Client) DeleteDNSRecords(dnsNames []string, logger logrus.FieldLogger) 
 		// Fetch the zone name for that customer DNS name
 		zoneName, found := c.getZoneName(zoneNameList, dnsName)
 		if !found {
-			return errors.Errorf("hosted zone for %q domain name not found", dnsName)
+			logger.Warnf("Hosted zone for %q domain name not found. Assuming record does not exist", dnsName)
+			continue
 		}
 
 		// Fetch the zone ID

--- a/model/client.go
+++ b/model/client.go
@@ -551,6 +551,38 @@ func (c *Client) DeleteInstallation(installationID string) error {
 	}
 }
 
+// AddInstallationDNS creates new DNS record for installation.
+func (c *Client) AddInstallationDNS(installationID string, request *AddDNSRecordRequest) (*InstallationDTO, error) {
+	resp, err := c.doPost(c.buildURL("/api/installation/%s/dns", installationID), request)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return InstallationDTOFromReader(resp.Body)
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// SetInstallationDomainPrimary sets Installation domain as primary.
+func (c *Client) SetInstallationDomainPrimary(installationID, installationDNSID string) (*InstallationDTO, error) {
+	resp, err := c.doPost(c.buildURL("/api/installation/%s/dns/%s/set-primary", installationID, installationDNSID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return InstallationDTOFromReader(resp.Body)
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // RestoreInstallationDatabase requests installation db restoration from the configured provisioning server.
 func (c *Client) RestoreInstallationDatabase(installationID, backupID string) (*InstallationDBRestorationOperation, error) {
 	resp, err := c.doPost(c.buildURL("/api/installations/operations/database/restorations"),


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Make it possible to add domains to existing Installations.

This PR adds two new endpoints and corresponding CLI commands:
- Add Installation domain.
- Set Installation domain as a primary.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add ability to add domains to existing Installations
```
