### PR TITLE
Add cloudprober for monitoring uptime of customer installations

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -45,6 +45,7 @@ func init() {
 	clusterCreateCmd.Flags().String("node-problem-detector-version", "", "The version of Node Problem Detector. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("metrics-server-version", "", "The version of Metrics Server. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("velero-version", "", "The version of Velero. Use 'stable' to provision the latest stable version published upstream.")
+	clusterCreateCmd.Flags().String("cloudprober-version", "", "The version of Cloudprober. Use 'stable' to provision the latest stable version published upstream.")
 	clusterCreateCmd.Flags().String("prometheus-operator-values", "", "The full Git URL of the desired chart value file's version for Prometheus Operator")
 	clusterCreateCmd.Flags().String("thanos-values", "", "The full Git URL of the desired chart value file's version for Thanos")
 	clusterCreateCmd.Flags().String("fluentbit-values", "", "The full Git URL of the desired chart value file's version for Fluent-Bit")
@@ -58,6 +59,7 @@ func init() {
 	clusterCreateCmd.Flags().String("node-problem-detector-values", "", "The full Git URL of the desired chart value file's version for Node Problem Detector")
 	clusterCreateCmd.Flags().String("metrics-server-values", "", "The full Git URL of the desired chart value file's version for Metrics Server")
 	clusterCreateCmd.Flags().String("velero-values", "", "The full Git URL of the desired chart value file's version for Velero")
+	clusterCreateCmd.Flags().String("cloudprober-values", "", "The full Git URL of the desired chart value file's version for Cloudprober")
 	clusterCreateCmd.Flags().String("networking", "amazon-vpc-routed-eni", "Networking mode to use, for example: weave, calico, canal, amazon-vpc-routed-eni")
 	clusterCreateCmd.Flags().String("vpc", "", "Set to use a shared VPC")
 	clusterCreateCmd.Flags().String("cluster", "", "The id of the cluster. If provided and the cluster exists the creation will be retried ignoring other parameters.")
@@ -78,6 +80,7 @@ func init() {
 	clusterProvisionCmd.Flags().String("node-problem-detector-version", "", "The version of the Node Problem Detector Helm chart")
 	clusterProvisionCmd.Flags().String("metrics-server-version", "", "The version of the Metrics Server Helm chart")
 	clusterProvisionCmd.Flags().String("velero-version", "", "The version of Velero. Use 'stable' to provision the latest stable version published upstream.")
+	clusterProvisionCmd.Flags().String("cloudprober-version", "", "The version of Cloudprober. Use 'stable' to provision the latest stable version published upstream.")
 
 	clusterProvisionCmd.Flags().String("prometheus-operator-values", "", "The full Git URL of the desired chart values for Prometheus Operator")
 	clusterProvisionCmd.Flags().String("thanos-values", "", "The full Git URL of the desired chart values for Thanos")
@@ -92,6 +95,7 @@ func init() {
 	clusterProvisionCmd.Flags().String("node-problem-detector-values", "", "The full Git URL of the desired chart values for the Node Problem Detector")
 	clusterProvisionCmd.Flags().String("metrics-server-values", "", "The full Git URL of the desired chart values for the Metrics Server")
 	clusterProvisionCmd.Flags().String("velero-values", "", "The full Git URL of the desired chart value file's version for Velero")
+	clusterProvisionCmd.Flags().String("cloudprober-values", "", "The full Git URL of the desired chart value file's version for Cloudprober")
 	clusterProvisionCmd.Flags().Bool("reprovision-all-utilities", false, "Set to true if all utilities should be reprovisioned and not just ones with new versions")
 
 	clusterProvisionCmd.MarkFlagRequired("cluster")
@@ -678,5 +682,8 @@ func processUtilityFlags(command *cobra.Command) map[string]*model.HelmUtilityVe
 		model.VeleroCanonicalName: {
 			Chart:      MustGetString("velero-version", command),
 			ValuesPath: MustGetString("velero-values", command)},
+		model.CloudproberCanonicalName: {
+			Chart:      MustGetString("cloudprober-version", command),
+			ValuesPath: MustGetString("cloudprober-values", command)},
 	}
 }

--- a/helm-charts/cloudprober_values.yaml
+++ b/helm-charts/cloudprober_values.yaml
@@ -1,0 +1,1 @@
+### Set the values for local Cloudprober utility testing

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -40,6 +40,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"node-problem-detector": {Chart: "2.0.5", ValuesPath: ""},
 				"metrics-server":        {Chart: "3.8.2", ValuesPath: ""},
 				"velero":                {Chart: "2.29.4", ValuesPath: ""},
+				"cloudprober":           {Chart: "0.1.0", ValuesPath: ""},
 			},
 		}
 	}
