### PR TITLE
[MM-47887] Tag RDS resources with the ClusterID they belong to

### DIFF
--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -11,6 +11,10 @@ const (
 	// DefaultAWSRegion is the default AWS region for AWS resources.
 	DefaultAWSRegion = "us-east-1"
 
+	// ClusterIDTagKey is the tag key used to tag resources with the cluster ID that
+	// it belongs to
+	ClusterIDTagKey = "CloudClusterID"
+
 	// VpcAvailableTagKey is the tag key to determine if a VPC is currently in
 	// use by a cluster or not.
 	VpcAvailableTagKey = "tag:Available"
@@ -25,7 +29,7 @@ const (
 
 	// VpcClusterIDTagKey is the tag key used to store the cluster ID of the
 	// cluster running in that VPC.
-	VpcClusterIDTagKey = "tag:CloudClusterID"
+	VpcClusterIDTagKey = "tag:" + ClusterIDTagKey
 
 	// VpcClusterOwnerKey is the tag key  used to store the owner of the
 	// cluster's human name so that the VPC's owner can be identified

--- a/internal/tools/aws/database.go
+++ b/internal/tools/aws/database.go
@@ -318,7 +318,7 @@ func (d *RDSDatabase) rdsDatabaseProvision(installationID string, logger log.Fie
 		return errors.Wrapf(err, "failed to convert database type to database engine")
 	}
 
-	tags, err := NewTags(VpcClusterIDTagKey, clusterID)
+	tags, err := NewTags(ClusterIDTagKey, clusterID)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate AWS Tags")
 	}

--- a/internal/tools/aws/rds.go
+++ b/internal/tools/aws/rds.go
@@ -99,6 +99,7 @@ func (a *Client) rdsEnsureDBClusterCreated(
 	password,
 	kmsKeyID,
 	databaseType string,
+	tags *Tags,
 	logger log.FieldLogger) error {
 
 	var engine, engineVersion, sgTagValue string
@@ -165,6 +166,7 @@ func (a *Client) rdsEnsureDBClusterCreated(
 		DBSubnetGroupName:     aws.String(dbSubnetGroupName),
 		VpcSecurityGroupIds:   aws.StringSlice(dbSecurityGroupIDs),
 		KmsKeyId:              aws.String(kmsKeyID),
+		Tags:                  tags.ToRDSTags(),
 	}
 
 	_, err = a.Service().rds.CreateDBCluster(input)
@@ -182,6 +184,7 @@ func (a *Client) rdsEnsureDBClusterInstanceCreated(
 	instanceName,
 	engine string,
 	instanceClass string,
+	tags *Tags,
 	logger log.FieldLogger) error {
 
 	_, err := a.Service().rds.DescribeDBInstances(&rds.DescribeDBInstancesInput{
@@ -199,6 +202,7 @@ func (a *Client) rdsEnsureDBClusterInstanceCreated(
 		DBInstanceClass:      aws.String(instanceClass),
 		Engine:               aws.String(engine),
 		PubliclyAccessible:   aws.Bool(false),
+		Tags:                 tags.ToRDSTags(),
 	})
 	if err != nil {
 		return err

--- a/internal/tools/aws/tags.go
+++ b/internal/tools/aws/tags.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/rds"
+)
+
+// Tags an abstract represtation of tags that can be converted to different AWS resource tags
+type Tags struct {
+	tags map[string]string
+}
+
+// Add adds a new tag in a key,value format
+func (t *Tags) Add(key, value string) {
+	t.tags[key] = value
+}
+
+// AddMany adds an indetermited amount of tags, must be even
+func (t *Tags) AddMany(items ...string) error {
+	if len(items)%2 != 0 {
+		return errors.New("add many requires an even number of arguments")
+	}
+
+	for i := 0; i < len(items); i = i + 2 {
+		t.tags[items[i]] = items[i+1]
+	}
+
+	return nil
+}
+
+// ToRDSTags convert the tags into an RDS tags format
+func (t *Tags) ToRDSTags() []*rds.Tag {
+	result := make([]*rds.Tag, 0, t.Len())
+
+	for k, v := range t.tags {
+		result = append(result, &rds.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+
+	return result
+}
+
+// ToEC2Tags convert the tags into an RDS tags format
+func (t *Tags) ToEC2Tags() []*ec2.Tag {
+	result := make([]*ec2.Tag, 0, t.Len())
+
+	for k, v := range t.tags {
+		result = append(result, &ec2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+
+	return result
+}
+
+// Len returns the number of tags
+func (t *Tags) Len() int {
+	return len(t.tags)
+}
+
+// NewTags create a new instance of AWSTags optionally adding some of them on creation
+func NewTags(items ...string) (*Tags, error) {
+	t := Tags{
+		tags: make(map[string]string),
+	}
+
+	if err := t.AddMany(items...); err != nil {
+		return nil, err
+	}
+
+	return &t, nil
+}

--- a/internal/tools/aws/tags_test.go
+++ b/internal/tools/aws/tags_test.go
@@ -1,0 +1,86 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagNewWithMany(t *testing.T) {
+	tags, err := NewTags("one", "two")
+	assert.NoError(t, err)
+	assert.Len(t, tags.tags, 1)
+	tags, err = NewTags("one", "two", "three", "four")
+	assert.NoError(t, err)
+	assert.Len(t, tags.tags, 2)
+}
+
+func TestTagLen(t *testing.T) {
+	tags, err := NewTags("one", "two")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, tags.Len())
+	tags.Add("other", "tag")
+	assert.Equal(t, 2, tags.Len())
+}
+
+func TestTagAdd(t *testing.T) {
+	tags, err := NewTags()
+	assert.NoError(t, err)
+	tags.Add("key", "value")
+	assert.Len(t, tags.tags, 1)
+}
+
+func TestTagAddMany(t *testing.T) {
+	tags, err := NewTags()
+	assert.NoError(t, err)
+	err = tags.AddMany("key", "value", "key2", "value2")
+	assert.NoError(t, err)
+	assert.Len(t, tags.tags, 2)
+}
+
+func TestTagAddManyOdd(t *testing.T) {
+	tags, err := NewTags()
+	assert.NoError(t, err)
+	err = tags.AddMany("key", "value", "key2")
+	assert.Error(t, err)
+}
+
+func TestTagsASRDSTags(t *testing.T) {
+	key := "key"
+	value := "value"
+	key2 := "key2"
+	value2 := "value2"
+	tags, err := NewTags(key, value, key2, value2)
+	assert.NoError(t, err)
+	assert.Equal(t, []*rds.Tag{
+		{
+			Key:   &key,
+			Value: &value,
+		},
+		{
+			Key:   &key2,
+			Value: &value2,
+		},
+	}, tags.ToRDSTags())
+}
+
+func TestTagsASEC2Tags(t *testing.T) {
+	key := "key"
+	value := "value"
+	key2 := "key2"
+	value2 := "value2"
+	tags, err := NewTags(key, value, key2, value2)
+	assert.NoError(t, err)
+	assert.Equal(t, []*ec2.Tag{
+		{
+			Key:   &key,
+			Value: &value,
+		},
+		{
+			Key:   &key2,
+			Value: &value2,
+		},
+	}, tags.ToEC2Tags())
+}


### PR DESCRIPTION
#### Summary

Add the `clusterID` tag to RDS resources on provision.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-47887

#### Release Note

```release-note
- Tag RDS resources with the ClusterID they belong to.
```
