### PR TITLE
[MM-46277] Properly (un)tag VPCs when releasing clusters from VPCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ goverall: $(GOVERALLS_GEN) ## Runs goveralls
 
 .PHONY: unittest
 unittest:
-	$(GO) test ./... -covermode=count -coverprofile=coverage.out
+	$(GO) test ./... -v -covermode=count -coverprofile=coverage.out
 
 .PHONY: verify-mocks
 verify-mocks:  $(MOCKGEN) mocks

--- a/go.sum
+++ b/go.sum
@@ -667,6 +667,7 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -112,7 +112,6 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 
 		return errors.Wrap(err, "unable to create kops cluster")
 	}
-	// Tag Public subnets & respective VPC for the secondary cluster if there is no error.
 	terraformClient, err := terraform.New(kops.GetOutputDirectory(), provisioner.params.S3StateStore, logger)
 	if err != nil {
 		return err

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -113,12 +113,6 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 		return errors.Wrap(err, "unable to create kops cluster")
 	}
 	// Tag Public subnets & respective VPC for the secondary cluster if there is no error.
-	if kopsMetadata.ChangeRequest.VPC != "" {
-		err = awsClient.TagResourcesByCluster(clusterResources, cluster, provisioner.params.Owner, logger)
-		if err != nil {
-			return err
-		}
-	}
 	terraformClient, err := terraform.New(kops.GetOutputDirectory(), provisioner.params.S3StateStore, logger)
 	if err != nil {
 		return err

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -513,7 +513,7 @@ func (a *Client) releaseVpc(cluster *model.Cluster, logger log.FieldLogger) erro
 
 			err = a.TagResource(*vpc.VpcId, trimTagPrefix(VpcSecondaryClusterIDTagKey), VpcClusterIDTagValueNone, logger)
 			if err != nil {
-				return errors.Wrapf(err, "unable to update %s", VpcClusterIDTagKey)
+				return errors.Wrapf(err, "unable to update %s", VpcSecondaryClusterIDTagKey)
 			}
 
 			return nil

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -465,7 +465,7 @@ func (a *Client) releaseVpc(cluster *model.Cluster, logger log.FieldLogger) erro
 		}
 	}
 
