### PR TITLE
Add installation deletion limit

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -110,7 +110,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("installation-enable-route53", false, "Specifies whether CNAME records for Installation should be created in Route53 as well.")
 	serverCmd.PersistentFlags().Bool("disable-dns-updates", false, "If set to true DNS updates will be disabled when updating Installations.")
 	serverCmd.PersistentFlags().Duration("installation-deletion-pending-time", 3*time.Minute, "The amount of time that installations will stay in the deletion queue before they are actually deleted. Set to 0 for immediate deletion.")
-	serverCmd.PersistentFlags().Int64("installation-deletion-max-updating", 25, "The maximum number of installations that can be updating when finalizing deletion of deletion-pending installations (similar to group max rolling).")
+	serverCmd.PersistentFlags().Int64("installation-deletion-max-updating", 25, "A soft limit on the number of installations that the provisioner will delete at one time from the group of deletion-pending installations.")
 
 	// DB clusters utilization configuration
 	serverCmd.PersistentFlags().Int("max-installations-rds-postgres-pgbouncer", toolsAWS.DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit, "Max installations per DB cluster of type RDS Postgres PGbouncer")

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -110,6 +110,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("installation-enable-route53", false, "Specifies whether CNAME records for Installation should be created in Route53 as well.")
 	serverCmd.PersistentFlags().Bool("disable-dns-updates", false, "If set to true DNS updates will be disabled when updating Installations.")
 	serverCmd.PersistentFlags().Duration("installation-deletion-pending-time", 3*time.Minute, "The amount of time that installations will stay in the deletion queue before they are actually deleted. Set to 0 for immediate deletion.")
+	serverCmd.PersistentFlags().Int64("installation-deletion-max-updating", 25, "The maximum number of installations that can be updating when finalizing deletion of deletion-pending installations (similar to group max rolling).")
 
 	// DB clusters utilization configuration
 	serverCmd.PersistentFlags().Int("max-installations-rds-postgres-pgbouncer", toolsAWS.DefaultRDSMultitenantPGBouncerDatabasePostgresCountLimit, "Max installations per DB cluster of type RDS Postgres PGbouncer")
