### PR TITLE
Optimize fetching InstallationDNS

### DIFF
--- a/internal/store/installation_dns.go
+++ b/internal/store/installation_dns.go
@@ -66,12 +66,17 @@ func (sqlStore *SQLStore) createInstallationDNS(db execer, installationID string
 
 // GetDNSRecordsForInstallation lists DNS Records for specified installation.
 func (sqlStore *SQLStore) GetDNSRecordsForInstallation(installationID string) ([]*model.InstallationDNS, error) {
-	return sqlStore.getDNSRecordsForInstallation(sqlStore.db, installationID)
+	return sqlStore.getDNSRecordsForInstallations(sqlStore.db, installationID)
 }
 
-func (sqlStore *SQLStore) getDNSRecordsForInstallation(db queryer, installationID string) ([]*model.InstallationDNS, error) {
+// GetDNSRecordsForInstallations lists DNS Records for specified installations.
+func (sqlStore *SQLStore) GetDNSRecordsForInstallations(installationIDs []string) ([]*model.InstallationDNS, error) {
+	return sqlStore.getDNSRecordsForInstallations(sqlStore.db, installationIDs...)
+}
+
+func (sqlStore *SQLStore) getDNSRecordsForInstallations(db queryer, installationIDs ...string) ([]*model.InstallationDNS, error) {
 	query := sq.Select(installationDNSColumns...).From(installationDNSTable).
-		Where("InstallationID = ?", installationID).
+		Where(sq.Eq{"InstallationID": installationIDs}).
 		Where("DeleteAt = 0").
 		OrderBy("CreateAt ASC")
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1973,4 +1973,17 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.38.0"), semver.MustParse("0.39.0"), func(e execer) error {
+		// Add index on InstallationDNS(InstallationID) to avoid full table scan
+		// for fetching all DNS records for single Installation.
+
+		_, err := e.Exec(`
+			CREATE INDEX ix_InstallationDNS_InstallationID on InstallationDNS(InstallationID)
+		`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR addresses some old todo, making InstallationDNS fetch in a single database query.
Additionally it adds index on InstallationID to InstallationDNS table to not perform full table scan when fetching InstallationDNS.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Optimize fetching InstallationDNS
```