-	if secondaryClusterID != "" {
+	if secondaryClusterID != VpcClusterIDTagValueNone {
 		err = a.TagResource(*vpc.VpcId, trimTagPrefix(VpcClusterIDTagKey), secondaryClusterID, logger)
 		if err != nil {
 			return errors.Wrapf(err, "unable to update %s", VpcClusterIDTagKey)
@@ -481,17 +481,17 @@ func (a *Client) releaseVpc(cluster *model.Cluster, logger log.FieldLogger) erro
 
 	err = a.TagResource(*vpc.VpcId, trimTagPrefix(VpcClusterIDTagKey), VpcClusterIDTagValueNone, logger)
 	if err != nil {
-		return errors.Wrapf(err, "unable to update %s", VpcClusterIDTagKey)
+		return errors.Wrapf(err, "unable to update %s for %s", VpcClusterIDTagKey, *vpc.VpcId)
 	}
 
 	err = a.TagResource(*vpc.VpcId, trimTagPrefix(VpcAvailableTagKey), VpcAvailableTagValueTrue, logger)
 	if err != nil {
-		return errors.Wrapf(err, "unable to update %s", VpcAvailableTagKey)
+		return errors.Wrapf(err, "unable to update %s for %s", VpcAvailableTagKey, *vpc.VpcId)
 	}
 
 	err = a.TagResource(*vpc.VpcId, trimTagPrefix(VpcClusterOwnerKey), VpcClusterOwnerValueNone, logger)
 	if err != nil {
-		return errors.Wrapf(err, "unable to untag owner from %s", vpc.VpcId)
+		return errors.Wrapf(err, "unable to untag %s from %s", VpcClusterOwnerKey, *vpc.VpcId)
 	}
 
 	logger.Debugf("Released VPC %s", vpc.VpcId)

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -318,7 +318,7 @@ func (a *Client) claimVpc(clusterResources ClusterResources, cluster *model.Clus
 		if len(vpcs) == 1 {
 			claimSecondaryCluster = true
 		} else {
-			return fmt.Errorf("Couldn't claim VPC %s as primary nor secondary cluster", clusterResources.VpcID)
+			return fmt.Errorf("couldn't claim VPC %s as primary nor secondary cluster", clusterResources.VpcID)
 		}
 	}
 

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -341,7 +341,7 @@ func (a *Client) claimVpc(clusterResources ClusterResources, cluster *model.Clus
 
 		err = a.TagResource(clusterResources.VpcID, trimTagPrefix(VpcClusterOwnerKey), owner, logger)
 		if err != nil {
-			return errors.Wrapf(err, "unable to update %s", VpcClusterIDTagKey)
+			return errors.Wrapf(err, "unable to update %s", VpcClusterOwnerKey)
 		}
 	}
 

--- a/internal/tools/aws/cluster_management_test.go
+++ b/internal/tools/aws/cluster_management_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (a *AWSTestSuite) TestClaimVPC() {
+func (a *AWSTestSuite) TestClaimVPCCreateCluster() {
 	owner := "test"
 	vpcID := "mock-vpc"
 	privateSubnetID := "private-id1"
@@ -24,188 +24,762 @@ func (a *AWSTestSuite) TestClaimVPC() {
 	cidrBlock := "100.0.0.0/16"
 	cluster := a.ClusterA
 
-	gomock.InOrder(
-		// ClaimVPC
-		a.Mocks.API.EC2.EXPECT().
-			DescribeVpcs(&ec2.DescribeVpcsInput{
-				VpcIds: aws.StringSlice([]string{vpcID}),
+	a.Run("claim without specific vpc", func() {
+		a.SetupTest()
+		gomock.InOrder(
+			a.Mocks.API.EC2.EXPECT().
+				DescribeVpcs(&ec2.DescribeVpcsInput{
+					Filters: []*ec2.Filter{
+						{
+							Name: aws.String(VpcAvailableTagKey),
+							Values: []*string{
+								aws.String(VpcAvailableTagValueFalse),
+							},
+						},
+						{
+							Name: aws.String(VpcClusterIDTagKey),
+							Values: []*string{
+								aws.String(cluster.ID),
+							},
+						},
+					},
+				}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{},
+				}, nil).
+				Times(1),
+			// List for total VPCs
+			a.Mocks.API.EC2.EXPECT().
+				DescribeVpcs(&ec2.DescribeVpcsInput{
+					Filters: []*ec2.Filter{
+						{
+							Name: aws.String(VpcAvailableTagKey),
+							Values: []*string{
+								aws.String(VpcAvailableTagValueTrue),
+								aws.String(VpcAvailableTagValueFalse),
+							},
+						},
+					},
+				}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{{
+						VpcId: aws.String(vpcID),
+					}, {
+						VpcId: aws.String("second"),
+					}},
+				}, nil).
+				Times(1),
+			// List available VPCs
+			a.Mocks.API.EC2.EXPECT().
+				DescribeVpcs(&ec2.DescribeVpcsInput{
+					Filters: []*ec2.Filter{
+						{
+							Name: aws.String(VpcAvailableTagKey),
+							Values: []*string{
+								aws.String(VpcAvailableTagValueTrue),
+							},
+						},
+					},
+				}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{{
+						VpcId:     aws.String(vpcID),
+						CidrBlock: aws.String(cidrBlock),
+					}},
+				}, nil).
+				Times(1),
+			// getClusterResourcesForVPC
+			a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:SubnetType"),
+						Values: aws.StringSlice([]string{"private"}),
+					},
+				},
 			}).
-			Return(&ec2.DescribeVpcsOutput{
-				Vpcs: []*ec2.Vpc{{
-					VpcId:     aws.String(vpcID),
-					CidrBlock: aws.String(cidrBlock),
-				}},
-			}, nil).
-			Times(1),
-		// getClusterResourcesForVPC
-		a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
-			Filters: []*ec2.Filter{
-				{
-					Name:   aws.String("vpc-id"),
-					Values: aws.StringSlice([]string{vpcID}),
+				Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{{
+						SubnetId: aws.String(privateSubnetID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:SubnetType"),
+						Values: aws.StringSlice([]string{"public"}),
+					},
 				},
-				{
-					Name:   aws.String("tag:SubnetType"),
-					Values: aws.StringSlice([]string{"private"}),
+			}).
+				Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{{
+						SubnetId: aws.String(publicSubnetID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"master"}),
+					},
 				},
-			},
-		}).
-			Return(&ec2.DescribeSubnetsOutput{
-				Subnets: []*ec2.Subnet{{
-					SubnetId: aws.String(privateSubnetID),
-				}},
-			}, nil).
-			Times(1),
-		a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
-			Filters: []*ec2.Filter{
-				{
-					Name:   aws.String("vpc-id"),
-					Values: aws.StringSlice([]string{vpcID}),
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(masterSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"worker"}),
+					},
 				},
-				{
-					Name:   aws.String("tag:SubnetType"),
-					Values: aws.StringSlice([]string{"public"}),
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(workerSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"calls"}),
+					},
 				},
