### PR TITLE
Add flags to configure max Installations per DB cluster

### DIFF
--- a/internal/tools/aws/database_multitenant_pgbouncer.go
+++ b/internal/tools/aws/database_multitenant_pgbouncer.go
@@ -31,21 +31,23 @@ import (
 // RDSMultitenantPGBouncerDatabase is a database backed by RDS that supports
 // multi-tenancy and pooled connections.
 type RDSMultitenantPGBouncerDatabase struct {
-	databaseType   string
-	installationID string
-	instanceID     string
-	db             SQLDatabaseManager
-	client         *Client
+	databaseType              string
+	installationID            string
+	instanceID                string
+	db                        SQLDatabaseManager
+	client                    *Client
+	maxSupportedInstallations int
 }
 
 // NewRDSMultitenantPGBouncerDatabase returns a new instance of
 // RDSMultitenantPGBouncerDatabase that implements database interface.
-func NewRDSMultitenantPGBouncerDatabase(databaseType, instanceID, installationID string, client *Client) *RDSMultitenantPGBouncerDatabase {
+func NewRDSMultitenantPGBouncerDatabase(databaseType, instanceID, installationID string, client *Client, installationsLimit int) *RDSMultitenantPGBouncerDatabase {
 	return &RDSMultitenantPGBouncerDatabase{
-		databaseType:   databaseType,
-		instanceID:     instanceID,
-		installationID: installationID,
-		client:         client,
+		databaseType:              databaseType,
+		instanceID:                instanceID,
+		installationID:            installationID,
+		client:                    client,
+		maxSupportedInstallations: valueOrDefault(installationsLimit, DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit),
 	}
 }
 
@@ -73,7 +75,7 @@ func (d *RDSMultitenantPGBouncerDatabase) DatabaseTypeTagValue() string {
 // MaxSupportedDatabases returns the maximum number of databases supported on
 // one RDS cluster for this database type.
 func (d *RDSMultitenantPGBouncerDatabase) MaxSupportedDatabases() int {
-	return DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit
+	return d.maxSupportedInstallations
 }
 
 // Provision claims a multitenant RDS cluster and creates a database schema for

--- a/internal/tools/aws/database_multitenant_test.go
+++ b/internal/tools/aws/database_multitenant_test.go
@@ -21,12 +21,13 @@ import (
 // data provisioner is running in multitenant database for the first time, so pretty much
 // the entire code will run here.
 func (a *AWSTestSuite) TestProvisioningMultitenantDatabase() {
-	database := RDSMultitenantDatabase{
-		databaseType:   model.DatabaseEngineTypeMySQL,
-		installationID: a.InstallationA.ID,
-		instanceID:     a.InstanceID,
-		client:         a.Mocks.AWS,
-	}
+	database := NewRDSMultitenantDatabase(
+		model.DatabaseEngineTypeMySQL,
+		a.InstanceID,
+		a.InstallationA.ID,
+		a.Mocks.AWS,
+		0,
+	)
 
 	databaseType := database.DatabaseTypeTagValue()
 

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -284,3 +284,10 @@ func ensureTagInTagset(key, value string, tags []*s3.Tag) bool {
 
 	return false
 }
+
+func valueOrDefault(val int, defVal int) int {
+	if val != 0 {
+		return val
+	}
+	return defVal
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This adds 3 flags for different types of DBs:
- `max-installations-rds-postgres-pgbouncer`
- `max-installations-rds-postgres`
- `max-installations-rds-mysql`

It defaults to the hardcoded constants. If value is set to 0, the default const will be used as well.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add flags to configure max Installations per DB cluster
```