@@ -270,6 +271,7 @@ var serverCmd = &cobra.Command{
 		backupRestoreToolImage, _ := command.Flags().GetString("backup-restore-tool-image")
 		backupJobTTL, _ := command.Flags().GetInt32("backup-job-ttl-seconds")
 		installationDeletionPendingTime, _ := command.Flags().GetDuration("installation-deletion-pending-time")
+		installationDeletionMaxUpdating, _ := command.Flags().GetInt64("installation-deletion-max-updating")
 
 		deployMySQLOperator, _ := command.Flags().GetBool("deploy-mysql-operator")
 		deployMinioOperator, _ := command.Flags().GetBool("deploy-minio-operator")
@@ -310,6 +312,7 @@ var serverCmd = &cobra.Command{
 			"state-store":                                   s3StateStore,
 			"working-directory":                             wd,
 			"installation-deletion-pending-time":            installationDeletionPendingTime,
+			"installation-deletion-max-updating":            installationDeletionMaxUpdating,
 			"balanced-installation-scheduling":              balancedInstallationScheduling,
 			"cluster-resource-threshold":                    clusterResourceThreshold,
 			"cluster-resource-threshold-cpu-override":       thresholdCPUOverride,
@@ -472,7 +475,7 @@ var serverCmd = &cobra.Command{
 		}
 		if installationDeletionSupervisor {
 			var slowMultiDoer supervisor.MultiDoer
-			slowMultiDoer = append(slowMultiDoer, supervisor.NewInstallationDeletionSupervisor(instanceID, installationDeletionPendingTime, sqlStore, eventsProducer, logger))
+			slowMultiDoer = append(slowMultiDoer, supervisor.NewInstallationDeletionSupervisor(instanceID, installationDeletionPendingTime, installationDeletionMaxUpdating, sqlStore, eventsProducer, logger))
 			slowSupervisor := supervisor.NewScheduler(slowMultiDoer, time.Duration(slowPoll)*time.Second)
 			defer slowSupervisor.Close()
 		}

--- a/internal/supervisor/installation_deletion.go
+++ b/internal/supervisor/installation_deletion.go
@@ -17,6 +17,7 @@ import (
 type installationDeletionStore interface {
 	GetInstallation(installationID string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error)
 	GetUnlockedInstallationsPendingDeletion() ([]*model.Installation, error)
+	GetInstallationsStatus() (*model.InstallationsStatus, error)
 	UpdateInstallationState(*model.Installation) error
 	installationLockStore
 
@@ -30,26 +31,31 @@ type installationDeletionStore interface {
 // The degree of parallelism is controlled by a weighted semaphore, intended to be shared with
 // other clients needing to coordinate background jobs.
 type InstallationDeletionSupervisor struct {
-	instanceID          string
-	deletionPendingTime time.Duration
-	store               installationDeletionStore
-	logger              log.FieldLogger
-	eventsProducer      eventProducer
+	instanceID               string
+	deletionPendingTime      time.Duration
+	currentlyUpdatingLimit   int64
+	currentlyUpdatingCounter int64
+	store                    installationDeletionStore
+	logger                   log.FieldLogger
+	eventsProducer           eventProducer
 }
 
 // NewInstallationDeletionSupervisor creates a new InstallationDeletionSupervisor.
 func NewInstallationDeletionSupervisor(
 	instanceID string,
 	deletionPendingTime time.Duration,
+	currentlyUpdatingLimit int64,
 	store installationDeletionStore,
 	eventsProducer eventProducer,
 	logger log.FieldLogger) *InstallationDeletionSupervisor {
 	return &InstallationDeletionSupervisor{
-		instanceID:          instanceID,
-		deletionPendingTime: deletionPendingTime,
-		store:               store,
-		eventsProducer:      eventsProducer,
-		logger:              logger,
+		instanceID:               instanceID,
+		deletionPendingTime:      deletionPendingTime,
+		currentlyUpdatingLimit:   currentlyUpdatingLimit,
+		currentlyUpdatingCounter: 0,
+		store:                    store,
+		eventsProducer:           eventsProducer,
+		logger:                   logger,
 	}
 }
 
@@ -66,7 +72,18 @@ func (s *InstallationDeletionSupervisor) Do() error {
 		return nil
 	}
 
+	status, err := s.store.GetInstallationsStatus()
+	if err != nil {
+		s.logger.WithError(err).Warn("Failed to query for installation status")
+		return nil
+	}
+	s.currentlyUpdatingCounter = status.InstallationsUpdating
+
 	for _, installation := range installations {
+		if s.currentlyUpdatingCounter >= s.currentlyUpdatingLimit {
+			s.logger.Infof("Max installation updating counter (%d) reached for pending deletions", s.currentlyUpdatingLimit)
+			return nil
+		}
 		s.Supervise(installation)
 	}
 
@@ -174,6 +191,7 @@ func (s *InstallationDeletionSupervisor) checkIfInstallationShouldBeDeleted(inst
 	}
 
 	logger.Info("Installation is ready for deletion")
+	s.currentlyUpdatingCounter++
 
 	return model.InstallationStateDeletionRequested
 }

--- a/internal/supervisor/installation_deletion.go
+++ b/internal/supervisor/installation_deletion.go
@@ -72,6 +72,11 @@ func (s *InstallationDeletionSupervisor) Do() error {
 		return nil
 	}
 
+	// Limit the number of installations that can be deleted at one time.
+	// NOTE: this is a bit of a soft limit. Multiple provisioners running at the
+	// same time could lead to a situation where the limit is exceeded. This
+	// was done initially to balance complexity while still having control over
+	// deletion spikes. A hard limit could be added in the future if required.
 	status, err := s.store.GetInstallationsStatus()
 	if err != nil {
 		s.logger.WithError(err).Warn("Failed to query for installation status")


### PR DESCRIPTION
When checking if an installation in the pending-deletion state
should be deleted, the supervisor now also respects a limit on the
maximum number of updating installations that are allowed at that
point in time. Any skipped installations due to hitting the limit
will be checked later and deleted.

Fixes https://mattermost.atlassian.net/browse/MM-46518

```release-note
Add installation deletion limit
```
