### PR TITLE
Kops upgrade to 1.23 and terraform bump to v1.0.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
     - image: cimg/go:1.17
       environment:
         CLOUD_DATABASE=postgres://cloud_test@localhost:5432/cloud_test?sslmode=disable
-    - image: circleci/postgres:11.2-alpine
+    - image: cimg/postgres:12.11
       environment:
         POSTGRES_USER: cloud_test
         POSTGRES_DB: cloud_test

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ DOCKER_BUILD_IMAGE = golang:1.17
 DOCKER_BASE_IMAGE = alpine:3.16
 
 ## Tool Versions
-TERRAFORM_VERSION=0.15.5
-KOPS_VERSION=v1.22.6
+TERRAFORM_VERSION=1.0.7
+KOPS_VERSION=v1.23.4
 HELM_VERSION=v3.5.3
-KUBECTL_VERSION=v1.21.2
+KUBECTL_VERSION=v1.24.4
 
 ################################################################################
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ The following is required to properly run the cloud server.
 ##### Note: when versions are specified, it is extremely important to follow the requirement. Newer versions will often not work as expected
 
 1. Install [Go](https://golang.org/doc/install)
-2. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) version v0.15.5
+2. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) version v1.0.7
    1. Try using [tfswitch](https://warrensbox.github.io/terraform-switcher/) for switching easily between versions
-3. Install [kops](https://github.com/kubernetes/kops/blob/master/docs/install.md) version 1.22.X
+3. Install [kops](https://github.com/kubernetes/kops/blob/master/docs/install.md) version 1.23.X
 4. Install [Helm](https://helm.sh/docs/intro/install/) version 3.5.X
 5. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 6. Install [golang/mock](https://github.com/golang/mock#installation) version 1.4.x


### PR DESCRIPTION
Issue: CLD-4229
Signed-off-by: Stavros Foteinopoulos <stafot@gmail.com>

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Kops upgrade to 1.23 and terraform bump to v1.0.7

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-4229

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Kops upgrade to 1.23 and terraform bump to v1.0.7
```
