### PR TITLE
[MM-44904] Adding installations to group based on conditions

### DIFF
--- a/internal/store/group_dto.go
+++ b/internal/store/group_dto.go
@@ -45,7 +45,14 @@ func (sqlStore *SQLStore) GetGroupDTOs(filter *model.GroupFilter) ([]*model.Grou
 
 	dtos := make([]*model.GroupDTO, 0, len(groups))
 	for _, g := range groups {
-		dtos = append(dtos, g.ToDTO(annotations[g.ID]))
+		gDTO := g.ToDTO(annotations[g.ID])
+		if filter.WithStatus {
+			gDTO.Status, err = sqlStore.GetGroupStatus(gDTO.ID)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get status from group")
+			}
+		}
+		dtos = append(dtos, gDTO)
 	}
 
 	return dtos, nil

--- a/internal/store/group_dto_test.go
+++ b/internal/store/group_dto_test.go
@@ -67,6 +67,18 @@ func Test_GroupDTO(t *testing.T) {
 		assert.Equal(t, group3.ToDTO(nil), group3DTO)
 	})
 
+	t.Run("get group DTOs with status", func(t *testing.T) {
+		groups, err := sqlStore.GetGroupDTOs(&model.GroupFilter{
+			Paging:     model.AllPagesNotDeleted(),
+			WithStatus: true,
+		})
+		assert.NoError(t, err)
+		assert.NotZero(t, len(groups))
+		for _, g := range groups {
+			assert.NotNil(t, g.Status)
+		}
+	})
+
 	t.Run("get group DTOs", func(t *testing.T) {
 		testCases := []struct {
 			Description string

--- a/model/group.go
+++ b/model/group.go
@@ -30,6 +30,9 @@ type Group struct {
 type GroupFilter struct {
 	Paging
 	Annotations *AnnotationsFilter
+
+	// WithStatus if the store should also retrieve the status for each group
+	WithStatus bool
 }
 
 // ToDTO returns Group joined with Annotations.

--- a/model/group_allocator.go
+++ b/model/group_allocator.go
@@ -1,0 +1,63 @@
+package model
+
+import (
+	"math/rand"
+)
+
+// InstallationGroupAllocator defines a way to allocate installations into groups based on
+// each allocator internal logic.
+type InstallationGroupAllocator interface {
+	Choose(groups []*GroupDTO) (*GroupDTO, error)
+}
+
+// RandomInstallationGroupAllocator allocates the installation in a random group
+type RandomInstallationGroupAllocator struct{}
+
+func (iga *RandomInstallationGroupAllocator) Choose(groups []*GroupDTO) (*GroupDTO, error) {
+	return groups[rand.Intn(len(groups))], nil
+}
+
+// NewRandomInstallationGroupAllocator
+func NewRandomInstallationGroupAllocator() InstallationGroupAllocator {
+	return &RandomInstallationGroupAllocator{}
+}
+
+// LowestCountInstallationGroupAllocator allocates the installation in the group that has the lowest
+// count for the defined state
+type LowestCountInstallationGroupAllocator struct {
+	// the state to check
+	installationState string
+}
+
+// getStateValue gets the value for the selected state to check from the provided group
+// defaults to the total instalations silently if the provided state is not handled
+func (iga *LowestCountInstallationGroupAllocator) getStateValue(group *GroupDTO) int64 {
+	switch iga.installationState {
+	case "updated":
+		return group.Status.InstallationsUpdated
+	default:
+		return group.Status.InstallationsTotal
+	}
+}
+
+// getLowestInstallationCount retrieves the lowest installation count group based on the defined state field
+func (iga *LowestCountInstallationGroupAllocator) getLowestInstallationCount(groups []*GroupDTO) (group *GroupDTO) {
+	for _, g := range groups {
+		if group == nil || iga.getStateValue(g) < iga.getStateValue(group) {
+			group = g
+		}
+	}
+
+	return
+}
+
+func (iga *LowestCountInstallationGroupAllocator) Choose(groups []*GroupDTO) (*GroupDTO, error) {
+	return iga.getLowestInstallationCount(groups), nil
+}
+
+// NewLowestCountInstallationGroupAllocator
+func NewLowestCountInstallationGroupAllocator(state string) InstallationGroupAllocator {
+	return &LowestCountInstallationGroupAllocator{
+		installationState: state,
+	}
+}

--- a/model/group_allocator_test.go
+++ b/model/group_allocator_test.go
@@ -1,0 +1,105 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestGroups() []*GroupDTO {
+	return []*GroupDTO{
+		{
+			Group: &Group{
+				ID:              "id1",
+				Sequence:        0,
+				Name:            "group1",
+				Version:         "1",
+				APISecurityLock: false,
+				LockAcquiredBy:  nil,
+				LockAcquiredAt:  int64(0),
+			},
+			Annotations: []*Annotation{{ID: "id", Name: "foo"}},
+			Status: &GroupStatus{
+				InstallationsTotal:   1,
+				InstallationsUpdated: 2,
+			},
+		},
+		{
+			Group: &Group{
+				ID:              "id2",
+				Sequence:        0,
+				Name:            "group2",
+				Version:         "1",
+				APISecurityLock: false,
+				LockAcquiredBy:  nil,
+				LockAcquiredAt:  int64(0),
+			},
+			Annotations: []*Annotation{{ID: "id", Name: "foo"}},
+			Status: &GroupStatus{
+				InstallationsTotal:   2,
+				InstallationsUpdated: 1,
+			},
+		},
+		{
+			Group: &Group{
+				ID:              "id2",
+				Sequence:        0,
+				Name:            "group2",
+				Version:         "1",
+				APISecurityLock: false,
+				LockAcquiredBy:  nil,
+				LockAcquiredAt:  int64(0),
+			},
+			Annotations: []*Annotation{{ID: "id", Name: "foo"}},
+			Status: &GroupStatus{
+				InstallationsTotal:   3,
+				InstallationsUpdated: 2,
+			},
+		},
+	}
+}
+
+// TestGroupAllocator common tests for group allocators
+func TestGroupAllocator(t *testing.T) {
+	allocators := map[string]InstallationGroupAllocator{
+		"Random":        NewRandomInstallationGroupAllocator(),
+		"LowestTotal":   NewLowestCountInstallationGroupAllocator("total"),
+		"LowestUpdated": NewLowestCountInstallationGroupAllocator("updated"),
+	}
+
+	for name, a := range allocators {
+		t.Run(name, func(t *testing.T) {
+			testGroupAllocatorOk(t, a)
+		})
+	}
+}
+
+// testGroupAllocatorOk checks that the provider allocator at least returns a group with no errors
+func testGroupAllocatorOk(t *testing.T, allocator InstallationGroupAllocator) {
+	groups := getTestGroups()
+	selectedGroup, err := allocator.Choose(groups)
+	assert.NoError(t, err)
+	assert.NotNil(t, selectedGroup)
+}
+
+// TestLowestInstallationCountTotal checks that the lowest installation count by total works ok
+func TestLowestInstallationCountTotal(t *testing.T) {
+	groups := getTestGroups()
+
+	allocator := NewLowestCountInstallationGroupAllocator("total")
+
+	chosenGroup, err := allocator.Choose(groups)
+	assert.NoError(t, err)
+	assert.Equal(t, groups[0].ID, chosenGroup.ID)
+}
+
+// TestLowestInstallationCountUpdated checks that the lowest installation count by updated works ok
+func TestLowestInstallationCountUpdated(t *testing.T) {
+	groups := getTestGroups()
+
+	allocator := NewLowestCountInstallationGroupAllocator("updated")
+
+	chosenGroup, err := allocator.Choose(groups)
+	assert.NoError(t, err)
+	assert.Equal(t, groups[1].ID, chosenGroup.ID)
+}

--- a/model/group_dto.go
+++ b/model/group_dto.go
@@ -13,6 +13,7 @@ import (
 type GroupDTO struct {
 	*Group
 	Annotations []*Annotation `json:"annotations"`
+	Status      *GroupStatus  `json:"status,omitempty"`
 }
 
 // GroupDTOFromReader decodes a json-encoded group DTO from the given io.Reader.


### PR DESCRIPTION
#### Summary

Refactor of the group allocation for new installations.

Previously, group allocation was performed randomly based on group annotations. This system is changed with this PR introducing the concept of a Group Allocator, which receives a list of groups and selects one based on it internal logic.

Two group allocations have been created, one Random, to preserve the original logic, and a new one to select a group based on the lowest count of total or updated installations.

Database utilization is quite heavy (since we need 6 queries to get the status for **one** group). If we only need the total installation count I could refactor the query or add a new method to the store/filter to retrieve the total installation count directly with the groups. (Which is probably the best way ahead for the time being).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44904

#### Release Note

```release-note
- Automatically add new installations to a group based on lowest installation count
```
