### PR TITLE
Use cluster resource cache for final scheduling action

### DIFF
--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -514,7 +514,7 @@ func (s *InstallationSupervisor) createClusterInstallation(cluster *model.Cluste
 		logger.WithError(err).Error("Invalid cluster installation size")
 		return nil
 	}
-	clusterResources, err := s.provisioner.GetClusterResources(cluster, true, logger)
+	clusterResources, err := s.getClusterResources(cluster, logger)
 	if err != nil {
 		logger.WithError(err).Error("Failed to get cluster resources")
 		return nil

--- a/k8s/resources.go
+++ b/k8s/resources.go
@@ -9,6 +9,9 @@ import corev1 "k8s.io/api/core/v1"
 // ClusterResources is a snapshot of a cluster's total and currently-used
 // resources.
 type ClusterResources struct {
+	TotalNodeCount   int64
+	SkippedNodeCount int64
+	WorkerNodeCount  int64
 	MilliTotalCPU    int64
 	MilliUsedCPU     int64
 	MilliTotalMemory int64


### PR DESCRIPTION
Previously, the cluster resource cache in the installation
supervisor was used to prioritize clusters with lower resource
utilization, but not for the final scheduling check. This change
has the supervisor use the cache for all resource calculations
in order to speed up installation creation.

Fixes https://mattermost.atlassian.net/browse/MM-45566

```release-note
Use cluster resource cache for final scheduling action
```