@@ -109,6 +110,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"node-problem-detector": {Chart: "2.0.5", ValuesPath: ""},
 				"metrics-server":        {Chart: "3.8.2", ValuesPath: ""},
 				"velero":                {Chart: "2.29.4", ValuesPath: ""},
+				"cloudprober":           {Chart: "0.1.0", ValuesPath: ""},
 			},
 		}, clusterRequest)
 	})

--- a/internal/provisioner/cloudprober.go
+++ b/internal/provisioner/cloudprober.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type cloudprober struct {
+	cluster        *model.Cluster
+	kops           *kops.Cmd
+	logger         log.FieldLogger
+	provisioner    *KopsProvisioner
+	actualVersion  *model.HelmUtilityVersion
+	desiredVersion *model.HelmUtilityVersion
+}
+
+func newCloudproberHandle(desiredVersion *model.HelmUtilityVersion, cluster *model.Cluster, provisioner *KopsProvisioner, kops *kops.Cmd, logger log.FieldLogger) (*cloudprober, error) {
+	if logger == nil {
+		return nil, fmt.Errorf("cannot instantiate Cloudprober handle with nil logger")
+	}
+
+	if cluster == nil {
+		return nil, errors.New("cannot create a connection to Cloudprober if the cluster provided is nil")
+	}
+
+	if provisioner == nil {
+
+		return nil, errors.New("cannot create a connection to Cloudprober if the provisioner provided is nil")
+	}
+	if kops == nil {
+		return nil, errors.New("cannot create a connection to Cloudprober if the Kops command provided is nil")
+	}
+	return &cloudprober{
+		cluster:        cluster,
+		kops:           kops,
+		logger:         logger.WithField("cluster-utility", model.CloudproberCanonicalName),
+		provisioner:    provisioner,
+		desiredVersion: desiredVersion,
+		actualVersion:  cluster.UtilityMetadata.ActualVersions.Cloudprober,
+	}, nil
+}
+
+func (f *cloudprober) CreateOrUpgrade() error {
+	logger := f.logger.WithField("cloudprober-action", "upgrade")
+	h := f.NewHelmDeployment(logger)
+
+	err := h.Update()
+	if err != nil {
+		return err
+	}
+
+	err = f.updateVersion(h)
+	return err
+}
+
+func (f *cloudprober) Name() string {
+	return model.CloudproberCanonicalName
+}
+
+func (f *cloudprober) Destroy() error {
+	return nil
+}
+
+func (f *cloudprober) Migrate() error {
+	return nil
+}
+
+func (f *cloudprober) DesiredVersion() *model.HelmUtilityVersion {
+	return f.desiredVersion
+}
+
+func (f *cloudprober) ActualVersion() *model.HelmUtilityVersion {
+	if f.actualVersion == nil {
+		return nil
+	}
+	return &model.HelmUtilityVersion{
+		Chart:      strings.TrimPrefix(f.actualVersion.Version(), "cloudprober-"),
+		ValuesPath: f.actualVersion.Values(),
+	}
+}
+
+func (f *cloudprober) NewHelmDeployment(logger log.FieldLogger) *helmDeployment {
+	return &helmDeployment{
+		chartDeploymentName: "cloudprober",
+		chartName:           "chartmuseum/cloudprober",
+		namespace:           "cloudprober",
+		kopsProvisioner:     f.provisioner,
+		kops:                f.kops,
+		logger:              logger,
+		desiredVersion:      f.desiredVersion,
+	}
+}
+
+func (f *cloudprober) ValuesPath() string {
+	if f.desiredVersion == nil {
+		return ""
+	}
+	return f.desiredVersion.Values()
+}
+
+func (f *cloudprober) updateVersion(h *helmDeployment) error {
+	actualVersion, err := h.Version()
+	if err != nil {
+		return err
+	}
+
+	f.actualVersion = actualVersion
+	return nil
+}

