### PR TITLE
[MM-46265] Uniform Cluster VPC resource tagging

### DIFF
--- a/internal/provisioner/eks_provisioner_cluster.go
+++ b/internal/provisioner/eks_provisioner_cluster.go
@@ -109,11 +109,6 @@ func (provisioner *EKSProvisioner) CreateCluster(cluster *model.Cluster, awsClie
 		}
 	}
 
-	clusterResources, err = awsClient.ClaimVPC(clusterResources.VpcID, cluster, provisioner.params.Owner, logger)
-	if err != nil {
-		return errors.Wrap(err, "Couldn't claim VPC")
-	}
-
 	// Update cluster to set VPC ID that is needed later.
 	cluster.ProvisionerMetadataEKS.VPC = clusterResources.VpcID
 	err = provisioner.clusterUpdateStore.UpdateCluster(cluster)

--- a/internal/provisioner/eks_provisioner_cluster.go
+++ b/internal/provisioner/eks_provisioner_cluster.go
@@ -109,6 +109,11 @@ func (provisioner *EKSProvisioner) CreateCluster(cluster *model.Cluster, awsClie
 		}
 	}
 
+	clusterResources, err = awsClient.ClaimVPC(clusterResources.VpcID, cluster, provisioner.params.Owner, logger)
+	if err != nil {
+		return errors.Wrap(err, "Couldn't claim VPC")
+	}
+
 	// Update cluster to set VPC ID that is needed later.
 	cluster.ProvisionerMetadataEKS.VPC = clusterResources.VpcID
 	err = provisioner.clusterUpdateStore.UpdateCluster(cluster)

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -81,20 +81,15 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 
 	var clusterResources aws.ClusterResources
 	if kopsMetadata.ChangeRequest.VPC != "" && provisioner.params.UseExistingAWSResources {
-		clusterResources, err = awsClient.GetVpcResourcesByVpcID(kopsMetadata.ChangeRequest.VPC, logger)
+		clusterResources, err = awsClient.ClaimVPC(kopsMetadata.ChangeRequest.VPC, cluster, provisioner.params.Owner, logger)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "Couldn't claim VPC")
 		}
 	} else if provisioner.params.UseExistingAWSResources {
 		clusterResources, err = awsClient.GetAndClaimVpcResources(cluster, provisioner.params.Owner, logger)
 		if err != nil {
 			return err
 		}
-	}
-
-	clusterResources, err = awsClient.ClaimVPC(clusterResources.VpcID, cluster, provisioner.params.Owner, logger)
-	if err != nil {
-		return errors.Wrap(err, "Couldn't claim VPC")
 	}
 
 	err = kops.CreateCluster(

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -92,6 +92,11 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 		}
 	}
 
