### PR TITLE
Optimize DNS search path

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -97,8 +97,9 @@ func init() {
 	serverCmd.PersistentFlags().Int("default-proxy-db-pool-size", 5, "The db proxy default pool size per user.")
 	serverCmd.PersistentFlags().Int("min-proxy-db-pool-size", 1, "The db proxy min pool size.")
 	serverCmd.PersistentFlags().String("kubecost-token", "", "Set a kubecost token")
-
-	// DB clusters utilization configuration
+	serverCmd.PersistentFlags().String("ndots-value", "5", "The default ndots value for installations.")
+	
+// DB clusters utilization configuration
 	serverCmd.PersistentFlags().Int("max-installations-rds-postgres-pgbouncer", toolsAWS.DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit, "Max installations per DB cluster of type RDS Postgres PGbouncer")
 	serverCmd.PersistentFlags().Int("max-installations-rds-postgres", toolsAWS.DefaultRDSMultitenantDatabasePostgresCountLimit, "Max installations per DB cluster of type RDS Postgres")
 	serverCmd.PersistentFlags().Int("max-installations-rds-mysql", toolsAWS.DefaultRDSMultitenantDatabaseMySQLCountLimit, "Max installations per DB cluster of type RDS MySQL")
@@ -190,6 +191,11 @@ var serverCmd = &cobra.Command{
 		kubecostToken, _ := command.Flags().GetString("kubecost-token")
 		if kubecostToken != "" {
 			os.Setenv(model.KubecostToken, kubecostToken)
+		}
+
+		ndotsDefaultValue, _ := command.Flags().GetString("ndots-value")
+		if ndotsDefaultValue != "" {
+			os.Setenv(model.NdotsValue, ndotsDefaultValue)
 		}
 
 		logger := logger.WithField("instance", instanceID)

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -98,8 +98,8 @@ func init() {
 	serverCmd.PersistentFlags().Int("min-proxy-db-pool-size", 1, "The db proxy min pool size.")
 	serverCmd.PersistentFlags().String("kubecost-token", "", "Set a kubecost token")
 	serverCmd.PersistentFlags().String("ndots-value", "5", "The default ndots value for installations.")
-	
-// DB clusters utilization configuration
+
+	// DB clusters utilization configuration
 	serverCmd.PersistentFlags().Int("max-installations-rds-postgres-pgbouncer", toolsAWS.DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit, "Max installations per DB cluster of type RDS Postgres PGbouncer")
 	serverCmd.PersistentFlags().Int("max-installations-rds-postgres", toolsAWS.DefaultRDSMultitenantDatabasePostgresCountLimit, "Max installations per DB cluster of type RDS Postgres")
 	serverCmd.PersistentFlags().Int("max-installations-rds-mysql", toolsAWS.DefaultRDSMultitenantDatabaseMySQLCountLimit, "Max installations per DB cluster of type RDS MySQL")
@@ -193,11 +193,6 @@ var serverCmd = &cobra.Command{
 			os.Setenv(model.KubecostToken, kubecostToken)
 		}
 
-		ndotsDefaultValue, _ := command.Flags().GetString("ndots-value")
-		if ndotsDefaultValue != "" {
-			os.Setenv(model.NdotsValue, ndotsDefaultValue)
-		}
-
 		logger := logger.WithField("instance", instanceID)
 
 		sqlStore, err := sqlStore(command)
@@ -259,6 +254,7 @@ var serverCmd = &cobra.Command{
 
 		deployMySQLOperator, _ := command.Flags().GetBool("deploy-mysql-operator")
 		deployMinioOperator, _ := command.Flags().GetBool("deploy-minio-operator")
+		ndotsDefaultValue, _ := command.Flags().GetString("ndots-value")
 		model.SetDeployOperators(deployMySQLOperator, deployMinioOperator)
 
 		wd, err := os.Getwd()
@@ -347,6 +343,7 @@ var serverCmd = &cobra.Command{
 			UseExistingAWSResources: useExistingResources,
 			DeployMysqlOperator:     deployMySQLOperator,
 			DeployMinioOperator:     deployMinioOperator,
+			NdotsValue:              ndotsDefaultValue,
 		}
 
 		// Setup the provisioner for actually effecting changes to clusters.

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -26,6 +26,7 @@ type ProvisioningParams struct {
 	UseExistingAWSResources bool
 	DeployMysqlOperator     bool
 	DeployMinioOperator     bool
+	NdotsValue              string
 }
 
 // KopsProvisioner provisions clusters using kops+terraform.

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -88,7 +87,6 @@ func (provisioner *crProvisionerWrapper) CreateClusterInstallation(cluster *mode
 	}
 
 	mattermostEnv := getMattermostEnvWithOverrides(installation)
-	ndotsValue := os.Getenv("ndots-value")
 
 	mattermost := &mmv1beta1.Mattermost{
 		ObjectMeta: metav1.ObjectMeta{
@@ -107,7 +105,7 @@ func (provisioner *crProvisionerWrapper) CreateClusterInstallation(cluster *mode
 			Scheduling: mmv1beta1.Scheduling{
 				Affinity: generateAffinityConfig(installation, clusterInstallation),
 			},
-			DNSConfig: setNdots(ndotsValue),
+			DNSConfig: setNdots(provisioner.params.NdotsValue),
 		},
 	}
 
@@ -232,8 +230,6 @@ func (provisioner *crProvisionerWrapper) UpdateClusterInstallation(cluster *mode
 
 	ctx := context.TODO()
 
-	ndotsValue := os.Getenv("ndots-value")
-
 	mattermost, err := k8sClient.MattermostClientsetV1Beta.MattermostV1beta1().Mattermosts(clusterInstallation.Namespace).Get(ctx, installationName, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "failed to get mattermost installation %s", clusterInstallation.ID)
@@ -246,7 +242,7 @@ func (provisioner *crProvisionerWrapper) UpdateClusterInstallation(cluster *mode
 
 	mattermost.Spec.Scheduling.Affinity = generateAffinityConfig(installation, clusterInstallation)
 
-	mattermost.Spec.DNSConfig = setNdots(ndotsValue)
+	mattermost.Spec.DNSConfig = setNdots(provisioner.params.NdotsValue)
 
 	version := translateMattermostVersion(installation.Version)
 	if mattermost.Spec.Version == version {

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -87,7 +88,7 @@ func (provisioner *crProvisionerWrapper) CreateClusterInstallation(cluster *mode
 	}
 
 	mattermostEnv := getMattermostEnvWithOverrides(installation)
-	ndotsValue := "1"
+	ndotsValue := os.Getenv("ndots-value")
 
 	mattermost := &mmv1beta1.Mattermost{
 		ObjectMeta: metav1.ObjectMeta{
@@ -231,7 +232,7 @@ func (provisioner *crProvisionerWrapper) UpdateClusterInstallation(cluster *mode
 
 	ctx := context.TODO()
 
-	ndotsValue := "1"
+	ndotsValue := os.Getenv("ndots-value")
 
 	mattermost, err := k8sClient.MattermostClientsetV1Beta.MattermostV1beta1().Mattermosts(clusterInstallation.Namespace).Get(ctx, installationName, metav1.GetOptions{})
 	if err != nil {

--- a/manifests/operator-manifests/mattermost/operator.yaml
+++ b/manifests/operator-manifests/mattermost/operator.yaml
@@ -24,7 +24,7 @@ spec:
           value: "20"
         - name: REQUEUE_ON_LIMIT_DELAY
           value: 20s
-        image: mattermost/mattermost-operator:v1.18.0
+        image: mattermost/mattermost-operator:v1.18.1
         imagePullPolicy: IfNotPresent
         name: mattermost-operator
         ports:

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -22,9 +22,6 @@ const (
 	// KubecostToken is the name of the Environment Variable which
 	// may contain a Kubecost token which kubecost helm chart needs
 	KubecostToken = "kubecost-token"
-	// NdotsValue is the name of the Environment Variable which
-	// may contain a Ndots value to be set on Mattermost Installations
-	NdotsValue = "ndots-value"
 )
 
 // Cluster represents a Kubernetes cluster.

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -22,6 +22,9 @@ const (
 	// KubecostToken is the name of the Environment Variable which
 	// may contain a Kubecost token which kubecost helm chart needs
 	KubecostToken = "kubecost-token"
+	// NdotsValue is the name of the Environment Variable which
+	// may contain a Ndots value to be set on Mattermost Installations
+	NdotsValue = "ndots-value"
 )
 
 // Cluster represents a Kubernetes cluster.


### PR DESCRIPTION
Optimize search path (aka ndots option) in Mattermost Cloud Workspaces

Issue: CLD-2512

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Optimize search path (aka ndots option) in Mattermost Cloud Workspaces

- Kubelet sets up in every pod by default in /etc/resolv.conf the option ndots:5 (don’t resolve a domain name as is unless it is FQDN)
- This value is convenient but not efficient. Might do more than 5 queries per DNS lookup
- Linux default is ndots:1 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-2512

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Optimize search path (aka ndots option) in Mattermost Cloud Workspaces
```