--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -164,10 +164,17 @@ func newUtilityGroupHandle(kops *kops.Cmd, provisioner *KopsProvisioner, cluster
 		return nil, errors.Wrap(err, "failed to get handle for Velero")
 	}
 
+	cloudprober, err := newCloudproberHandle(
+		cluster.DesiredUtilityVersion(model.VeleroCanonicalName), cluster,
+		provisioner, kops, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get handle for cloudprober")
+	}
+
 	// the order of utilities here matters; the utilities are deployed
 	// in order to resolve dependencies between them
 	return &utilityGroup{
-		utilities:   []Utility{nginx, nginxInternal, prometheusOperator, thanos, fluentbit, teleport, pgbouncer, promtail, kubecost, nodeProblemDetector, rtcd, metricsServer, velero},
+		utilities:   []Utility{nginx, nginxInternal, prometheusOperator, thanos, fluentbit, teleport, pgbouncer, promtail, kubecost, nodeProblemDetector, rtcd, metricsServer, velero, cloudprober},
 		kops:        kops,
 		provisioner: provisioner,
 		cluster:     cluster,

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -37,6 +37,8 @@ const (
 	MetricsServerCanonicalName = "metrics-server"
 	// VeleroCanonicalName is the canonical string representation of velero
 	VeleroCanonicalName = "velero"
+	// CloudproberCanonicalName is the canonical string representation of Cloudprber
+	CloudproberCanonicalName = "cloudprober"
 	// GitlabOAuthTokenKey is the name of the Environment Variable which
 	// may contain an OAuth token for accessing GitLab repositories over
 	// HTTPS, used for fetching values files
@@ -85,6 +87,8 @@ var DefaultUtilityVersions map[string]*HelmUtilityVersion = map[string]*HelmUtil
 	MetricsServerCanonicalName: {Chart: "3.8.2", ValuesPath: ""},
 	// VeleroCanonicalName defines the default version for the Helm chart
 	VeleroCanonicalName: {Chart: "2.29.4", ValuesPath: ""},
+	// CloudproberCanonicalName defines the default version for the Helm chart
+	CloudproberCanonicalName: {Chart: "0.1.0", ValuesPath: ""},
 }
 
 var defaultUtilityValuesFileNames map[string]string = map[string]string{
@@ -101,6 +105,7 @@ var defaultUtilityValuesFileNames map[string]string = map[string]string{
 	NodeProblemDetectorCanonicalName: "node_problem_detector_values.yaml",
 	MetricsServerCanonicalName:       "metrics_server_values.yaml",
 	VeleroCanonicalName:              "velero_values.yaml",
+	CloudproberCanonicalName:         "cloudprober_values.yaml",
 }
 
 var (
@@ -146,6 +151,7 @@ type UtilityGroupVersions struct {
 	NodeProblemDetector *HelmUtilityVersion
 	MetricsServer       *HelmUtilityVersion
 	Velero              *HelmUtilityVersion
+	Cloudprober         *HelmUtilityVersion
 }
 
 // AsMap returns the UtilityGroupVersion represented as a map with the
@@ -166,6 +172,7 @@ func (h *UtilityGroupVersions) AsMap() map[string]*HelmUtilityVersion {
 		NodeProblemDetectorCanonicalName: h.NodeProblemDetector,
 		MetricsServerCanonicalName:       h.MetricsServer,
 		VeleroCanonicalName:              h.Velero,
+		CloudproberCanonicalName:         h.Cloudprober,
 	}
 }
 
@@ -302,6 +309,8 @@ func setUtilityVersion(versions *UtilityGroupVersions, utility string, desiredVe
 		versions.MetricsServer = desiredVersion
 	case VeleroCanonicalName:
 		versions.Velero = desiredVersion
+	case CloudproberCanonicalName:
+		versions.Cloudprober = desiredVersion
 	}
 }
 

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -36,6 +36,7 @@ func TestGetUtilityVersion(t *testing.T) {
 		NodeProblemDetector: &HelmUtilityVersion{Chart: "7"},
 		MetricsServer:       &HelmUtilityVersion{Chart: "8"},
 		Velero:              &HelmUtilityVersion{Chart: "9"},
+		Cloudprober:         &HelmUtilityVersion{Chart: "10"},
 	}
 
 	assert.Equal(t, &HelmUtilityVersion{Chart: "3"}, getUtilityVersion(u, PrometheusOperatorCanonicalName))
@@ -45,6 +46,7 @@ func TestGetUtilityVersion(t *testing.T) {
 	assert.Equal(t, &HelmUtilityVersion{Chart: "7"}, getUtilityVersion(u, NodeProblemDetectorCanonicalName))
 	assert.Equal(t, &HelmUtilityVersion{Chart: "8"}, getUtilityVersion(u, MetricsServerCanonicalName))
 	assert.Equal(t, &HelmUtilityVersion{Chart: "9"}, getUtilityVersion(u, VeleroCanonicalName))
+	assert.Equal(t, &HelmUtilityVersion{Chart: "10"}, getUtilityVersion(u, CloudproberCanonicalName))
 	assert.Equal(t, nilHuv, getUtilityVersion(u, "anything else"))
 }
 
@@ -139,6 +141,7 @@ func TestGetActualVersion(t *testing.T) {
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "123456789"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "1234567899"},
 				Velero:              &HelmUtilityVersion{Chart: "12345678910"},
+				Cloudprober:         &HelmUtilityVersion{Chart: "123456789101"},
 			},
 			ActualVersions: UtilityGroupVersions{
 				PrometheusOperator:  &HelmUtilityVersion{Chart: "kube-prometheus-stack-9.4"},
@@ -153,6 +156,7 @@ func TestGetActualVersion(t *testing.T) {
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "node-problem-detector-2.0.5"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "metrics-server-3.8.2"},
 				Velero:              &HelmUtilityVersion{Chart: "velero-2.29.4"},
+				Cloudprober:         &HelmUtilityVersion{Chart: "cloudprober-0.1.0"},
 			},
 		},
 	}
