### PR TITLE
Add external database type support

### DIFF
--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -136,6 +136,7 @@ type Provisioner interface {
 // AwsClient describes the interface required to communicate with the AWS
 type AwsClient interface {
 	SwitchClusterTags(clusterID string, targetClusterID string, logger log.FieldLogger) error
+	SecretsManagerValidateExternalDatabaseSecret(name string) error
 	RDSDBCLusterExists(awsID string) (bool, error)
 }
 

--- a/internal/api/db_multitenant_database_test.go
+++ b/internal/api/db_multitenant_database_test.go
@@ -277,6 +277,10 @@ func (m mockAWSClient) SwitchClusterTags(clusterID string, targetClusterID strin
 	return nil
 }
 
+func (m mockAWSClient) SecretsManagerValidateExternalDatabaseSecret(name string) error {
+	return nil
+}
+
 func (m mockAWSClient) RDSDBCLusterExists(awsID string) (bool, error) {
 	if awsID != m.expectedRDSID {
 		panic("expected different RDS ID")

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -196,6 +196,15 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		}
 	}
 
+	if createInstallationRequest.Database == model.InstallationDatabaseExternal {
+		err = c.AwsClient.SecretsManagerValidateExternalDatabaseSecret(createInstallationRequest.ExternalDatabaseConfig.SecretName)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to validate external secret")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	}
+
 	installation := model.Installation{
 		Name:                       createInstallationRequest.Name,
 		OwnerID:                    createInstallationRequest.OwnerID,
@@ -211,6 +220,7 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		MattermostEnv:              createInstallationRequest.MattermostEnv,
 		PriorityEnv:                createInstallationRequest.PriorityEnv,
 		SingleTenantDatabaseConfig: createInstallationRequest.SingleTenantDatabaseConfig.ToDBConfig(createInstallationRequest.Database),
+		ExternalDatabaseConfig:     createInstallationRequest.ExternalDatabaseConfig.ToDBConfig(createInstallationRequest.Database),
 		CRVersion:                  model.DefaultCRVersion,
 		State:                      model.InstallationStateCreationRequested,
 	}

--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -515,6 +515,20 @@ func (mr *MockAWSMockRecorder) SecretsManagerGetPGBouncerAuthUserPassword(vpcID 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretsManagerGetPGBouncerAuthUserPassword", reflect.TypeOf((*MockAWS)(nil).SecretsManagerGetPGBouncerAuthUserPassword), vpcID)
 }
 
+// SecretsManagerValidateExternalDatabaseSecret mocks base method
+func (m *MockAWS) SecretsManagerValidateExternalDatabaseSecret(name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretsManagerValidateExternalDatabaseSecret", name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SecretsManagerValidateExternalDatabaseSecret indicates an expected call of SecretsManagerValidateExternalDatabaseSecret
+func (mr *MockAWSMockRecorder) SecretsManagerValidateExternalDatabaseSecret(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretsManagerValidateExternalDatabaseSecret", reflect.TypeOf((*MockAWS)(nil).SecretsManagerValidateExternalDatabaseSecret), name)
+}
+
 // SwitchClusterTags mocks base method
 func (m *MockAWS) SwitchClusterTags(clusterID, targetClusterID string, logger logrus.FieldLogger) error {
 	m.ctrl.T.Helper()

--- a/internal/mocks/model/installation_database.go
+++ b/internal/mocks/model/installation_database.go
@@ -188,6 +188,21 @@ func (m *MockInstallationDatabaseStoreInterface) EXPECT() *MockInstallationDatab
 	return m.recorder
 }
 
+// GetInstallation mocks base method
+func (m *MockInstallationDatabaseStoreInterface) GetInstallation(id string, includeGroupConfig, includeGroupConfigOverrides bool) (*model.Installation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInstallation", id, includeGroupConfig, includeGroupConfigOverrides)
+	ret0, _ := ret[0].(*model.Installation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInstallation indicates an expected call of GetInstallation
+func (mr *MockInstallationDatabaseStoreInterfaceMockRecorder) GetInstallation(id, includeGroupConfig, includeGroupConfigOverrides interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallation", reflect.TypeOf((*MockInstallationDatabaseStoreInterface)(nil).GetInstallation), id, includeGroupConfig, includeGroupConfigOverrides)
+}
+
 // GetClusterInstallations mocks base method
 func (m *MockInstallationDatabaseStoreInterface) GetClusterInstallations(filter *model.ClusterInstallationFilter) ([]*model.ClusterInstallation, error) {
 	m.ctrl.T.Helper()

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -143,6 +143,23 @@ func TestInstallations(t *testing.T) {
 	err = sqlStore.CreateInstallation(installation4, nil, fixDNSRecords(4))
 	require.NoError(t, err)
 
+	time.Sleep(1 * time.Millisecond)
+
+	installation5 := &model.Installation{
+		Name:                   "test5",
+		OwnerID:                ownerID2,
+		Version:                "version",
+		Database:               model.InstallationDatabaseMysqlOperator,
+		Filestore:              model.InstallationFilestoreMinioOperator,
+		Size:                   mmv1alpha1.Size100String,
+		Affinity:               model.InstallationAffinityIsolated,
+		State:                  model.InstallationStateCreationRequested,
+		ExternalDatabaseConfig: &model.ExternalDatabaseConfig{SecretName: "test-secret"},
+	}
+
+	err = sqlStore.CreateInstallation(installation5, nil, fixDNSRecords(5))
+	require.NoError(t, err)
+
 	t.Run("get unknown installation", func(t *testing.T) {
 		installation, err := sqlStore.GetInstallation("unknown", false, false)
 		require.NoError(t, err)
@@ -175,6 +192,17 @@ func TestInstallations(t *testing.T) {
 		err = sqlStore.DeleteInstallation(installation4.ID)
 		require.NoError(t, err)
 		installation4, err = sqlStore.GetInstallation(installation4.ID, false, false)
+		require.NoError(t, err)
+	})
+
+	t.Run("get and delete installation 5", func(t *testing.T) {
+		installation, err := sqlStore.GetInstallation(installation5.ID, false, false)
+		require.NoError(t, err)
+		require.Equal(t, installation5, installation)
+
+		err = sqlStore.DeleteInstallation(installation5.ID)
+		require.NoError(t, err)
+		installation5, err = sqlStore.GetInstallation(installation5.ID, false, false)
 		require.NoError(t, err)
 	})
 
@@ -247,7 +275,7 @@ func TestInstallations(t *testing.T) {
 					IncludeDeleted: true,
 				},
 			},
-			[]*model.Installation{installation1, installation2, installation3, installation4},
+			[]*model.Installation{installation1, installation2, installation3, installation4, installation5},
 		},
 		{
 			"owner 1",
@@ -279,7 +307,7 @@ func TestInstallations(t *testing.T) {
 				OwnerID: ownerID2,
 				Paging:  model.AllPagesWithDeleted(),
 			},
-			[]*model.Installation{installation3, installation4},
+			[]*model.Installation{installation3, installation4, installation5},
 		},
 		{
 			"group 1",

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1960,4 +1960,17 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.37.0"), semver.MustParse("0.38.0"), func(e execer) error {
+		// Add ExternalDatabaseConfigRaw column for installations.
+
+		_, err := e.Exec(`
+				ALTER TABLE Installation
+				ADD COLUMN ExternalDatabaseConfigRaw BYTEA NULL;
+				`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -553,6 +553,10 @@ func (a *mockAWS) SecretsManagerGetPGBouncerAuthUserPassword(vpcID string) (stri
 	return "password", nil
 }
 
+func (a *mockAWS) SecretsManagerValidateExternalDatabaseSecret(name string) error {
+	return nil
+}
+
 type mockEventProducer struct{}
 
 func (m *mockEventProducer) ProduceInstallationStateChangeEvent(installation *model.Installation, oldState string, extraDataFields ...events.DataField) error {

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -88,6 +88,7 @@ type AWS interface {
 	TagResourcesByCluster(clusterResources ClusterResources, cluster *model.Cluster, owner string, logger log.FieldLogger) error
 
 	SecretsManagerGetPGBouncerAuthUserPassword(vpcID string) (string, error)
+	SecretsManagerValidateExternalDatabaseSecret(name string) error
 	SwitchClusterTags(clusterID string, targetClusterID string, logger log.FieldLogger) error
 
 	EnsureEKSCluster(cluster *model.Cluster, resources ClusterResources, eksMetadata model.EKSMetadata) (*eks.Cluster, error)

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -48,7 +48,7 @@ const (
 
 	// DefaultDatabasePostgresVersion is the default version of PostgreSQL used
 	// when creating databases.
-	DefaultDatabasePostgresVersion = "11.7"
+	DefaultDatabasePostgresVersion = "11.13"
 
 	// DefaultDBSubnetGroupName is the default DB subnet group name used when
 	// creating DB clusters. This group name is defined by the owner of the AWS

--- a/internal/tools/aws/database_external.go
+++ b/internal/tools/aws/database_external.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package aws
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ExternalDatabase is a database that is created and managed outside of the
+// cloud provisioner.
+type ExternalDatabase struct {
+	installationID string
+	client         *Client
+}
+
+// NewExternalDatabase returns a new instance of ExternalDatabase that
+// implements database interface.
+func NewExternalDatabase(installationID string, client *Client) *ExternalDatabase {
+	return &ExternalDatabase{
+		installationID: installationID,
+		client:         client,
+	}
+}
+
+// IsValid returns if the given external database configuration is valid.
+func (d *ExternalDatabase) IsValid() error {
+	if len(d.installationID) == 0 {
+		return errors.New("installation ID is not set")
+	}
+
+	return nil
+}
+
+// Provision logs that no further setup is needed for the precreated external
+// database.
+func (d *ExternalDatabase) Provision(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	logger = logger.WithField("external-database", ExternalDatabaseName(d.installationID))
+	logger.Info("External database requires no pre-provisioning; skipping...")
+
+	return nil
+}
+
+// GenerateDatabaseSecret creates the k8s database spec and secret for
+// accessing the external database.
+func (d *ExternalDatabase) GenerateDatabaseSecret(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) (*corev1.Secret, error) {
+	err := d.IsValid()
+	if err != nil {
+		return nil, errors.Wrap(err, "external database configuration is invalid")
+	}
+
+	externalDatabaseName := ExternalDatabaseName(d.installationID)
+
+	logger = logger.WithField("external-database", externalDatabaseName)
+
+	installation, err := store.GetInstallation(d.installationID, false, false)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get installation")
+	}
+
+	logger.Debugf("Using AWS secret %s for external database connections", installation.ExternalDatabaseConfig.SecretName)
+
+	result, err := d.client.Service().secretsManager.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: &installation.ExternalDatabaseConfig.SecretName,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get secret value for database")
+	}
+
+	externalSecret, err := extractExternalDatabaseSecret(*result.SecretString)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal secret payload")
+	}
+
+	secret := externalSecret.ToInstallationDBSecret(externalDatabaseName)
+
+	logger.Debug("External database configuration generated for cluster installation")
+
+	return secret.ToK8sSecret(false), nil
+}
+
+// Teardown logs that no further actions are required for external database teardown.
+func (d *ExternalDatabase) Teardown(store model.InstallationDatabaseStoreInterface, keepData bool, logger log.FieldLogger) error {
+	logger = logger.WithField("external-database", ExternalDatabaseName(d.installationID))
+	logger.Info("External database requires no teardown; skipping...")
+	if keepData {
+		logger.Warn("Database preservation was requested, but isn't currently possible with external databases")
+	}
+
+	return nil
+}
+
+// Snapshot is not supported for external databases.
+func (d *ExternalDatabase) Snapshot(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	return errors.New("Snapshot is not supported for external databases")
+}
+
+// TeardownMigrated is not supported for external databases.
+func (d *ExternalDatabase) TeardownMigrated(store model.InstallationDatabaseStoreInterface, migrationOp *model.InstallationDBMigrationOperation, logger log.FieldLogger) error {
+	return errors.New("TeardownMigrated is not supported for external databases")
+}
+
+// MigrateOut is not supported for external databases.
+func (d *ExternalDatabase) MigrateOut(store model.InstallationDatabaseStoreInterface, dbMigration *model.InstallationDBMigrationOperation, logger log.FieldLogger) error {
+	return errors.New("MigrateOut is not supported for external databases")
+}
+
+// MigrateTo is not supported for external databases.
+func (d *ExternalDatabase) MigrateTo(store model.InstallationDatabaseStoreInterface, dbMigration *model.InstallationDBMigrationOperation, logger log.FieldLogger) error {
+	return errors.New("MigrateTo is not supported for external databases")
+}
+
+// RollbackMigration is not supported for external databases.
+func (d *ExternalDatabase) RollbackMigration(store model.InstallationDatabaseStoreInterface, dbMigration *model.InstallationDBMigrationOperation, logger log.FieldLogger) error {
+	return errors.New("RollbackMigration is not supported for external databases")
+}
+
+// RefreshResourceMetadata ensures various database resource's metadata are correct.
+func (d *ExternalDatabase) RefreshResourceMetadata(store model.InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	return nil
+}
+
+type externalDatabaseSecret struct {
+	DataSource         string `json:"DataSource"`
+	DataSourceReplicas string `json:"DataSourceReplicas"`
+	ConnectionCheckURL string `json:"ConnectionCheckURL"`
+}
+
+// Validate performs a basic sanity check on the exteranl database secret.
+func (s *externalDatabaseSecret) Validate() error {
+	if len(s.DataSource) == 0 {
+		return errors.New("DataSource value is empty")
+	}
+	if len(s.DataSourceReplicas) == 0 {
+		return errors.New("DataSourceReplicas value is empty")
+	}
+
+	return nil
+}
+
+// ToInstallationDBSecret converts an externalDatabaseSecret to a k8s secret.
+func (s *externalDatabaseSecret) ToInstallationDBSecret(name string) InstallationDBSecret {
+	return InstallationDBSecret{
+		InstallationSecretName: name,
+		ConnectionString:       s.DataSource,
+		ReadReplicasURL:        s.DataSourceReplicas,
+		DBCheckURL:             s.ConnectionCheckURL,
+	}
+}
+
+func extractExternalDatabaseSecret(payload string) (*externalDatabaseSecret, error) {
+	var secret externalDatabaseSecret
+	err := json.Unmarshal([]byte(payload), &secret)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to marshal secrets manager payload")
+	}
+
+	err = secret.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "extracted external database secret failed validation")
+	}
+
+	return &secret, nil
+}
+
+// SecretsManagerValidateExternalDatabaseSecret pulls down the secret with the
+// provided name and validates it as an external database secret.
+func (a *Client) SecretsManagerValidateExternalDatabaseSecret(name string) error {
+	result, err := a.Service().secretsManager.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: &name,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to get secret value for database")
+	}
+
+	_, err = extractExternalDatabaseSecret(*result.SecretString)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmarshal secret payload")
+	}
+
+	return nil
+}

--- a/internal/tools/aws/helpers.go
+++ b/internal/tools/aws/helpers.go
@@ -162,6 +162,11 @@ func MattermostRDSDatabaseName(installationID string) string {
 	return fmt.Sprintf("%s%s", rdsDatabaseNamePrefix, installationID)
 }
 
+// ExternalDatabaseName formats the name of an externally managed database.
+func ExternalDatabaseName(installationID string) string {
+	return fmt.Sprintf("external-database-%s", installationID)
+}
+
 // RDSMultitenantClusterSecretDescription formats the text used for describing a
 // multitenant database's secret key.
 func RDSMultitenantClusterSecretDescription(installationID, rdsClusterID string) string {

--- a/internal/tools/utils/utils.go
+++ b/internal/tools/utils/utils.go
@@ -138,6 +138,8 @@ func (r *ResourceUtil) GetDatabase(installationID, dbType string) model.Database
 	switch dbType {
 	case model.InstallationDatabaseMysqlOperator:
 		return model.NewMysqlOperatorDatabase()
+	case model.InstallationDatabaseExternal:
+		return aws.NewExternalDatabase(installationID, r.awsClient)
 	case model.InstallationDatabaseSingleTenantRDSMySQL:
 		return aws.NewRDSDatabase(model.DatabaseEngineTypeMySQL, installationID, r.awsClient, r.disableDBCheck)
 	case model.InstallationDatabaseSingleTenantRDSPostgres:

--- a/model/external_database.go
+++ b/model/external_database.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// ExternalDatabaseConfig represents configuration for an externally managed
+// database.
+type ExternalDatabaseConfig struct {
+	SecretName string
+}
+
+// ToJSON marshals database configuration to JSON if it is not nil.
+func (cfg *ExternalDatabaseConfig) ToJSON() ([]byte, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	return json.Marshal(cfg)
+}
+
+// ExternalDatabaseRequest represents requested configuration of an external
+// database.
+type ExternalDatabaseRequest struct {
+	SecretName string
+}
+
+// Validate validates an ExternalDatabaseRequest.
+func (request *ExternalDatabaseRequest) Validate() error {
+	if len(request.SecretName) == 0 {
+		return errors.New("no external database secret name providied")
+	}
+
+	return nil
+}
+
+// ToDBConfig converts ExternalDatabaseRequest to ExternalDatabaseConfig if the
+// database type is external.
+func (request *ExternalDatabaseRequest) ToDBConfig(database string) *ExternalDatabaseConfig {
+	if database != InstallationDatabaseExternal || request == nil {
+		return nil
+	}
+
+	return &ExternalDatabaseConfig{
+		SecretName: request.SecretName,
+	}
+}

--- a/model/external_database_test.go
+++ b/model/external_database_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model_test
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateExternalDatabaseRequest(t *testing.T) {
+	for _, testCase := range []struct {
+		description string
+		request     model.ExternalDatabaseRequest
+		valid       bool
+	}{
+		{
+			description: "valid request",
+			request:     model.ExternalDatabaseRequest{SecretName: "test-secret"},
+			valid:       true,
+		},
+		{
+			description: "empty secret name",
+			request:     model.ExternalDatabaseRequest{},
+			valid:       false,
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			err := testCase.request.Validate()
+			if testCase.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestExternalDatabaseRequestToDBConfig(t *testing.T) {
+	for _, testCase := range []struct {
+		description    string
+		database       string
+		request        model.ExternalDatabaseRequest
+		expectedConfig *model.ExternalDatabaseConfig
+	}{
+		{
+			description:    "not external database",
+			database:       model.InstallationDatabaseMultiTenantRDSPostgres,
+			request:        model.ExternalDatabaseRequest{SecretName: "test-secret"},
+			expectedConfig: nil,
+		},
+		{
+			description: "external database",
+			database:    model.InstallationDatabaseExternal,
+			request: model.ExternalDatabaseRequest{
+				SecretName: "test-secret",
+			},
+			expectedConfig: &model.ExternalDatabaseConfig{
+				SecretName: "test-secret",
+			},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			config := testCase.request.ToDBConfig(testCase.database)
+			require.Equal(t, testCase.expectedConfig, config)
+		})
+	}
+}

--- a/model/installation.go
+++ b/model/installation.go
@@ -34,6 +34,8 @@ type Installation struct {
 	Image                      string
 	Name                       string
 	Database                   string
+	SingleTenantDatabaseConfig *SingleTenantDatabaseConfig `json:"SingleTenantDatabaseConfig,omitempty"`
+	ExternalDatabaseConfig     *ExternalDatabaseConfig     `json:"ExternalDatabaseConfig,omitempty"`
 	Filestore                  string
 	License                    string
 	MattermostEnv              EnvVarMap
@@ -47,8 +49,7 @@ type Installation struct {
 	APISecurityLock            bool
 	LockAcquiredBy             *string
 	LockAcquiredAt             int64
-	GroupOverrides             map[string]string           `json:"GroupOverrides,omitempty"`
-	SingleTenantDatabaseConfig *SingleTenantDatabaseConfig `json:"SingleTenantDatabaseConfig,omitempty"`
+	GroupOverrides             map[string]string `json:"GroupOverrides,omitempty"`
 
 	// configconfigMergedWithGroup is set when the installation configuration
 	// has been overridden with group configuration. This value can then be

--- a/model/installation_database.go
+++ b/model/installation_database.go
@@ -30,6 +30,12 @@ const (
 	// InstallationDatabaseMultiTenantRDSPostgresPGBouncer is a PostgreSQL
 	// multitenant database hosted via Amazon RDS that has pooled connections.
 	InstallationDatabaseMultiTenantRDSPostgresPGBouncer = "aws-multitenant-rds-postgres-pgbouncer"
+	// InstallationDatabaseExternal is a database that is created and managed
+	// outside of the cloud provisioner. No provisioning or teardown is performed
+	// on this database type. An AWS secret with connection strings and
+	// credentials must be specified on installation creation when using this
+	// database type.
+	InstallationDatabaseExternal = "external"
 
 	// DatabaseEngineTypeMySQL is a MySQL database.
 	DatabaseEngineTypeMySQL = "mysql"
@@ -58,6 +64,7 @@ type Database interface {
 // TODO(gsagula): Consider renaming this interface to InstallationDatabaseInterface. For reference,
 // https://github.com/mattermost/mattermost-cloud/pull/209#discussion_r424597373
 type InstallationDatabaseStoreInterface interface {
+	GetInstallation(id string, includeGroupConfig, includeGroupConfigOverrides bool) (*Installation, error)
 	GetClusterInstallations(filter *ClusterInstallationFilter) ([]*ClusterInstallation, error)
 	GetMultitenantDatabases(filter *MultitenantDatabaseFilter) ([]*MultitenantDatabase, error)
 	GetMultitenantDatabase(multitenantdatabaseID string) (*MultitenantDatabase, error)
@@ -159,6 +166,7 @@ func IsSupportedDatabase(database string) bool {
 	case InstallationDatabaseMultiTenantRDSPostgres:
 	case InstallationDatabaseMultiTenantRDSPostgresPGBouncer:
 	case InstallationDatabaseMysqlOperator:
+	case InstallationDatabaseExternal:
 	default:
 		return false
 	}

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -56,6 +56,8 @@ type CreateInstallationRequest struct {
 	GroupSelectionAnnotations []string
 	// SingleTenantDatabaseConfig is ignored if Database is not single tenant mysql or postgres.
 	SingleTenantDatabaseConfig SingleTenantDatabaseRequest
+	// ExternalDatabaseConfig is ignored if Database is not single external.
+	ExternalDatabaseConfig ExternalDatabaseRequest
 }
 
 // https://man7.org/linux/man-pages/man7/hostname.7.html
@@ -160,10 +162,17 @@ func (request *CreateInstallationRequest) Validate() error {
 		}
 	}
 
-	if !deployMinioOperator && request.Filestore == "minio-operator" {
+	if request.Database == InstallationDatabaseExternal {
+		err = request.ExternalDatabaseConfig.Validate()
+		if err != nil {
+			return errors.Wrap(err, "external database config is invalid")
+		}
+	}
+
+	if !deployMinioOperator && request.Filestore == InstallationFilestoreMinioOperator {
 		return errors.Errorf("minio filestore cannot be used when minio operator is not deployed")
 	}
-	if !deployMySQLOperator && request.Database == "mysql-operator" {
+	if !deployMySQLOperator && request.Database == InstallationDatabaseMysqlOperator {
 		return errors.Errorf("mysql operator database cannot be used when mysql operator is not deployed")
 	}
 	return checkSpaces(request)

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -264,6 +264,30 @@ func TestCreateInstallationRequestValid(t *testing.T) {
 				DNSNames: []string{"my invalid-dns.com"},
 			},
 		},
+		{
+			"valid external database",
+			false,
+			&model.CreateInstallationRequest{
+				OwnerID:  "owner1",
+				Name:     "my-installation",
+				DNSNames: []string{"my-installation.example.com"},
+				Database: model.InstallationDatabaseExternal,
+				ExternalDatabaseConfig: model.ExternalDatabaseRequest{
+					SecretName: "test-secret",
+				},
+			},
+		},
+		{
+			"invalid external database",
+			true,
+			&model.CreateInstallationRequest{
+				OwnerID:                "owner1",
+				Name:                   "my-installation",
+				DNSNames:               []string{"my-installation.example.com"},
+				Database:               model.InstallationDatabaseExternal,
+				ExternalDatabaseConfig: model.ExternalDatabaseRequest{},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This new database type can be used to create installations with any pre-created database as long as the installation can successfully connect. The credentials for external databases are pulled down from a pre-created AWS Secret Manager secret. No management of the database or the secret are performed by the provisioner.

Fixes https://mattermost.atlassian.net/browse/MM-46848

```release-note
Add external database type support
```
