### PR TITLE
Installation deletion pending review

### DIFF
--- a/cmd/cloud/dashboard.go
+++ b/cmd/cloud/dashboard.go
@@ -83,13 +83,15 @@ var dashboardCmd = &cobra.Command{
 			}
 
 			installationCount := len(installations)
-			var installationStableCount, installationsHibernatingCount int
+			var installationStableCount, installationsHibernatingCount, installationsPendingDeletionCount int
 			for _, installation := range installations {
 				switch installation.State {
 				case model.ClusterInstallationStateStable:
 					installationStableCount++
 				case model.InstallationStateHibernating:
 					installationsHibernatingCount++
+				case model.InstallationStateDeletionPending:
+					installationsPendingDeletionCount++
 				default:
 					unstableList = append(unstableList, fmt.Sprintf("Installation: %s | %s (%s)", installation.ID, installation.DNS, installation.State))
 				}
@@ -98,7 +100,7 @@ var dashboardCmd = &cobra.Command{
 			table.Append([]string{
 				"Installation",
 				toStr(installationCount),
-				fmt.Sprintf("%d (H=%d)", installationStableCount+installationsHibernatingCount, installationsHibernatingCount),
+				fmt.Sprintf("%d (H=%d, DP=%d)", installationStableCount+installationsHibernatingCount, installationsHibernatingCount, installationsPendingDeletionCount),
 				toStr(installationCount - (installationStableCount + installationsHibernatingCount)),
 			})
 

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -108,9 +108,8 @@ func init() {
 	serverCmd.PersistentFlags().String("ndots-value", "5", "The default ndots value for installations.")
 	serverCmd.PersistentFlags().Bool("disable-db-init-check", false, "Whether to disable init container with database check.")
 	serverCmd.PersistentFlags().Bool("installation-enable-route53", false, "Specifies whether CNAME records for Installation should be created in Route53 as well.")
-	serverCmd.PersistentFlags().Duration("installation-deletion-pending-time", 3*time.Minute, "The amount of time that installations will stay in the deletion queue before they are actually deleted. Set to 0 for immediate deletion.")
-	serverCmd.PersistentFlags().Duration("installation-deletion-pending-time", time.Hour, "The amount of time that installations will stay in the deletion queue before they are actually deleted. Set to 0 for immediate deletion.")
 	serverCmd.PersistentFlags().Bool("disable-dns-updates", false, "If set to true DNS updates will be disabled when updating Installations.")
+	serverCmd.PersistentFlags().Duration("installation-deletion-pending-time", 3*time.Minute, "The amount of time that installations will stay in the deletion queue before they are actually deleted. Set to 0 for immediate deletion.")
 
 	// DB clusters utilization configuration
 	serverCmd.PersistentFlags().Int("max-installations-rds-postgres-pgbouncer", toolsAWS.DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit, "Max installations per DB cluster of type RDS Postgres PGbouncer")

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -108,7 +108,7 @@ func init() {
 	serverCmd.PersistentFlags().String("ndots-value", "5", "The default ndots value for installations.")
 	serverCmd.PersistentFlags().Bool("disable-db-init-check", false, "Whether to disable init container with database check.")
 	serverCmd.PersistentFlags().Bool("installation-enable-route53", false, "Specifies whether CNAME records for Installation should be created in Route53 as well.")
-	serverCmd.PersistentFlags().Duration("installation-deletion-pending-time", time.Hour, "The amount of time that installations will stay in the deletion queue before they are actually deleted. Set to 0 for immediate deletion.")
+	serverCmd.PersistentFlags().Duration("installation-deletion-pending-time", 3*time.Minute, "The amount of time that installations will stay in the deletion queue before they are actually deleted. Set to 0 for immediate deletion.")
 
 	// DB clusters utilization configuration
 	serverCmd.PersistentFlags().Int("max-installations-rds-postgres-pgbouncer", toolsAWS.DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit, "Max installations per DB cluster of type RDS Postgres PGbouncer")

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -212,12 +212,14 @@ func (sqlStore *SQLStore) GetInstallationsStatus() (*model.InstallationsStatus, 
 	}
 	stableCount := stateCounts[model.InstallationStateStable]
 	hibernatingCount := stateCounts[model.InstallationStateHibernating]
+	pendingDeletionCount := stateCounts[model.InstallationStateDeletionPending]
 
 	return &model.InstallationsStatus{
-		InstallationsTotal:       totalCount,
-		InstallationsStable:      stableCount,
-		InstallationsHibernating: hibernatingCount,
-		InstallationsUpdating:    totalCount - stableCount - hibernatingCount,
+		InstallationsTotal:           totalCount,
+		InstallationsStable:          stableCount,
+		InstallationsHibernating:     hibernatingCount,
+		InstallationsPendingDeletion: pendingDeletionCount,
+		InstallationsUpdating:        totalCount - stableCount - hibernatingCount - pendingDeletionCount,
 	}, nil
 }
 

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -907,6 +907,7 @@ func TestGetInstallationsStatus(t *testing.T) {
 	assert.Equal(t, int64(1), status.InstallationsTotal)
 	assert.Equal(t, int64(0), status.InstallationsStable)
 	assert.Equal(t, int64(0), status.InstallationsHibernating)
+	assert.Equal(t, int64(0), status.InstallationsPendingDeletion)
 	assert.Equal(t, int64(1), status.InstallationsUpdating)
 
 	time.Sleep(1 * time.Millisecond)
@@ -931,6 +932,7 @@ func TestGetInstallationsStatus(t *testing.T) {
 	assert.Equal(t, int64(2), status.InstallationsTotal)
 	assert.Equal(t, int64(1), status.InstallationsStable)
 	assert.Equal(t, int64(0), status.InstallationsHibernating)
+	assert.Equal(t, int64(0), status.InstallationsPendingDeletion)
 	assert.Equal(t, int64(1), status.InstallationsUpdating)
 
 	time.Sleep(1 * time.Millisecond)
@@ -955,6 +957,32 @@ func TestGetInstallationsStatus(t *testing.T) {
 	assert.Equal(t, int64(3), status.InstallationsTotal)
 	assert.Equal(t, int64(1), status.InstallationsStable)
 	assert.Equal(t, int64(1), status.InstallationsHibernating)
+	assert.Equal(t, int64(0), status.InstallationsPendingDeletion)
+	assert.Equal(t, int64(1), status.InstallationsUpdating)
+
+	time.Sleep(1 * time.Millisecond)
+
+	installation4 := &model.Installation{
+		Name:      "test4",
+		OwnerID:   model.NewID(),
+		Version:   "version",
+		License:   "this-is-a-license",
+		Database:  model.InstallationDatabaseMysqlOperator,
+		Filestore: model.InstallationFilestoreMinioOperator,
+		Size:      mmv1alpha1.Size100String,
+		Affinity:  model.InstallationAffinityIsolated,
+		State:     model.InstallationStateDeletionPending,
+	}
+
+	err = sqlStore.CreateInstallation(installation4, nil, fixDNSRecords(4))
+	require.NoError(t, err)
+
+	status, err = sqlStore.GetInstallationsStatus()
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), status.InstallationsTotal)
+	assert.Equal(t, int64(1), status.InstallationsStable)
+	assert.Equal(t, int64(1), status.InstallationsHibernating)
+	assert.Equal(t, int64(1), status.InstallationsPendingDeletion)
 	assert.Equal(t, int64(1), status.InstallationsUpdating)
 
 	time.Sleep(1 * time.Millisecond)
@@ -964,9 +992,10 @@ func TestGetInstallationsStatus(t *testing.T) {
 
 	status, err = sqlStore.GetInstallationsStatus()
 	require.NoError(t, err)
-	assert.Equal(t, int64(2), status.InstallationsTotal)
+	assert.Equal(t, int64(3), status.InstallationsTotal)
 	assert.Equal(t, int64(1), status.InstallationsStable)
 	assert.Equal(t, int64(1), status.InstallationsHibernating)
+	assert.Equal(t, int64(1), status.InstallationsPendingDeletion)
 	assert.Equal(t, int64(0), status.InstallationsUpdating)
 }
 

--- a/internal/supervisor/installation_deletion.go
+++ b/internal/supervisor/installation_deletion.go
@@ -166,9 +166,10 @@ func (s *InstallationDeletionSupervisor) checkIfInstallationShouldBeDeleted(inst
 	// Check to see if enough time has passed that the installation should be
 	// deleted.
 	timeSincePending := time.Since(model.TimeFromMillis(deletionQueuedEvent.Event.Timestamp))
-	logger = logger.WithField("time-spent-pending-deletion", timeSincePending)
+	logger = logger.WithField("time-spent-pending-deletion", timeSincePending.String())
 	if timeSincePending < s.deletionPendingTime {
-		logger.WithField("time-until-deletion", s.deletionPendingTime-timeSincePending).Debug("Installation is not ready for deletion")
+		timeUntilDeletion := s.deletionPendingTime - timeSincePending
+		logger.WithField("time-until-deletion", timeUntilDeletion.String()).Debug("Installation is not ready for deletion")
 		return model.InstallationStateDeletionPending
 	}
 

--- a/model/group_status.go
+++ b/model/group_status.go
@@ -11,11 +11,12 @@ import (
 
 // GroupStatus represents the status of a group.
 type GroupStatus struct {
-	InstallationsTotal          int64
-	InstallationsUpdated        int64
-	InstallationsUpdating       int64
-	InstallationsHibernating    int64
-	InstallationsAwaitingUpdate int64
+	InstallationsTotal           int64
+	InstallationsUpdated         int64
+	InstallationsUpdating        int64
+	InstallationsHibernating     int64
+	InstallationsPendingDeletion int64
+	InstallationsAwaitingUpdate  int64
 }
 
 // GroupsStatus represents the status of a groups.

--- a/model/installation_status.go
+++ b/model/installation_status.go
@@ -11,10 +11,11 @@ import (
 
 // InstallationsStatus represents the status of all installations.
 type InstallationsStatus struct {
-	InstallationsTotal       int64
-	InstallationsStable      int64
-	InstallationsHibernating int64
-	InstallationsUpdating    int64
+	InstallationsTotal           int64
+	InstallationsStable          int64
+	InstallationsHibernating     int64
+	InstallationsPendingDeletion int64
+	InstallationsUpdating        int64
 }
 
 // InstallationsStatusFromReader decodes a json-encoded InstallationsStatus from the given io.Reader.


### PR DESCRIPTION
This change does the following:
 - Tunes the installation-deletion-pending-time flag default value
   to be more developer friendly.
 - Updates the dashboard command to account for pending deletions.
 - Updates the installation status and group status objects to
   account for pending deletions.
 - Changes some time log fields to be strings for better readability.

Fixes https://mattermost.atlassian.net/browse/MM-46460

```release-note
Additional internal accounting for deletion-pending installations
```
