### PR TITLE
Add ingress annotation reflecting the Installation hibernation state

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -1066,6 +1066,8 @@ func getIngressAnnotations() map[string]string {
 				  proxy_cache_lock on;
 				  proxy_cache_key "$host$request_uri$cookie_user";`,
 		"nginx.org/server-snippets": "gzip on;",
+		// Used for CloudProber
+		"state": "running",
 	}
 }
 
@@ -1074,6 +1076,8 @@ func getIngressAnnotations() map[string]string {
 func getHibernatingIngressAnnotations() map[string]string {
 	annotations := getIngressAnnotations()
 	annotations["nginx.ingress.kubernetes.io/configuration-snippet"] = "return 410;"
+	// Used for CloudProber
+	annotations["state"] = "hibernated"
 
 	return annotations
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This adds ingress annotation that reflects whether the Installation is hibernated or not.

This does not reflect the exact state of installation but only if it is hibernated or not, meaning it can still be starting or updating, therefore we need to adjust for that, ideally not raising alerts until some time passed.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add ingress annotation reflecting the Installation hibernation state
```
