### PR TITLE
Remove Blackbox related logic from hibernation flow

### DIFF
--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -284,17 +284,17 @@ func (mr *MockAWSMockRecorder) DeletePublicCNAME(dnsName, logger interface{}) *g
 }
 
 // UpsertPublicCNAMEs mocks base method
-func (m *MockAWS) UpsertPublicCNAMEs(dnsNames, recordIDs, endpoints []string, logger logrus.FieldLogger) error {
+func (m *MockAWS) UpsertPublicCNAMEs(dnsNames, endpoints []string, logger logrus.FieldLogger) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertPublicCNAMEs", dnsNames, recordIDs, endpoints, logger)
+	ret := m.ctrl.Call(m, "UpsertPublicCNAMEs", dnsNames, endpoints, logger)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpsertPublicCNAMEs indicates an expected call of UpsertPublicCNAMEs
-func (mr *MockAWSMockRecorder) UpsertPublicCNAMEs(dnsNames, recordIDs, endpoints, logger interface{}) *gomock.Call {
+func (mr *MockAWSMockRecorder) UpsertPublicCNAMEs(dnsNames, endpoints, logger interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertPublicCNAMEs", reflect.TypeOf((*MockAWS)(nil).UpsertPublicCNAMEs), dnsNames, recordIDs, endpoints, logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertPublicCNAMEs", reflect.TypeOf((*MockAWS)(nil).UpsertPublicCNAMEs), dnsNames, endpoints, logger)
 }
 
 // TagResource mocks base method

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -885,7 +885,7 @@ func (s *InstallationSupervisor) waitForUpdateStable(installation *model.Install
 	}
 
 	// This state can happen from update, therefore new DNS could have been added.
-	err = s.upsertPublicCNAMEs(dnsNames, "", endpoints, logger)
+	err = s.aws.UpsertPublicCNAMEs(dnsNames, endpoints, logger)
 	if err != nil {
 		logger.WithError(err).Warn("Failed to update the installation route53 records")
 		return installation.State
@@ -942,19 +942,7 @@ func (s *InstallationSupervisor) verifyClusterInstallationResourcesMatchInstalla
 }
 
 func (s *InstallationSupervisor) hibernateInstallation(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
-	dnsRecords, err := s.store.GetDNSRecordsForInstallation(installation.ID)
-	if err != nil {
-		logger.WithError(err).Error("Failed to get DNS records for Installation")
-		return installation.State
-	}
-
-	err = s.updatePublicRecordsIDForCNAME(model.DNSNamesFromRecords(dnsRecords), aws.HibernatingInstallationResourceRecordIDPrefix, logger)
-	if err != nil {
-		logger.WithError(err).Warn("Failed to update the installation route53 record with hibernation prefix")
-		return installation.State
-	}
-
-	err = s.resourceUtil.GetDatabaseForInstallation(installation).RefreshResourceMetadata(s.store, logger)
+	err := s.resourceUtil.GetDatabaseForInstallation(installation).RefreshResourceMetadata(s.store, logger)
 	if err != nil {
 		logger.WithError(err).Warn("Failed to update database resource metadata")
 		return installation.State
@@ -1487,7 +1475,7 @@ func (s *InstallationSupervisor) configureDNS(installation *model.Installation, 
 	}
 	domainNames := model.DNSNamesFromRecords(dnsRecords)
 
-	err = s.upsertPublicCNAMEs(domainNames, "", endpoints, logger)
+	err = s.aws.UpsertPublicCNAMEs(domainNames, endpoints, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to create DNS CNAME records")
 	}
@@ -1670,21 +1658,6 @@ func (s *InstallationSupervisor) updatePublicRecordsIDForCNAME(dnsNames []string
 			return err
 		}
 	}
-	return nil
-}
-
-// The record ID will be set to DNS name with idSuffix appended after '-'.
-func (s *InstallationSupervisor) upsertPublicCNAMEs(dnsNames []string, idSuffix string, endpoints []string, logger log.FieldLogger) error {
-	recordIDs := make([]string, 0, len(dnsNames))
-	for _, d := range dnsNames {
-		recordIDs = append(recordIDs, determineRecordID(d, idSuffix))
-	}
-
-	err := s.aws.UpsertPublicCNAMEs(dnsNames, recordIDs, endpoints, logger)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -444,7 +444,7 @@ func (a *mockAWS) CreatePublicCNAME(dnsName string, dnsEndpoints []string, dnsId
 	return nil
 }
 
-func (a *mockAWS) UpsertPublicCNAMEs(dnsNames, recordIDs, endpoints []string, logger log.FieldLogger) error {
+func (a *mockAWS) UpsertPublicCNAMEs(dnsNames, endpoints []string, logger log.FieldLogger) error {
 	return nil
 }
 

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -64,7 +64,7 @@ type AWS interface {
 	IsProvisionedPrivateCNAME(dnsName string, logger log.FieldLogger) bool
 	DeletePrivateCNAME(dnsName string, logger log.FieldLogger) error
 	DeletePublicCNAME(dnsName string, logger log.FieldLogger) error
-	UpsertPublicCNAMEs(dnsNames, recordIDs []string, endpoints []string, logger log.FieldLogger) error
+	UpsertPublicCNAMEs(dnsNames []string, endpoints []string, logger log.FieldLogger) error
 
 	TagResource(resourceID, key, value string, logger log.FieldLogger) error
 	UntagResource(resourceID, key, value string, logger log.FieldLogger) error

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -104,22 +104,18 @@ func (a *Client) UpdatePublicRecordIDForCNAME(dnsName, newID string, logger log.
 
 // UpsertPublicCNAMEs updates or creates specified dnsNames.
 // The record ID will be set to DNS name with idSuffix appended after '-'.
-func (a *Client) UpsertPublicCNAMEs(dnsNames, recordIDs []string, endpoints []string, logger log.FieldLogger) error {
-	if len(dnsNames) != len(recordIDs) {
-		return errors.New("expected the same number of DNS names and record IDs")
-	}
-
+func (a *Client) UpsertPublicCNAMEs(dnsNames []string, endpoints []string, logger log.FieldLogger) error {
 	// TODO: for now we do not expect having multiple domains for the same hosted zone
 	// therefore we just do updates in a loop instead of trying to batch.
 	// If this ever changes, we can optimize by updating all records in same zone at once
 
-	for i, dns := range dnsNames {
+	for _, dns := range dnsNames {
 		zoneID, found := a.getDNSZoneID(dns)
 		if !found {
 			return errors.Errorf("hosted zone for %q domain name not found", dns)
 		}
 
-		err := a.upsertCNAMERecord(zoneID, dns, recordIDs[i], endpoints, logger)
+		err := a.upsertCNAMERecord(zoneID, dns, dns, endpoints, logger)
 		if err != nil {
 			return errors.Wrapf(err, "failed to update CNAME for DNS %q", dns)
 		}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Remove Blackbox related logic from hibernation flow. This is the first step to clean up Route53 dependency (if we decide to remove it completely).

We should wait with the merge until Blackbox is removed fully.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Remove Blackbox related logic from hibernation flow
```