-			},
-		}).
-			Return(&ec2.DescribeSubnetsOutput{
-				Subnets: []*ec2.Subnet{{
-					SubnetId: aws.String(publicSubnetID),
-				}},
-			}, nil).
-			Times(1),
-		a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
-			Filters: []*ec2.Filter{
-				{
-					Name:   aws.String("vpc-id"),
-					Values: aws.StringSlice([]string{vpcID}),
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(callsSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			// claimVpc
+			a.Mocks.API.EC2.EXPECT().DescribeVpcs(&ec2.DescribeVpcsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String(VpcAvailableTagKey),
+						Values: aws.StringSlice([]string{VpcAvailableTagValueTrue}),
+					},
+					{
+						Name:   aws.String(VpcClusterIDTagKey),
+						Values: aws.StringSlice([]string{VpcClusterIDTagValueNone}),
+					},
 				},
-				{
-					Name:   aws.String("tag:NodeType"),
-					Values: aws.StringSlice([]string{"master"}),
+			}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{{
+						VpcId:     aws.String(vpcID),
+						CidrBlock: aws.String(cidrBlock),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: []*string{
+					aws.String(vpcID),
 				},
-			},
-		}).
-			Return(&ec2.DescribeSecurityGroupsOutput{
-				SecurityGroups: []*ec2.SecurityGroup{{
-					GroupId: aws.String(masterSecurityGroupID),
-				}},
-			}, nil).
-			Times(1),
-		a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
-			Filters: []*ec2.Filter{
-				{
-					Name:   aws.String("vpc-id"),
-					Values: aws.StringSlice([]string{vpcID}),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String(trimTagPrefix(VpcAvailableTagKey)),
+						Value: aws.String(VpcAvailableTagValueFalse),
+					},
 				},
-				{
-					Name:   aws.String("tag:NodeType"),
-					Values: aws.StringSlice([]string{"worker"}),
+			}).
+				Return(nil, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: []*string{
+					aws.String(vpcID),
 				},
-			},
-		}).
-			Return(&ec2.DescribeSecurityGroupsOutput{
-				SecurityGroups: []*ec2.SecurityGroup{{
-					GroupId: aws.String(workerSecurityGroupID),
-				}},
-			}, nil).
-			Times(1),
-		a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
-			Filters: []*ec2.Filter{
-				{
-					Name:   aws.String("vpc-id"),
-					Values: aws.StringSlice([]string{vpcID}),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String(trimTagPrefix(VpcClusterIDTagKey)),
+						Value: aws.String(cluster.ID),
+					},
 				},
-				{
-					Name:   aws.String("tag:NodeType"),
-					Values: aws.StringSlice([]string{"calls"}),
+			}).
+				Return(nil, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: []*string{
+					aws.String(vpcID),
 				},
-			},
-		}).
-			Return(&ec2.DescribeSecurityGroupsOutput{
-				SecurityGroups: []*ec2.SecurityGroup{{
-					GroupId: aws.String(callsSecurityGroupID),
-				}},
-			}, nil).
-			Times(1),
-		// claimVpc
-		a.Mocks.API.EC2.EXPECT().DescribeVpcs(&ec2.DescribeVpcsInput{
-			Filters: []*ec2.Filter{
-				{
-					Name:   aws.String("vpc-id"),
-					Values: aws.StringSlice([]string{vpcID}),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String(trimTagPrefix(VpcClusterOwnerKey)),
+						Value: aws.String(owner),
+					},
 				},
-				{
-					Name:   aws.String(VpcAvailableTagKey),
-					Values: aws.StringSlice([]string{VpcAvailableTagValueTrue}),
-				},
-				{
-					Name:   aws.String(VpcClusterIDTagKey),
-					Values: aws.StringSlice([]string{VpcClusterIDTagValueNone}),
-				},
-			},
-		}).
-			Return(&ec2.DescribeVpcsOutput{
-				Vpcs: []*ec2.Vpc{{
-					VpcId:     aws.String(vpcID),
-					CidrBlock: aws.String(cidrBlock),
-				}},
-			}, nil).
-			Times(1),
-		a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
-			Resources: []*string{
-				aws.String(vpcID),
-			},
-			Tags: []*ec2.Tag{
-				{
-					Key:   aws.String(trimTagPrefix(VpcAvailableTagKey)),
-					Value: aws.String(VpcAvailableTagValueFalse),
-				},
-			},
-		}).
-			Return(nil, nil).
-			Times(1),
-		a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
-			Resources: []*string{
-				aws.String(vpcID),
-			},
-			Tags: []*ec2.Tag{
-				{
-					Key:   aws.String(trimTagPrefix(VpcClusterIDTagKey)),
-					Value: aws.String(cluster.ID),
-				},
-			},
-		}).
-			Return(nil, nil).
-			Times(1),
-		a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
-			Resources: []*string{
-				aws.String(vpcID),
-			},
-			Tags: []*ec2.Tag{
-				{
-					Key:   aws.String(trimTagPrefix(VpcClusterOwnerKey)),
-					Value: aws.String(owner),
-				},
-			},
-		}).
-			Return(nil, nil).
-			Times(1),
-		a.Mocks.API.EC2.EXPECT().CreateTags(gomock.Any()).
-			Return(nil, nil).
-			Times(3),
-	)
+			}).
+				Return(nil, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(gomock.Any()).
+				Return(nil, nil).
+				Times(3),
+		)
 
