### PR TITLE
Add option to disable DB check init containers

### DIFF
--- a/internal/tools/aws/database_multitenant_test.go
+++ b/internal/tools/aws/database_multitenant_test.go
@@ -27,6 +27,7 @@ func (a *AWSTestSuite) TestProvisioningMultitenantDatabase() {
 		a.InstallationA.ID,
 		a.Mocks.AWS,
 		0,
+		false,
 	)
 
 	databaseType := database.DatabaseTypeTagValue()

--- a/internal/tools/aws/database_test.go
+++ b/internal/tools/aws/database_test.go
@@ -343,7 +343,7 @@ func TestDatabaseProvision(t *testing.T) {
 	logger := log.New()
 	database := NewRDSDatabase(model.DatabaseEngineTypeMySQL, id, &Client{
 		mux: &sync.Mutex{},
-	})
+	}, false)
 
 	err := database.Provision(nil, logger)
 	require.NoError(t, err)
@@ -358,7 +358,7 @@ func TestDatabaseTeardown(t *testing.T) {
 	logger := log.New()
 	database := NewRDSDatabase(model.DatabaseEngineTypeMySQL, id, &Client{
 		mux: &sync.Mutex{},
-	})
+	}, false)
 
 	err := database.Teardown(nil, false, logger)
 	require.NoError(t, err)

--- a/internal/tools/aws/secret.go
+++ b/internal/tools/aws/secret.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package aws
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// InstallationDBSecret represents data required for creating database
+// secret for an Installation.
+type InstallationDBSecret struct {
+	InstallationSecretName string
+	ConnectionString       string
+	DBCheckURL             string
+	ReadReplicasURL        string
+}
+
+// ToK8sSecret creates Kubernetes secret from InstallationDBSecret.
+func (s InstallationDBSecret) ToK8sSecret(disableDBCheck bool) *corev1.Secret {
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: s.InstallationSecretName,
+		},
+		StringData: map[string]string{
+			"DB_CONNECTION_STRING":              s.ConnectionString,
+			"MM_SQLSETTINGS_DATASOURCEREPLICAS": s.ReadReplicasURL,
+		},
+	}
+	if !disableDBCheck && s.DBCheckURL != "" {
+		secret.StringData["DB_CONNECTION_CHECK_URL"] = s.DBCheckURL
+	}
+
+	return &secret
+}

--- a/internal/tools/aws/secret_test.go
+++ b/internal/tools/aws/secret_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInstallationDBSecret_ToK8sSecret(t *testing.T) {
+
+	for _, testCase := range []struct {
+		description        string
+		installationSecret InstallationDBSecret
+		disableDBCheck     bool
+		expectedSecret     *corev1.Secret
+	}{
+		{
+			description: "full secret, do not disable check",
+			installationSecret: InstallationDBSecret{
+				InstallationSecretName: "secret",
+				ConnectionString:       "postgres://localhost",
+				DBCheckURL:             "postgres://check",
+				ReadReplicasURL:        "postgres://read",
+			},
+			disableDBCheck: false,
+			expectedSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret",
+				},
+				StringData: map[string]string{
+					"DB_CONNECTION_STRING":              "postgres://localhost",
+					"MM_SQLSETTINGS_DATASOURCEREPLICAS": "postgres://read",
+					"DB_CONNECTION_CHECK_URL":           "postgres://check",
+				},
+			},
+		},
+		{
+			description: "full secret, disable check",
+			installationSecret: InstallationDBSecret{
+				InstallationSecretName: "secret",
+				ConnectionString:       "postgres://localhost",
+				DBCheckURL:             "postgres://check",
+				ReadReplicasURL:        "postgres://read",
+			},
+			disableDBCheck: true,
+			expectedSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret",
+				},
+				StringData: map[string]string{
+					"DB_CONNECTION_STRING":              "postgres://localhost",
+					"MM_SQLSETTINGS_DATASOURCEREPLICAS": "postgres://read",
+				},
+			},
+		},
+		{
+			description: "secret without check",
+			installationSecret: InstallationDBSecret{
+				InstallationSecretName: "secret",
+				ConnectionString:       "postgres://localhost",
+				ReadReplicasURL:        "postgres://read",
+			},
+			disableDBCheck: false,
+			expectedSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret",
+				},
+				StringData: map[string]string{
+					"DB_CONNECTION_STRING":              "postgres://localhost",
+					"MM_SQLSETTINGS_DATASOURCEREPLICAS": "postgres://read",
+				},
+			},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			k8sSecret := testCase.installationSecret.ToK8sSecret(testCase.disableDBCheck)
+			assert.Equal(t, testCase.expectedSecret, k8sSecret)
+		})
+	}
+
+}

