### PR TITLE
change auth_query of pgbouncer to not use the function

### DIFF
--- a/internal/provisioner/pgbouncer.go
+++ b/internal/provisioner/pgbouncer.go
@@ -179,7 +179,7 @@ const baseIni = `
 listen_addr = *
 listen_port = 5432
 auth_file = /etc/userlist/userlist.txt
-auth_query = SELECT usename, passwd FROM pgbouncer.get_auth($1)
+auth_query = SELECT usename, passwd FROM pgbouncer.pgbouncer_users WHERE usename=$1
 admin_users = admin
 ignore_startup_parameters = extra_float_digits
 tcp_keepalive = 1


### PR DESCRIPTION
#### Summary
change auth_query of pgbouncer to not use the function

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-4414

#### Release Note

```release-note
change auth_query of pgbouncer to not use the function
```
