### PR TITLE
Add cluster-installation `ready` state

### DIFF
--- a/internal/supervisor/cluster_installation_test.go
+++ b/internal/supervisor/cluster_installation_test.go
@@ -290,10 +290,11 @@ func TestClusterInstallationSupervisorSupervise(t *testing.T) {
 			InitialState  string
 			ExpectedState string
 		}{
-			{"unexpected state", model.ClusterInstallationStateStable, model.ClusterInstallationStateStable},
-			{"creation requested", model.ClusterInstallationStateCreationRequested, model.ClusterInstallationStateReconciling},
-			{"creation reconciling", model.ClusterInstallationStateReconciling, model.ClusterInstallationStateStable},
-			{"deletion requested", model.ClusterInstallationStateDeletionRequested, model.ClusterInstallationStateDeleted},
+			{"unexpected state", "invalid-state", "invalid-state"},
+			{"creation-requested", model.ClusterInstallationStateCreationRequested, model.ClusterInstallationStateReconciling},
+			{"reconciling", model.ClusterInstallationStateReconciling, model.ClusterInstallationStateStable},
+			{"ready", model.ClusterInstallationStateReady, model.ClusterInstallationStateStable},
+			{"deletion-requested", model.ClusterInstallationStateDeletionRequested, model.ClusterInstallationStateDeleted},
 		}
 
 		for _, tc := range testCases {

--- a/model/cluster_installation_states.go
+++ b/model/cluster_installation_states.go
@@ -17,6 +17,8 @@ const (
 	ClusterInstallationStateDeleted = "deleted"
 	// ClusterInstallationStateReconciling is a cluster installation that in undergoing changes and is not yet stable.
 	ClusterInstallationStateReconciling = "reconciling"
+	// ClusterInstallationStateReady is a cluster installation in a ready state where it is nearly stable.
+	ClusterInstallationStateReady = "ready"
 	// ClusterInstallationStateStable is a cluster installation in a stable state and undergoing no changes.
 	ClusterInstallationStateStable = "stable"
 )
@@ -32,6 +34,7 @@ var AllClusterInstallationStates = []string{
 	ClusterInstallationStateDeletionFailed,
 	ClusterInstallationStateDeleted,
 	ClusterInstallationStateReconciling,
+	ClusterInstallationStateReady,
 	ClusterInstallationStateStable,
 }
 
@@ -45,5 +48,6 @@ var AllClusterInstallationStates = []string{
 var AllClusterInstallationStatesPendingWork = []string{
 	ClusterInstallationStateCreationRequested,
 	ClusterInstallationStateReconciling,
+	ClusterInstallationStateReady,
 	ClusterInstallationStateDeletionRequested,
 }


### PR DESCRIPTION
The Mattermost Operator exposes a ready state which indicates that an installation is nearly stable and can handle incoming requests. Instead of always translating this state to stable internally, this change records the ready state so that actions can be taken if desired with context that the installation is not completely stable yet.

The installation supervisor will now proceed with creation when an installation is ready, while other flows such as installation updates require the installation to be stable before proceeding.

Fixes https://mattermost.atlassian.net/browse/MM-46952

```release-note
Add cluster-installation ready state
```
