### PR TITLE
Sort DNS records in test for deterministic outcome

### DIFF
--- a/internal/api/installation_dns.go
+++ b/internal/api/installation_dns.go
@@ -127,15 +127,17 @@ func handleSetDomainNamePrimary(c *Context, w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		c.Logger.WithError(err).Error("Failed to create installation state change event")
 	}
-	// Refresh DNS records after switch
-	installationDTO.DNSRecords, err = c.Store.GetDNSRecordsForInstallation(installationDTO.ID)
+
+	unlockOnce()
+
+	// Refresh whole Installation after switch.
+	installationDTO, err = c.Store.GetInstallationDTO(installationDTO.ID, false, false)
 	if err != nil {
-		c.Logger.WithError(err).Error("Failed to get DNS records after primary switch")
+		c.Logger.WithError(err).Error("Failed to get Installation DTO after primary switch")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	unlockOnce()
 	c.Supervisor.Do()
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/installation_dns_test.go
+++ b/internal/api/installation_dns_test.go
@@ -6,6 +6,7 @@ package api_test
 
 import (
 	"net/http/httptest"
+	"sort"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -174,8 +175,16 @@ func Test_SetDomainNamePrimary(t *testing.T) {
 	installation, err = client.SetInstallationDomainPrimary(installation.ID, installation.DNSRecords[2].ID)
 	require.NoError(t, err)
 	assert.Equal(t, true, installation.DNSRecords[2].IsPrimary)
+	// Sort to ensure the order matches.
+	sort.Slice(installation.DNSRecords, func(i, j int) bool {
+		return installation.DNSRecords[i].DomainName < installation.DNSRecords[j].DomainName
+	})
 
 	installationFetched, err := client.GetInstallation(installation.ID, nil)
 	require.NoError(t, err)
+	// Sort to ensure the order matches.
+	sort.Slice(installationFetched.DNSRecords, func(i, j int) bool {
+		return installationFetched.DNSRecords[i].DomainName < installationFetched.DNSRecords[j].DomainName
+	})
 	assert.Equal(t, installationFetched, installation)
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The test is flaky due to not deterministic order of DNS records and how the response is constructed. This PR fixes it by sorting records before comparing Installation objects. Additionally, we fetch the whole Installation object after the switch to make sure it is fully up to date and alligned with regular installation query.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
