### PR TITLE
Allow changing Installation group based on annotations

### DIFF
--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -55,6 +55,11 @@ func init() {
 	groupJoinCmd.MarkFlagRequired("group")
 	groupJoinCmd.MarkFlagRequired("installation")
 
+	groupAssignCmd.Flags().String("installation", "", "The id of the installation to assign to the group.")
+	groupAssignCmd.Flags().StringArray("group-selection-annotation", []string{}, "Group annotations based on which the installation should be assigned.")
+	groupAssignCmd.MarkFlagRequired("installation")
+	groupAssignCmd.MarkFlagRequired("group-selection-annotation")
+
 	groupLeaveCmd.Flags().String("installation", "", "The id of the installation to leave its currently configured group.")
 	groupLeaveCmd.Flags().Bool("retain-config", true, "Whether to retain the group configuration values or not.")
 	groupLeaveCmd.MarkFlagRequired("installation")
@@ -67,6 +72,7 @@ func init() {
 	groupCmd.AddCommand(groupGetStatusCmd)
 	groupCmd.AddCommand(groupGetGroupsStatusCmd)
 	groupCmd.AddCommand(groupJoinCmd)
+	groupCmd.AddCommand(groupAssignCmd)
 	groupCmd.AddCommand(groupLeaveCmd)
 	groupCmd.AddCommand(groupAnnotationCmd)
 }
@@ -309,6 +315,27 @@ var groupJoinCmd = &cobra.Command{
 		err := client.JoinGroup(groupID, installationID)
 		if err != nil {
 			return errors.Wrap(err, "failed to join group")
+		}
+
+		return nil
+	},
+}
+
+var groupAssignCmd = &cobra.Command{
+	Use:   "assign",
+	Short: "Assign an installation to the group based on annotations, leaving any existing group.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		installationID, _ := command.Flags().GetString("installation")
+		annotations, _ := command.Flags().GetStringArray("group-selection-annotation")
+
+		err := client.AssignGroup(installationID, model.AssignInstallationGroupRequest{GroupSelectionAnnotations: annotations})
+		if err != nil {
+			return errors.Wrap(err, "failed to assign group")
 		}
 
 		return nil

--- a/model/client.go
+++ b/model/client.go
@@ -1101,6 +1101,23 @@ func (c *Client) JoinGroup(groupID, installationID string) error {
 	}
 }
 
+// AssignGroup joins an installation to the group selected by annotations, leaving any existing group.
+func (c *Client) AssignGroup(installationID string, assignRequest AssignInstallationGroupRequest) error {
+	resp, err := c.doPost(c.buildURL("/api/installation/%s/group/assign", installationID), assignRequest)
+	if err != nil {
+		return err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+
+	default:
+		return errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // LeaveGroup removes an installation from its group, if any.
 func (c *Client) LeaveGroup(installationID string, request *LeaveGroupRequest) error {
 	u, err := url.Parse(c.buildURL("/api/installation/%s/group", installationID))

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -389,3 +389,19 @@ func NewPatchInstallationRequestFromReader(reader io.Reader) (*PatchInstallation
 
 	return &patchInstallationRequest, nil
 }
+
+// AssignInstallationGroupRequest specifies request body for installation group assignment.
+type AssignInstallationGroupRequest struct {
+	GroupSelectionAnnotations []string
+}
+
+// NewAssignInstallationGroupRequestFromReader will create a AssignInstallationGroupRequest from an io.Reader with JSON data.
+func NewAssignInstallationGroupRequestFromReader(reader io.Reader) (*AssignInstallationGroupRequest, error) {
+	var assignGroupRequest AssignInstallationGroupRequest
+	err := json.NewDecoder(reader).Decode(&assignGroupRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode assign group request")
+	}
+
+	return &assignGroupRequest, nil
+}

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -616,6 +616,36 @@ func TestNewPatchInstallationRequestFromReader(t *testing.T) {
 	})
 }
 
+func TestNewAssignInstallationGroupFromReader(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		request, err := model.NewAssignInstallationGroupRequestFromReader(bytes.NewReader([]byte(
+			``,
+		)))
+		require.NoError(t, err)
+		require.Equal(t, &model.AssignInstallationGroupRequest{}, request)
+	})
+
+	t.Run("invalid request", func(t *testing.T) {
+		request, err := model.NewAssignInstallationGroupRequestFromReader(bytes.NewReader([]byte(
+			`{test`,
+		)))
+		require.Error(t, err)
+		require.Nil(t, request)
+	})
+
+	t.Run("request", func(t *testing.T) {
+		request, err := model.NewAssignInstallationGroupRequestFromReader(bytes.NewReader([]byte(`{
+			"GroupSelectionAnnotations": ["test1", "test2"]
+		}`)))
+		require.NoError(t, err)
+
+		expected := &model.AssignInstallationGroupRequest{
+			GroupSelectionAnnotations: []string{"test1", "test2"},
+		}
+		require.Equal(t, expected, request)
+	})
+}
+
 func sToP(s string) *string {
 	return &s
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Support changing installation group based on annotations.
```
cloud group assign --group-selection-annotation [ANNOTATIONS] --installation [INSTALLATION]
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Allow changing Installation group based on annotations
```
