### PR TITLE
Add flag to disable DNS updates on Installation update

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -433,8 +433,7 @@ var serverCmd = &cobra.Command{
 			multiDoer = append(multiDoer, supervisor.NewGroupSupervisor(sqlStore, eventsProducer, instanceID, logger))
 		}
 		if installationSupervisor {
-			multiDoer = append(multiDoer, supervisor.NewInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, keepDatabaseData, keepFilestoreData, installationScheduling, resourceUtil, logger, cloudMetrics, eventsProducer, forceCRUpgrade, dnsManager, disableDNSUpdates
-			))
+			multiDoer = append(multiDoer, supervisor.NewInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, instanceID, keepDatabaseData, keepFilestoreData, installationScheduling, resourceUtil, logger, cloudMetrics, eventsProducer, forceCRUpgrade, dnsManager, disableDNSUpdates))
 		}
 		if clusterInstallationSupervisor {
 			multiDoer = append(multiDoer, supervisor.NewClusterInstallationSupervisor(sqlStore, kopsProvisioner, awsClient, eventsProducer, instanceID, logger, cloudMetrics))

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -554,7 +554,7 @@ func TestInstallationSupervisorDo(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		mockStore := &mockInstallationStore{}
 
-		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, nil, false, &mockCloudflareClient{})
+		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, nil, false, &mockCloudflareClient{}, false)
 		err := supervisor.Do()
 		require.NoError(t, err)
 
@@ -572,7 +572,7 @@ func TestInstallationSupervisorDo(t *testing.T) {
 		mockStore.Installation = mockStore.UnlockedInstallationsPendingWork[0]
 		mockStore.UnlockChan = make(chan interface{})
 
-		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, &mockEventProducer{}, false, &mockCloudflareClient{})
+		supervisor := supervisor.NewInstallationSupervisor(mockStore, &mockInstallationProvisioner{}, &mockAWS{}, "instanceID", false, false, standardSchedulingOptions, &utils.ResourceUtil{}, logger, cloudMetrics, &mockEventProducer{}, false, &mockCloudflareClient{}, false)
 		err := supervisor.Do()
 		require.NoError(t, err)
 
@@ -646,7 +646,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -700,7 +700,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -749,7 +749,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		owner := model.NewID()
@@ -790,7 +790,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -836,7 +836,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -890,7 +890,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -944,7 +944,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -998,7 +998,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1052,7 +1052,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1105,7 +1105,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1171,7 +1171,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1224,7 +1224,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1277,7 +1277,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1330,7 +1330,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1383,7 +1383,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1456,7 +1456,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1509,7 +1509,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1562,7 +1562,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		owner := model.NewID()
@@ -1602,7 +1602,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1655,7 +1655,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1699,7 +1699,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1752,7 +1752,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1818,7 +1818,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1871,7 +1871,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1937,7 +1937,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -1990,7 +1990,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2066,7 +2066,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2119,7 +2119,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2172,7 +2172,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2225,7 +2225,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2490,7 +2490,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2543,7 +2543,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2596,7 +2596,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2649,7 +2649,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2702,7 +2702,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2765,7 +2765,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2838,7 +2838,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2892,7 +2892,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				cloudMetrics,
 				testutil.SetupTestEventsProducer(sqlStore, logger),
 				false,
-				&mockCloudflareClient{},
+				&mockCloudflareClient{}, false,
 			)
 
 			cluster := standardStableTestCluster()
@@ -2937,7 +2937,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				cloudMetrics,
 				testutil.SetupTestEventsProducer(sqlStore, logger),
 				false,
-				&mockCloudflareClient{},
+				&mockCloudflareClient{}, false,
 			)
 
 			cluster := standardStableTestCluster()
@@ -2986,7 +2986,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				cloudMetrics,
 				testutil.SetupTestEventsProducer(sqlStore, logger),
 				false,
-				&mockCloudflareClient{},
+				&mockCloudflareClient{}, false,
 			)
 
 			cluster := standardStableTestCluster()
@@ -3063,7 +3063,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				cloudMetrics,
 				testutil.SetupTestEventsProducer(sqlStore, logger),
 				false,
-				&mockCloudflareClient{},
+				&mockCloudflareClient{}, false,
 			)
 
 			cluster := standardStableTestCluster()
@@ -3123,7 +3123,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -3171,7 +3171,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster1 := standardStableTestCluster()
@@ -3239,7 +3239,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				cloudMetrics,
 				testutil.SetupTestEventsProducer(sqlStore, logger),
 				false,
-				&mockCloudflareClient{},
+				&mockCloudflareClient{}, false,
 			)
 
 			cluster := standardStableTestCluster()
@@ -3274,7 +3274,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				cloudMetrics,
 				testutil.SetupTestEventsProducer(sqlStore, logger),
 				false,
-				&mockCloudflareClient{},
+				&mockCloudflareClient{}, false,
 			)
 
 			cluster := standardStableTestCluster()
@@ -3309,7 +3309,7 @@ func TestInstallationSupervisor(t *testing.T) {
 				cloudMetrics,
 				testutil.SetupTestEventsProducer(sqlStore, logger),
 				false,
-				&mockCloudflareClient{},
+				&mockCloudflareClient{}, false,
 			)
 
 			cluster := standardStableTestCluster()
@@ -3345,7 +3345,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			cloudMetrics,
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			true,
-			&mockCloudflareClient{},
+			&mockCloudflareClient{}, false,
 		)
 
 		cluster := standardStableTestCluster()

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -2279,6 +2279,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
 			&mockCloudflareClient{},
+			false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2332,6 +2333,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
 			&mockCloudflareClient{},
+			false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2385,6 +2387,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
 			&mockCloudflareClient{},
+			false,
 		)
 
 		cluster := standardStableTestCluster()
@@ -2438,6 +2441,7 @@ func TestInstallationSupervisor(t *testing.T) {
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			false,
 			&mockCloudflareClient{},
+			false,
 		)
 
 		cluster := standardStableTestCluster()


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR adds `--disable-dns-updates` to the Provisioner which allows skipping DNS update step on the Installation update.

Updates are required for multi-dns support, however for other cases can be safely disabled.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add flag to disable DNS updates on Installation update
```