--- a/internal/tools/aws/session_test.go
+++ b/internal/tools/aws/session_test.go
@@ -28,10 +28,10 @@ func TestSanitizeParams(t *testing.T) {
 		{
 			description: "redact not allowed keys",
 			params: map[string]interface{}{
-				"Name":         "Awesome Name",
-				"Description":  "test",
+				"Name":               "Awesome Name",
+				"Description":        "test",
 				"MasterUserPassword": "password",
-				"SecretString": map[string]string{"user": "test", "password": "pass"},
+				"SecretString":       map[string]string{"user": "test", "password": "pass"},
 				"Tags": []map[string]interface{}{
 					{"some_name": "some value"},
 					{"tag": "tag"},
@@ -42,9 +42,9 @@ func TestSanitizeParams(t *testing.T) {
 		{
 			description: "redact custom type",
 			params: secretsmanager.CreateSecretInput{
-				Name:                        aws.String("name"),
-				SecretBinary:                []byte("secret bytes"),
-				SecretString:                aws.String("super secret"),
+				Name:         aws.String("name"),
+				SecretBinary: []byte("secret bytes"),
+				SecretString: aws.String("super secret"),
 			},
 			expected: `{"AddReplicaRegions":null,"ClientRequestToken":null,"Description":null,"ForceOverwriteReplicaSecret":null,"KmsKeyId":null,"Name":"name","SecretBinary":"*****","SecretString":"*****","Tags":null}`,
 		},

--- a/internal/tools/utils/utils.go
+++ b/internal/tools/utils/utils.go
@@ -86,6 +86,7 @@ type ResourceUtil struct {
 	awsClient                    *aws.Client
 	instanceID                   string
 	dbClusterUtilizationSettings DBClusterUtilizationSettings
+	disableDBCheck               bool
 }
 
 // DBClusterUtilizationSettings define maximum utilization of database clusters.
@@ -96,11 +97,16 @@ type DBClusterUtilizationSettings struct {
 }
 
 // NewResourceUtil returns a new instance of ResourceUtil.
-func NewResourceUtil(instanceID string, awsClient *aws.Client, dbClusterUtilization DBClusterUtilizationSettings) *ResourceUtil {
+func NewResourceUtil(
+	instanceID string,
+	awsClient *aws.Client,
+	dbClusterUtilization DBClusterUtilizationSettings,
+	disableDBCheck bool) *ResourceUtil {
 	return &ResourceUtil{
 		awsClient:                    awsClient,
 		instanceID:                   instanceID,
 		dbClusterUtilizationSettings: dbClusterUtilization,
+		disableDBCheck:               disableDBCheck,
 	}
 }
 
@@ -133,9 +139,9 @@ func (r *ResourceUtil) GetDatabase(installationID, dbType string) model.Database
 	case model.InstallationDatabaseMysqlOperator:
 		return model.NewMysqlOperatorDatabase()
 	case model.InstallationDatabaseSingleTenantRDSMySQL:
-		return aws.NewRDSDatabase(model.DatabaseEngineTypeMySQL, installationID, r.awsClient)
+		return aws.NewRDSDatabase(model.DatabaseEngineTypeMySQL, installationID, r.awsClient, r.disableDBCheck)
 	case model.InstallationDatabaseSingleTenantRDSPostgres:
-		return aws.NewRDSDatabase(model.DatabaseEngineTypePostgres, installationID, r.awsClient)
+		return aws.NewRDSDatabase(model.DatabaseEngineTypePostgres, installationID, r.awsClient, r.disableDBCheck)
 	case model.InstallationDatabaseMultiTenantRDSMySQL:
 		return aws.NewRDSMultitenantDatabase(
 			model.DatabaseEngineTypeMySQL,
@@ -143,6 +149,7 @@ func (r *ResourceUtil) GetDatabase(installationID, dbType string) model.Database
 			installationID,
 			r.awsClient,
 			r.dbClusterUtilizationSettings.MaxInstallationsRDSMySQL,
+			r.disableDBCheck,
 		)
 	case model.InstallationDatabaseMultiTenantRDSPostgres:
 		return aws.NewRDSMultitenantDatabase(
@@ -151,6 +158,7 @@ func (r *ResourceUtil) GetDatabase(installationID, dbType string) model.Database
 			installationID,
 			r.awsClient,
 			r.dbClusterUtilizationSettings.MaxInstallationsRDSPostgres,
+			r.disableDBCheck,
 		)
 	case model.InstallationDatabaseMultiTenantRDSPostgresPGBouncer:
 		return aws.NewRDSMultitenantPGBouncerDatabase(
@@ -159,6 +167,7 @@ func (r *ResourceUtil) GetDatabase(installationID, dbType string) model.Database
 			installationID,
 			r.awsClient,
 			r.dbClusterUtilizationSettings.MaxInstallationsRDSPostgresPGBouncer,
+			r.disableDBCheck,
 		)
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add `--disable-db-init-check` flag to disable DB check init containers for Installations.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add option to disable DB check init containers
```