@@ -193,6 +197,9 @@ func TestGetActualVersion(t *testing.T) {
 	version = c.ActualUtilityVersion(VeleroCanonicalName)
 	assert.Equal(t, &HelmUtilityVersion{Chart: "velero-2.29.4"}, version)
 
+	version = c.ActualUtilityVersion(CloudproberCanonicalName)
+	assert.Equal(t, &HelmUtilityVersion{Chart: "cloudprober-0.1.0"}, version)
+
 	version = c.ActualUtilityVersion("something else that doesn't exist")
 	assert.Equal(t, version, nilHuv)
 }
@@ -213,6 +220,7 @@ func TestGetDesiredVersion(t *testing.T) {
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "123456789"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "1234567899"},
 				Velero:              &HelmUtilityVersion{Chart: "12345678910"},
+				Cloudprober:         &HelmUtilityVersion{Chart: "123456789101"},
 			},
 			ActualVersions: UtilityGroupVersions{
 				PrometheusOperator:  &HelmUtilityVersion{Chart: "kube-prometheus-stack-9.4"},
@@ -227,6 +235,7 @@ func TestGetDesiredVersion(t *testing.T) {
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "node-problem-detector-2.0.5"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "metrics-server-3.8.2"},
 				Velero:              &HelmUtilityVersion{Chart: "velero-2.29.4"},
+				Cloudprober:         &HelmUtilityVersion{Chart: "cloudprober-0.1.0"},
 			},
 		},
 	}
@@ -266,6 +275,9 @@ func TestGetDesiredVersion(t *testing.T) {
 
 	version = c.DesiredUtilityVersion(VeleroCanonicalName)
 	assert.Equal(t, &HelmUtilityVersion{Chart: "12345678910"}, version)
+
+	version = c.DesiredUtilityVersion(CloudproberCanonicalName)
+	assert.Equal(t, &HelmUtilityVersion{Chart: "123456789101"}, version)
 
 	version = c.DesiredUtilityVersion("something else that doesn't exist")
 	assert.Equal(t, nilHuv, version)


### PR DESCRIPTION
### Summary
Cloudprober will replace blackbox implementation and automatically auto-detects the ingresses
based on specific provided filters which rely on k8s labels.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-2538

#### Release Note
```release-note
Add an extra utility, Cloudprober, to monitor uptime of the customer installations
```