+	clusterResources, err = awsClient.ClaimVPC(clusterResources.VpcID, cluster, provisioner.params.Owner, logger)
+	if err != nil {
+		return errors.Wrap(err, "Couldn't claim VPC")
+	}
+
 	err = kops.CreateCluster(
 		kopsMetadata.Name,
 		cluster.Provider,

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -83,7 +83,7 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 	if kopsMetadata.ChangeRequest.VPC != "" && provisioner.params.UseExistingAWSResources {
 		clusterResources, err = awsClient.ClaimVPC(kopsMetadata.ChangeRequest.VPC, cluster, provisioner.params.Owner, logger)
 		if err != nil {
-			return errors.Wrap(err, "Couldn't claim VPC")
+			return errors.Wrap(err, "couldn't claim VPC")
 		}
 	} else if provisioner.params.UseExistingAWSResources {
 		clusterResources, err = awsClient.GetAndClaimVpcResources(cluster, provisioner.params.Owner, logger)

--- a/internal/provisioner/pgbouncer.go
+++ b/internal/provisioner/pgbouncer.go
@@ -265,18 +265,19 @@ func generatePGBouncerUserlist(vpcID string, awsClient aws.AWS) (string, error) 
 }
 
 // PGBouncerConfig contains the configuration for the PGBouncer utility.
-////////////////////////////////////////////////////////////////////////////////
-// - MaxDatabaseConnectionsPerPool is the maximum number of connections per
-//   logical database pool when using proxy databases.
-// - MinPoolSize is the minimum pool size.
-// - DefaultPoolSize is the default pool size per user.
-// - ReservePoolSize is the default pool size per user.
-// - MaxClientConnections is the maximum client connections.
-// - ServerIdleTimeout is the server idle timeout.
-// - ServerLifetime is the server lifetime.
-// - ServerResetQueryAlways is boolean 0 or 1 whether server_reset_query should
-//   be run in all pooling modes.
-////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////
+//   - MaxDatabaseConnectionsPerPool is the maximum number of connections per
+//     logical database pool when using proxy databases.
+//   - MinPoolSize is the minimum pool size.
+//   - DefaultPoolSize is the default pool size per user.
+//   - ReservePoolSize is the default pool size per user.
+//   - MaxClientConnections is the maximum client connections.
+//   - ServerIdleTimeout is the server idle timeout.
+//   - ServerLifetime is the server lifetime.
+//   - ServerResetQueryAlways is boolean 0 or 1 whether server_reset_query should
+//     be run in all pooling modes.
+//
+// //////////////////////////////////////////////////////////////////////////////
 type PGBouncerConfig struct {
 	MinPoolSize                   int
 	DefaultPoolSize               int

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -232,11 +232,6 @@ func (a *Client) GetAndClaimVpcResources(cluster *model.Cluster, owner string, l
 			continue
 		}
 
-		err = a.claimVpc(clusterResources, cluster, owner, logger)
-		if err != nil {
-			return clusterResources, err
-		}
-
 		return clusterResources, nil
 	}
 
@@ -476,7 +471,6 @@ func (a *Client) GetVpcResourcesByVpcID(vpcID string, logger log.FieldLogger) (C
 
 // TagResourcesByCluster for secondary cluster.
 func (a *Client) TagResourcesByCluster(clusterResources ClusterResources, cluster *model.Cluster, owner string, logger log.FieldLogger) error {
-
 	for _, subnet := range clusterResources.PublicSubnetsIDs {
 		err := a.TagResource(subnet, fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster)), "shared", logger)
 		if err != nil {
@@ -493,7 +487,6 @@ func (a *Client) TagResourcesByCluster(clusterResources ClusterResources, cluste
 
 // SwitchClusterTags after migration.
 func (a *Client) SwitchClusterTags(clusterID string, targetClusterID string, logger log.FieldLogger) error {
-
 	clusterResources, err := a.GetVpcResources(clusterID, logger)
 	if err != nil {
 		return errors.Wrapf(err, "unable to get vpc resources for %s", clusterID)

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -232,6 +232,11 @@ func (a *Client) GetAndClaimVpcResources(cluster *model.Cluster, owner string, l
 			continue
 		}
 
+		err = a.claimVpc(clusterResources, cluster, owner, logger)
+		if err != nil {
+			return clusterResources, err
+		}
+
 		return clusterResources, nil
 	}
 

--- a/internal/tools/aws/cluster_management_test.go
+++ b/internal/tools/aws/cluster_management_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+)
+
+func (a *AWSTestSuite) TestClaimVPC() {
+	owner := "test"
+	vpcID := "mock-vpc"
+	privateSubnetID := "private-id1"
+	publicSubnetID := "public-id1"
+	masterSecurityGroupID := "master-sg-id"
+	workerSecurityGroupID := "worker-sg-id"
+	callsSecurityGroupID := "calls-sg-id"
+	cidrBlock := "100.0.0.0/16"
+	cluster := a.ClusterA
+
+	gomock.InOrder(
+		// ClaimVPC
+		a.Mocks.API.EC2.EXPECT().
+			DescribeVpcs(&ec2.DescribeVpcsInput{
+				VpcIds: aws.StringSlice([]string{vpcID}),
+			}).
+			Return(&ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{{
+					VpcId:     aws.String(vpcID),
+					CidrBlock: aws.String(cidrBlock),
+				}},
+			}, nil).
+			Times(1),
+		// getClusterResourcesForVPC
+		a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("vpc-id"),
+					Values: aws.StringSlice([]string{vpcID}),
+				},
+				{
+					Name:   aws.String("tag:SubnetType"),
+					Values: aws.StringSlice([]string{"private"}),
+				},
+			},
+		}).
+			Return(&ec2.DescribeSubnetsOutput{
+				Subnets: []*ec2.Subnet{{
+					SubnetId: aws.String(privateSubnetID),
+				}},
+			}, nil).
+			Times(1),
+		a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("vpc-id"),
+					Values: aws.StringSlice([]string{vpcID}),
+				},
+				{
+					Name:   aws.String("tag:SubnetType"),
+					Values: aws.StringSlice([]string{"public"}),
+				},
+			},
+		}).
+			Return(&ec2.DescribeSubnetsOutput{
+				Subnets: []*ec2.Subnet{{
+					SubnetId: aws.String(publicSubnetID),
+				}},
+			}, nil).
+			Times(1),
+		a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("vpc-id"),
+					Values: aws.StringSlice([]string{vpcID}),
+				},
+				{
+					Name:   aws.String("tag:NodeType"),
+					Values: aws.StringSlice([]string{"master"}),
+				},
+			},
+		}).
+			Return(&ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{{
+					GroupId: aws.String(masterSecurityGroupID),
+				}},
+			}, nil).
+			Times(1),
+		a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("vpc-id"),
+					Values: aws.StringSlice([]string{vpcID}),
+				},
+				{
+					Name:   aws.String("tag:NodeType"),
+					Values: aws.StringSlice([]string{"worker"}),
+				},
+			},
+		}).
+			Return(&ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{{
+					GroupId: aws.String(workerSecurityGroupID),
+				}},
+			}, nil).
+			Times(1),
+		a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("vpc-id"),
+					Values: aws.StringSlice([]string{vpcID}),
+				},
+				{
+					Name:   aws.String("tag:NodeType"),
+					Values: aws.StringSlice([]string{"calls"}),
+				},
+			},
+		}).
+			Return(&ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{{
+					GroupId: aws.String(callsSecurityGroupID),
+				}},
+			}, nil).
+			Times(1),
+		// claimVpc
+		a.Mocks.API.EC2.EXPECT().DescribeVpcs(&ec2.DescribeVpcsInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("vpc-id"),
+					Values: aws.StringSlice([]string{vpcID}),
+				},
+				{
+					Name:   aws.String(VpcAvailableTagKey),
+					Values: aws.StringSlice([]string{VpcAvailableTagValueTrue}),
+				},
+				{
+					Name:   aws.String(VpcClusterIDTagKey),
+					Values: aws.StringSlice([]string{VpcClusterIDTagValueNone}),
+				},
+			},
+		}).
+			Return(&ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{{
+					VpcId:     aws.String(vpcID),
+					CidrBlock: aws.String(cidrBlock),
+				}},
+			}, nil).
+			Times(1),
+		a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+			Resources: []*string{
+				aws.String(vpcID),
+			},
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String(trimTagPrefix(VpcAvailableTagKey)),
+					Value: aws.String(VpcAvailableTagValueFalse),
+				},
+			},
+		}).
+			Return(nil, nil).
+			Times(1),
+		a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+			Resources: []*string{
+				aws.String(vpcID),
+			},
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String(trimTagPrefix(VpcClusterIDTagKey)),
+					Value: aws.String(cluster.ID),
+				},
+			},
+		}).
+			Return(nil, nil).
+			Times(1),
+		a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+			Resources: []*string{
+				aws.String(vpcID),
+			},
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String(trimTagPrefix(VpcClusterOwnerKey)),
+					Value: aws.String(owner),
+				},
+			},
+		}).
+			Return(nil, nil).
+			Times(1),
+		a.Mocks.API.EC2.EXPECT().CreateTags(gomock.Any()).
+			Return(nil, nil).
+			Times(3),
+	)
+
+	logger := logrus.New()
+
+	clusterResources, err := a.Mocks.AWS.ClaimVPC(vpcID, cluster, owner, logger)
+	a.Assert().NoError(err)
+	a.Assert().Equal(clusterResources.VpcID, vpcID)
+	a.Assert().Contains(clusterResources.PrivateSubnetIDs, privateSubnetID)
+	a.Assert().Contains(clusterResources.PublicSubnetsIDs, publicSubnetID)
+	a.Assert().Contains(clusterResources.MasterSecurityGroupIDs, masterSecurityGroupID)
+	a.Assert().Contains(clusterResources.WorkerSecurityGroupIDs, workerSecurityGroupID)
+	a.Assert().Contains(clusterResources.CallsSecurityGroupIDs, callsSecurityGroupID)
+}


### PR DESCRIPTION
#### Summary

Use the same tagging approach for cluster creation independently if a VPC is specified.

Add some basic testing.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46265

#### Release Note

```release-note
Fixed cluster VPC resource tagging when specifying a custom VPC
```