-	logger := logrus.New()
+		logger := logrus.New()
 
-	clusterResources, err := a.Mocks.AWS.ClaimVPC(vpcID, cluster, owner, logger)
-	a.Assert().NoError(err)
-	a.Assert().Equal(clusterResources.VpcID, vpcID)
-	a.Assert().Contains(clusterResources.PrivateSubnetIDs, privateSubnetID)
-	a.Assert().Contains(clusterResources.PublicSubnetsIDs, publicSubnetID)
-	a.Assert().Contains(clusterResources.MasterSecurityGroupIDs, masterSecurityGroupID)
-	a.Assert().Contains(clusterResources.WorkerSecurityGroupIDs, workerSecurityGroupID)
-	a.Assert().Contains(clusterResources.CallsSecurityGroupIDs, callsSecurityGroupID)
+		clusterResources, err := a.Mocks.AWS.GetAndClaimVpcResources(cluster, owner, logger)
+		// clusterResources, err := a.Mocks.AWS.ClaimVPC(vpcID, cluster, owner, logger)
+		a.Assert().NoError(err)
+		a.Assert().Equal(clusterResources.VpcID, vpcID)
+		a.Assert().Contains(clusterResources.PrivateSubnetIDs, privateSubnetID)
+		a.Assert().Contains(clusterResources.PublicSubnetsIDs, publicSubnetID)
+		a.Assert().Contains(clusterResources.MasterSecurityGroupIDs, masterSecurityGroupID)
+		a.Assert().Contains(clusterResources.WorkerSecurityGroupIDs, workerSecurityGroupID)
+		a.Assert().Contains(clusterResources.CallsSecurityGroupIDs, callsSecurityGroupID)
+	})
+
+	a.Run("claim with specific vpc as primary cluster", func() {
+		a.SetupTest()
+		gomock.InOrder(
+			// ClaimVPC
+			a.Mocks.API.EC2.EXPECT().
+				DescribeVpcs(&ec2.DescribeVpcsInput{
+					VpcIds: aws.StringSlice([]string{vpcID}),
+				}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{{
+						VpcId:     aws.String(vpcID),
+						CidrBlock: aws.String(cidrBlock),
+					}},
+				}, nil).
+				Times(1),
+			// getClusterResourcesForVPC
+			a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:SubnetType"),
+						Values: aws.StringSlice([]string{"private"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{{
+						SubnetId: aws.String(privateSubnetID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:SubnetType"),
+						Values: aws.StringSlice([]string{"public"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{{
+						SubnetId: aws.String(publicSubnetID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"master"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(masterSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"worker"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(workerSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"calls"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(callsSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			// claimVpc
+			a.Mocks.API.EC2.EXPECT().DescribeVpcs(&ec2.DescribeVpcsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String(VpcAvailableTagKey),
+						Values: aws.StringSlice([]string{VpcAvailableTagValueTrue}),
+					},
+					{
+						Name:   aws.String(VpcClusterIDTagKey),
+						Values: aws.StringSlice([]string{VpcClusterIDTagValueNone}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{{
+						VpcId:     aws.String(vpcID),
+						CidrBlock: aws.String(cidrBlock),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: []*string{
+					aws.String(vpcID),
+				},
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String(trimTagPrefix(VpcAvailableTagKey)),
+						Value: aws.String(VpcAvailableTagValueFalse),
+					},
+				},
+			}).
+				Return(nil, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: []*string{
+					aws.String(vpcID),
+				},
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String(trimTagPrefix(VpcClusterIDTagKey)),
+						Value: aws.String(cluster.ID),
+					},
+				},
+			}).
+				Return(nil, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: []*string{
+					aws.String(vpcID),
+				},
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String(trimTagPrefix(VpcClusterOwnerKey)),
+						Value: aws.String(owner),
+					},
+				},
+			}).
+				Return(nil, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(gomock.Any()).
+				Return(nil, nil).
+				Times(3),
+		)
+
+		logger := logrus.New()
+
+		clusterResources, err := a.Mocks.AWS.ClaimVPC(vpcID, cluster, owner, logger)
+		a.Assert().NoError(err)
+		a.Assert().Equal(clusterResources.VpcID, vpcID)
+		a.Assert().Contains(clusterResources.PrivateSubnetIDs, privateSubnetID)
+		a.Assert().Contains(clusterResources.PublicSubnetsIDs, publicSubnetID)
+		a.Assert().Contains(clusterResources.MasterSecurityGroupIDs, masterSecurityGroupID)
+		a.Assert().Contains(clusterResources.WorkerSecurityGroupIDs, workerSecurityGroupID)
+		a.Assert().Contains(clusterResources.CallsSecurityGroupIDs, callsSecurityGroupID)
+	})
+
+	a.Run("claim with specific vpc as secondary cluster", func() {
+		a.SetupTest()
+		gomock.InOrder(
+			// ClaimVPC
+			a.Mocks.API.EC2.EXPECT().
+				DescribeVpcs(&ec2.DescribeVpcsInput{
+					VpcIds: aws.StringSlice([]string{vpcID}),
+				}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{{
+						VpcId:     aws.String(vpcID),
+						CidrBlock: aws.String(cidrBlock),
+					}},
+				}, nil).
+				Times(1),
+			// getClusterResourcesForVPC
+			a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:SubnetType"),
+						Values: aws.StringSlice([]string{"private"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{{
+						SubnetId: aws.String(privateSubnetID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:SubnetType"),
+						Values: aws.StringSlice([]string{"public"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{{
+						SubnetId: aws.String(publicSubnetID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"master"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(masterSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"worker"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(workerSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"calls"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(callsSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			// claimVpc
+			a.Mocks.API.EC2.EXPECT().DescribeVpcs(&ec2.DescribeVpcsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String(VpcAvailableTagKey),
+						Values: aws.StringSlice([]string{VpcAvailableTagValueTrue}),
+					},
+					{
+						Name:   aws.String(VpcClusterIDTagKey),
+						Values: aws.StringSlice([]string{VpcClusterIDTagValueNone}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeVpcs(&ec2.DescribeVpcsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String(VpcAvailableTagKey),
+						Values: aws.StringSlice([]string{VpcAvailableTagValueFalse}),
+					},
+					{
+						Name:   aws.String(VpcSecondaryClusterIDTagKey),
+						Values: aws.StringSlice([]string{VpcClusterIDTagValueNone}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{{
+						VpcId:     aws.String(vpcID),
+						CidrBlock: aws.String(cidrBlock),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: []*string{
+					aws.String(vpcID),
+				},
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String(trimTagPrefix(VpcSecondaryClusterIDTagKey)),
+						Value: aws.String(cluster.ID),
+					},
+				},
+			}).
+				Return(nil, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(gomock.Any()).
+				Return(nil, nil).
+				Times(3),
+		)
+
+		logger := logrus.New()
+
+		clusterResources, err := a.Mocks.AWS.ClaimVPC(vpcID, cluster, owner, logger)
+		a.Assert().NoError(err)
+		a.Assert().Equal(clusterResources.VpcID, vpcID)
+		a.Assert().Contains(clusterResources.PrivateSubnetIDs, privateSubnetID)
+		a.Assert().Contains(clusterResources.PublicSubnetsIDs, publicSubnetID)
+		a.Assert().Contains(clusterResources.MasterSecurityGroupIDs, masterSecurityGroupID)
+		a.Assert().Contains(clusterResources.WorkerSecurityGroupIDs, workerSecurityGroupID)
+		a.Assert().Contains(clusterResources.CallsSecurityGroupIDs, callsSecurityGroupID)
+	})
+
+	a.Run("claim with specific unavailable vpc", func() {
+		a.SetupTest()
+		gomock.InOrder(
+			// ClaimVPC
+			a.Mocks.API.EC2.EXPECT().
+				DescribeVpcs(&ec2.DescribeVpcsInput{
+					VpcIds: aws.StringSlice([]string{vpcID}),
+				}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{{
+						VpcId:     aws.String(vpcID),
+						CidrBlock: aws.String(cidrBlock),
+					}},
+				}, nil).
+				Times(1),
+			// getClusterResourcesForVPC
+			a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:SubnetType"),
+						Values: aws.StringSlice([]string{"private"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{{
+						SubnetId: aws.String(privateSubnetID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:SubnetType"),
+						Values: aws.StringSlice([]string{"public"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{{
+						SubnetId: aws.String(publicSubnetID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"master"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(masterSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"worker"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(workerSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"calls"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(callsSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			// claimVpc
+			a.Mocks.API.EC2.EXPECT().DescribeVpcs(&ec2.DescribeVpcsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String(VpcAvailableTagKey),
+						Values: aws.StringSlice([]string{VpcAvailableTagValueTrue}),
+					},
+					{
+						Name:   aws.String(VpcClusterIDTagKey),
+						Values: aws.StringSlice([]string{VpcClusterIDTagValueNone}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeVpcs(&ec2.DescribeVpcsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String(VpcAvailableTagKey),
+						Values: aws.StringSlice([]string{VpcAvailableTagValueFalse}),
+					},
+					{
+						Name:   aws.String(VpcSecondaryClusterIDTagKey),
+						Values: aws.StringSlice([]string{VpcClusterIDTagValueNone}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{},
+				}, nil).
+				Times(1),
+		)
+
+		logger := logrus.New()
+
+		_, err := a.Mocks.AWS.ClaimVPC(vpcID, cluster, owner, logger)
+		a.Assert().Error(err)
+	})
 }
 
 func (a *AWSTestSuite) TestReleaseVPC() {

--- a/internal/tools/aws/cluster_management_test.go
+++ b/internal/tools/aws/cluster_management_test.go
@@ -5,6 +5,8 @@
 package aws
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
@@ -204,4 +206,374 @@ func (a *AWSTestSuite) TestClaimVPC() {
 	a.Assert().Contains(clusterResources.MasterSecurityGroupIDs, masterSecurityGroupID)
 	a.Assert().Contains(clusterResources.WorkerSecurityGroupIDs, workerSecurityGroupID)
 	a.Assert().Contains(clusterResources.CallsSecurityGroupIDs, callsSecurityGroupID)
+}
+
+func (a *AWSTestSuite) TestReleaseVPC() {
+	vpcID := "mock-vpc"
+	publicSubnetID := "public-id1"
+	callsSecurityGroupID := "calls-sg-id"
+	cluster := a.ClusterA
+
+	a.Run("release primary cluster", func() {
+		a.SetupTest()
+		gomock.InOrder(
+			// GetVpcsWithFilters
+			a.Mocks.API.EC2.EXPECT().
+				DescribeVpcs(&ec2.DescribeVpcsInput{
+					Filters: []*ec2.Filter{{
+						Name:   aws.String(VpcAvailableTagKey),
+						Values: []*string{aws.String(VpcAvailableTagValueFalse)},
+					}, {
+						Name:   aws.String(VpcSecondaryClusterIDTagKey),
+						Values: []*string{aws.String(cluster.ID)},
+					}},
+				}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{}, // Faking no VPCs as secondary cluster
+				}, nil).
+				Times(1),
+			// GetVpcsWithFilters
+			a.Mocks.API.EC2.EXPECT().
+				DescribeVpcs(&ec2.DescribeVpcsInput{
+					Filters: []*ec2.Filter{{
+						Name:   aws.String(VpcAvailableTagKey),
+						Values: []*string{aws.String(VpcAvailableTagValueFalse)},
+					}, {
+						Name:   aws.String(VpcClusterIDTagKey),
+						Values: []*string{aws.String(cluster.ID)},
+					}},
+				}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{{
+						VpcId: &vpcID,
+						Tags: []*ec2.Tag{{ // VPC has no secondary clusters
+							Key:   aws.String(trimTagPrefix(VpcSecondaryClusterIDTagKey)),
+							Value: aws.String(VpcClusterIDTagValueNone),
+						}},
+					}},
+				}, nil).
+				Times(1),
+			// getClusterResourcesForVPC
+			a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:SubnetType"),
+						Values: aws.StringSlice([]string{"public"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{{
+						SubnetId: aws.String(publicSubnetID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DeleteTags(&ec2.DeleteTagsInput{
+				Resources: aws.StringSlice([]string{publicSubnetID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster))),
+					Value: aws.String("shared"),
+				}},
+			}).
+				// Return(&ec2.DeleteTagsOutput{}, gomock.Any()).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"calls"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(callsSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DeleteTags(&ec2.DeleteTagsInput{
+				Resources: aws.StringSlice([]string{callsSecurityGroupID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster))),
+					Value: aws.String("shared"),
+				}},
+			}).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DeleteTags(&ec2.DeleteTagsInput{
+				Resources: aws.StringSlice([]string{callsSecurityGroupID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("KubernetesCluster"),
+					Value: aws.String(getClusterTag(cluster)),
+				}},
+			}).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: aws.StringSlice([]string{vpcID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(trimTagPrefix(VpcClusterIDTagKey)),
+					Value: aws.String(VpcClusterIDTagValueNone),
+				}},
+			}).
+				// Return(gomock.Any()).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: aws.StringSlice([]string{vpcID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(trimTagPrefix(VpcAvailableTagKey)),
+					Value: aws.String(VpcAvailableTagValueTrue),
+				}},
+			}).
+				// Return(gomock.Any()).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: aws.StringSlice([]string{vpcID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(trimTagPrefix(VpcClusterOwnerKey)),
+					Value: aws.String(VpcClusterIDTagValueNone),
+				}},
+			}).
+				// Return(gomock.Any()).
+				Times(1),
+		)
+
+		logger := logrus.New()
+
+		err := a.Mocks.AWS.ReleaseVpc(cluster, logger)
+		a.Assert().NoError(err)
+	})
+
+	a.Run("release secondary cluster", func() {
+		a.SetupTest()
+		gomock.InOrder(
+			// GetVpcsWithFilters
+			a.Mocks.API.EC2.EXPECT().
+				DescribeVpcs(&ec2.DescribeVpcsInput{
+					Filters: []*ec2.Filter{{
+						Name:   aws.String(VpcAvailableTagKey),
+						Values: []*string{aws.String(VpcAvailableTagValueFalse)},
+					}, {
+						Name:   aws.String(VpcSecondaryClusterIDTagKey),
+						Values: []*string{aws.String(cluster.ID)},
+					}},
+				}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{{
+						VpcId: &vpcID,
+						Tags: []*ec2.Tag{{ // VPC has no secondary clusters
+							Key:   aws.String(trimTagPrefix(VpcSecondaryClusterIDTagKey)),
+							Value: aws.String(cluster.ID),
+						}},
+					}},
+				}, nil).
+				Times(1),
+			// getClusterResourcesForVPC
+			a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:SubnetType"),
+						Values: aws.StringSlice([]string{"public"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{{
+						SubnetId: aws.String(publicSubnetID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DeleteTags(&ec2.DeleteTagsInput{
+				Resources: aws.StringSlice([]string{publicSubnetID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster))),
+					Value: aws.String("shared"),
+				}},
+			}).
+				// Return(&ec2.DeleteTagsOutput{}, gomock.Any()).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"calls"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(callsSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DeleteTags(&ec2.DeleteTagsInput{
+				Resources: aws.StringSlice([]string{callsSecurityGroupID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster))),
+					Value: aws.String("shared"),
+				}},
+			}).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DeleteTags(&ec2.DeleteTagsInput{
+				Resources: aws.StringSlice([]string{callsSecurityGroupID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("KubernetesCluster"),
+					Value: aws.String(getClusterTag(cluster)),
+				}},
+			}).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: aws.StringSlice([]string{vpcID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(trimTagPrefix(VpcSecondaryClusterIDTagKey)),
+					Value: aws.String(VpcClusterIDTagValueNone),
+				}},
+			}).
+				// Return(gomock.Any()).
+				Times(1),
+		)
+
+		logger := logrus.New()
+
+		err := a.Mocks.AWS.ReleaseVpc(cluster, logger)
+		a.Assert().NoError(err)
+	})
+
+	a.Run("release primary cluster and promote secondary cluster", func() {
+		gomock.InOrder(
+			// GetVpcsWithFilters
+			a.Mocks.API.EC2.EXPECT().
+				DescribeVpcs(&ec2.DescribeVpcsInput{
+					Filters: []*ec2.Filter{{
+						Name:   aws.String(VpcAvailableTagKey),
+						Values: []*string{aws.String(VpcAvailableTagValueFalse)},
+					}, {
+						Name:   aws.String(VpcSecondaryClusterIDTagKey),
+						Values: []*string{aws.String(cluster.ID)},
+					}},
+				}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{}, // Faking no VPCs as secondary cluster
+				}, nil).
+				Times(1),
+			// GetVpcsWithFilters
+			a.Mocks.API.EC2.EXPECT().
+				DescribeVpcs(&ec2.DescribeVpcsInput{
+					Filters: []*ec2.Filter{{
+						Name:   aws.String(VpcAvailableTagKey),
+						Values: []*string{aws.String(VpcAvailableTagValueFalse)},
+					}, {
+						Name:   aws.String(VpcClusterIDTagKey),
+						Values: []*string{aws.String(cluster.ID)},
+					}},
+				}).
+				Return(&ec2.DescribeVpcsOutput{
+					Vpcs: []*ec2.Vpc{{
+						VpcId: &vpcID,
+						Tags: []*ec2.Tag{{ // VPC has no secondary clusters
+							Key:   aws.String(trimTagPrefix(VpcSecondaryClusterIDTagKey)),
+							Value: aws.String(a.ClusterB.ID),
+						}},
+					}},
+				}, nil).
+				Times(1),
+			// getClusterResourcesForVPC
+			a.Mocks.API.EC2.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:SubnetType"),
+						Values: aws.StringSlice([]string{"public"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{{
+						SubnetId: aws.String(publicSubnetID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DeleteTags(&ec2.DeleteTagsInput{
+				Resources: aws.StringSlice([]string{publicSubnetID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster))),
+					Value: aws.String("shared"),
+				}},
+			}).
+				// Return(&ec2.DeleteTagsOutput{}, gomock.Any()).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: aws.StringSlice([]string{vpcID}),
+					},
+					{
+						Name:   aws.String("tag:NodeType"),
+						Values: aws.StringSlice([]string{"calls"}),
+					},
+				},
+			}).
+				Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []*ec2.SecurityGroup{{
+						GroupId: aws.String(callsSecurityGroupID),
+					}},
+				}, nil).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DeleteTags(&ec2.DeleteTagsInput{
+				Resources: aws.StringSlice([]string{callsSecurityGroupID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", getClusterTag(cluster))),
+					Value: aws.String("shared"),
+				}},
+			}).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().DeleteTags(&ec2.DeleteTagsInput{
+				Resources: aws.StringSlice([]string{callsSecurityGroupID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("KubernetesCluster"),
+					Value: aws.String(getClusterTag(cluster)),
+				}},
+			}).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: aws.StringSlice([]string{vpcID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(trimTagPrefix(VpcClusterIDTagKey)),
+					Value: aws.String(a.ClusterB.ID),
+				}},
+			}).
+				Times(1),
+			a.Mocks.API.EC2.EXPECT().CreateTags(&ec2.CreateTagsInput{
+				Resources: aws.StringSlice([]string{vpcID}),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String(trimTagPrefix(VpcSecondaryClusterIDTagKey)),
+					Value: aws.String(VpcClusterIDTagValueNone),
+				}},
+			}).
+				Times(1),
+		)
+
+		logger := logrus.New()
+
+		err := a.Mocks.AWS.ReleaseVpc(cluster, logger)
+		a.Assert().NoError(err)
+	})
 }


### PR DESCRIPTION
#### Summary

This fixes the logic when releasing clusters from VPCs based on the following logic:

```mermaid
graph TD
	DC[Delete Cluster] --> IsPrimary{Is Primary Cluster in VPC}
	IsPrimary -->|Yes| HasSecondaryCluster{Has Secondary CLuster}
	IsPrimary -->|No| a[CloudSecondaryClusterID = none]
	HasSecondaryCluster{Has Secondary Cluster in VPC} -->|Yes| c[CloudClusterID = CloudSecondaryClusterID]
	c --- b[CloudSecondaryClusterID = none]
	HasSecondaryCluster -->|No| d[CloudClusterID = none]
	d --- e[Owner = none]
	e --- f[Available = true]
```

```mermaid
graph TD
	style err fill:#ff6961
	init[Create Cluster] --> ContainsPrimaryCluster{VPC contains primary cluster}
	ContainsPrimaryCluster -->|Yes| HasSecondaryCluster{VPC contains Secondary CLuster}
	ContainsPrimaryCluster -->|No| a[CloudClusterID = id]
	a --- e[Owner = owner]
	e --- f[Available = false]
	HasSecondaryCluster -->|Yes| err(Error)
	HasSecondaryCluster -->|No| d[CloudSecondaryClusterID = id]
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46277

#### Release Note

```release-note
Properly (un)tag VPCs when releasing clusters from VPCs.
```
