### PR TITLE
Bump kube-spot-termination-notice-handler to v1.21.2

### DIFF
--- a/manifests/k8s-spot-termination-handler/k8s-spot-termination-handler.yaml
+++ b/manifests/k8s-spot-termination-handler/k8s-spot-termination-handler.yaml
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: k8s-spot-termination-handler
       containers:
         - name: k8s-spot-termination-handler
-          image: mattermost/kube-spot-termination-notice-handler:v1.21.0
+          image: mattermost/kube-spot-termination-notice-handler:v1.21.2
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_NAME


### PR DESCRIPTION
Issue: CLD-3739

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Bump kube-spot-termination-notice-handler to v1.21.2

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-3739

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Bump kube-spot-termination-notice-handler to v1.21.2
```
