### PR TITLE
Refactor utilities to not depend on Kops

### DIFF
--- a/internal/provisioner/fluentbit_test.go
+++ b/internal/provisioner/fluentbit_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	mocks "github.com/mattermost/mattermost-cloud/internal/mocks/aws-tools"
-	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
 	"github.com/mattermost/mattermost-cloud/model"
 
 	"github.com/golang/mock/gomock"
@@ -20,18 +19,16 @@ func TestNewHelmDeploymentWithDefaultConfiguration(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	provisioner := &KopsProvisioner{}
 	logger := log.New()
 	awsClient := mocks.NewMockAWS(ctrl)
-	kops := &kops.Cmd{}
 	fluentbit, err := newFluentbitHandle(&model.Cluster{
 		UtilityMetadata: &model.UtilityMetadata{
 			ActualVersions: model.UtilityGroupVersions{},
 		},
-	}, &model.HelmUtilityVersion{Chart: "1.2.3"}, provisioner, awsClient, kops, logger)
+	}, &model.HelmUtilityVersion{Chart: "1.2.3"}, "kubeconfig", awsClient, logger)
 	require.NoError(t, err, "should not error when creating new fluentbit handler")
 	require.NotNil(t, fluentbit, "fluentbit should not be nil")
 
-	helmDeployment := fluentbit.NewHelmDeployment(logger)
+	helmDeployment := fluentbit.NewHelmDeployment()
 	require.NotNil(t, helmDeployment, "helmDeployment should not be nil")
 }

--- a/internal/provisioner/metrics_server_test.go
+++ b/internal/provisioner/metrics_server_test.go
@@ -7,7 +7,6 @@ package provisioner
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
 	"github.com/mattermost/mattermost-cloud/model"
 
 	"github.com/golang/mock/gomock"
@@ -19,14 +18,12 @@ func TestNewHelmDeploymentWithDefaultConfigurationMetricsServer(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	provisioner := &KopsProvisioner{}
 	logger := log.New()
-	kops := &kops.Cmd{}
 	metricsServer, err := newMetricsServerHandle(&model.HelmUtilityVersion{Chart: "3.8.2"}, &model.Cluster{
 		UtilityMetadata: &model.UtilityMetadata{
 			ActualVersions: model.UtilityGroupVersions{},
 		},
-	}, provisioner, kops, logger)
+	}, "kubeconfig", logger)
 	require.NoError(t, err, "should not error when creating new metrics server handler")
 	require.NotNil(t, metricsServer, "metrics server should not be nil")
 

--- a/internal/provisioner/node_problem_detector_test.go
+++ b/internal/provisioner/node_problem_detector_test.go
@@ -7,7 +7,6 @@ package provisioner
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
 	"github.com/mattermost/mattermost-cloud/model"
 
 	"github.com/golang/mock/gomock"
@@ -19,14 +18,12 @@ func TestNewHelmDeploymentWithDefaultConfigurationNodeProblemDetector(t *testing
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	provisioner := &KopsProvisioner{}
 	logger := log.New()
-	kops := &kops.Cmd{}
 	nodeProblemDetector, err := newNodeProblemDetectorHandle(&model.HelmUtilityVersion{Chart: "2.0.5"}, &model.Cluster{
 		UtilityMetadata: &model.UtilityMetadata{
 			ActualVersions: model.UtilityGroupVersions{},
 		},
-	}, provisioner, kops, logger)
+	}, "kubeconfig", logger)
 	require.NoError(t, err, "should not error when creating new node-problem-detector handler")
 	require.NotNil(t, nodeProblemDetector, "node-problem-detector should not be nil")
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Refactor utilities to not depend on `kops.Cmd` and `KopsProvisioner`.

This makes it possible to reuse the whole utilities code for EKS provisioning. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Refactor utilities to not depend on Kops
```
