### PR TITLE
[CLD-3774] Allow mattermost port to be accessed by prometheus in network policy

### DIFF
--- a/manifests/network-policies/mm-installation-netpol.yaml
+++ b/manifests/network-policies/mm-installation-netpol.yaml
@@ -23,6 +23,8 @@ spec:
           name: prometheus
     ports:
     - protocol: TCP
+      port: 8065 # MM
+    - protocol: TCP
       port: 8067 # MM
     - protocol: TCP
       port: 9125 # MySQL


### PR DESCRIPTION
#### Summary
- Allow mattermost port to be accessed by prometheus in network policy



#### Release Note

```release-note
- Allow mattermost port to be accessed by prometheus in network policy
```
