### PR TITLE
[MM-46849] Use rotator when resizing a cluster

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -525,6 +525,16 @@ func (provisioner *KopsProvisioner) ResizeCluster(cluster *model.Cluster, awsCli
 		return err
 	}
 
+	if cluster.ProvisionerMetadataKops.RotatorRequest.Config != nil {
+		if *cluster.ProvisionerMetadataKops.RotatorRequest.Config.UseRotator {
+			logger.Info("Using node rotator for node resize")
+			err = provisioner.RotateClusterNodes(cluster)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	err = kops.RollingUpdateCluster(kopsMetadata.Name)
 	if err != nil {
 		return err

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -237,29 +237,8 @@ func (p *PatchUpgradeClusterRequest) Validate() error {
 	}
 
 	if p.RotatorConfig != nil {
-		if p.RotatorConfig.UseRotator == nil {
-			return errors.Errorf("rotator config use rotator should be set")
-		}
-
-		if *p.RotatorConfig.UseRotator {
-			if p.RotatorConfig.EvictGracePeriod == nil {
-				return errors.Errorf("rotator config evict grace period should be set")
-			}
-			if p.RotatorConfig.MaxDrainRetries == nil {
-				return errors.Errorf("rotator config max drain retries should be set")
-			}
-			if p.RotatorConfig.MaxScaling == nil {
-				return errors.Errorf("rotator config max scaling should be set")
-			}
-			if p.RotatorConfig.WaitBetweenDrains == nil {
-				return errors.Errorf("rotator config wait between drains should be set")
-			}
-			if p.RotatorConfig.WaitBetweenRotations == nil {
-				return errors.Errorf("rotator config wait between rotations should be set")
-			}
-			if p.RotatorConfig.WaitBetweenPodEvictions == nil {
-				return errors.Errorf("rotator config wait between pod evictions should be set")
-			}
+		if err := p.RotatorConfig.Validate(); err != nil {
+			return err
 		}
 	}
 

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -75,6 +75,35 @@ type RotatorConfig struct {
 	WaitBetweenPodEvictions *int  `json:"wait-between-pod-evictions,omitempty"`
 }
 
+// Validate validates that the provided attributes for the rotator are set
+func (r RotatorConfig) Validate() error {
+	if r.UseRotator == nil {
+		return errors.Errorf("rotator config use rotator should be set")
+	}
+
+	if *r.UseRotator {
+		if r.EvictGracePeriod == nil {
+			return errors.Errorf("rotator config evict grace period should be set")
+		}
+		if r.MaxDrainRetries == nil {
+			return errors.Errorf("rotator config max drain retries should be set")
+		}
+		if r.MaxScaling == nil {
+			return errors.Errorf("rotator config max scaling should be set")
+		}
+		if r.WaitBetweenRotations == nil {
+			return errors.Errorf("rotator config wait between rotations should be set")
+		}
+		if r.WaitBetweenDrains == nil {
+			return errors.Errorf("rotator config wait between drains should be set")
+		}
+		if r.WaitBetweenPodEvictions == nil {
+			return errors.Errorf("rotator config wait between pod evictions should be set")
+		}
+	}
+	return nil
+}
+
 // ValidateChangeRequest ensures that the ChangeRequest has at least one
 // actionable value.
 func (km *KopsMetadata) ValidateChangeRequest() error {

--- a/model/kops_metadata_test.go
+++ b/model/kops_metadata_test.go
@@ -551,3 +551,97 @@ func TestGetKopsResizeSetActionsFromChanges(t *testing.T) {
 		})
 	}
 }
+
+func TestRotatorConfigValidation(t *testing.T) {
+	boolValue := true
+	intValue := 10
+
+	t.Run("UseRotator can't be nil", func(t *testing.T) {
+		rotatorConfig := model.RotatorConfig{}
+		require.Error(t, rotatorConfig.Validate())
+	})
+	t.Run("EvictGracePeriod must be set", func(t *testing.T) {
+		rotatorConfig := model.RotatorConfig{
+			UseRotator: &boolValue,
+			// EvictGracePeriod: &intValue,
+			MaxDrainRetries:         &intValue,
+			MaxScaling:              &intValue,
+			WaitBetweenRotations:    &intValue,
+			WaitBetweenDrains:       &intValue,
+			WaitBetweenPodEvictions: &intValue,
+		}
+		require.Error(t, rotatorConfig.Validate())
+	})
+	t.Run("MaxDrainRetries must be set", func(t *testing.T) {
+		rotatorConfig := model.RotatorConfig{
+			UseRotator:       &boolValue,
+			EvictGracePeriod: &intValue,
+			// MaxDrainRetries:         &intValue,
+			MaxScaling:              &intValue,
+			WaitBetweenRotations:    &intValue,
+			WaitBetweenDrains:       &intValue,
+			WaitBetweenPodEvictions: &intValue,
+		}
+		require.Error(t, rotatorConfig.Validate())
+	})
+	t.Run("MaxScaling must be set", func(t *testing.T) {
+		rotatorConfig := model.RotatorConfig{
+			UseRotator:       &boolValue,
+			EvictGracePeriod: &intValue,
+			MaxDrainRetries:  &intValue,
+			// MaxScaling:              &intValue,
+			WaitBetweenRotations:    &intValue,
+			WaitBetweenDrains:       &intValue,
+			WaitBetweenPodEvictions: &intValue,
+		}
+		require.Error(t, rotatorConfig.Validate())
+	})
+	t.Run("WaitBetweenRotations must be set", func(t *testing.T) {
+		rotatorConfig := model.RotatorConfig{
+			UseRotator:       &boolValue,
+			EvictGracePeriod: &intValue,
+			MaxDrainRetries:  &intValue,
+			MaxScaling:       &intValue,
+			// WaitBetweenRotations:    &intValue,
+			WaitBetweenDrains:       &intValue,
+			WaitBetweenPodEvictions: &intValue,
+		}
+		require.Error(t, rotatorConfig.Validate())
+	})
+	t.Run("WaitBetweenDrains must be set", func(t *testing.T) {
+		rotatorConfig := model.RotatorConfig{
+			UseRotator:           &boolValue,
+			EvictGracePeriod:     &intValue,
+			MaxDrainRetries:      &intValue,
+			MaxScaling:           &intValue,
+			WaitBetweenRotations: &intValue,
+			// WaitBetweenDrains:       &intValue,
+			WaitBetweenPodEvictions: &intValue,
+		}
+		require.Error(t, rotatorConfig.Validate())
+	})
+	t.Run("WaitBetweenPodEvictions must be set", func(t *testing.T) {
+		rotatorConfig := model.RotatorConfig{
+			UseRotator:           &boolValue,
+			EvictGracePeriod:     &intValue,
+			MaxDrainRetries:      &intValue,
+			MaxScaling:           &intValue,
+			WaitBetweenRotations: &intValue,
+			WaitBetweenDrains:    &intValue,
+			// WaitBetweenPodEvictions: &intValue,
+		}
+		require.Error(t, rotatorConfig.Validate())
+	})
+	t.Run("valid RotatorConfig", func(t *testing.T) {
+		rotatorConfig := model.RotatorConfig{
+			UseRotator:              &boolValue,
+			EvictGracePeriod:        &intValue,
+			MaxDrainRetries:         &intValue,
+			MaxScaling:              &intValue,
+			WaitBetweenRotations:    &intValue,
+			WaitBetweenDrains:       &intValue,
+			WaitBetweenPodEvictions: &intValue,
+		}
+		require.NoError(t, rotatorConfig.Validate())
+	})
+}


### PR DESCRIPTION
#### Summary

Add [rotator](https://github.com/mattermost/rotator) support to the resize operation of `cluster` in the same way we use it for `upgrade`. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46849


#### Release Note

```release-note
- Add rotator support to resize operation
```
