### PR TITLE
Support custom Installation sizes in Provisioner

### DIFF
--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -23,7 +23,6 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/mattermost/mattermost-cloud/model"
-	mmv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
 )
 
 const (
@@ -440,7 +439,7 @@ func (s *InstallationSupervisor) prioritizeLowerUtilizedClusters(clusters []*mod
 			logger.WithError(err).Error("Failed to get cluster resources")
 			continue
 		}
-		size, err := mmv1alpha1.GetClusterSize(installation.Size)
+		size, err := model.GetInstallationSize(installation.Size)
 		if err != nil {
 			logger.WithError(err).Error("Invalid cluster installation size")
 			continue
@@ -509,7 +508,7 @@ func (s *InstallationSupervisor) createClusterInstallation(cluster *model.Cluste
 
 	// Begin final resource check.
 
-	size, err := mmv1alpha1.GetClusterSize(installation.Size)
+	size, err := model.GetInstallationSize(installation.Size)
 	if err != nil {
 		logger.WithError(err).Error("Invalid cluster installation size")
 		return nil

--- a/model/group_dto_test.go
+++ b/model/group_dto_test.go
@@ -6,8 +6,9 @@ package model
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGroupDTOFromReader(t *testing.T) {

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
-	mmv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
 )
 
 // requireAnnotatedInstallations if set, installations need to be annotated with at least one annotation.
@@ -116,9 +114,9 @@ func (request *CreateInstallationRequest) Validate() error {
 		return err
 	}
 
-	_, err = mmv1alpha1.GetClusterSize(request.Size)
+	_, err = GetInstallationSize(request.Size)
 	if err != nil {
-		return errors.Wrap(err, "invalid size")
+		return errors.Wrap(err, "invalid Installation size")
 	}
 	_, err = url.Parse(request.DNS)
 	if err != nil {
@@ -325,7 +323,7 @@ func (p *PatchInstallationRequest) Validate() error {
 		return errors.New("provided image update value was blank")
 	}
 	if p.Size != nil {
-		_, err := mmv1alpha1.GetClusterSize(*p.Size)
+		_, err := GetInstallationSize(*p.Size)
 		if err != nil {
 			return errors.Wrap(err, "invalid size")
 		}

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -6,7 +6,10 @@ package model_test
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
+
+	"github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
 
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/assert"
@@ -138,6 +141,33 @@ func TestCreateInstallationRequestValid(t *testing.T) {
 				PriorityEnv: model.EnvVarMap{
 					"key1": {Value: ""},
 				},
+			},
+		},
+		{
+			"invalid size",
+			true,
+			&model.CreateInstallationRequest{
+				OwnerID: "owner1",
+				DNS:     "domain4321.com",
+				Size:    "some-size",
+			},
+		},
+		{
+			"valid Operator size",
+			false,
+			&model.CreateInstallationRequest{
+				OwnerID: "owner1",
+				DNS:     "domain4321.com",
+				Size:    v1alpha1.Size5000String,
+			},
+		},
+		{
+			"valid Provisioner size",
+			false,
+			&model.CreateInstallationRequest{
+				OwnerID: "owner1",
+				DNS:     "domain4321.com",
+				Size:    fmt.Sprintf("%s-10", model.SizeProvisionerXL),
 			},
 		},
 		{
@@ -376,6 +406,27 @@ func TestPatchInstallationRequestValid(t *testing.T) {
 			true,
 			&model.PatchInstallationRequest{
 				Image: sToP(""),
+			},
+		},
+		{
+			"invalid size",
+			true,
+			&model.PatchInstallationRequest{
+				Size: sToP("some-size"),
+			},
+		},
+		{
+			"valid Operator size",
+			false,
+			&model.PatchInstallationRequest{
+				Size: sToP(v1alpha1.Size5000String),
+			},
+		},
+		{
+			"valid Provisioner size",
+			false,
+			&model.PatchInstallationRequest{
+				Size: sToP(fmt.Sprintf("%s-10", model.SizeProvisionerXL)),
 			},
 		},
 	}

--- a/model/mattermost_size.go
+++ b/model/mattermost_size.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// ProvisionerSizePrefix is a provisioner specific Installation size prefix.
+const ProvisionerSizePrefix = "provisioner"
+
+// SizeProvisionerXL specifies custom Installation size.
+const SizeProvisionerXL = "provisionerXL"
+
+// GetInstallationSize returns Installation size based on its name.
+func GetInstallationSize(size string) (v1alpha1.ClusterInstallationSize, error) {
+	// We check first if it is one of Operator sizes, if not we expect custom
+	// provisioner size.
+	mmSize, err := v1alpha1.GetClusterSize(size)
+	if err == nil {
+		return mmSize, nil
+	}
+
+	return ParseProvisionerSize(size)
+}
+
+// ParseProvisionerSize parses Provisioner specific Installation size with
+// configurable replicas count.
+// The size should be specified in form:
+// [SIZE_NAME]-[NUMBER_OF_REPLICAS]
+// If number of replicas is not specified the default value for the size wil
+// be used.
+func ParseProvisionerSize(size string) (v1alpha1.ClusterInstallationSize, error) {
+	parts := strings.Split(size, "-")
+
+	var resources v1alpha1.ClusterInstallationSize
+	switch parts[0] {
+	case SizeProvisionerXL:
+		resources = SizeProvisionerXLResources
+	default:
+		return v1alpha1.ClusterInstallationSize{}, errors.Errorf("unrecognized installation size %q", parts[0])
+	}
+
+	if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
+		return resources, nil
+	}
+
+	replicas, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return v1alpha1.ClusterInstallationSize{}, errors.Wrap(err, "failed to parse number of replicas from custom provisioner size")
+	}
+
+	resources.App.Replicas = int32(replicas)
+
+	return resources, nil
+}
+
+// SizeProvisionerXLResources specifies resources for Installation size.
+var SizeProvisionerXLResources = v1alpha1.ClusterInstallationSize{
+	App: v1alpha1.ComponentSize{
+		Replicas: 4,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4000m"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+	},
+	Minio: v1alpha1.ComponentSize{
+		Replicas: 4,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+		},
+	},
+	Database: v1alpha1.ComponentSize{
+		Replicas: 3,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+		},
+	},
+}

--- a/model/mattermost_size.go
+++ b/model/mattermost_size.go
@@ -36,7 +36,7 @@ func GetInstallationSize(size string) (v1alpha1.ClusterInstallationSize, error) 
 // configurable replicas count.
 // The size should be specified in form:
 // [SIZE_NAME]-[NUMBER_OF_REPLICAS]
-// If number of replicas is not specified the default value for the size wil
+// If number of replicas is not specified the default value for the size will
 // be used.
 func ParseProvisionerSize(size string) (v1alpha1.ClusterInstallationSize, error) {
 	parts := strings.Split(size, "-")

--- a/model/mattermost_size.go
+++ b/model/mattermost_size.go
@@ -49,8 +49,14 @@ func ParseProvisionerSize(size string) (v1alpha1.ClusterInstallationSize, error)
 		return v1alpha1.ClusterInstallationSize{}, errors.Errorf("unrecognized installation size %q", parts[0])
 	}
 
-	if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
+	if len(parts) == 1 {
 		return resources, nil
+	}
+	if len(parts) > 2 {
+		return v1alpha1.ClusterInstallationSize{}, errors.Errorf("expected at most 2 size segments found %d", len(parts))
+	}
+	if strings.TrimSpace(parts[1]) == "" {
+		return v1alpha1.ClusterInstallationSize{}, errors.Errorf("replicas segment cannot be empty")
 	}
 
 	replicas, err := strconv.Atoi(parts[1])

--- a/model/mattermost_size_test.go
+++ b/model/mattermost_size_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseProvisionerSize(t *testing.T) {
+
+	provisionerXL6Replicas := SizeProvisionerXLResources
+	provisionerXL6Replicas.App.Replicas = 6
+
+	provisionerXL1Replica := SizeProvisionerXLResources
+	provisionerXL1Replica.App.Replicas = 1
+
+	for _, testCase := range []struct {
+		description  string
+		size         string
+		expectedSize v1alpha1.ClusterInstallationSize
+		error        string
+	}{
+		{
+			description:  "correct size, no replicas",
+			size:         "provisionerXL",
+			expectedSize: SizeProvisionerXLResources,
+		},
+		{
+			description:  "correct size, custom replicas (6)",
+			size:         "provisionerXL-6",
+			expectedSize: provisionerXL6Replicas,
+		},
+		{
+			description:  "correct size, ignore other vals",
+			size:         "provisionerXL-1-6",
+			expectedSize: provisionerXL1Replica,
+		},
+		{
+			description: "unknown size",
+			size:        "provisionerS",
+			error:       "unrecognized installation size",
+		},
+		{
+			description: "invalid repicas value",
+			size:        "provisionerXL-two",
+			error:       "failed to parse number of replicas from custom provisioner size",
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			resSize, err := ParseProvisionerSize(testCase.size)
+			assert.Equal(t, testCase.expectedSize, resSize)
+			if testCase.error != "" {
+				assert.ErrorContains(t, err, testCase.error)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/model/mattermost_size_test.go
+++ b/model/mattermost_size_test.go
@@ -36,9 +36,14 @@ func TestParseProvisionerSize(t *testing.T) {
 			expectedSize: provisionerXL6Replicas,
 		},
 		{
-			description:  "correct size, ignore other vals",
-			size:         "provisionerXL-1-6",
-			expectedSize: provisionerXL1Replica,
+			description: "do not allow more than 2 segments",
+			size:        "provisionerXL-1-6",
+			error:       "expected at most 2 size segments",
+		},
+		{
+			description: "do not allow dash without replicas",
+			size:        "provisionerXL-",
+			error:       "replicas segment cannot be empty",
 		},
 		{
 			description: "unknown size",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR adds support for custom Installation sizes in Provisioner.
The size should be specified in form:
```
[SIZE_NAME]-[NUMBER_OF_MM_REPLICAS]
```
If the number of replicas is not specified the default value for the size will be used.

Currently, there is only one size added, we can add more according to our needs.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Support custom Installation sizes in Provisioner
```
