### PR TITLE
[CLD-4269] Migrate calico cni only APIs from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1 

### DIFF
--- a/manifests/calico-network-policy-only.yaml
+++ b/manifests/calico-network-policy-only.yaml
@@ -138,7 +138,7 @@ spec:
 ---
 # Create all the CustomResourceDefinitions needed for
 # Calico policy-only mode.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
@@ -154,7 +154,7 @@ spec:
     plural: felixconfigurations
     singular: felixconfiguration
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ipamblocks.crd.projectcalico.org
@@ -170,7 +170,7 @@ spec:
     plural: ipamblocks
     singular: ipamblock
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: blockaffinities.crd.projectcalico.org
@@ -186,7 +186,7 @@ spec:
     plural: blockaffinities
     singular: blockaffinity
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
@@ -202,7 +202,7 @@ spec:
     plural: bgpconfigurations
     singular: bgpconfiguration
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgppeers.crd.projectcalico.org
@@ -218,7 +218,7 @@ spec:
     plural: bgppeers
     singular: bgppeer
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
@@ -234,7 +234,7 @@ spec:
     plural: ippools
     singular: ippool
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
@@ -250,7 +250,7 @@ spec:
     plural: hostendpoints
     singular: hostendpoint
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
@@ -266,7 +266,7 @@ spec:
     plural: clusterinformations
     singular: clusterinformation
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
@@ -282,7 +282,7 @@ spec:
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
@@ -298,7 +298,7 @@ spec:
     plural: globalnetworksets
     singular: globalnetworkset
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
@@ -314,7 +314,7 @@ spec:
     plural: networkpolicies
     singular: networkpolicy
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org


### PR DESCRIPTION
#### Summary
- Migrate calico cni only APIs from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1 

#### Release Note
```release-note
- Migrate calico cni only APIs from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1 
```
