### PR TITLE
EKS cluster creation with AWS API

### DIFF
--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -5,6 +5,8 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"strings"
 	"sync"
 
@@ -47,9 +49,10 @@ type AWS interface {
 
 	GetCloudEnvironmentName() string
 
-	GetAndClaimVpcResources(clusterID, owner string, logger log.FieldLogger) (ClusterResources, error)
+	GetAndClaimVpcResources(cluster *model.Cluster, owner string, logger log.FieldLogger) (ClusterResources, error)
+	ClaimVPC(vpcID string, cluster *model.Cluster, owner string, logger log.FieldLogger) (ClusterResources, error)
 	GetVpcResources(clusterID string, logger log.FieldLogger) (ClusterResources, error)
-	ReleaseVpc(clusterID string, logger log.FieldLogger) error
+	ReleaseVpc(cluster *model.Cluster, logger log.FieldLogger) error
 	AttachPolicyToRole(roleName, policyName string, logger log.FieldLogger) error
 	DetachPolicyFromRole(roleName, policyName string, logger log.FieldLogger) error
 
@@ -81,10 +84,17 @@ type AWS interface {
 	GetCIDRByVPCTag(vpcTagName string, logger log.FieldLogger) (string, error)
 
 	GetVpcResourcesByVpcID(vpcID string, logger log.FieldLogger) (ClusterResources, error)
-	TagResourcesByCluster(clusterResources ClusterResources, clusterID string, owner string, logger log.FieldLogger) error
+	TagResourcesByCluster(clusterResources ClusterResources, cluster *model.Cluster, owner string, logger log.FieldLogger) error
 
 	SecretsManagerGetPGBouncerAuthUserPassword(vpcID string) (string, error)
 	SwitchClusterTags(clusterID string, targetClusterID string, logger log.FieldLogger) error
+
+	EnsureEKSCluster(cluster *model.Cluster, resources ClusterResources, eksMetadata model.EKSMetadata) (*eks.Cluster, error)
+	EnsureEKSClusterNodeGroups(cluster *model.Cluster, resources ClusterResources, eksMetadata model.EKSMetadata) ([]*eks.Nodegroup, error)
+	GetEKSCluster(clusterName string) (*eks.Cluster, error)
+	IsClusterReady(clusterName string) (bool, error)
+	EnsureNodeGroupsDeleted(cluster *model.Cluster) (bool, error)
+	EnsureEKSClusterDeleted(cluster *model.Cluster) (bool, error)
 }
 
 // Client is a client for interacting with AWS resources in a single AWS account.
@@ -136,6 +146,7 @@ type Service struct {
 	dynamodb              dynamodbiface.DynamoDBAPI
 	sts                   stsiface.STSAPI
 	appAutoscaling        applicationautoscalingiface.ApplicationAutoScalingAPI
+	eks                   eksiface.EKSAPI
 }
 
 // NewService creates a new instance of Service.
@@ -153,6 +164,7 @@ func NewService(sess *session.Session) *Service {
 		dynamodb:              dynamodb.New(sess),
 		sts:                   sts.New(sess),
 		appAutoscaling:        applicationautoscaling.New(sess),
+		eks:                   eks.New(sess),
 	}
 }
 

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -6,9 +6,9 @@ package aws
 
 import (
 	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -140,9 +140,28 @@ func (a *Client) getClusterResourcesForVPC(vpcID, vpcCIDR string, logger log.Fie
 	return clusterResources, nil
 }
 
+func (a *Client) ClaimVPC(vpcID string, cluster *model.Cluster, owner string, logger log.FieldLogger) (ClusterResources, error) {
+	vpcOut, err := a.Service().ec2.DescribeVpcs(&ec2.DescribeVpcsInput{VpcIds: stringsToPtr([]string{vpcID})})
+	if err != nil {
+		return ClusterResources{}, errors.Wrap(err, "failed to describe vpc")
+	}
+
+	clusterResources, err := a.getClusterResourcesForVPC(vpcID, *vpcOut.Vpcs[0].CidrBlock, logger)
+	if err != nil {
+		return ClusterResources{}, errors.Wrap(err, "failed to get cluster resources for VPC")
+	}
+
+	err = a.claimVpc(clusterResources, cluster, owner, logger)
+	if err != nil {
+		return ClusterResources{}, errors.Wrap(err, "failed to claim VPC")
+	}
+
+	return clusterResources, nil
+}
+
 // GetAndClaimVpcResources creates ClusterResources from an available VPC and
 // tags them appropriately.
-func (a *Client) GetAndClaimVpcResources(clusterID, owner string, logger log.FieldLogger) (ClusterResources, error) {
+func (a *Client) GetAndClaimVpcResources(cluster *model.Cluster, owner string, logger log.FieldLogger) (ClusterResources, error) {
 	// First, check if a VPC has been claimed by this cluster. If only one has
 	// already been claimed, then return that with no error.
 	clusterAlreadyClaimedFilter := []*ec2.Filter{
@@ -155,7 +174,7 @@ func (a *Client) GetAndClaimVpcResources(clusterID, owner string, logger log.Fie
 		{
 			Name: aws.String(VpcClusterIDTagKey),
 			Values: []*string{
-				aws.String(clusterID),
+				aws.String(cluster.ID),
 			},
 		},
 	}
@@ -164,7 +183,7 @@ func (a *Client) GetAndClaimVpcResources(clusterID, owner string, logger log.Fie
 		return ClusterResources{}, err
 	}
 	if len(clusterAlreadyClaimedVpcs) > 1 {
-		return ClusterResources{}, fmt.Errorf("multiple VPCs (%d) have been claimed by cluster %s; aborting claim process", len(clusterAlreadyClaimedVpcs), clusterID)
+		return ClusterResources{}, fmt.Errorf("multiple VPCs (%d) have been claimed by cluster %s; aborting claim process", len(clusterAlreadyClaimedVpcs), cluster.ID)
 	}
 	if len(clusterAlreadyClaimedVpcs) == 1 {
 		return a.getClusterResourcesForVPC(*clusterAlreadyClaimedVpcs[0].VpcId, *clusterAlreadyClaimedVpcs[0].CidrBlock, logger)
@@ -211,7 +230,7 @@ func (a *Client) GetAndClaimVpcResources(clusterID, owner string, logger log.Fie
 			continue
 		}
 
-		err = a.claimVpc(clusterResources, clusterID, owner, logger)
+		err = a.claimVpc(clusterResources, cluster, owner, logger)
 		if err != nil {
 			return clusterResources, err
 		}
@@ -233,8 +252,8 @@ func (a *Client) GetVpcResources(clusterID string, logger log.FieldLogger) (Clus
 }
 
 // ReleaseVpc changes the tags on a VPC to mark it as "available" again.
-func (a *Client) ReleaseVpc(clusterID string, logger log.FieldLogger) error {
-	return a.releaseVpc(clusterID, logger)
+func (a *Client) ReleaseVpc(cluster *model.Cluster, logger log.FieldLogger) error {
+	return a.releaseVpc(cluster, logger)
 }
 
 // claimVpc will claim the given VPC for a cluster if a final race-check passes.
@@ -242,7 +261,7 @@ func (a *Client) ReleaseVpc(clusterID string, logger log.FieldLogger) error {
 //   - Requires the VPC to exist. #mindblown
 //   - VPC availabiltiy tag must be "true"
 //   - VPC cluster ID tag must by "none"
-func (a *Client) claimVpc(clusterResources ClusterResources, clusterID string, owner string, logger log.FieldLogger) error {
+func (a *Client) claimVpc(clusterResources ClusterResources, cluster *model.Cluster, owner string, logger log.FieldLogger) error {
 	vpcFilter := []*ec2.Filter{
 		{
 			Name:   aws.String("vpc-id"),
@@ -275,7 +294,7 @@ func (a *Client) claimVpc(clusterResources ClusterResources, clusterID string, o
 		return errors.Wrapf(err, "unable to update %s", VpcAvailableTagKey)
 	}
 
-	err = a.TagResource(clusterResources.VpcID, trimTagPrefix(VpcClusterIDTagKey), clusterID, logger)
+	err = a.TagResource(clusterResources.VpcID, trimTagPrefix(VpcClusterIDTagKey), cluster.ID, logger)
 	if err != nil {
 		return errors.Wrapf(err, "unable to update %s", VpcClusterIDTagKey)
 	}
@@ -286,19 +305,19 @@ func (a *Client) claimVpc(clusterResources ClusterResources, clusterID string, o
 	}
 
 	for _, subnet := range clusterResources.PublicSubnetsIDs {
-		err = a.TagResource(subnet, fmt.Sprintf("kubernetes.io/cluster/%s", fmt.Sprintf("%s-kops.k8s.local", clusterID)), "shared", logger)
+		err = a.TagResource(subnet, fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster)), "shared", logger)
 		if err != nil {
 			return errors.Wrap(err, "failed to tag subnet")
 		}
 	}
 
 	for _, callsSecurityGroup := range clusterResources.CallsSecurityGroupIDs {
-		err = a.TagResource(callsSecurityGroup, fmt.Sprintf("kubernetes.io/cluster/%s", fmt.Sprintf("%s-kops.k8s.local", clusterID)), "shared", logger)
+		err = a.TagResource(callsSecurityGroup, fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster)), "shared", logger)
 		if err != nil {
 			return errors.Wrap(err, "failed to tag subnet")
 		}
 
-		err = a.TagResource(callsSecurityGroup, "KubernetesCluster", fmt.Sprintf("%s-kops.k8s.local", clusterID), logger)
+		err = a.TagResource(callsSecurityGroup, "KubernetesCluster", getClusterTag(cluster), logger)
 		if err != nil {
 			return errors.Wrap(err, "failed to tag subnet")
 		}
@@ -309,7 +328,7 @@ func (a *Client) claimVpc(clusterResources ClusterResources, clusterID string, o
 	return nil
 }
 
-func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
+func (a *Client) releaseVpc(cluster *model.Cluster, logger log.FieldLogger) error {
 	var isSecondaryCluster bool = false
 	secondaryVpcFilters := []*ec2.Filter{
 		{
@@ -318,7 +337,7 @@ func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
 		},
 		{
 			Name:   aws.String(VpcSecondaryClusterIDTagKey),
-			Values: []*string{aws.String(clusterID)},
+			Values: []*string{aws.String(cluster.ID)},
 		},
 	}
 	vpcs, err := a.GetVpcsWithFilters(secondaryVpcFilters)
@@ -337,7 +356,7 @@ func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
 			},
 			{
 				Name:   aws.String(VpcClusterIDTagKey),
-				Values: []*string{aws.String(clusterID)},
+				Values: []*string{aws.String(cluster.ID)},
 			},
 		}
 
@@ -348,7 +367,7 @@ func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
 	}
 	numVPCs := len(vpcs)
 	if numVPCs == 0 {
-		logger.Warnf("No VPCs are currently claimed by cluster %s, assuming already released", clusterID)
+		logger.Warnf("No VPCs are currently claimed by cluster %s, assuming already released", cluster.ID)
 		return nil
 	}
 	if numVPCs != 1 {
@@ -356,7 +375,7 @@ func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
 		for i, vpc := range vpcs {
 			logger.WithField("tags", vpc.Tags).Warnf("VPC %d: %s", i+1, *vpc.VpcId)
 		}
-		return fmt.Errorf("multiple VPCs (%d) have been claimed by cluster %s; aborting release process", numVPCs, clusterID)
+		return fmt.Errorf("multiple VPCs (%d) have been claimed by cluster %s; aborting release process", numVPCs, cluster.ID)
 	}
 
 	publicSubnetFilter := []*ec2.Filter{
@@ -376,7 +395,7 @@ func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
 	}
 
 	for _, subnet := range publicSubnets {
-		err = a.UntagResource(*subnet.SubnetId, fmt.Sprintf("kubernetes.io/cluster/%s", fmt.Sprintf("%s-kops.k8s.local", clusterID)), "shared", logger)
+		err = a.UntagResource(*subnet.SubnetId, fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster)), "shared", logger)
 		if err != nil {
 			return errors.Wrap(err, "failed to untag subnet")
 		}
@@ -399,12 +418,12 @@ func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
 	}
 
 	for _, callsSecurityGroup := range callsSecurityGroups {
-		err = a.UntagResource(*callsSecurityGroup.GroupId, fmt.Sprintf("kubernetes.io/cluster/%s", fmt.Sprintf("%s-kops.k8s.local", clusterID)), "shared", logger)
+		err = a.UntagResource(*callsSecurityGroup.GroupId, fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster)), "shared", logger)
 		if err != nil {
 			return errors.Wrap(err, "failed to tag security group")
 		}
 
-		err = a.UntagResource(*callsSecurityGroup.GroupId, "KubernetesCluster", fmt.Sprintf("%s-kops.k8s.local", clusterID), logger)
+		err = a.UntagResource(*callsSecurityGroup.GroupId, "KubernetesCluster", getClusterTag(cluster), logger)
 		if err != nil {
 			return errors.Wrap(err, "failed to tag security group")
 		}
@@ -415,7 +434,7 @@ func (a *Client) releaseVpc(clusterID string, logger log.FieldLogger) error {
 		if err != nil {
 			return errors.Wrapf(err, "unable to update %s", VpcSecondaryClusterIDTagKey)
 		}
-		logger.Debugf("Secondary cluster %s related tags has been unset from VPC %s", clusterID, *vpcs[0].VpcId)
+		logger.Debugf("Secondary cluster %s related tags has been unset from VPC %s", cluster.ID, *vpcs[0].VpcId)
 		return nil
 	}
 	err = a.TagResource(*vpcs[0].VpcId, trimTagPrefix(VpcClusterIDTagKey), VpcClusterIDTagValueNone, logger)
@@ -445,6 +464,7 @@ func (a *Client) GetVpcResourcesByVpcID(vpcID string, logger log.FieldLogger) (C
 			aws.String(vpcID),
 		},
 	}
+
 	vpcCidr, err := a.Service().ec2.DescribeVpcs(input)
 	if err != nil {
 		return ClusterResources{}, errors.Wrapf(err, "failed to fetch the VPC information using VPC ID %s", vpcID)
@@ -453,16 +473,16 @@ func (a *Client) GetVpcResourcesByVpcID(vpcID string, logger log.FieldLogger) (C
 }
 
 // TagResourcesByCluster for secondary cluster.
-func (a *Client) TagResourcesByCluster(clusterResources ClusterResources, clusterID string, owner string, logger log.FieldLogger) error {
+func (a *Client) TagResourcesByCluster(clusterResources ClusterResources, cluster *model.Cluster, owner string, logger log.FieldLogger) error {
 
 	for _, subnet := range clusterResources.PublicSubnetsIDs {
-		err := a.TagResource(subnet, fmt.Sprintf("kubernetes.io/cluster/%s", fmt.Sprintf("%s-kops.k8s.local", clusterID)), "shared", logger)
+		err := a.TagResource(subnet, fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster)), "shared", logger)
 		if err != nil {
 			return errors.Wrap(err, "failed to tag subnet")
 		}
 	}
 
-	err := a.TagResource(clusterResources.VpcID, trimTagPrefix(VpcSecondaryClusterIDTagKey), clusterID, logger)
+	err := a.TagResource(clusterResources.VpcID, trimTagPrefix(VpcSecondaryClusterIDTagKey), cluster.ID, logger)
 	if err != nil {
 		return errors.Wrapf(err, "unable to update %s", VpcSecondaryClusterIDTagKey)
 	}
@@ -488,4 +508,18 @@ func (a *Client) SwitchClusterTags(clusterID string, targetClusterID string, log
 	}
 
 	return nil
+}
+
+func getClusterTag(cluster *model.Cluster) string {
+	if cluster.ProvisionerMetadataEKS != nil {
+		return eksClusterTag(cluster.ID)
+	}
+	return kopsClusterTag(cluster.ID)
+}
+
+func kopsClusterTag(clusterID string) string {
+	return fmt.Sprintf("%s-kops.k8s.local", clusterID)
+}
+func eksClusterTag(clusterID string) string {
+	return clusterID
 }

--- a/internal/tools/aws/eks.go
+++ b/internal/tools/aws/eks.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+)
+
+func (a *Client) CreateEKSCluster(cluster *model.Cluster, resources ClusterResources, eksMetadata model.EKSMetadata) (*eks.Cluster, error) {
+	// TODO: we do not expect to query that many subnets but for safety
+	// we can check the NextToken.
+	subnetsOut, err := a.Service().ec2.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		SubnetIds: stringsToPtr(resources.PublicSubnetsIDs),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to describe subnets")
+	}
+
+	subnetsIDs := []*string{}
+	for _, sub := range subnetsOut.Subnets {
+		// TODO: for some reason it is not possible to creates EKS in this zone
+		if *sub.AvailabilityZone == "us-east-1e" {
+			continue
+		}
+		subnetsIDs = append(subnetsIDs, sub.SubnetId)
+	}
+
+	vpcConfig := eks.VpcConfigRequest{
+		EndpointPrivateAccess: nil,
+		EndpointPublicAccess:  nil,
+		SecurityGroupIds:      stringsToPtr(resources.MasterSecurityGroupIDs),
+		SubnetIds:             subnetsIDs,
+	}
+
+	// TODO: we can allow further parametrization in the future
+	input := eks.CreateClusterInput{
+		Name:               aws.String(cluster.ID),
+		ResourcesVpcConfig: &vpcConfig,
+		RoleArn:            eksMetadata.ClusterRoleARN,
+		Version:            eksMetadata.KubernetesVersion,
+	}
+
+	out, err := a.Service().eks.CreateCluster(&input)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create EKS cluster")
+	}
+
+	return out.Cluster, nil
+}
+
+func (a *Client) EnsureEKSCluster(cluster *model.Cluster, resources ClusterResources, eksMetadata model.EKSMetadata) (*eks.Cluster, error) {
+	input := eks.DescribeClusterInput{
+		Name: aws.String(cluster.ID),
+	}
+
+	out, err := a.Service().eks.DescribeCluster(&input)
+	if err != nil {
+		if IsErrorResourceNotFound(err) {
+			return a.CreateEKSCluster(cluster, resources, eksMetadata)
+		}
+		return nil, errors.Wrap(err, "failed to check if EKS cluster exists")
+	}
+
+	return out.Cluster, nil
+}
+
+func (a *Client) EnsureEKSClusterNodeGroups(cluster *model.Cluster, resources ClusterResources, eksMetadata model.EKSMetadata) ([]*eks.Nodegroup, error) {
+	return a.CreateNodeGroups(cluster.ID, resources, eksMetadata)
+}
+
+func (a *Client) CreateNodeGroups(clusterName string, resources ClusterResources, eksMetadata model.EKSMetadata) ([]*eks.Nodegroup, error) {
+	// If more node groups exist than we expect, this function will not
+	// delete them, nor return them.
+	existingNgs, err := a.listNodeGroups(clusterName)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list existing node groups")
+	}
+
+	allNodeGroups := make([]*eks.Nodegroup, 0, len(eksMetadata.EKSNodeGroups))
+
+	for ngName, ngCfg := range eksMetadata.EKSNodeGroups {
+		// If given node group already exist, just return it
+		foundExisting := false
+		for _, existingNg := range existingNgs {
+			if *existingNg.NodegroupName == ngName {
+				// TODO: theoretically the node group config could change
+				// so we probably should update here.
+				allNodeGroups = append(allNodeGroups, existingNg)
+				foundExisting = true
+				break
+			}
+		}
+		if foundExisting {
+			continue
+		}
+
+		nodeGroupReq := eks.CreateNodegroupInput{
+			ClusterName:    aws.String(clusterName),
+			InstanceTypes:  ngCfg.InstanceTypes,
+			NodeRole:       ngCfg.RoleARN,
+			NodegroupName:  aws.String(ngName),
+			ReleaseVersion: ngCfg.AMIVersion,
+			ScalingConfig: &eks.NodegroupScalingConfig{
+				DesiredSize: ngCfg.DesiredSize,
+				MaxSize:     ngCfg.MaxSize,
+				MinSize:     ngCfg.MinSize,
+			},
+			Subnets: stringsToPtr(resources.PrivateSubnetIDs),
+			Version: eksMetadata.KubernetesVersion,
+		}
+
+		out, err := a.Service().eks.CreateNodegroup(&nodeGroupReq)
+		if err != nil {
+
+			return nil, errors.Wrap(err, "failed to create one of the node groups")
+		}
+
+		allNodeGroups = append(allNodeGroups, out.Nodegroup)
+	}
+	return allNodeGroups, nil
+}
+
+func (a *Client) IsClusterReady(clusterName string) (bool, error) {
+	cluster, err := a.GetEKSCluster(clusterName)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get EKS cluster")
+	}
+
+	if cluster.Status == nil {
+		return false, nil
+	}
+	if *cluster.Status == eks.ClusterStatusFailed {
+		return false, errors.New("cluster creation failed")
+	}
+	if *cluster.Status != eks.ClusterStatusActive {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (a *Client) GetEKSCluster(clusterName string) (*eks.Cluster, error) {
+	input := eks.DescribeClusterInput{
+		Name: aws.String(clusterName),
+	}
+
+	out, err := a.Service().eks.DescribeCluster(&input)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create EKS cluster")
+	}
+
+	return out.Cluster, nil
+}
+
+func (a *Client) EnsureNodeGroupsDeleted(cluster *model.Cluster) (bool, error) {
+	nodeGroups, err := a.listNodeGroups(cluster.ID)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to list node groups for the cluster")
+	}
+	// Node groups deleted, we can return
+	if len(nodeGroups) == 0 {
+		return true, nil
+	}
+
+	for _, ng := range nodeGroups {
+		if ng.Status != nil {
+			if *ng.Status == eks.NodegroupStatusDeleting {
+				continue
+			}
+			if *ng.Status == eks.NodegroupStatusDeleteFailed {
+				return false, errors.Wrapf(err, "node group deletion failed %q", *ng.NodegroupName)
+			}
+		}
+
+		delNgReq := &eks.DeleteNodegroupInput{
+			ClusterName:   aws.String(cluster.ID),
+			NodegroupName: ng.NodegroupName,
+		}
+
+		_, err = a.Service().eks.DeleteNodegroup(delNgReq)
+		if err != nil {
+			return false, errors.Wrap(err, "failed to delete node group")
+		}
+	}
+
+	// Node groups still exist therefore we return false
+	return false, nil
+}
+
+func (a *Client) EnsureEKSClusterDeleted(cluster *model.Cluster) (bool, error) {
+	input := eks.DescribeClusterInput{
+		Name: aws.String(cluster.ID),
+	}
+
+	out, err := a.Service().eks.DescribeCluster(&input)
+	if err != nil {
+		// Cluster was deleted
+		if IsErrorResourceNotFound(err) {
+			return true, nil
+		}
+		return false, errors.Wrap(err, "failed to check if EKS cluster exists")
+	}
+
+	// Still deleting
+	if out.Cluster.Status != nil && *out.Cluster.Status == eks.ClusterStatusDeleting {
+		return false, nil
+	}
+
+	delInput := &eks.DeleteClusterInput{Name: aws.String(cluster.ID)}
+	_, err = a.Service().eks.DeleteCluster(delInput)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to trigger EKS cluster deletion")
+	}
+
+	// Cluster just started deletion
+	return false, nil
+}
+
+func (a *Client) listNodeGroups(clusterName string) ([]*eks.Nodegroup, error) {
+	listNgInput := eks.ListNodegroupsInput{
+		ClusterName: aws.String(clusterName),
+	}
+
+	nodeGroups := make([]*eks.Nodegroup, 0)
+	for {
+		ngListOut, err := a.Service().eks.ListNodegroups(&listNgInput)
+		if err != nil {
+			// If cluster does not exist anymore, listing node groups will
+			// fail with ResourceNotFoundException.
+			if IsErrorResourceNotFound(err) {
+				return nodeGroups, nil
+			}
+			return nil, errors.Wrap(err, "failed to list node groups for the cluster")
+		}
+
+		for _, ng := range ngListOut.Nodegroups {
+			ngInput := eks.DescribeNodegroupInput{
+				ClusterName:   aws.String(clusterName),
+				NodegroupName: ng,
+			}
+			out, err := a.Service().eks.DescribeNodegroup(&ngInput)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to describe node group %q", *ng)
+			}
+			nodeGroups = append(nodeGroups, out.Nodegroup)
+		}
+
+		if ngListOut.NextToken == nil {
+			break
+		}
+		listNgInput.NextToken = ngListOut.NextToken
+	}
+
+	return nodeGroups, nil
+}
+
+func stringsToPtr(list []string) []*string {
+	out := make([]*string, 0, len(list))
+
+	for i := range list {
+		out = append(out, &list[i])
+	}
+	return out
+}

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -98,6 +98,30 @@ func IsErrorCode(err error, code string) bool {
 	return false
 }
 
