### PR TITLE
Fix cloudprober helm handler

### DIFF
--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -165,7 +165,7 @@ func newUtilityGroupHandle(kops *kops.Cmd, provisioner *KopsProvisioner, cluster
 	}
 
 	cloudprober, err := newCloudproberHandle(
-		cluster.DesiredUtilityVersion(model.VeleroCanonicalName), cluster,
+		cluster.DesiredUtilityVersion(model.CloudproberCanonicalName), cluster,
 		provisioner, kops, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get handle for cloudprober")


### PR DESCRIPTION
#### Summary
Typo after creating the cloudprober handler for the utility group

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-2538

#### Release Note
```release-note
Fix typo for cloudprober canonical name and its handler
```
