### PR TITLE
[CLD-4033] Update Cloudprober to latest version

### DIFF
--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -40,7 +40,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"node-problem-detector": {Chart: "2.0.5", ValuesPath: ""},
 				"metrics-server":        {Chart: "3.8.2", ValuesPath: ""},
 				"velero":                {Chart: "2.31.3", ValuesPath: ""},
-				"cloudprober":           {Chart: "0.1.0", ValuesPath: ""},
+				"cloudprober":           {Chart: "0.1.1", ValuesPath: ""},
 			},
 		}
 	}
@@ -110,7 +110,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"node-problem-detector": {Chart: "2.0.5", ValuesPath: ""},
 				"metrics-server":        {Chart: "3.8.2", ValuesPath: ""},
 				"velero":                {Chart: "2.31.3", ValuesPath: ""},
-				"cloudprober":           {Chart: "0.1.0", ValuesPath: ""},
+				"cloudprober":           {Chart: "0.1.1", ValuesPath: ""},
 			},
 		}, clusterRequest)
 	})

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -88,7 +88,7 @@ var DefaultUtilityVersions map[string]*HelmUtilityVersion = map[string]*HelmUtil
 	// VeleroCanonicalName defines the default version for the Helm chart
 	VeleroCanonicalName: {Chart: "2.31.3", ValuesPath: ""},
 	// CloudproberCanonicalName defines the default version for the Helm chart
-	CloudproberCanonicalName: {Chart: "0.1.0", ValuesPath: ""},
+	CloudproberCanonicalName: {Chart: "0.1.1", ValuesPath: ""},
 }
 
 var defaultUtilityValuesFileNames map[string]string = map[string]string{

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -156,7 +156,7 @@ func TestGetActualVersion(t *testing.T) {
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "node-problem-detector-2.0.5"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "metrics-server-3.8.2"},
 				Velero:              &HelmUtilityVersion{Chart: "velero-2.31.3"},
-				Cloudprober:         &HelmUtilityVersion{Chart: "cloudprober-0.1.0"},
+				Cloudprober:         &HelmUtilityVersion{Chart: "cloudprober-0.1.1"},
 			},
 		},
 	}
@@ -198,7 +198,7 @@ func TestGetActualVersion(t *testing.T) {
 	assert.Equal(t, &HelmUtilityVersion{Chart: "velero-2.31.3"}, version)
 
 	version = c.ActualUtilityVersion(CloudproberCanonicalName)
-	assert.Equal(t, &HelmUtilityVersion{Chart: "cloudprober-0.1.0"}, version)
+	assert.Equal(t, &HelmUtilityVersion{Chart: "cloudprober-0.1.1"}, version)
 
 	version = c.ActualUtilityVersion("something else that doesn't exist")
 	assert.Equal(t, version, nilHuv)
@@ -235,7 +235,7 @@ func TestGetDesiredVersion(t *testing.T) {
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "node-problem-detector-2.0.5"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "metrics-server-3.8.2"},
 				Velero:              &HelmUtilityVersion{Chart: "velero-2.31.3"},
-				Cloudprober:         &HelmUtilityVersion{Chart: "cloudprober-0.1.0"},
+				Cloudprober:         &HelmUtilityVersion{Chart: "cloudprober-0.1.1"},
 			},
 		},
 	}


### PR DESCRIPTION
#### Summary
- Update Cloudprober to latest version v0.1.1

#### Release Note
```release-note
- Update Cloudprober to latest version v0.1.1
```
