### PR TITLE
Add more error logging for mmctl failures

### DIFF
--- a/cmd/cloud/dashboard.go
+++ b/cmd/cloud/dashboard.go
@@ -105,7 +105,7 @@ var dashboardCmd = &cobra.Command{
 				"Installation",
 				toStr(installationCount),
 				fmt.Sprintf("%d (H=%d, DP=%d)", installationStableCount+installationsHibernatingCount, installationsHibernatingCount, installationsPendingDeletionCount),
-				toStr(installationCount - (installationStableCount + installationsHibernatingCount)),
+				toStr(installationCount - (installationStableCount + installationsHibernatingCount + installationsPendingDeletionCount)),
 			})
 
 			// Cluster Installations

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -777,7 +777,7 @@ func (provisioner *KopsProvisioner) ExecClusterInstallationCLI(cluster *model.Cl
 	output, execErr := k8sClient.RemoteCommand("POST", execRequest.URL())
 
 	if execErr != nil {
-		logger.WithError(execErr).Warn("Command `%s` on pod %s finished in %.0f seconds, but encountered an error", strings.Join(args, " "), pod.Name, time.Since(now).Seconds())
+		logger.WithError(execErr).Warnf("Command `%s` on pod %s finished in %.0f seconds, but encountered an error", strings.Join(args, " "), pod.Name, time.Since(now).Seconds())
 	} else {
 		logger.Debugf("Command `%s` on pod %s finished in %.0f seconds", strings.Join(args, " "), pod.Name, time.Since(now).Seconds())
 	}

--- a/internal/provisioner/kops_provisioner_cluster_installation.go
+++ b/internal/provisioner/kops_provisioner_cluster_installation.go
@@ -776,7 +776,11 @@ func (provisioner *KopsProvisioner) ExecClusterInstallationCLI(cluster *model.Cl
 	now := time.Now()
 	output, execErr := k8sClient.RemoteCommand("POST", execRequest.URL())
 
-	logger.Debugf("Command `%s` on pod %s finished in %.0f seconds", strings.Join(args, " "), pod.Name, time.Since(now).Seconds())
+	if execErr != nil {
+		logger.WithError(execErr).Warn("Command `%s` on pod %s finished in %.0f seconds, but encountered an error", strings.Join(args, " "), pod.Name, time.Since(now).Seconds())
+	} else {
+		logger.Debugf("Command `%s` on pod %s finished in %.0f seconds", strings.Join(args, " "), pod.Name, time.Since(now).Seconds())
+	}
 
 	return output, execErr, nil
 }


### PR DESCRIPTION
These logs can be used to better understand why mmctl exec failures occurred. Also contains a small fix for the dashboard CLI command.

```release-note
Add more error logging for mmctl failures
```
