### PR TITLE
Remove legacy metrics-server removal code

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -326,23 +326,6 @@ func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster, aws
 		return errors.Wrap(err, "failed to delete PodDisruptionBudget calico-typha")
 	}
 
-	// Need to remove two items from the metrics-server because the fields after the creation are immutable so the
-	// create/update does not work. We might want to refactor this in the future to avoid this
-	logger.Info("Cleaning up some metrics-server resources to reapply")
-	err = k8sClient.Clientset.CoreV1().Services("kube-system").Delete(ctx, "metrics-server", metav1.DeleteOptions{})
-	if k8sErrors.IsNotFound(err) {
-		logger.Info("Service metrics-server not found; skipping...")
-	} else if err != nil {
-		return errors.Wrap(err, "failed to delete service metrics-server")
-	}
-
-	err = k8sClient.KubeagClientSet.ApiregistrationV1beta1().APIServices().Delete(ctx, "v1beta1.metrics.k8s.io", metav1.DeleteOptions{})
-	if k8sErrors.IsNotFound(err) {
-		logger.Info("APIService v1beta1.metrics.k8s.io not found; skipping...")
-	} else if err != nil {
-		return errors.Wrap(err, "failed to delete APIService v1beta1.metrics.k8s.io")
-	}
-
 	err = k8sClient.Clientset.AppsV1().DaemonSets("kube-system").Delete(ctx, "k8s-spot-termination-handler", metav1.DeleteOptions{})
 	if k8sErrors.IsNotFound(err) {
 		logger.Info("DaemonSet k8s-spot-termination-handler not found; skipping...")


### PR DESCRIPTION


Issue: CLD-2586




#### Summary
Remove legacy metrics-server removal code as it causes problems on re-provision process

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-2586

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Remove legacy metrics-server removal code.
```
