### PR TITLE
add server flag for server_reset_query_always and change its default …

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -108,6 +108,7 @@ func init() {
 	serverCmd.PersistentFlags().Int("max-client-connections", 20000, "The db proxy max client connections.")
 	serverCmd.PersistentFlags().Int("server-idle-timeout", 30, "The server idle timeout.")
 	serverCmd.PersistentFlags().Int("server-lifetime", 300, "The server lifetime.")
+	serverCmd.PersistentFlags().Int("server-reset-query-always", 0, "Whether server_reset_query should be run in all pooling modes.")
 
 	serverCmd.PersistentFlags().String("kubecost-token", "", "Set a kubecost token")
 	serverCmd.PersistentFlags().String("ndots-value", "5", "The default ndots value for installations.")
@@ -178,6 +179,9 @@ var serverCmd = &cobra.Command{
 
 		serverLifetime, _ := command.Flags().GetInt("server-lifetime")
 		model.SetServerLifetime(serverLifetime)
+
+		serverResetQueryAlways, _ := command.Flags().GetInt("server-reset-query-always")
+		model.SetServerResetQueryAlways(serverResetQueryAlways)
 
 		gitlabOAuthToken, _ := command.Flags().GetString("gitlab-oauth")
 		if len(gitlabOAuthToken) == 0 {

--- a/internal/provisioner/pgbouncer.go
+++ b/internal/provisioner/pgbouncer.go
@@ -198,7 +198,7 @@ max_client_conn = %d
 max_db_connections = %d
 server_idle_timeout = %d
 server_lifetime = %d
-server_reset_query_always = 1
+server_reset_query_always = %d
 
 [databases]
 `
@@ -248,7 +248,7 @@ func generatePGBouncerIni(vpcID string, store model.ClusterUtilityDatabaseStoreI
 }
 
 func generatePGBouncerBaseIni() string {
-	return fmt.Sprintf(baseIni, model.GetMinPoolSize(), model.GetDefaultPoolSize(), model.GetReservePoolSize(), model.GetMaxClientConnections(), model.GetMaxDatabaseConnectionsPerPool(), model.GetServerIdleTimeout(), model.GetServerLifetime())
+	return fmt.Sprintf(baseIni, model.GetMinPoolSize(), model.GetDefaultPoolSize(), model.GetReservePoolSize(), model.GetMaxClientConnections(), model.GetMaxDatabaseConnectionsPerPool(), model.GetServerIdleTimeout(), model.GetServerLifetime(), model.GetServerResetQueryAlways())
 }
 
 func generatePGBouncerUserlist(vpcID string, awsClient aws.AWS) (string, error) {

--- a/model/multitenant_database.go
+++ b/model/multitenant_database.go
@@ -55,6 +55,9 @@ var serverIdleTimeout int = 30
 // serverLifetime is the server lifetime
 var serverLifetime int = 300
 
+// serverResetQueryAlways is boolean 0 or 1 whether server_reset_query should be run in all pooling modes.
+var serverResetQueryAlways int = 0
+
 // SetMaxDatabaseConnectionsPerPool is used to define how many database
 // connections are created per logical database pool with proxy databases.
 func SetMaxDatabaseConnectionsPerPool(val int) error {
@@ -101,6 +104,11 @@ func SetServerLifetime(val int) {
 	serverLifetime = val
 }
 
+// SetServerResetQueryAlways is used to define 0 or 1 whether server_reset_query should be run in all pooling modes.
+func SetServerResetQueryAlways(val int) {
+	serverResetQueryAlways = val
+}
+
 // GetMaxDatabaseConnectionsPerPool returns the value of
 // maxDatabaseConnectionsPerPool.
 func GetMaxDatabaseConnectionsPerPool() int {
@@ -135,6 +143,11 @@ func GetServerIdleTimeout() int {
 // GetServerLifetime returns the value of serverLifetime.
 func GetServerLifetime() int {
 	return serverLifetime
+}
+
+// GetServerResetQueryAlways returns the value of serverResetQueryAlways.
+func GetServerResetQueryAlways() int {
+	return serverResetQueryAlways
 }
 
 // MultitenantDatabase represents database infrastructure that contains multiple


### PR DESCRIPTION
#### Summary
add server flag for server_reset_query_always and change its default value to 0.
Adding it as a flag will give the ability to revert it easily back to 1 in case something goes wrong in production.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-4228

#### Release Note


```release-note
add server flag for server-reset-query-always and set default value to 0
```
