### PR TITLE
Temporary disable calico-node daemonset check

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -506,9 +506,10 @@ func (provisioner *KopsProvisioner) ProvisionCluster(cluster *model.Cluster, aws
 			return err
 		}
 		// Pods for k8s-spot-termination-handler do not mean to be schedule in every cluster so doesn't need to fail provision in this case
-		if len(pods.Items) == 0 && daemonSet != "k8s-spot-termination-handler" {
-			return fmt.Errorf("no pods found from %s/%s daemonSet", namespace, daemonSet)
-		}
+		//TODO: Temporary disable this check due to a bug described in detail in CLD-4227
+		//if len(pods.Items) == 0 && daemonSet != "k8s-spot-termination-handler" {
+		//	return fmt.Errorf("no pods found from %s/%s daemonSet", namespace, daemonSet)
+		//}
 
 		for _, pod := range pods.Items {
 			logger.Infof("Waiting up to %d seconds for %q/%q pod %q to start...", wait, namespace, daemonSet, pod.GetName())


### PR DESCRIPTION
Issue: CLD-4268
Signed-off-by: Stavros Foteinopoulos <stafot@gmail.com>

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Temporary disable calico-node daemonset check.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-4268

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Temporary disable calico-node daemonset check
```