+// IsErrorResourceNotFound asserts that an AWS error is
+// ResourceNotFoundException.
+func IsErrorResourceNotFound(err error) bool {
+	if err != nil {
+		awsErr, ok := err.(awserr.Error)
+		if ok {
+			return awsErr.Code() == "ResourceNotFoundException"
+		}
+	}
+	return false
+}
+
+// IsErrorResourceInUseException asserts that an AWS error is
+// ResourceInUseException.
+func IsErrorResourceInUseException(err error) bool {
+	if err != nil {
+		awsErr, ok := err.(awserr.Error)
+		if ok {
+			return awsErr.Code() == "ResourceInUseException"
+		}
+	}
+	return false
+}
+
 // RDSMultitenantSecretName formats the name of a secret used in a multitenant RDS database.
 func RDSMultitenantSecretName(id string) string {
 	return fmt.Sprintf("rds-multitenant-%s", id)

--- a/internal/tools/aws/vpc.go
+++ b/internal/tools/aws/vpc.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-// GetCIDRByVPCTag creates a record in Route53 for a public domain name.
+// GetCIDRByVPCTag fetches VPC CIDR block by 'Name' tag.
 func (a *Client) GetCIDRByVPCTag(vpcTagName string, logger log.FieldLogger) (string, error) {
 	vpcInput := ec2.DescribeVpcsInput{
 		Filters: []*ec2.Filter{

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -32,6 +32,7 @@ type Cluster struct {
 	ProviderMetadataAWS     *AWSMetadata
 	Provisioner             string
 	ProvisionerMetadataKops *KopsMetadata
+	ProvisionerMetadataEKS *EKSMetadata
 	UtilityMetadata         *UtilityMetadata
 	AllowInstallations      bool
 	CreateAt                int64

--- a/model/cluster_eks.go
+++ b/model/cluster_eks.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import "encoding/json"
+
+type EKSMetadata struct {
+	KubernetesVersion *string
+	VPC               string
+	Networking        string
+	ClusterRoleARN    *string
+
+	EKSNodeGroups EKSNodeGroups
+}
+
+type EKSNodeGroups map[string]EKSNodeGroup
+
+type EKSNodeGroup struct {
+	RoleARN       *string
+	InstanceTypes []*string
+	AMIVersion    *string
+	DesiredSize   *int64
+	MinSize       *int64
+	MaxSize       *int64
+}
+
+// NewEKSMetadata creates an instance of EKSMetadata given the raw provisioner metadata.
+func NewEKSMetadata(metadataBytes []byte) (*EKSMetadata, error) {
+	// Check if length of metadata is 0 as opposed to if the value is nil. This
+	// is done to avoid an issue encountered where the metadata value provided
+	// had a length of 0, but had non-zero capacity.
+	if len(metadataBytes) == 0 || string(metadataBytes) == "null" {
+		// TODO: remove "null" check after sqlite is gone.
+		return nil, nil
+	}
+
+	eksMetadata := EKSMetadata{}
+	err := json.Unmarshal(metadataBytes, &eksMetadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return &eksMetadata, nil
+}

--- a/model/cluster_eks_test.go
+++ b/model/cluster_eks_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNewKopsMetadata(t *testing.T) {
+	t.Run("nil payload", func(t *testing.T) {
+		eksMetadata, err := NewEKSMetadata(nil)
+		require.NoError(t, err)
+		require.Nil(t, eksMetadata)
+	})
+
+	t.Run("invalid payload", func(t *testing.T) {
+		_, err := NewEKSMetadata([]byte(`{`))
+		require.Error(t, err)
+	})
+
+	t.Run("valid payload", func(t *testing.T) {
+		eksMetadata, err := NewEKSMetadata([]byte(`{"ClusterRoleARN": "test"}`))
+		require.NoError(t, err)
+		require.Equal(t, "test", *eksMetadata.ClusterRoleARN)
+	})
+}

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -19,6 +19,11 @@ const (
 	NetworkingAmazon = "amazon-vpc-routed-eni"
 )
 
+var (
+	defaultEKSRoleARN       string
+	defaultNodeGroupRoleARN string
+)
+
 // CreateClusterRequest specifies the parameters for a new cluster.
 type CreateClusterRequest struct {
 	Provider               string                         `json:"provider,omitempty"`
@@ -37,6 +42,12 @@ type CreateClusterRequest struct {
 	Networking             string                         `json:"networking,omitempty"`
 	VPC                    string                         `json:"vpc,omitempty"`
 	MaxPodsPerNode         int64
+	EKSConfig              *EKSConfig `json:"EKSConfig,omitempty"`
+}
+
+type EKSConfig struct {
+	ClusterRoleARN *string                 `json:"clusterRoleARN,omitempty"`
+	NodeGroups     map[string]EKSNodeGroup `json:"nodeGroups,omitempty"`
 }
 
 func (request *CreateClusterRequest) setUtilityDefaults(utilityName string) {
@@ -91,6 +102,18 @@ func (request *CreateClusterRequest) SetDefaults() {
 	if len(request.Networking) == 0 {
 		request.Networking = NetworkingCalico
 	}
+	if request.EKSConfig != nil {
+		if request.EKSConfig.ClusterRoleARN == nil {
+			request.EKSConfig.ClusterRoleARN = &defaultEKSRoleARN
+		}
+
+		for _, ng := range request.EKSConfig.NodeGroups {
+			if ng.RoleARN == nil {
+				ng.RoleARN = &defaultNodeGroupRoleARN
+			}
+		}
+	}
+
 	if request.DesiredUtilityVersions == nil {
 		request.DesiredUtilityVersions = make(map[string]*HelmUtilityVersion)
 	}
@@ -118,6 +141,12 @@ func (request *CreateClusterRequest) Validate() error {
 		return errors.Errorf("max pods per node (%d) must be 10 or greater", request.MaxPodsPerNode)
 	}
 	// TODO: check zones and instance types?
+
+	if request.EKSConfig != nil {
+		if len(request.EKSConfig.NodeGroups) == 0 {
+			return errors.Errorf("at least 1 node group is required when using EKS")
+		}
+	}
 
 	if !contains(GetSupportedCniList(), request.Networking) {
 		return errors.Errorf("unsupported cluster networking option %s", request.Networking)

--- a/model/cluster_request_test.go
+++ b/model/cluster_request_test.go
@@ -24,6 +24,7 @@ func TestCreateClusterRequestValid(t *testing.T) {
 		{"negative master count", &model.CreateClusterRequest{MasterCount: -1}, true},
 		{"mismatched node count", &model.CreateClusterRequest{NodeMinCount: 2, NodeMaxCount: 3}, true},
 		{"max pods too low", &model.CreateClusterRequest{MaxPodsPerNode: 1}, true},
+		{"eks no node group", &model.CreateClusterRequest{EKSConfig: &model.EKSConfig{}}, true},
 	}
 
 	for _, tc := range testCases {

--- a/model/cluster_states.go
+++ b/model/cluster_states.go
@@ -9,6 +9,8 @@ const (
 	ClusterStateStable = "stable"
 	// ClusterStateCreationRequested is a cluster in the process of being created.
 	ClusterStateCreationRequested = "creation-requested"
+	// ClusterStateCreationInProgress is a cluster that is being actively created.
+	ClusterStateCreationInProgress = "creation-in-progress"
 	// ClusterStateCreationFailed is a cluster that failed creation.
 	ClusterStateCreationFailed = "creation-failed"
 	// ClusterStateProvisioningRequested is a cluster in the process of being
@@ -41,6 +43,7 @@ var AllClusterStates = []string{
 	ClusterStateStable,
 	ClusterStateRefreshMetadata,
 	ClusterStateCreationRequested,
+	ClusterStateCreationInProgress,
 	ClusterStateCreationFailed,
 	ClusterStateProvisioningRequested,
 	ClusterStateProvisioningFailed,
@@ -60,6 +63,7 @@ var AllClusterStates = []string{
 // cluster supervisor should perform some action on its next work cycle.
 var AllClusterStatesPendingWork = []string{
 	ClusterStateCreationRequested,
+	ClusterStateCreationInProgress,
 	ClusterStateProvisioningRequested,
 	ClusterStateRefreshMetadata,
 	ClusterStateUpgradeRequested,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR contains the following changes:
- Add new type `EKSMetadata` to `Cluster`.
- Extend AWS client with methods to create and delete EKS clusters and node groups.
- Refactor some methods to work both with Kops and EKS.
- Add some supporting methods.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
EKS cluster creation with AWS API
```
