### PR TITLE
Accept 'ready' for Cluster Installation; Update Operator to 1.19.0-rc.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.10.4
 	github.com/mattermost/awat v0.0.0-20210616202500-f0bdd4f43f90
-	github.com/mattermost/mattermost-operator v1.18.0
+	github.com/mattermost/mattermost-operator v1.19.0-rc.0
 	github.com/mattermost/rotator v0.2.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -1107,8 +1107,8 @@ github.com/mattermost/ldap v0.0.0-20191128190019-9f62ba4b8d4d/go.mod h1:HLbgMEI5
 github.com/mattermost/ldap v3.0.4+incompatible/go.mod h1:b4reDCcGpBxJ4WX0f224KFY+OR0npin7or7EFpeIko4=
 github.com/mattermost/mattermost-cloud v0.39.0/go.mod h1:GbWfZajyp+DvdEpoNfFeJ3ZplwTtDV9pl6PhNnp+wq4=
 github.com/mattermost/mattermost-operator v1.12.0/go.mod h1:a6pSJI6bDaIfO65M/Hvuqg8kUNYQQYDHLayoT5XZx5o=
-github.com/mattermost/mattermost-operator v1.18.0 h1:knJvxKHy8HzmC7r5gHwqCZ9xSfgVahRyNkyUEElXbaQ=
-github.com/mattermost/mattermost-operator v1.18.0/go.mod h1:427nFmeCyiwJ9N0J7hpYJNYE6a3DjPdwl0Vpel3JHVg=
+github.com/mattermost/mattermost-operator v1.19.0-rc.0 h1:DMfLj9dtsjS5+wMenwI1GRXtG9ev6+KN/MehZ/Zr/M4=
+github.com/mattermost/mattermost-operator v1.19.0-rc.0/go.mod h1:427nFmeCyiwJ9N0J7hpYJNYE6a3DjPdwl0Vpel3JHVg=
 github.com/mattermost/mattermost-server/v5 v5.23.0/go.mod h1:nMrt08IvThjybZpXPe/nqe/oJuvJxhqKkGI+m7M0R00=
 github.com/mattermost/mmetl v0.0.2-0.20210316151859-38824e5f5efd/go.mod h1:w6GNqrudkzs/GddfgqkgUqsXVQ/4ImK5JJfNj5KJeUQ=
 github.com/mattermost/rotator v0.2.0 h1:R3dlMHZjGR7t5T2bk76heDwpypl9rd2sZj4GoAZyuWU=

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -543,7 +543,7 @@ func (provisioner *crProvisionerWrapper) IsResourceReady(cluster *model.Cluster,
 		return false, errors.Wrap(err, "failed to get ClusterInstallation Custom Resource")
 	}
 
-	if cr.Status.State != mmv1beta1.Stable {
+	if cr.Status.State != mmv1beta1.Stable && cr.Status.State != mmv1beta1.Ready {
 		return false, nil
 	}
 	if cr.Status.ObservedGeneration != 0 {

--- a/manifests/operator-manifests/mattermost/operator.yaml
+++ b/manifests/operator-manifests/mattermost/operator.yaml
@@ -24,7 +24,9 @@ spec:
           value: "20"
         - name: REQUEUE_ON_LIMIT_DELAY
           value: 20s
-        image: mattermost/mattermost-operator:v1.18.1
+        - name: MAX_RECONCILE_CONCURRENCY
+          value: "10"
+        image: mattermost/mattermost-operator:v1.19.0-rc.0
         imagePullPolicy: IfNotPresent
         name: mattermost-operator
         ports:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Provisioner will now consider CR that is in `ready` state as Cluster Installation that finished reconciling.

For `ready` state support we also bump the Operator to the new pre-release.

It also includes the recent change with parallel reconciliation.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Accept 'ready' for Cluster Installation
Update Operator to 1.19.0-rc.0
```
