### PR TITLE
Add installation deletion queuing

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -91,6 +91,9 @@ func init() {
 	installationDeleteCmd.Flags().String("installation", "", "The id of the installation to be deleted.")
 	installationDeleteCmd.MarkFlagRequired("installation")
 
+	installationCancelDeletionCmd.Flags().String("installation", "", "The id of the installation to cancel pending deletion for.")
+	installationCancelDeletionCmd.MarkFlagRequired("installation")
+
 	installationRecoveryCmd.Flags().String("installation", "", "The id of the installation to be recovered.")
 	installationRecoveryCmd.Flags().String("installation-database", "", "The original multitenant database id of the installation to be recovered.")
 	installationRecoveryCmd.Flags().String("database", "sqlite://cloud.db", "The database backing the provisioning server.")
@@ -103,6 +106,7 @@ func init() {
 	installationCmd.AddCommand(installationCreateCmd)
 	installationCmd.AddCommand(installationUpdateCmd)
 	installationCmd.AddCommand(installationDeleteCmd)
+	installationCmd.AddCommand(installationCancelDeletionCmd)
 	installationCmd.AddCommand(installationHibernateCmd)
 	installationCmd.AddCommand(installationWakeupCmd)
 	installationCmd.AddCommand(installationGetCmd)
@@ -280,6 +284,26 @@ var installationDeleteCmd = &cobra.Command{
 		err := client.DeleteInstallation(installationID)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete installation")
+		}
+
+		return nil
+	},
+}
+
+var installationCancelDeletionCmd = &cobra.Command{
+	Use:   "cancel-deletion",
+	Short: "Cancels the pending deletion of an installation.",
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		serverAddress, _ := command.Flags().GetString("server")
+		client := model.NewClient(serverAddress)
+
+		installationID, _ := command.Flags().GetString("installation")
+
+		err := client.CancelInstallationDeletion(installationID)
+		if err != nil {
+			return errors.Wrap(err, "failed to cancel installation deletion")
 		}
 
 		return nil

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -76,7 +76,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("installation-supervisor", true, "Whether this server will run an installation supervisor or not.")
 	serverCmd.PersistentFlags().Bool("installation-db-restoration-supervisor", false, "Whether this server will run an installation db restoration supervisor or not.")
 	serverCmd.PersistentFlags().Bool("installation-db-migration-supervisor", false, "Whether this server will run an installation db migration supervisor or not.")
-	serverCmd.PersistentFlags().Bool("installation-deletion-supervisor", false, "Whether this server will run a installation deletion supervisor or not. (slow-poll supervisor)")
+	serverCmd.PersistentFlags().Bool("installation-deletion-supervisor", true, "Whether this server will run a installation deletion supervisor or not. (slow-poll supervisor)")
 	serverCmd.PersistentFlags().Bool("cluster-installation-supervisor", true, "Whether this server will run a cluster installation supervisor or not.")
 	serverCmd.PersistentFlags().Bool("backup-supervisor", false, "Whether this server will run a backup supervisor or not.")
 	serverCmd.PersistentFlags().Bool("import-supervisor", false, "Whether this server will run a workspace import supervisor or not.")

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -70,15 +70,17 @@ func init() {
 
 	// Supervisors
 	serverCmd.PersistentFlags().Int("poll", 30, "The interval in seconds to poll for background work.")
+	serverCmd.PersistentFlags().Int("slow-poll", 60, "The interval in seconds to poll for background work for supervisors that are not time sensitive (slow-poll supervisors).")
 	serverCmd.PersistentFlags().Bool("cluster-supervisor", true, "Whether this server will run a cluster supervisor or not.")
 	serverCmd.PersistentFlags().Bool("group-supervisor", false, "Whether this server will run an installation group supervisor or not.")
 	serverCmd.PersistentFlags().Bool("installation-supervisor", true, "Whether this server will run an installation supervisor or not.")
+	serverCmd.PersistentFlags().Bool("installation-db-restoration-supervisor", false, "Whether this server will run an installation db restoration supervisor or not.")
+	serverCmd.PersistentFlags().Bool("installation-db-migration-supervisor", false, "Whether this server will run an installation db migration supervisor or not.")
+	serverCmd.PersistentFlags().Bool("installation-deletion-supervisor", false, "Whether this server will run a installation deletion supervisor or not. (slow-poll supervisor)")
 	serverCmd.PersistentFlags().Bool("cluster-installation-supervisor", true, "Whether this server will run a cluster installation supervisor or not.")
 	serverCmd.PersistentFlags().Bool("backup-supervisor", false, "Whether this server will run a backup supervisor or not.")
 	serverCmd.PersistentFlags().Bool("import-supervisor", false, "Whether this server will run a workspace import supervisor or not.")
 	serverCmd.PersistentFlags().String("awat", "http://localhost:8077", "The location of the Automatic Workspace Archive Translator if the import supervisor is being used.")
-	serverCmd.PersistentFlags().Bool("installation-db-restoration-supervisor", false, "Whether this server will run an installation db restoration supervisor or not.")
-	serverCmd.PersistentFlags().Bool("installation-db-migration-supervisor", false, "Whether this server will run an installation db migration supervisor or not.")
 
 	// Scheduling options
 	serverCmd.PersistentFlags().Bool("balanced-installation-scheduling", false, "Whether to schedule installations on the cluster with the greatest percentage of available resources or not. (slows down scheduling speed as cluster count increases)")
@@ -106,6 +108,7 @@ func init() {
 	serverCmd.PersistentFlags().String("ndots-value", "5", "The default ndots value for installations.")
 	serverCmd.PersistentFlags().Bool("disable-db-init-check", false, "Whether to disable init container with database check.")
 	serverCmd.PersistentFlags().Bool("installation-enable-route53", false, "Specifies whether CNAME records for Installation should be created in Route53 as well.")
+	serverCmd.PersistentFlags().Duration("installation-deletion-pending-time", time.Hour, "The amount of time that installations will stay in the deletion queue before they are actually deleted. Set to 0 for immediate deletion.")
 
 	// DB clusters utilization configuration
 	serverCmd.PersistentFlags().Int("max-installations-rds-postgres-pgbouncer", toolsAWS.DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit, "Max installations per DB cluster of type RDS Postgres PGbouncer")
@@ -239,6 +242,7 @@ var serverCmd = &cobra.Command{
 		clusterSupervisor, _ := command.Flags().GetBool("cluster-supervisor")
 		groupSupervisor, _ := command.Flags().GetBool("group-supervisor")
 		installationSupervisor, _ := command.Flags().GetBool("installation-supervisor")
+		installationDeletionSupervisor, _ := command.Flags().GetBool("installation-deletion-supervisor")
 		clusterInstallationSupervisor, _ := command.Flags().GetBool("cluster-installation-supervisor")
 		backupSupervisor, _ := command.Flags().GetBool("backup-supervisor")
 		importSupervisor, _ := command.Flags().GetBool("import-supervisor")
@@ -264,6 +268,7 @@ var serverCmd = &cobra.Command{
 		useExistingResources, _ := command.Flags().GetBool("use-existing-aws-resources")
 		backupRestoreToolImage, _ := command.Flags().GetString("backup-restore-tool-image")
 		backupJobTTL, _ := command.Flags().GetInt32("backup-job-ttl-seconds")
+		installationDeletionPendingTime, _ := command.Flags().GetDuration("installation-deletion-pending-time")
 
 		deployMySQLOperator, _ := command.Flags().GetBool("deploy-mysql-operator")
 		deployMinioOperator, _ := command.Flags().GetBool("deploy-minio-operator")
@@ -293,6 +298,7 @@ var serverCmd = &cobra.Command{
 			"cluster-supervisor":                            clusterSupervisor,
 			"group-supervisor":                              groupSupervisor,
 			"installation-supervisor":                       installationSupervisor,
+			"installation-deletion-supervisor":              installationDeletionSupervisor,
 			"cluster-installation-supervisor":               clusterInstallationSupervisor,
 			"backup-supervisor":                             backupSupervisor,
 			"import-supervisor":                             importSupervisor,
@@ -301,6 +307,7 @@ var serverCmd = &cobra.Command{
 			"store-version":                                 currentVersion,
 			"state-store":                                   s3StateStore,
 			"working-directory":                             wd,
+			"installation-deletion-pending-time":            installationDeletionPendingTime,
 			"balanced-installation-scheduling":              balancedInstallationScheduling,
 			"cluster-resource-threshold":                    clusterResourceThreshold,
 			"cluster-resource-threshold-cpu-override":       thresholdCPUOverride,
@@ -453,8 +460,19 @@ var serverCmd = &cobra.Command{
 			logger.WithField("poll", poll).Info("Scheduler is disabled")
 		}
 
-		supervisor := supervisor.NewScheduler(multiDoer, time.Duration(poll)*time.Second)
-		defer supervisor.Close()
+		standardSupervisor := supervisor.NewScheduler(multiDoer, time.Duration(poll)*time.Second)
+		defer standardSupervisor.Close()
+
+		slowPoll, _ := command.Flags().GetInt("slow-poll")
+		if slowPoll == 0 {
+			logger.WithField("slow-poll", slowPoll).Info("Slow scheduler is disabled")
+		}
+		if installationDeletionSupervisor {
+			var slowMultiDoer supervisor.MultiDoer
+			slowMultiDoer = append(slowMultiDoer, supervisor.NewInstallationDeletionSupervisor(instanceID, installationDeletionPendingTime, sqlStore, eventsProducer, logger))
+			slowSupervisor := supervisor.NewScheduler(slowMultiDoer, time.Duration(slowPoll)*time.Second)
+			defer slowSupervisor.Close()
+		}
 
 		metricsPort, _ := command.Flags().GetInt("metrics-port")
 		metricsRouter := mux.NewRouter()
@@ -482,7 +500,7 @@ var serverCmd = &cobra.Command{
 
 		api.Register(router, &api.Context{
 			Store:         sqlStore,
-			Supervisor:    supervisor,
+			Supervisor:    standardSupervisor,
 			Provisioner:   kopsProvisioner,
 			DBProvider:    resourceUtil,
 			EventProducer: eventsProducer,

--- a/internal/supervisor/installation_deletion_test.go
+++ b/internal/supervisor/installation_deletion_test.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package supervisor_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/internal/events"
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/supervisor"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
+	"github.com/mattermost/mattermost-cloud/model"
+	mmv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+type mockInstallationDeletionStore struct {
+	Installation                         *model.Installation
+	UnlockedInstallationsPendingDeletion []*model.Installation
+	Events                               []*model.StateChangeEventData
+
+	UnlockChan              chan interface{}
+	UpdateInstallationCalls int
+
+	mockMultitenantDBStore
+}
+
+func (s *mockInstallationDeletionStore) GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error) {
+	return s.Installation, nil
+}
+
+func (s *mockInstallationDeletionStore) GetUnlockedInstallationsPendingDeletion() ([]*model.Installation, error) {
+	return s.UnlockedInstallationsPendingDeletion, nil
+}
+
+func (s *mockInstallationDeletionStore) UpdateInstallationState(installation *model.Installation) error {
+	s.UpdateInstallationCalls++
+	return nil
+}
+
+func (s *mockInstallationDeletionStore) LockInstallation(installationID, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (s *mockInstallationDeletionStore) UnlockInstallation(installationID, lockerID string, force bool) (bool, error) {
+	if s.UnlockChan != nil {
+		close(s.UnlockChan)
+	}
+	return true, nil
+}
+
+func (s *mockInstallationDeletionStore) GetStateChangeEvents(filter *model.StateChangeEventFilter) ([]*model.StateChangeEventData, error) {
+	return s.Events, nil
+}
+
+func (s *mockInstallationDeletionStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error) {
+	return nil, nil
+}
+
+type mockEventsProducer struct{}
+
+func (s *mockEventsProducer) ProduceInstallationStateChangeEvent(installation *model.Installation, oldState string, extraDataFields ...events.DataField) error {
+	return nil
+}
+
+func (s *mockEventsProducer) ProduceClusterStateChangeEvent(cluster *model.Cluster, oldState string, extraDataFields ...events.DataField) error {
+	return nil
+}
+
+func (s *mockEventsProducer) ProduceClusterInstallationStateChangeEvent(clusterInstallation *model.ClusterInstallation, oldState string, extraDataFields ...events.DataField) error {
+	return nil
+}
+
+func TestInstallationDeletionSupervisor_Do(t *testing.T) {
+	t.Run("no installation deletion operations pending work", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		mockStore := &mockInstallationDeletionStore{}
+
+		supervisor := supervisor.NewInstallationDeletionSupervisor("instanceID", time.Hour, mockStore, &mockEventsProducer{}, logger)
+		err := supervisor.Do()
+		require.NoError(t, err)
+
+		require.Equal(t, 0, mockStore.UpdateInstallationCalls)
+	})
+
+	t.Run("mock check installation deletion", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		mockStore := &mockInstallationDeletionStore{}
+
+		mockStore.UnlockedInstallationsPendingDeletion = []*model.Installation{{
+			ID:    model.NewID(),
+			State: model.InstallationStateDeletionPending,
+		}}
+		mockStore.Installation = mockStore.UnlockedInstallationsPendingDeletion[0]
+		mockStore.Events = []*model.StateChangeEventData{{Event: model.Event{Timestamp: 1646160276464}}}
+		mockStore.UnlockChan = make(chan interface{})
+
+		supervisor := supervisor.NewInstallationDeletionSupervisor("instanceID", time.Hour, mockStore, &mockEventsProducer{}, logger)
+		err := supervisor.Do()
+		require.NoError(t, err)
+
+		<-mockStore.UnlockChan
+		require.Equal(t, 1, mockStore.UpdateInstallationCalls)
+	})
+}
+
+func TestInstallationDeletionSupervisor_Supervise(t *testing.T) {
+	t.Run("unknown state", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
+		supervisor := supervisor.NewInstallationDeletionSupervisor("instanceID", time.Hour, sqlStore, &mockEventsProducer{}, logger)
+
+		installation := &model.Installation{
+			OwnerID:  "blah",
+			Version:  "version",
+			Name:     "dns",
+			Size:     mmv1alpha1.Size100String,
+			Affinity: model.InstallationAffinityIsolated,
+			State:    "badstate",
+		}
+
+		err := sqlStore.CreateInstallation(installation, nil, testutil.DNSForInstallation("dns.example.com"))
+		require.NoError(t, err)
+
+		supervisor.Supervise(installation)
+		installation, err = sqlStore.GetInstallation(installation.ID, false, false)
+		require.NoError(t, err)
+		require.Equal(t, "badstate", installation.State)
+	})
+
+	t.Run("deletion pending, not ready for deletion", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
+		supervisor := supervisor.NewInstallationDeletionSupervisor("instanceID", time.Hour, sqlStore, &mockEventsProducer{}, logger)
+
+		installation := &model.Installation{
+			OwnerID:  "blah",
+			Version:  "version",
+			Name:     "dns",
+			Size:     mmv1alpha1.Size100String,
+			Affinity: model.InstallationAffinityIsolated,
+			State:    model.InstallationStateDeletionPending,
+		}
+
+		err := sqlStore.CreateInstallation(installation, nil, testutil.DNSForInstallation("dns.example.com"))
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		event := &model.StateChangeEventData{
+			Event: model.Event{
+				EventType: model.ResourceStateChangeEventType,
+				Timestamp: model.GetMillis(),
+			},
+			StateChange: model.StateChangeEvent{
+				OldState:     "old",
+				NewState:     model.InstallationStateDeletionPending,
+				ResourceID:   installation.ID,
+				ResourceType: "installation",
+			},
+		}
+
+		err = sqlStore.CreateStateChangeEvent(event)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		supervisor.Supervise(installation)
+		installation, err = sqlStore.GetInstallation(installation.ID, false, false)
+		require.NoError(t, err)
+		require.Equal(t, model.InstallationStateDeletionPending, installation.State)
+	})
+
+	t.Run("deletion pending, ready for deletion", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		sqlStore := store.MakeTestSQLStore(t, logger)
+		defer store.CloseConnection(t, sqlStore)
+
+		supervisor := supervisor.NewInstallationDeletionSupervisor("instanceID", time.Nanosecond, sqlStore, &mockEventsProducer{}, logger)
+
+		installation := &model.Installation{
+			OwnerID:  "blah",
+			Version:  "version",
+			Name:     "dns",
+			Size:     mmv1alpha1.Size100String,
+			Affinity: model.InstallationAffinityIsolated,
+			State:    model.InstallationStateDeletionPending,
+		}
+
+		err := sqlStore.CreateInstallation(installation, nil, testutil.DNSForInstallation("dns.example.com"))
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		event := &model.StateChangeEventData{
+			Event: model.Event{
+				EventType: model.ResourceStateChangeEventType,
+				Timestamp: model.GetMillis(),
+			},
+			StateChange: model.StateChangeEvent{
+				OldState:     "old",
+				NewState:     model.InstallationStateDeletionPending,
+				ResourceID:   installation.ID,
+				ResourceType: "installation",
+			},
+		}
+
+		err = sqlStore.CreateStateChangeEvent(event)
+		require.NoError(t, err)
+
+		time.Sleep(1 * time.Millisecond)
+
+		supervisor.Supervise(installation)
+		installation, err = sqlStore.GetInstallation(installation.ID, false, false)
+		require.NoError(t, err)
+		require.Equal(t, model.InstallationStateDeletionRequested, installation.State)
+	})
+}

--- a/model/client.go
+++ b/model/client.go
@@ -551,6 +551,24 @@ func (c *Client) DeleteInstallation(installationID string) error {
 	}
 }
 
+// CancelInstallationDeletion cancels the deletion of an installation that is
+// still pending deletion
+func (c *Client) CancelInstallationDeletion(installationID string) error {
+	resp, err := c.doPost(c.buildURL("/api/installation/%s/cancel_deletion", installationID), nil)
+	if err != nil {
+		return err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return nil
+
+	default:
+		return errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // AddInstallationDNS creates new DNS record for installation.
 func (c *Client) AddInstallationDNS(installationID string, request *AddDNSRecordRequest) (*InstallationDTO, error) {
 	resp, err := c.doPost(c.buildURL("/api/installation/%s/dns", installationID), request)

--- a/model/installation.go
+++ b/model/installation.go
@@ -119,9 +119,13 @@ func (i *Installation) DeletionDateString() string {
 // GetDatabaseWeight returns a value corresponding to the
 // TODO: maybe consider installation size in the future as well?
 func (i *Installation) GetDatabaseWeight() float64 {
-	if i.State == InstallationStateHibernationRequested ||
-		i.State == InstallationStateHibernationInProgress ||
-		i.State == InstallationStateHibernating {
+	switch i.State {
+	case InstallationStateHibernationRequested,
+		InstallationStateHibernationInProgress,
+		InstallationStateHibernating,
+		InstallationStateDeletionPendingRequested,
+		InstallationStateDeletionPendingInProgress,
+		InstallationStateDeletionPending:
 		return HibernatingDatabaseWeight
 	}
 

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -51,7 +51,20 @@ const (
 	// is complete but whose completion has not yet been noted by the
 	// AWAT. It is otherwise the same as a stable state.
 	InstallationStateImportComplete = "import-complete"
-	// InstallationStateDeletionRequested is an installation to be deleted.
+	// InstallationStateDeletionPendingRequested is an installation that is marked
+	// to be moved to the deletion-pending state.
+	InstallationStateDeletionPendingRequested = "deletion-pending-requested"
+	// InstallationStateDeletionPendingInProgress is an installation that is being
+	// placed into a deletion-pending state.
+	InstallationStateDeletionPendingInProgress = "deletion-pending-in-progress"
+	// InstallationStateDeletionPending is an installation that is pending
+	// deletion.
+	InstallationStateDeletionPending = "deletion-pending"
+	// InstallationStateDeletionCancellationRequested is an installation that is
+	// requested to have its pending deletion cancelled.
+	InstallationStateDeletionCancellationRequested = "deletion-cancellation-requested"
+	// InstallationStateDeletionRequested is an installation that deletion has
+	// been requested on.
 	InstallationStateDeletionRequested = "deletion-requested"
 	// InstallationStateDeletionInProgress is an installation being deleted.
 	InstallationStateDeletionInProgress = "deletion-in-progress"
@@ -101,6 +114,10 @@ var AllInstallationStates = []string{
 	InstallationStateUpdateFailed,
 	InstallationStateImportInProgress,
 	InstallationStateImportComplete,
+	InstallationStateDeletionPendingRequested,
+	InstallationStateDeletionPendingInProgress,
+	InstallationStateDeletionPending,
+	InstallationStateDeletionCancellationRequested,
 	InstallationStateDeletionRequested,
 	InstallationStateDeletionInProgress,
 	InstallationStateDeletionFinalCleanup,
@@ -131,10 +148,13 @@ var AllInstallationStatesPendingWork = []string{
 	InstallationStateWakeUpRequested,
 	InstallationStateUpdateRequested,
 	InstallationStateUpdateInProgress,
+	InstallationStateDNSMigrationHibernating,
+	InstallationStateDeletionPendingRequested,
+	InstallationStateDeletionPendingInProgress,
+	InstallationStateDeletionCancellationRequested,
 	InstallationStateDeletionRequested,
 	InstallationStateDeletionInProgress,
 	InstallationStateDeletionFinalCleanup,
-	InstallationStateDNSMigrationHibernating,
 }
 
 // AllInstallationRequestStates is a list of all states that an installation can
@@ -147,8 +167,10 @@ var AllInstallationRequestStates = []string{
 	InstallationStateHibernationRequested,
 	InstallationStateWakeUpRequested,
 	InstallationStateUpdateRequested,
-	InstallationStateDeletionRequested,
 	InstallationStateDNSMigrationHibernating,
+	InstallationStateDeletionPendingRequested,
+	InstallationStateDeletionCancellationRequested,
+	InstallationStateDeletionRequested,
 }
 
 // ValidTransitionState returns whether an installation can be transitioned into
@@ -180,8 +202,19 @@ var (
 			InstallationStateUpdateInProgress,
 			InstallationStateUpdateFailed,
 		},
-		InstallationStateDeletionRequested: {
+		InstallationStateDeletionPendingRequested: {
 			InstallationStateStable,
+			InstallationStateUpdateRequested,
+			InstallationStateUpdateInProgress,
+			InstallationStateUpdateFailed,
+			InstallationStateHibernating,
+			InstallationStateDeletionPendingRequested,
+			InstallationStateDeletionPendingInProgress,
+		},
+		InstallationStateDeletionCancellationRequested: {
+			InstallationStateDeletionPending,
+		},
+		InstallationStateDeletionRequested: {
 			InstallationStateCreationRequested,
 			InstallationStateCreationPreProvisioning,
 			InstallationStateCreationInProgress,
@@ -189,14 +222,7 @@ var (
 			InstallationStateCreationNoCompatibleClusters,
 			InstallationStateCreationFinalTasks,
 			InstallationStateCreationFailed,
-			InstallationStateUpdateRequested,
-			InstallationStateUpdateInProgress,
-			InstallationStateUpdateFailed,
-			InstallationStateImportInProgress,
-			InstallationStateImportComplete,
-			InstallationStateHibernationRequested,
-			InstallationStateHibernationInProgress,
-			InstallationStateHibernating,
+			InstallationStateDeletionPending,
 			InstallationStateDeletionRequested,
 			InstallationStateDeletionInProgress,
 			InstallationStateDeletionFinalCleanup,

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -222,7 +222,6 @@ var (
 			InstallationStateCreationNoCompatibleClusters,
 			InstallationStateCreationFinalTasks,
 			InstallationStateCreationFailed,
-			InstallationStateDeletionPending,
 			InstallationStateDeletionRequested,
 			InstallationStateDeletionInProgress,
 			InstallationStateDeletionFinalCleanup,

--- a/model/installation_states_test.go
+++ b/model/installation_states_test.go
@@ -66,7 +66,7 @@ func TestInstallation_ValidTransitionState(t *testing.T) {
 		{
 			oldState: InstallationStateDeletionPending,
 			newState: InstallationStateDeletionRequested,
-			isValid:  true,
+			isValid:  false,
 		},
 		{
 			oldState: InstallationStateCreationNoCompatibleClusters,

--- a/model/installation_states_test.go
+++ b/model/installation_states_test.go
@@ -43,6 +43,41 @@ func TestInstallation_ValidTransitionState(t *testing.T) {
 			newState: InstallationStateUpdateRequested,
 			isValid:  false,
 		},
+		{
+			oldState: InstallationStateStable,
+			newState: InstallationStateDeletionRequested,
+			isValid:  false,
+		},
+		{
+			oldState: InstallationStateStable,
+			newState: InstallationStateDeletionPendingRequested,
+			isValid:  true,
+		},
+		{
+			oldState: InstallationStateHibernating,
+			newState: InstallationStateDeletionRequested,
+			isValid:  false,
+		},
+		{
+			oldState: InstallationStateHibernating,
+			newState: InstallationStateDeletionPendingRequested,
+			isValid:  true,
+		},
+		{
+			oldState: InstallationStateDeletionPending,
+			newState: InstallationStateDeletionRequested,
+			isValid:  true,
+		},
+		{
+			oldState: InstallationStateCreationNoCompatibleClusters,
+			newState: InstallationStateDeletionRequested,
+			isValid:  true,
+		},
+		{
+			oldState: InstallationStateCreationInProgress,
+			newState: InstallationStateDeletionRequested,
+			isValid:  true,
+		},
 	} {
 		t.Run(testCase.oldState+" to "+testCase.newState, func(t *testing.T) {
 			installation := Installation{State: testCase.oldState}

--- a/model/installation_test.go
+++ b/model/installation_test.go
@@ -385,3 +385,35 @@ func TestInstallation_GetEnvVars(t *testing.T) {
 		})
 	}
 }
+
+func TestInstallationGetDatabaseWeight(t *testing.T) {
+	for _, testCase := range []struct {
+		installation   Installation
+		expectedWeight float64
+	}{
+		{
+			Installation{State: InstallationStateStable},
+			DefaultDatabaseWeight,
+		},
+		{
+			Installation{State: InstallationStateUpdateInProgress},
+			DefaultDatabaseWeight,
+		},
+		{
+			Installation{State: InstallationStateHibernating},
+			HibernatingDatabaseWeight,
+		},
+		{
+			Installation{State: InstallationStateDeletionPendingRequested},
+			HibernatingDatabaseWeight,
+		},
+		{
+			Installation{State: InstallationStateDeletionPending},
+			HibernatingDatabaseWeight,
+		},
+	} {
+		t.Run(testCase.installation.State, func(t *testing.T) {
+			assert.Equal(t, testCase.expectedWeight, testCase.installation.GetDatabaseWeight())
+		})
+	}
+}


### PR DESCRIPTION
This new logic changes how installations are deleted by the
provisioner. Now, installations enter a deletion pending state
when they were previously in a state that enabled them to have
created persistent data. This deletion pending state acts as a
type of 'soft deletion' where actual deletion of the installation
and its data occurs at a later time as configured in the provisioner.
This time can be lowered to zero to provide immediate deletion
similar to the existing behavior.

Fixes https://mattermost.atlassian.net/browse/MM-45742

```release-note
Add installation deletion queuing
```
