### PR TITLE
Add cluster resource threshold scheduling overrides

### DIFF
--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -133,11 +133,11 @@ type InstallationSupervisorCache struct {
 // InstallationSupervisorSchedulingOptions are the various options that control
 // how installation scheduling occurs.
 type InstallationSupervisorSchedulingOptions struct {
-	balanceInstallations               bool
-	clusterResourceThresholdCPU        int
-	clusterResourceThresholdMemory     int
-	clusterResourceThresholdPodCount   int
-	clusterResourceThresholdScaleValue int
+	BalanceInstallations               bool
+	ClusterResourceThresholdCPU        int
+	ClusterResourceThresholdMemory     int
+	ClusterResourceThresholdPodCount   int
+	ClusterResourceThresholdScaleValue int
 }
 
 // NewInstallationSupervisor creates a new InstallationSupervisor.
@@ -176,20 +176,20 @@ func NewInstallationSupervisor(
 // NewInstallationSupervisorSchedulingOptions creates a new InstallationSupervisorSchedulingOptions.
 func NewInstallationSupervisorSchedulingOptions(balanceInstallations bool, clusterResourceThreshold, thresholdCPUOverride, thresholdMemoryOverride, thresholdPodCountOverride, clusterResourceThresholdScaleValue int) InstallationSupervisorSchedulingOptions {
 	schedulingOptions := InstallationSupervisorSchedulingOptions{
-		balanceInstallations:               balanceInstallations,
-		clusterResourceThresholdCPU:        clusterResourceThreshold,
-		clusterResourceThresholdMemory:     clusterResourceThreshold,
-		clusterResourceThresholdPodCount:   clusterResourceThreshold,
-		clusterResourceThresholdScaleValue: clusterResourceThresholdScaleValue,
+		BalanceInstallations:               balanceInstallations,
+		ClusterResourceThresholdCPU:        clusterResourceThreshold,
+		ClusterResourceThresholdMemory:     clusterResourceThreshold,
+		ClusterResourceThresholdPodCount:   clusterResourceThreshold,
+		ClusterResourceThresholdScaleValue: clusterResourceThresholdScaleValue,
 	}
 	if thresholdCPUOverride != 0 {
-		schedulingOptions.clusterResourceThresholdCPU = thresholdCPUOverride
+		schedulingOptions.ClusterResourceThresholdCPU = thresholdCPUOverride
 	}
 	if thresholdMemoryOverride != 0 {
-		schedulingOptions.clusterResourceThresholdMemory = thresholdMemoryOverride
+		schedulingOptions.ClusterResourceThresholdMemory = thresholdMemoryOverride
 	}
 	if thresholdPodCountOverride != 0 {
-		schedulingOptions.clusterResourceThresholdPodCount = thresholdPodCountOverride
+		schedulingOptions.ClusterResourceThresholdPodCount = thresholdPodCountOverride
 	}
 
 	return schedulingOptions
@@ -197,17 +197,17 @@ func NewInstallationSupervisorSchedulingOptions(balanceInstallations bool, clust
 
 // Validate validates InstallationSupervisorSchedulingOptions.
 func (so *InstallationSupervisorSchedulingOptions) Validate() error {
-	if so.clusterResourceThresholdCPU < 10 || so.clusterResourceThresholdCPU > 100 {
-		return errors.Errorf("cluster CPU resource threshold (%d) must be set between 10 and 100", so.clusterResourceThresholdCPU)
+	if so.ClusterResourceThresholdCPU < 10 || so.ClusterResourceThresholdCPU > 100 {
+		return errors.Errorf("cluster CPU resource threshold (%d) must be set between 10 and 100", so.ClusterResourceThresholdCPU)
 	}
-	if so.clusterResourceThresholdMemory < 10 || so.clusterResourceThresholdMemory > 100 {
-		return errors.Errorf("cluster memory resource threshold (%d) must be set between 10 and 100", so.clusterResourceThresholdMemory)
+	if so.ClusterResourceThresholdMemory < 10 || so.ClusterResourceThresholdMemory > 100 {
+		return errors.Errorf("cluster memory resource threshold (%d) must be set between 10 and 100", so.ClusterResourceThresholdMemory)
 	}
-	if so.clusterResourceThresholdPodCount < 10 || so.clusterResourceThresholdPodCount > 100 {
-		return errors.Errorf("cluster pod count resource threshold (%d) must be set between 10 and 100", so.clusterResourceThresholdPodCount)
+	if so.ClusterResourceThresholdPodCount < 10 || so.ClusterResourceThresholdPodCount > 100 {
+		return errors.Errorf("cluster pod count resource threshold (%d) must be set between 10 and 100", so.ClusterResourceThresholdPodCount)
 	}
-	if so.clusterResourceThresholdScaleValue < 0 || so.clusterResourceThresholdScaleValue > 10 {
-		return errors.Errorf("cluster resource threshold scale value (%d) must be set between 0 and 10", so.clusterResourceThresholdScaleValue)
+	if so.ClusterResourceThresholdScaleValue < 0 || so.ClusterResourceThresholdScaleValue > 10 {
+		return errors.Errorf("cluster resource threshold scale value (%d) must be set between 0 and 10", so.ClusterResourceThresholdScaleValue)
 	}
 
 	return nil
@@ -428,7 +428,7 @@ func (s *InstallationSupervisor) createInstallation(installation *model.Installa
 		logger.Warnf("No clusters found matching the filter, installation annotations are: [%s]", strings.Join(getAnnotationsNames(annotations), ", "))
 	}
 
-	if s.scheduling.balanceInstallations {
+	if s.scheduling.BalanceInstallations {
 		logger.Info("Attempting to schedule installation on the lowest-utilized cluster")
 		clusters = s.prioritizeLowerUtilizedClusters(clusters, installation, instanceID, logger)
 	}
@@ -566,16 +566,16 @@ func (s *InstallationSupervisor) createClusterInstallation(cluster *model.Cluste
 	memoryPercent := clusterResources.CalculateMemoryPercentUsed(installationMemRequirement)
 	podPercent := clusterResources.CalculatePodCountPercentUsed(installationPodCountRequirement)
 
-	if cpuPercent > s.scheduling.clusterResourceThresholdCPU ||
-		memoryPercent > s.scheduling.clusterResourceThresholdMemory ||
-		podPercent > s.scheduling.clusterResourceThresholdPodCount {
-		if s.scheduling.clusterResourceThresholdScaleValue == 0 ||
+	if cpuPercent > s.scheduling.ClusterResourceThresholdCPU ||
+		memoryPercent > s.scheduling.ClusterResourceThresholdMemory ||
+		podPercent > s.scheduling.ClusterResourceThresholdPodCount {
+		if s.scheduling.ClusterResourceThresholdScaleValue == 0 ||
 			cluster.ProvisionerMetadataKops.NodeMinCount == cluster.ProvisionerMetadataKops.NodeMaxCount ||
 			cluster.State != model.ClusterStateStable {
 			logger.WithFields(log.Fields{
-				"scheduling-cpu-threshold":       s.scheduling.clusterResourceThresholdCPU,
-				"scheduling-memory-threshold":    s.scheduling.clusterResourceThresholdMemory,
-				"scheduling-pod-count-threshold": s.scheduling.clusterResourceThresholdPodCount,
+				"scheduling-cpu-threshold":       s.scheduling.ClusterResourceThresholdCPU,
+				"scheduling-memory-threshold":    s.scheduling.ClusterResourceThresholdMemory,
+				"scheduling-pod-count-threshold": s.scheduling.ClusterResourceThresholdPodCount,
 			}).Debugf("Cluster %s would exceed the cluster load threshold: CPU=%d%% (+%dm), Memory=%d%% (+%dMi), PodCount=%d%% (+%d)",
 				cluster.ID,
 				cpuPercent, installationCPURequirement,
@@ -590,7 +590,7 @@ func (s *InstallationSupervisor) createClusterInstallation(cluster *model.Cluste
 		// updating the cluster. We should try to reuse some of the API flow
 		// that already does this.
 
-		newWorkerCount := cluster.ProvisionerMetadataKops.NodeMinCount + int64(s.scheduling.clusterResourceThresholdScaleValue)
+		newWorkerCount := cluster.ProvisionerMetadataKops.NodeMinCount + int64(s.scheduling.ClusterResourceThresholdScaleValue)
 		if newWorkerCount > cluster.ProvisionerMetadataKops.NodeMaxCount {
 			newWorkerCount = cluster.ProvisionerMetadataKops.NodeMaxCount
 		}
@@ -1631,7 +1631,7 @@ func (c *InstallationSupervisorCache) getCachedClusterResources(clusterID string
 
 func (s *InstallationSupervisor) initializeInstallationResourcesCacheManager() {
 	s.cache.initialized = true
-	if !s.scheduling.balanceInstallations {
+	if !s.scheduling.BalanceInstallations {
 		return
 	}
 	s.cache.running = true

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -543,7 +543,8 @@ func (m *mockCloudflareClient) DeleteDNSRecords(customerDNSName []string, logger
 }
 
 func TestInstallationSupervisorDo(t *testing.T) {
-	standardSchedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(false, 80, 0)
+	standardSchedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(false, 80, 0, 0, 0, 0)
+	require.NoError(t, standardSchedulingOptions.Validate())
 
 	t.Run("no installations pending work", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
@@ -577,7 +578,8 @@ func TestInstallationSupervisorDo(t *testing.T) {
 }
 
 func TestInstallationSupervisor(t *testing.T) {
-	standardSchedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(false, 80, 0)
+	standardSchedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(false, 80, 0, 0, 0, 0)
+	require.NoError(t, standardSchedulingOptions.Validate())
 
 	expectInstallationState := func(t *testing.T, sqlStore *store.SQLStore, installation *model.Installation, expectedState string) {
 		t.Helper()
@@ -2890,7 +2892,8 @@ func TestInstallationSupervisor(t *testing.T) {
 				UsedPodCount:     100,
 			},
 		}
-		schedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(false, 80, 2)
+		schedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(false, 80, 0, 0, 0, 2)
+		require.NoError(t, schedulingOptions.Validate())
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			mockInstallationProvisioner,
@@ -2937,7 +2940,8 @@ func TestInstallationSupervisor(t *testing.T) {
 		sqlStore := store.MakeTestSQLStore(t, logger)
 		defer store.CloseConnection(t, sqlStore)
 
-		schedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 0)
+		schedulingOptions := supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 0, 0, 0, 0)
+		require.NoError(t, schedulingOptions.Validate())
 		supervisor := supervisor.NewInstallationSupervisor(
 			sqlStore,
 			&mockInstallationProvisioner{},

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -3155,3 +3155,131 @@ func TestInstallationSupervisor(t *testing.T) {
 		require.Equal(t, model.V1betaCRVersion, updatedInstallation.CRVersion)
 	})
 }
+
+func TestInstallationSupervisorSchedulingOptions(t *testing.T) {
+	for _, testCase := range []struct {
+		name            string
+		inputOptions    supervisor.InstallationSupervisorSchedulingOptions
+		expectedOptions supervisor.InstallationSupervisorSchedulingOptions
+		expectError     bool
+	}{
+		{
+			name:         "valid, no overrides",
+			inputOptions: supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 0, 0, 0, 2),
+			expectedOptions: supervisor.InstallationSupervisorSchedulingOptions{
+				BalanceInstallations:               true,
+				ClusterResourceThresholdCPU:        80,
+				ClusterResourceThresholdMemory:     80,
+				ClusterResourceThresholdPodCount:   80,
+				ClusterResourceThresholdScaleValue: 2,
+			},
+			expectError: false,
+		},
+		{
+			name:         "valid, cpu override",
+			inputOptions: supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 40, 0, 0, 2),
+			expectedOptions: supervisor.InstallationSupervisorSchedulingOptions{
+				BalanceInstallations:               true,
+				ClusterResourceThresholdCPU:        40,
+				ClusterResourceThresholdMemory:     80,
+				ClusterResourceThresholdPodCount:   80,
+				ClusterResourceThresholdScaleValue: 2,
+			},
+			expectError: false,
+		},
+		{
+			name:         "valid, memory override",
+			inputOptions: supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 0, 40, 0, 2),
+			expectedOptions: supervisor.InstallationSupervisorSchedulingOptions{
+				BalanceInstallations:               true,
+				ClusterResourceThresholdCPU:        80,
+				ClusterResourceThresholdMemory:     40,
+				ClusterResourceThresholdPodCount:   80,
+				ClusterResourceThresholdScaleValue: 2,
+			},
+			expectError: false,
+		},
+		{
+			name:         "valid, pod count override",
+			inputOptions: supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 0, 0, 40, 2),
+			expectedOptions: supervisor.InstallationSupervisorSchedulingOptions{
+				BalanceInstallations:               true,
+				ClusterResourceThresholdCPU:        80,
+				ClusterResourceThresholdMemory:     80,
+				ClusterResourceThresholdPodCount:   40,
+				ClusterResourceThresholdScaleValue: 2,
+			},
+			expectError: false,
+		},
+		{
+			name:         "invalid, no overrides",
+			inputOptions: supervisor.NewInstallationSupervisorSchedulingOptions(true, -1, 0, 0, 0, 2),
+			expectedOptions: supervisor.InstallationSupervisorSchedulingOptions{
+				BalanceInstallations:               true,
+				ClusterResourceThresholdCPU:        -1,
+				ClusterResourceThresholdMemory:     -1,
+				ClusterResourceThresholdPodCount:   -1,
+				ClusterResourceThresholdScaleValue: 2,
+			},
+			expectError: true,
+		},
+		{
+			name:         "invalid, cpu override",
+			inputOptions: supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 2, 0, 0, 2),
+			expectedOptions: supervisor.InstallationSupervisorSchedulingOptions{
+				BalanceInstallations:               true,
+				ClusterResourceThresholdCPU:        2,
+				ClusterResourceThresholdMemory:     80,
+				ClusterResourceThresholdPodCount:   80,
+				ClusterResourceThresholdScaleValue: 2,
+			},
+			expectError: true,
+		},
+		{
+			name:         "invalid, memory override",
+			inputOptions: supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 0, 2, 0, 2),
+			expectedOptions: supervisor.InstallationSupervisorSchedulingOptions{
+				BalanceInstallations:               true,
+				ClusterResourceThresholdCPU:        80,
+				ClusterResourceThresholdMemory:     2,
+				ClusterResourceThresholdPodCount:   80,
+				ClusterResourceThresholdScaleValue: 2,
+			},
+			expectError: true,
+		},
+		{
+			name:         "invalid, pod count override",
+			inputOptions: supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 0, 0, 2, 2),
+			expectedOptions: supervisor.InstallationSupervisorSchedulingOptions{
+				BalanceInstallations:               true,
+				ClusterResourceThresholdCPU:        80,
+				ClusterResourceThresholdMemory:     80,
+				ClusterResourceThresholdPodCount:   2,
+				ClusterResourceThresholdScaleValue: 2,
+			},
+			expectError: true,
+		},
+		{
+			name:         "invalid, scale value out of bounds",
+			inputOptions: supervisor.NewInstallationSupervisorSchedulingOptions(true, 80, 0, 0, 0, -1),
+			expectedOptions: supervisor.InstallationSupervisorSchedulingOptions{
+				BalanceInstallations:               true,
+				ClusterResourceThresholdCPU:        80,
+				ClusterResourceThresholdMemory:     80,
+				ClusterResourceThresholdPodCount:   80,
+				ClusterResourceThresholdScaleValue: -1,
+			},
+			expectError: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.inputOptions, testCase.expectedOptions)
+			err := testCase.expectedOptions.Validate()
+			if testCase.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
These overrides can be used to tweak the threshold value used in
cluster scheduling for individual resource types.

If this type of scheduling behavior works well then the values will
be moved to the cluster resource.

Fixes https://mattermost.atlassian.net/browse/MM-45849

```release-note
Add cluster resource threshold scheduling overrides
```
