### PR TITLE
Add option to enable/disable Route53 DNS records creation

### DIFF
--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -283,6 +283,20 @@ func (mr *MockAWSMockRecorder) DeletePublicCNAME(dnsName, logger interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePublicCNAME", reflect.TypeOf((*MockAWS)(nil).DeletePublicCNAME), dnsName, logger)
 }
 
+// DeletePublicCNAMEs mocks base method
+func (m *MockAWS) DeletePublicCNAMEs(dnsName []string, logger logrus.FieldLogger) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePublicCNAMEs", dnsName, logger)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeletePublicCNAMEs indicates an expected call of DeletePublicCNAMEs
+func (mr *MockAWSMockRecorder) DeletePublicCNAMEs(dnsName, logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePublicCNAMEs", reflect.TypeOf((*MockAWS)(nil).DeletePublicCNAMEs), dnsName, logger)
+}
+
 // UpsertPublicCNAMEs mocks base method
 func (m *MockAWS) UpsertPublicCNAMEs(dnsNames, endpoints []string, logger logrus.FieldLogger) error {
 	m.ctrl.T.Helper()

--- a/internal/supervisor/dns.go
+++ b/internal/supervisor/dns.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package supervisor
+
+import (
+	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// Route53DNSProvider wraps route53 function calls to implement
+// InstallationDNSProvider interface.
+type Route53DNSProvider struct {
+	aws aws.AWS
+}
+
+// NewRoute53DNSProvider creates Route53 Installation DNS Provider.
+func NewRoute53DNSProvider(aws aws.AWS) *Route53DNSProvider {
+	return &Route53DNSProvider{aws: aws}
+}
+
+// CreateDNSRecords creates or updates Route53 CNAME records.
+func (r *Route53DNSProvider) CreateDNSRecords(customerDNSName []string, dnsEndpoints []string, logger logrus.FieldLogger) error {
+	return r.aws.UpsertPublicCNAMEs(customerDNSName, dnsEndpoints, logger)
+}
+
+// DeleteDNSRecords deletes Route53 CNAME records.
+func (r *Route53DNSProvider) DeleteDNSRecords(customerDNSName []string, logger logrus.FieldLogger) error {
+	return r.aws.DeletePublicCNAMEs(customerDNSName, logger)
+}
+
+// DNSManager wraps multiple InstallationDNSProviders.
+type DNSManager struct {
+	providers []InstallationDNSProvider
+}
+
+// NewDNSManager creates new DNSManager without any providers.
+func NewDNSManager() *DNSManager {
+	return &DNSManager{providers: []InstallationDNSProvider{}}
+}
+
+// AddProvider adds InstallationDNSProvider to the DNSManager.
+func (dm *DNSManager) AddProvider(provider InstallationDNSProvider) {
+	dm.providers = append(dm.providers, provider)
+}
+
+// IsValid verifies if DNS providers are registered with DNSManager.
+func (dm *DNSManager) IsValid() error {
+	if len(dm.providers) == 0 {
+		return errors.Errorf("error: no Installation DNS providers registerd")
+	}
+	return nil
+}
+
+// CreateDNSRecords creates DNS records with all registered providers.
+func (dm *DNSManager) CreateDNSRecords(customerDNSName []string, dnsEndpoints []string, logger logrus.FieldLogger) error {
+	for _, provider := range dm.providers {
+		err := provider.CreateDNSRecords(customerDNSName, dnsEndpoints, logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to create DNS record for one of the providers")
+		}
+	}
+	return nil
+}
+
+// DeleteDNSRecords deletes DNS record from all registered providers.
+func (dm *DNSManager) DeleteDNSRecords(customerDNSName []string, logger logrus.FieldLogger) error {
+	for _, provider := range dm.providers {
+		err := provider.DeleteDNSRecords(customerDNSName, logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete DNS record for one of the providers")
+		}
+	}
+	return nil
+}

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -464,6 +464,10 @@ func (a *mockAWS) DeletePublicCNAME(dnsName string, logger log.FieldLogger) erro
 	return nil
 }
 
+func (a *mockAWS) DeletePublicCNAMEs(dnsNames []string, logger log.FieldLogger) error {
+	return nil
+}
+
 func (a *mockAWS) GetPublicHostedZoneNames() []string {
 	return []string{"public.host.name.example.com"}
 }

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -64,6 +64,7 @@ type AWS interface {
 	IsProvisionedPrivateCNAME(dnsName string, logger log.FieldLogger) bool
 	DeletePrivateCNAME(dnsName string, logger log.FieldLogger) error
 	DeletePublicCNAME(dnsName string, logger log.FieldLogger) error
+	DeletePublicCNAMEs(dnsName []string, logger log.FieldLogger) error
 	UpsertPublicCNAMEs(dnsNames []string, endpoints []string, logger log.FieldLogger) error
 
 	TagResource(resourceID, key, value string, logger log.FieldLogger) error

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -132,6 +132,22 @@ func (a *Client) DeletePublicCNAME(dnsName string, logger log.FieldLogger) error
 	return a.deleteCNAME(zoneID, dnsName, logger)
 }
 
+// DeletePublicCNAMEs deletes AWS route53 records for a public domain name.
+func (a *Client) DeletePublicCNAMEs(dnsNames []string, logger log.FieldLogger) error {
+	for _, dns := range dnsNames {
+		zoneID, found := a.getDNSZoneID(dns)
+		if !found {
+			logger.Warnf("hosted zone for %q domain name not found, skipping CNAME deletion", dns)
+			continue
+		}
+		err := a.deleteCNAME(zoneID, dns, logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete CNAME")
+		}
+	}
+	return nil
+}
+
 // GetPrivateHostedZoneID returns the private R53 hosted zone ID for the AWS
 // account.
 func (a *Client) GetPrivateHostedZoneID() string {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This adds new flag `installation-enable-route53` which allows skipping creation/deletion of Route53 records for Installations.

**By default Route53 will be disabled and need to use it, the flag needs to be explicitly enabled**.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add option to disable Route53 DNS records creation
```
