### PR TITLE
Add pod count capacity scheduling

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -1022,7 +1022,7 @@ func (provisioner *KopsProvisioner) GetClusterResources(cluster *model.Cluster, 
 	}
 
 	var allPods []v1.Pod
-	var totalCPU, totalMemory, workerNodeCount int64
+	var totalCPU, totalMemory, totalPodCount, workerNodeCount int64
 	for _, node := range nodes.Items {
 		var skipNode bool
 
@@ -1056,6 +1056,7 @@ func (provisioner *KopsProvisioner) GetClusterResources(cluster *model.Cluster, 
 			allPods = append(allPods, nodePods.Items...)
 			totalCPU += node.Status.Allocatable.Cpu().MilliValue()
 			totalMemory += node.Status.Allocatable.Memory().MilliValue()
+			totalPodCount += node.Status.Allocatable.Pods().Value()
 			workerNodeCount++
 		}
 	}
@@ -1069,6 +1070,8 @@ func (provisioner *KopsProvisioner) GetClusterResources(cluster *model.Cluster, 
 		MilliUsedCPU:     usedCPU,
 		MilliTotalMemory: totalMemory,
 		MilliUsedMemory:  usedMemory,
+		TotalPodCount:    totalPodCount,
+		UsedPodCount:     int64(len(allPods)),
 	}, nil
 }
 

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -356,10 +356,12 @@ func (p *mockInstallationProvisioner) GetClusterResources(cluster *model.Cluster
 	}
 
 	return &k8s.ClusterResources{
-			MilliTotalCPU:    100000,
-			MilliUsedCPU:     100,
+			MilliTotalCPU:    1000,
+			MilliUsedCPU:     200,
 			MilliTotalMemory: 100000000000000,
-			MilliUsedMemory:  100,
+			MilliUsedMemory:  25000000000000,
+			TotalPodCount:    1000,
+			UsedPodCount:     100,
 		},
 		nil
 }
@@ -2826,6 +2828,8 @@ func TestInstallationSupervisor(t *testing.T) {
 					MilliUsedCPU:     100,
 					MilliTotalMemory: 200,
 					MilliUsedMemory:  100,
+					TotalPodCount:    200,
+					UsedPodCount:     100,
 				},
 			}
 			supervisor := supervisor.NewInstallationSupervisor(
@@ -2882,6 +2886,8 @@ func TestInstallationSupervisor(t *testing.T) {
 				MilliUsedCPU:     100,
 				MilliTotalMemory: 200,
 				MilliUsedMemory:  100,
+				TotalPodCount:    200,
+				UsedPodCount:     100,
 			},
 		}
 		schedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(false, 80, 2)

--- a/k8s/resources.go
+++ b/k8s/resources.go
@@ -13,6 +13,8 @@ type ClusterResources struct {
 	MilliUsedCPU     int64
 	MilliTotalMemory int64
 	MilliUsedMemory  int64
+	TotalPodCount    int64
+	UsedPodCount     int64
 }
 
 // CalculateCPUPercentUsed calculates the CPU usage percentage of a cluster with
@@ -27,6 +29,13 @@ func (r *ClusterResources) CalculateCPUPercentUsed(additional int64) int {
 // memory usage of the cluster.
 func (r *ClusterResources) CalculateMemoryPercentUsed(additional int64) int {
 	return int((float64(r.MilliUsedMemory+additional) / float64(r.MilliTotalMemory)) * 100)
+}
+
+// CalculatePodCountPercentUsed calculates the pod count usage percentage of a
+// cluster with an optional additional load. Pass in 0 to calculate the current
+// pod count usage of the cluster.
+func (r *ClusterResources) CalculatePodCountPercentUsed(additional int64) int {
+	return int((float64(r.UsedPodCount+additional) / float64(r.TotalPodCount)) * 100)
 }
 
 // CalculateTotalPodMilliResourceRequests calculates the total CPU and memory


### PR DESCRIPTION
This new scheduling logic adds pod counts into scheduling
consideration. Current pod counts vs total pod capacity now factors
into usage calculations and also is checked vs the resource
threshold value configured in the provisioner.

Fixes https://mattermost.atlassian.net/browse/MM-45491

```release-note
Add pod count capacity scheduling
```
