### PR TITLE
Add option to force restart Installations in the group

### DIFF
--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -35,7 +35,8 @@ func init() {
 	groupUpdateCmd.Flags().Int64("max-rolling", 0, "The maximum number of installations that can be updated at one time when a group is updated")
 	groupUpdateCmd.Flags().StringArray("mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	groupUpdateCmd.Flags().Bool("mattermost-env-clear", false, "Clears all env var data.")
-	groupUpdateCmd.Flags().Bool("force-sequence-update", false, "Forces the group version sequence to be increased by 1 even when no updates are present")
+	groupUpdateCmd.Flags().Bool("force-sequence-update", false, "Forces the group version sequence to be increased by 1 even when no updates are present.")
+	groupUpdateCmd.Flags().Bool("force-installation-restart", false, "Forces the restart of all installations in the group even if Mattermost CR does not change.")
 	groupUpdateCmd.MarkFlagRequired("group")
 
 	groupDeleteCmd.Flags().String("group", "", "The id of the group to be deleted.")
@@ -146,6 +147,7 @@ var groupUpdateCmd = &cobra.Command{
 		mattermostEnv, _ := command.Flags().GetStringArray("mattermost-env")
 		mattermostEnvClear, _ := command.Flags().GetBool("mattermost-env-clear")
 		forceSequenceUpdate, _ := command.Flags().GetBool("force-sequence-update")
+		forceInstallationRestart, _ := command.Flags().GetBool("force-installation-restart")
 
 		envVarMap, err := parseEnvVarInput(mattermostEnv, mattermostEnvClear)
 		if err != nil {
@@ -153,14 +155,15 @@ var groupUpdateCmd = &cobra.Command{
 		}
 
 		request := &model.PatchGroupRequest{
-			ID:                  groupID,
-			Name:                getStringFlagPointer(command, "name"),
-			Description:         getStringFlagPointer(command, "description"),
-			Version:             getStringFlagPointer(command, "version"),
-			Image:               getStringFlagPointer(command, "image"),
-			MaxRolling:          getInt64FlagPointer(command, "max-rolling"),
-			MattermostEnv:       envVarMap,
-			ForceSequenceUpdate: forceSequenceUpdate,
+			ID:                        groupID,
+			Name:                      getStringFlagPointer(command, "name"),
+			Description:               getStringFlagPointer(command, "description"),
+			Version:                   getStringFlagPointer(command, "version"),
+			Image:                     getStringFlagPointer(command, "image"),
+			MaxRolling:                getInt64FlagPointer(command, "max-rolling"),
+			MattermostEnv:             envVarMap,
+			ForceSequenceUpdate:       forceSequenceUpdate,
+			ForceInstallationsRestart: forceInstallationRestart,
 		}
 
 		dryRun, _ := command.Flags().GetBool("dry-run")

--- a/model/group_request_test.go
+++ b/model/group_request_test.go
@@ -297,6 +297,28 @@ func TestPatchGroupRequestApply(t *testing.T) {
 				},
 			},
 		},
+		{
+			"force restart",
+			true,
+			&model.PatchGroupRequest{
+				ForceInstallationsRestart: true,
+			},
+			&model.Group{
+				Image:    "image1",
+				Sequence: 1,
+				MattermostEnv: model.EnvVarMap{
+					"key1": {Value: "value1"},
+				},
+			},
+			&model.Group{
+				Image:    "image1",
+				Sequence: 1,
+				MattermostEnv: model.EnvVarMap{
+					"key1":                               {Value: "value1"},
+					"CLOUD_PROVISIONER_ENFORCED_RESTART": {Value: "force-restart-at-sequence-1"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR adds an option to force restart Installations in the group.

It is separate from `force-sequence-update` as there might be changes in which case we want to force sequence update but not necessarily the pods restart (ex. changing some ingress annotations would require sequence update but not Installation restart).

The new flag is called `force-installation-restart`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add option to force restart Installations in the group
```
