### PR TITLE
Set default_text_search_config to pg_catalog.english

### DIFF
--- a/internal/tools/aws/database_multitenant_pgbouncer.go
+++ b/internal/tools/aws/database_multitenant_pgbouncer.go
@@ -481,6 +481,11 @@ func (d *RDSMultitenantPGBouncerDatabase) ensureLogicalDatabaseSetup(databaseNam
 		return errors.Wrap(err, "failed to perform pgbouncer setup")
 	}
 
+	err = d.ensureDefaultTextSearchConfig(ctx, databaseName)
+	if err != nil {
+		return errors.Wrap(err, "failed to ensure default text search config")
+	}
+
 	installationSecret, err := d.ensureMultitenantDatabaseSecretIsCreated(rdsCluster.DBClusterIdentifier, &vpcID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get a secret for installation")
@@ -590,6 +595,16 @@ func (d *RDSMultitenantPGBouncerDatabase) ensurePGBouncerDatabasePrep(ctx contex
 	_, err = d.db.QueryContext(ctx, query)
 	if err != nil {
 		return errors.Wrap(err, "failed to run auth user lookup query SQL command")
+	}
+
+	return nil
+}
+
+func (d *RDSMultitenantPGBouncerDatabase) ensureDefaultTextSearchConfig(ctx context.Context, databaseName string) error {
+	query := fmt.Sprintf(`ALTER DATABASE %s SET default_text_search_config TO "pg_catalog.english";`, databaseName)
+	_, err := d.db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run SQL command to set default_text_search_config to pg_catalog.english")
 	}
 
 	return nil


### PR DESCRIPTION
When managing logical databases for PGBouncer, we now set the `default_text_search_config` value to `pg_catalog.english` in order to increase Mattermost query performance.

Fixes https://mattermost.atlassian.net/browse/MM-48143

```release-note
Set default_text_search_config to pg_catalog.english
```
