### PR TITLE
move 'server' & 'dry-run' flags to global flagset

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -80,10 +80,10 @@ func newCmdClusterCreate() *cobra.Command {
 		Use:   "create",
 		Short: "Create a cluster.",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			return executeClusterCreateCmd(cf)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceUsage = true
 			cf.clusterFlags.addFlags(cmd)
 			return
 		},
@@ -190,10 +190,10 @@ func newCmdClusterProvision() *cobra.Command {
 		Use:   "provision",
 		Short: "Provision/Re-provision a cluster's k8s resources.",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			return executeClusterProvisionCmd(pf)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceUsage = true
 			pf.clusterFlags.addFlags(cmd)
 			return
 		},
@@ -241,10 +241,10 @@ func newCmdClusterUpdate() *cobra.Command {
 		Use:   "update",
 		Short: "Updates a cluster's configuration.",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			return executeClusterUpdateCmd(uf)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceUsage = true
 			uf.clusterFlags.addFlags(cmd)
 			return
 		},
@@ -292,10 +292,10 @@ func newCmdClusterUpgrade() *cobra.Command {
 		Use:   "upgrade",
 		Short: "Upgrade k8s on a cluster.",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			return executeClusterUpgradeCmd(uf)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceUsage = true
 			uf.clusterFlags.addFlags(cmd)
 			uf.clusterUpgradeFlagChanged.addFlags(cmd)
 			return
@@ -354,10 +354,10 @@ func newCmdClusterResize() *cobra.Command {
 		Use:   "resize",
 		Short: "Resize a k8s cluster",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			return executeClusterResizeCmd(rf)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceUsage = true
 			rf.clusterFlags.addFlags(cmd)
 			return
 		},
@@ -424,10 +424,10 @@ func newCmdClusterDelete() *cobra.Command {
 		Use:   "delete",
 		Short: "Delete a cluster.",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			return executeClusterDeleteCmd(df)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceUsage = true
 			df.clusterFlags.addFlags(cmd)
 			return
 		},
@@ -455,10 +455,10 @@ func newCmdClusterGet() *cobra.Command {
 		Use:   "get",
 		Short: "Get a particular cluster.",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			return executeClusterGetCmd(gf)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceUsage = true
 			gf.clusterFlags.addFlags(cmd)
 			return
 		},
@@ -493,10 +493,10 @@ func newCmdClusterList() *cobra.Command {
 		Use:   "list",
 		Short: "List created clusters.",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			return executeClusterListCmd(lf)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceUsage = true
 			lf.clusterFlags.addFlags(cmd)
 			return
 		},
@@ -578,6 +578,7 @@ func newCmdClusterUtilities() *cobra.Command {
 		Use:   "utilities",
 		Short: "Show metadata regarding utility services running in a cluster.",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			client := model.NewClient(uf.serverAddress)
 
 			metadata, err := client.GetClusterUtilities(uf.cluster)
@@ -592,7 +593,6 @@ func newCmdClusterUtilities() *cobra.Command {
 			return nil
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceUsage = true
 			uf.clusterFlags.addFlags(cmd)
 			return
 		},
@@ -607,14 +607,11 @@ func newCmdClusterSizeDictionary() *cobra.Command {
 		Use:   "dictionary",
 		Short: "Shows predefined cluster size templates.",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			if err := printJSON(clusterdictionary.ValidSizes); err != nil {
 				return errors.Wrap(err, "failed to print cluster dictionary")
 			}
 			return nil
-		},
-		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceUsage = true
-			return
 		},
 	}
 
@@ -629,14 +626,11 @@ func newCmdClusterShowStateReport() *cobra.Command {
 		Use:   "state-report",
 		Short: "Shows information regarding changing cluster state.",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			if err := printJSON(model.GetClusterRequestStateReport()); err != nil {
 				return err
 			}
 			return nil
-		},
-		PreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceUsage = true
-			return
 		},
 	}
 

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -28,24 +28,22 @@ const (
 )
 
 func newCmdCluster() *cobra.Command {
-	var globalFlags globalFlags
-
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Manipulate clusters managed by the provisioning server.",
 	}
 
-	globalFlags.addFlags(cmd)
+	setClusterFlags(cmd)
 
-	cmd.AddCommand(newCmdClusterCreate(&globalFlags))
-	cmd.AddCommand(newCmdClusterProvision(&globalFlags))
-	cmd.AddCommand(newCmdClusterUpdate(&globalFlags))
-	cmd.AddCommand(newCmdClusterUpgrade(&globalFlags))
-	cmd.AddCommand(newCmdClusterResize(&globalFlags))
-	cmd.AddCommand(newCmdClusterDelete(&globalFlags))
-	cmd.AddCommand(newCmdClusterGet(&globalFlags))
-	cmd.AddCommand(newCmdClusterList(&globalFlags))
-	cmd.AddCommand(newCmdClusterUtilities(&globalFlags))
+	cmd.AddCommand(newCmdClusterCreate())
+	cmd.AddCommand(newCmdClusterProvision())
+	cmd.AddCommand(newCmdClusterUpdate())
+	cmd.AddCommand(newCmdClusterUpgrade())
+	cmd.AddCommand(newCmdClusterResize())
+	cmd.AddCommand(newCmdClusterDelete())
+	cmd.AddCommand(newCmdClusterGet())
+	cmd.AddCommand(newCmdClusterList())
+	cmd.AddCommand(newCmdClusterUtilities())
 
 	cmd.AddCommand(newCmdClusterSizeDictionary())
 	cmd.AddCommand(newCmdClusterShowStateReport())
@@ -75,7 +73,7 @@ func getRotatorConfigFromFlags(rc rotatorConfig) model.RotatorConfig {
 	}
 }
 
-func newCmdClusterCreate(globalFlags *globalFlags) *cobra.Command {
+func newCmdClusterCreate() *cobra.Command {
 	var cf clusterCreateFlags
 
 	cmd := &cobra.Command{
@@ -84,13 +82,10 @@ func newCmdClusterCreate(globalFlags *globalFlags) *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterCreateCmd(cf)
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if globalFlags == nil {
-				return errors.New("invalid global flagset")
-			}
-			cf.globalFlags = *globalFlags
+		PreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
-			return nil
+			cf.clusterFlags.addFlags(cmd)
+			return
 		},
 	}
 	cf.addFlags(cmd)
@@ -99,7 +94,6 @@ func newCmdClusterCreate(globalFlags *globalFlags) *cobra.Command {
 }
 
 func executeClusterCreateCmd(cf clusterCreateFlags) error {
-
 	client := model.NewClient(cf.serverAddress)
 
 	if cf.cluster != "" {
@@ -189,7 +183,7 @@ func executeClusterCreateCmd(cf clusterCreateFlags) error {
 
 }
 
-func newCmdClusterProvision(globalFlags *globalFlags) *cobra.Command {
+func newCmdClusterProvision() *cobra.Command {
 	var pf clusterProvisionFlags
 
 	cmd := &cobra.Command{
@@ -198,13 +192,10 @@ func newCmdClusterProvision(globalFlags *globalFlags) *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterProvisionCmd(pf)
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if globalFlags == nil {
-				return errors.New("invalid global flagset")
-			}
-			pf.globalFlags = *globalFlags
+		PreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
-			return nil
+			pf.clusterFlags.addFlags(cmd)
+			return
 		},
 	}
 	pf.addFlags(cmd)
@@ -243,7 +234,7 @@ func executeClusterProvisionCmd(pf clusterProvisionFlags) error {
 
 }
 
-func newCmdClusterUpdate(globalFlags *globalFlags) *cobra.Command {
+func newCmdClusterUpdate() *cobra.Command {
 	var uf clusterUpdateFlags
 
 	cmd := &cobra.Command{
@@ -252,13 +243,10 @@ func newCmdClusterUpdate(globalFlags *globalFlags) *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterUpdateCmd(uf)
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if globalFlags == nil {
-				return errors.New("invalid global flagset")
-			}
-			uf.globalFlags = *globalFlags
+		PreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
-			return nil
+			uf.clusterFlags.addFlags(cmd)
+			return
 		},
 	}
 	uf.addFlags(cmd)
@@ -297,7 +285,7 @@ func executeClusterUpdateCmd(uf clusterUpdateFlags) error {
 
 }
 
-func newCmdClusterUpgrade(globalFlags *globalFlags) *cobra.Command {
+func newCmdClusterUpgrade() *cobra.Command {
 	var uf clusterUpgradeFlags
 
 	cmd := &cobra.Command{
@@ -306,13 +294,11 @@ func newCmdClusterUpgrade(globalFlags *globalFlags) *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterUpgradeCmd(uf)
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if globalFlags == nil {
-				return errors.New("invalid global flagset")
-			}
-			uf.globalFlags = *globalFlags
+		PreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
-			return nil
+			uf.clusterFlags.addFlags(cmd)
+			uf.clusterUpgradeFlagChanged.addFlags(cmd)
+			return
 		},
 	}
 	uf.addFlags(cmd)
@@ -361,7 +347,7 @@ func executeClusterUpgradeCmd(uf clusterUpgradeFlags) error {
 
 }
 
-func newCmdClusterResize(globalFlags *globalFlags) *cobra.Command {
+func newCmdClusterResize() *cobra.Command {
 	var rf clusterResizeFlags
 
 	cmd := &cobra.Command{
@@ -370,13 +356,10 @@ func newCmdClusterResize(globalFlags *globalFlags) *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterResizeCmd(rf)
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if globalFlags == nil {
-				return errors.New("invalid global flagset")
-			}
-			rf.globalFlags = *globalFlags
+		PreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
-			return nil
+			rf.clusterFlags.addFlags(cmd)
+			return
 		},
 	}
 	rf.addFlags(cmd)
@@ -434,7 +417,7 @@ func executeClusterResizeCmd(rf clusterResizeFlags) error {
 
 }
 
-func newCmdClusterDelete(globalFlags *globalFlags) *cobra.Command {
+func newCmdClusterDelete() *cobra.Command {
 	var df clusterDeleteFlags
 
 	cmd := &cobra.Command{
@@ -443,13 +426,10 @@ func newCmdClusterDelete(globalFlags *globalFlags) *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterDeleteCmd(df)
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if globalFlags == nil {
-				return errors.New("invalid global flagset")
-			}
-			df.globalFlags = *globalFlags
+		PreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
-			return nil
+			df.clusterFlags.addFlags(cmd)
+			return
 		},
 	}
 	df.addFlags(cmd)
@@ -468,7 +448,7 @@ func executeClusterDeleteCmd(df clusterDeleteFlags) error {
 	return nil
 }
 
-func newCmdClusterGet(globalFlags *globalFlags) *cobra.Command {
+func newCmdClusterGet() *cobra.Command {
 	var gf clusterGetFlags
 
 	cmd := &cobra.Command{
@@ -477,13 +457,10 @@ func newCmdClusterGet(globalFlags *globalFlags) *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterGetCmd(gf)
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if globalFlags == nil {
-				return errors.New("invalid global flagset")
-			}
-			gf.globalFlags = *globalFlags
+		PreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
-			return nil
+			gf.clusterFlags.addFlags(cmd)
+			return
 		},
 	}
 	gf.addFlags(cmd)
@@ -509,7 +486,7 @@ func executeClusterGetCmd(gf clusterGetFlags) error {
 	return nil
 }
 
-func newCmdClusterList(globalFlags *globalFlags) *cobra.Command {
+func newCmdClusterList() *cobra.Command {
 	var lf clusterListFlags
 
 	cmd := &cobra.Command{
@@ -518,13 +495,10 @@ func newCmdClusterList(globalFlags *globalFlags) *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterListCmd(lf)
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if globalFlags == nil {
-				return errors.New("invalid global flagset")
-			}
-			lf.globalFlags = *globalFlags
+		PreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
-			return nil
+			lf.clusterFlags.addFlags(cmd)
+			return
 		},
 	}
 	lf.addFlags(cmd)
@@ -597,7 +571,7 @@ func defaultClustersTableData(clusters []*model.ClusterDTO) ([]string, [][]strin
 	return keys, values
 }
 
-func newCmdClusterUtilities(globalFlags *globalFlags) *cobra.Command {
+func newCmdClusterUtilities() *cobra.Command {
 	var uf clusterUtilitiesFlags
 
 	cmd := &cobra.Command{
@@ -617,13 +591,10 @@ func newCmdClusterUtilities(globalFlags *globalFlags) *cobra.Command {
 
 			return nil
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if globalFlags == nil {
-				return errors.New("invalid global flagset")
-			}
-			uf.globalFlags = *globalFlags
+		PreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
-			return nil
+			uf.clusterFlags.addFlags(cmd)
+			return
 		},
 	}
 	uf.addFlags(cmd)

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -28,20 +28,24 @@ const (
 )
 
 func newCmdCluster() *cobra.Command {
+	var globalFlags globalFlags
+
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Manipulate clusters managed by the provisioning server.",
 	}
 
-	cmd.AddCommand(newCmdClusterCreate())
-	cmd.AddCommand(newCmdClusterProvision())
-	cmd.AddCommand(newCmdClusterUpdate())
-	cmd.AddCommand(newCmdClusterUpgrade())
-	cmd.AddCommand(newCmdClusterResize())
-	cmd.AddCommand(newCmdClusterDelete())
-	cmd.AddCommand(newCmdClusterGet())
-	cmd.AddCommand(newCmdClusterList())
-	cmd.AddCommand(newCmdClusterUtilities())
+	globalFlags.addFlags(cmd)
+
+	cmd.AddCommand(newCmdClusterCreate(&globalFlags))
+	cmd.AddCommand(newCmdClusterProvision(&globalFlags))
+	cmd.AddCommand(newCmdClusterUpdate(&globalFlags))
+	cmd.AddCommand(newCmdClusterUpgrade(&globalFlags))
+	cmd.AddCommand(newCmdClusterResize(&globalFlags))
+	cmd.AddCommand(newCmdClusterDelete(&globalFlags))
+	cmd.AddCommand(newCmdClusterGet(&globalFlags))
+	cmd.AddCommand(newCmdClusterList(&globalFlags))
+	cmd.AddCommand(newCmdClusterUtilities(&globalFlags))
 
 	cmd.AddCommand(newCmdClusterSizeDictionary())
 	cmd.AddCommand(newCmdClusterShowStateReport())
@@ -71,7 +75,7 @@ func getRotatorConfigFromFlags(rc rotatorConfig) model.RotatorConfig {
 	}
 }
 
-func newCmdClusterCreate() *cobra.Command {
+func newCmdClusterCreate(globalFlags *globalFlags) *cobra.Command {
 	var cf clusterCreateFlags
 
 	cmd := &cobra.Command{
@@ -80,9 +84,13 @@ func newCmdClusterCreate() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterCreateCmd(cf)
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if globalFlags == nil {
+				return errors.New("invalid global flagset")
+			}
+			cf.globalFlags = *globalFlags
 			cmd.SilenceUsage = true
-			return
+			return nil
 		},
 	}
 	cf.addFlags(cmd)
@@ -91,6 +99,7 @@ func newCmdClusterCreate() *cobra.Command {
 }
 
 func executeClusterCreateCmd(cf clusterCreateFlags) error {
+
 	client := model.NewClient(cf.serverAddress)
 
 	if cf.cluster != "" {
@@ -180,7 +189,7 @@ func executeClusterCreateCmd(cf clusterCreateFlags) error {
 
 }
 
-func newCmdClusterProvision() *cobra.Command {
+func newCmdClusterProvision(globalFlags *globalFlags) *cobra.Command {
 	var pf clusterProvisionFlags
 
 	cmd := &cobra.Command{
@@ -189,9 +198,13 @@ func newCmdClusterProvision() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterProvisionCmd(pf)
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if globalFlags == nil {
+				return errors.New("invalid global flagset")
+			}
+			pf.globalFlags = *globalFlags
 			cmd.SilenceUsage = true
-			return
+			return nil
 		},
 	}
 	pf.addFlags(cmd)
@@ -230,7 +243,7 @@ func executeClusterProvisionCmd(pf clusterProvisionFlags) error {
 
 }
 
-func newCmdClusterUpdate() *cobra.Command {
+func newCmdClusterUpdate(globalFlags *globalFlags) *cobra.Command {
 	var uf clusterUpdateFlags
 
 	cmd := &cobra.Command{
@@ -239,9 +252,13 @@ func newCmdClusterUpdate() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterUpdateCmd(uf)
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if globalFlags == nil {
+				return errors.New("invalid global flagset")
+			}
+			uf.globalFlags = *globalFlags
 			cmd.SilenceUsage = true
-			return
+			return nil
 		},
 	}
 	uf.addFlags(cmd)
@@ -280,7 +297,7 @@ func executeClusterUpdateCmd(uf clusterUpdateFlags) error {
 
 }
 
-func newCmdClusterUpgrade() *cobra.Command {
+func newCmdClusterUpgrade(globalFlags *globalFlags) *cobra.Command {
 	var uf clusterUpgradeFlags
 
 	cmd := &cobra.Command{
@@ -289,10 +306,13 @@ func newCmdClusterUpgrade() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterUpgradeCmd(uf)
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if globalFlags == nil {
+				return errors.New("invalid global flagset")
+			}
+			uf.globalFlags = *globalFlags
 			cmd.SilenceUsage = true
-			uf.clusterUpgradeFlagChanged.addFlags(cmd)
-			return
+			return nil
 		},
 	}
 	uf.addFlags(cmd)
@@ -341,7 +361,7 @@ func executeClusterUpgradeCmd(uf clusterUpgradeFlags) error {
 
 }
 
-func newCmdClusterResize() *cobra.Command {
+func newCmdClusterResize(globalFlags *globalFlags) *cobra.Command {
 	var rf clusterResizeFlags
 
 	cmd := &cobra.Command{
@@ -350,9 +370,13 @@ func newCmdClusterResize() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterResizeCmd(rf)
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if globalFlags == nil {
+				return errors.New("invalid global flagset")
+			}
+			rf.globalFlags = *globalFlags
 			cmd.SilenceUsage = true
-			return
+			return nil
 		},
 	}
 	rf.addFlags(cmd)
@@ -410,7 +434,7 @@ func executeClusterResizeCmd(rf clusterResizeFlags) error {
 
 }
 
-func newCmdClusterDelete() *cobra.Command {
+func newCmdClusterDelete(globalFlags *globalFlags) *cobra.Command {
 	var df clusterDeleteFlags
 
 	cmd := &cobra.Command{
@@ -419,9 +443,13 @@ func newCmdClusterDelete() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterDeleteCmd(df)
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if globalFlags == nil {
+				return errors.New("invalid global flagset")
+			}
+			df.globalFlags = *globalFlags
 			cmd.SilenceUsage = true
-			return
+			return nil
 		},
 	}
 	df.addFlags(cmd)
@@ -440,7 +468,7 @@ func executeClusterDeleteCmd(df clusterDeleteFlags) error {
 	return nil
 }
 
-func newCmdClusterGet() *cobra.Command {
+func newCmdClusterGet(globalFlags *globalFlags) *cobra.Command {
 	var gf clusterGetFlags
 
 	cmd := &cobra.Command{
@@ -449,9 +477,13 @@ func newCmdClusterGet() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterGetCmd(gf)
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if globalFlags == nil {
+				return errors.New("invalid global flagset")
+			}
+			gf.globalFlags = *globalFlags
 			cmd.SilenceUsage = true
-			return
+			return nil
 		},
 	}
 	gf.addFlags(cmd)
@@ -477,7 +509,7 @@ func executeClusterGetCmd(gf clusterGetFlags) error {
 	return nil
 }
 
-func newCmdClusterList() *cobra.Command {
+func newCmdClusterList(globalFlags *globalFlags) *cobra.Command {
 	var lf clusterListFlags
 
 	cmd := &cobra.Command{
@@ -486,9 +518,13 @@ func newCmdClusterList() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			return executeClusterListCmd(lf)
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if globalFlags == nil {
+				return errors.New("invalid global flagset")
+			}
+			lf.globalFlags = *globalFlags
 			cmd.SilenceUsage = true
-			return
+			return nil
 		},
 	}
 	lf.addFlags(cmd)
@@ -561,7 +597,7 @@ func defaultClustersTableData(clusters []*model.ClusterDTO) ([]string, [][]strin
 	return keys, values
 }
 
-func newCmdClusterUtilities() *cobra.Command {
+func newCmdClusterUtilities(globalFlags *globalFlags) *cobra.Command {
 	var uf clusterUtilitiesFlags
 
 	cmd := &cobra.Command{
@@ -581,9 +617,13 @@ func newCmdClusterUtilities() *cobra.Command {
 
 			return nil
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if globalFlags == nil {
+				return errors.New("invalid global flagset")
+			}
+			uf.globalFlags = *globalFlags
 			cmd.SilenceUsage = true
-			return
+			return nil
 		},
 	}
 	uf.addFlags(cmd)

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -74,30 +74,30 @@ func getRotatorConfigFromFlags(rc rotatorConfig) model.RotatorConfig {
 }
 
 func newCmdClusterCreate() *cobra.Command {
-	var cf clusterCreateFlags
+	var flags clusterCreateFlags
 
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a cluster.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			return executeClusterCreateCmd(cf)
+			return executeClusterCreateCmd(flags)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			cf.clusterFlags.addFlags(cmd)
+			flags.clusterFlags.addFlags(cmd)
 			return
 		},
 	}
-	cf.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }
 
-func executeClusterCreateCmd(cf clusterCreateFlags) error {
-	client := model.NewClient(cf.serverAddress)
+func executeClusterCreateCmd(flags clusterCreateFlags) error {
+	client := model.NewClient(flags.serverAddress)
 
-	if cf.cluster != "" {
-		err := client.RetryCreateCluster(cf.cluster)
+	if flags.cluster != "" {
+		err := client.RetryCreateCluster(flags.cluster)
 		if err != nil {
 			return errors.Wrap(err, "failed to retry cluster creation")
 		}
@@ -105,19 +105,19 @@ func executeClusterCreateCmd(cf clusterCreateFlags) error {
 	}
 
 	request := &model.CreateClusterRequest{
-		Provider:               cf.provider,
-		Version:                cf.version,
-		KopsAMI:                cf.kopsAMI,
-		Zones:                  strings.Split(cf.zones, ","),
-		AllowInstallations:     cf.allowInstallations,
-		DesiredUtilityVersions: processUtilityFlags(cf.utilityFlags),
-		Annotations:            cf.annotations,
-		Networking:             cf.networking,
-		VPC:                    cf.vpc,
+		Provider:               flags.provider,
+		Version:                flags.version,
+		KopsAMI:                flags.kopsAMI,
+		Zones:                  strings.Split(flags.zones, ","),
+		AllowInstallations:     flags.allowInstallations,
+		DesiredUtilityVersions: processUtilityFlags(flags.utilityFlags),
+		Annotations:            flags.annotations,
+		Networking:             flags.networking,
+		VPC:                    flags.vpc,
 	}
 
-	if cf.useEKS {
-		nodeGroupsConfigRaw, err := os.ReadFile(cf.eksNodeGroupsConfig)
+	if flags.useEKS {
+		nodeGroupsConfigRaw, err := os.ReadFile(flags.eksNodeGroupsConfig)
 		if err != nil {
 			return errors.Wrap(err, "failed to read node groups config")
 		}
@@ -127,40 +127,40 @@ func executeClusterCreateCmd(cf clusterCreateFlags) error {
 			return errors.Wrap(err, "failed to unmarshal node groups config")
 		}
 		request.EKSConfig = &model.EKSConfig{
-			ClusterRoleARN: &cf.eksRoleArn,
+			ClusterRoleARN: &flags.eksRoleArn,
 			NodeGroups:     nodeGroupsConfig,
 		}
 	}
 
-	err := clusterdictionary.ApplyToCreateClusterRequest(cf.size, request)
+	err := clusterdictionary.ApplyToCreateClusterRequest(flags.size, request)
 	if err != nil {
 		return errors.Wrap(err, "failed to apply size values")
 	}
 
-	if len(cf.masterInstanceType) != 0 {
-		request.MasterInstanceType = cf.masterInstanceType
+	if len(flags.masterInstanceType) != 0 {
+		request.MasterInstanceType = flags.masterInstanceType
 	}
 
-	if cf.masterCount != 0 {
-		request.MasterCount = cf.masterCount
+	if flags.masterCount != 0 {
+		request.MasterCount = flags.masterCount
 	}
 
-	if len(cf.nodeInstanceType) != 0 {
-		request.NodeInstanceType = cf.nodeInstanceType
+	if len(flags.nodeInstanceType) != 0 {
+		request.NodeInstanceType = flags.nodeInstanceType
 	}
 
-	if cf.nodeCount != 0 {
+	if flags.nodeCount != 0 {
 		// Setting different min and max counts in currently not supported
 		// with the kops create cluster flag.
-		request.NodeMinCount = cf.nodeCount
-		request.NodeMaxCount = cf.nodeCount
+		request.NodeMinCount = flags.nodeCount
+		request.NodeMaxCount = flags.nodeCount
 	}
 
-	if cf.maxPodsPerNode != 0 {
-		request.MaxPodsPerNode = cf.maxPodsPerNode
+	if flags.maxPodsPerNode != 0 {
+		request.MaxPodsPerNode = flags.maxPodsPerNode
 	}
 
-	if cf.dryRun {
+	if flags.dryRun {
 		err = printJSON(request)
 		if err != nil {
 			return errors.Wrap(err, "failed to print API request")
@@ -184,34 +184,34 @@ func executeClusterCreateCmd(cf clusterCreateFlags) error {
 }
 
 func newCmdClusterProvision() *cobra.Command {
-	var pf clusterProvisionFlags
+	var flags clusterProvisionFlags
 
 	cmd := &cobra.Command{
 		Use:   "provision",
 		Short: "Provision/Re-provision a cluster's k8s resources.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			return executeClusterProvisionCmd(pf)
+			return executeClusterProvisionCmd(flags)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			pf.clusterFlags.addFlags(cmd)
+			flags.clusterFlags.addFlags(cmd)
 			return
 		},
 	}
-	pf.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }
 
-func executeClusterProvisionCmd(pf clusterProvisionFlags) error {
-	client := model.NewClient(pf.serverAddress)
+func executeClusterProvisionCmd(flags clusterProvisionFlags) error {
+	client := model.NewClient(flags.serverAddress)
 
 	request := &model.ProvisionClusterRequest{
-		Force:                  pf.reprovisionAllUtilities,
-		DesiredUtilityVersions: processUtilityFlags(pf.utilityFlags),
+		Force:                  flags.reprovisionAllUtilities,
+		DesiredUtilityVersions: processUtilityFlags(flags.utilityFlags),
 	}
 
-	if pf.dryRun {
+	if flags.dryRun {
 		err := printJSON(request)
 		if err != nil {
 			return errors.Wrap(err, "failed to print API request")
@@ -220,7 +220,7 @@ func executeClusterProvisionCmd(pf clusterProvisionFlags) error {
 		return nil
 	}
 
-	cluster, err := client.ProvisionCluster(pf.cluster, request)
+	cluster, err := client.ProvisionCluster(flags.cluster, request)
 	if err != nil {
 		return errors.Wrap(err, "failed to provision cluster")
 	}
@@ -235,34 +235,34 @@ func executeClusterProvisionCmd(pf clusterProvisionFlags) error {
 }
 
 func newCmdClusterUpdate() *cobra.Command {
-	var uf clusterUpdateFlags
+	var flags clusterUpdateFlags
 
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Updates a cluster's configuration.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			return executeClusterUpdateCmd(uf)
+			return executeClusterUpdateCmd(flags)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			uf.clusterFlags.addFlags(cmd)
+			flags.clusterFlags.addFlags(cmd)
 			return
 		},
 	}
-	uf.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }
 
-func executeClusterUpdateCmd(uf clusterUpdateFlags) error {
+func executeClusterUpdateCmd(flags clusterUpdateFlags) error {
 
-	client := model.NewClient(uf.serverAddress)
+	client := model.NewClient(flags.serverAddress)
 
 	request := &model.UpdateClusterRequest{
-		AllowInstallations: uf.allowInstallations,
+		AllowInstallations: flags.allowInstallations,
 	}
 
-	if uf.dryRun {
+	if flags.dryRun {
 		err := printJSON(request)
 		if err != nil {
 			return errors.Wrap(err, "failed to print API request")
@@ -271,7 +271,7 @@ func executeClusterUpdateCmd(uf clusterUpdateFlags) error {
 		return nil
 	}
 
-	cluster, err := client.UpdateCluster(uf.cluster, request)
+	cluster, err := client.UpdateCluster(flags.cluster, request)
 	if err != nil {
 		return errors.Wrap(err, "failed to update cluster")
 	}
@@ -286,45 +286,45 @@ func executeClusterUpdateCmd(uf clusterUpdateFlags) error {
 }
 
 func newCmdClusterUpgrade() *cobra.Command {
-	var uf clusterUpgradeFlags
+	var flags clusterUpgradeFlags
 
 	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrade k8s on a cluster.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			return executeClusterUpgradeCmd(uf)
+			return executeClusterUpgradeCmd(flags)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			uf.clusterFlags.addFlags(cmd)
-			uf.clusterUpgradeFlagChanged.addFlags(cmd)
+			flags.clusterFlags.addFlags(cmd)
+			flags.clusterUpgradeFlagChanged.addFlags(cmd)
 			return
 		},
 	}
-	uf.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }
 
-func executeClusterUpgradeCmd(uf clusterUpgradeFlags) error {
-	client := model.NewClient(uf.serverAddress)
+func executeClusterUpgradeCmd(flags clusterUpgradeFlags) error {
+	client := model.NewClient(flags.serverAddress)
 
-	rotatorConfig := getRotatorConfigFromFlags(uf.rotatorConfig)
+	rotatorConfig := getRotatorConfigFromFlags(flags.rotatorConfig)
 
 	request := &model.PatchUpgradeClusterRequest{
 		RotatorConfig: &rotatorConfig,
 	}
 
-	if uf.isVersionChanged {
-		request.Version = &uf.version
+	if flags.isVersionChanged {
+		request.Version = &flags.version
 	}
-	if uf.isKopsAmiChanged {
-		request.KopsAMI = &uf.kopsAMI
+	if flags.isKopsAmiChanged {
+		request.KopsAMI = &flags.kopsAMI
 	}
-	if uf.isMaxPodsPerNodeChanged {
-		request.MaxPodsPerNode = &uf.maxPodsPerNode
+	if flags.isMaxPodsPerNodeChanged {
+		request.MaxPodsPerNode = &flags.maxPodsPerNode
 	}
-	if uf.dryRun {
+	if flags.dryRun {
 		err := printJSON(request)
 		if err != nil {
 			return errors.Wrap(err, "failed to print API request")
@@ -333,7 +333,7 @@ func executeClusterUpgradeCmd(uf clusterUpgradeFlags) error {
 		return nil
 	}
 
-	cluster, err := client.UpgradeCluster(uf.cluster, request)
+	cluster, err := client.UpgradeCluster(flags.cluster, request)
 	if err != nil {
 		return errors.Wrap(err, "failed to upgrade cluster")
 	}
@@ -348,53 +348,53 @@ func executeClusterUpgradeCmd(uf clusterUpgradeFlags) error {
 }
 
 func newCmdClusterResize() *cobra.Command {
-	var rf clusterResizeFlags
+	var flags clusterResizeFlags
 
 	cmd := &cobra.Command{
 		Use:   "resize",
 		Short: "Resize a k8s cluster",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			return executeClusterResizeCmd(rf)
+			return executeClusterResizeCmd(flags)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			rf.clusterFlags.addFlags(cmd)
+			flags.clusterFlags.addFlags(cmd)
 			return
 		},
 	}
-	rf.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }
 
-func executeClusterResizeCmd(rf clusterResizeFlags) error {
-	client := model.NewClient(rf.serverAddress)
+func executeClusterResizeCmd(flags clusterResizeFlags) error {
+	client := model.NewClient(flags.serverAddress)
 
-	rotatorConfig := getRotatorConfigFromFlags(rf.rotatorConfig)
+	rotatorConfig := getRotatorConfigFromFlags(flags.rotatorConfig)
 
 	request := &model.PatchClusterSizeRequest{
 		RotatorConfig: &rotatorConfig,
 	}
 
 	// Apply values from 'size' constant and then apply overrides.
-	err := clusterdictionary.ApplyToPatchClusterSizeRequest(rf.size, request)
+	err := clusterdictionary.ApplyToPatchClusterSizeRequest(flags.size, request)
 	if err != nil {
 		return errors.Wrap(err, "failed to apply size values")
 	}
 
-	if len(rf.nodeInstanceType) != 0 {
-		request.NodeInstanceType = &rf.nodeInstanceType
+	if len(flags.nodeInstanceType) != 0 {
+		request.NodeInstanceType = &flags.nodeInstanceType
 	}
 
-	if rf.nodeMinCount != 0 {
-		request.NodeMinCount = &rf.nodeMinCount
+	if flags.nodeMinCount != 0 {
+		request.NodeMinCount = &flags.nodeMinCount
 	}
 
-	if rf.nodeMaxCount != 0 {
-		request.NodeMaxCount = &rf.nodeMaxCount
+	if flags.nodeMaxCount != 0 {
+		request.NodeMaxCount = &flags.nodeMaxCount
 	}
 
-	if rf.dryRun {
+	if flags.dryRun {
 		err = printJSON(request)
 		if err != nil {
 			return errors.Wrap(err, "failed to print API request")
@@ -403,7 +403,7 @@ func executeClusterResizeCmd(rf clusterResizeFlags) error {
 		return nil
 	}
 
-	cluster, err := client.ResizeCluster(rf.cluster, request)
+	cluster, err := client.ResizeCluster(flags.cluster, request)
 	if err != nil {
 		return errors.Wrap(err, "failed to resize cluster")
 	}
@@ -418,29 +418,29 @@ func executeClusterResizeCmd(rf clusterResizeFlags) error {
 }
 
 func newCmdClusterDelete() *cobra.Command {
-	var df clusterDeleteFlags
+	var flags clusterDeleteFlags
 
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete a cluster.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			return executeClusterDeleteCmd(df)
+			return executeClusterDeleteCmd(flags)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			df.clusterFlags.addFlags(cmd)
+			flags.clusterFlags.addFlags(cmd)
 			return
 		},
 	}
-	df.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }
 
-func executeClusterDeleteCmd(df clusterDeleteFlags) error {
-	client := model.NewClient(df.serverAddress)
+func executeClusterDeleteCmd(flags clusterDeleteFlags) error {
+	client := model.NewClient(flags.serverAddress)
 
-	err := client.DeleteCluster(df.cluster)
+	err := client.DeleteCluster(flags.cluster)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete cluster")
 	}
@@ -449,29 +449,29 @@ func executeClusterDeleteCmd(df clusterDeleteFlags) error {
 }
 
 func newCmdClusterGet() *cobra.Command {
-	var gf clusterGetFlags
+	var flags clusterGetFlags
 
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Get a particular cluster.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			return executeClusterGetCmd(gf)
+			return executeClusterGetCmd(flags)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			gf.clusterFlags.addFlags(cmd)
+			flags.clusterFlags.addFlags(cmd)
 			return
 		},
 	}
-	gf.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }
 
-func executeClusterGetCmd(gf clusterGetFlags) error {
-	client := model.NewClient(gf.serverAddress)
+func executeClusterGetCmd(flags clusterGetFlags) error {
+	client := model.NewClient(flags.serverAddress)
 
-	cluster, err := client.GetCluster(gf.cluster)
+	cluster, err := client.GetCluster(flags.cluster)
 	if err != nil {
 		return errors.Wrap(err, "failed to query cluster")
 	}
@@ -487,29 +487,29 @@ func executeClusterGetCmd(gf clusterGetFlags) error {
 }
 
 func newCmdClusterList() *cobra.Command {
-	var lf clusterListFlags
+	var flags clusterListFlags
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List created clusters.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			return executeClusterListCmd(lf)
+			return executeClusterListCmd(flags)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			lf.clusterFlags.addFlags(cmd)
+			flags.clusterFlags.addFlags(cmd)
 			return
 		},
 	}
-	lf.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }
 
-func executeClusterListCmd(lf clusterListFlags) error {
-	client := model.NewClient(lf.serverAddress)
+func executeClusterListCmd(flags clusterListFlags) error {
+	client := model.NewClient(flags.serverAddress)
 
-	paging := getPaging(lf.pagingFlags)
+	paging := getPaging(flags.pagingFlags)
 
 	clusters, err := client.GetClusters(&model.GetClustersRequest{
 		Paging: paging,
@@ -518,7 +518,7 @@ func executeClusterListCmd(lf clusterListFlags) error {
 		return errors.Wrap(err, "failed to query clusters")
 	}
 
-	if enabled, customCols := getTableOutputOption(lf.tableOptions); enabled {
+	if enabled, customCols := getTableOutputOption(flags.tableOptions); enabled {
 		var keys []string
 		var vals [][]string
 
@@ -572,16 +572,16 @@ func defaultClustersTableData(clusters []*model.ClusterDTO) ([]string, [][]strin
 }
 
 func newCmdClusterUtilities() *cobra.Command {
-	var uf clusterUtilitiesFlags
+	var flags clusterUtilitiesFlags
 
 	cmd := &cobra.Command{
 		Use:   "utilities",
 		Short: "Show metadata regarding utility services running in a cluster.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(uf.serverAddress)
+			client := model.NewClient(flags.serverAddress)
 
-			metadata, err := client.GetClusterUtilities(uf.cluster)
+			metadata, err := client.GetClusterUtilities(flags.cluster)
 			if err != nil {
 				return err
 			}
@@ -593,11 +593,11 @@ func newCmdClusterUtilities() *cobra.Command {
 			return nil
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			uf.clusterFlags.addFlags(cmd)
+			flags.clusterFlags.addFlags(cmd)
 			return
 		},
 	}
-	uf.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }

--- a/cmd/cloud/cluster_flag.go
+++ b/cmd/cloud/cluster_flag.go
@@ -1,13 +1,15 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+)
 
-type clusterFlags struct {
+type globalFlags struct {
 	serverAddress string
 	dryRun        bool
 }
 
-func (flags *clusterFlags) addFlags(command *cobra.Command) {
+func (flags *globalFlags) addFlags(command *cobra.Command) {
 	command.PersistentFlags().StringVar(&flags.serverAddress, "server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
 	command.PersistentFlags().BoolVar(&flags.dryRun, "dry-run", false, "When set to true, only print the API request without sending it.")
 }
@@ -127,7 +129,7 @@ func (flags *sizeOptions) addFlags(command *cobra.Command) {
 }
 
 type clusterCreateFlags struct {
-	clusterFlags
+	globalFlags
 	createRequestOptions
 	eksFlags
 	utilityFlags
@@ -136,7 +138,6 @@ type clusterCreateFlags struct {
 }
 
 func (flags *clusterCreateFlags) addFlags(command *cobra.Command) {
-	flags.clusterFlags.addFlags(command)
 	flags.createRequestOptions.addFlags(command)
 	flags.eksFlags.addFlags(command)
 	flags.utilityFlags.addFlags(command)
@@ -146,14 +147,13 @@ func (flags *clusterCreateFlags) addFlags(command *cobra.Command) {
 }
 
 type clusterProvisionFlags struct {
-	clusterFlags
+	globalFlags
 	utilityFlags
 	cluster                 string
 	reprovisionAllUtilities bool
 }
 
 func (flags *clusterProvisionFlags) addFlags(command *cobra.Command) {
-	flags.clusterFlags.addFlags(command)
 	flags.utilityFlags.addFlags(command)
 
 	command.Flags().StringVar(&flags.cluster, "cluster", "", "The id of the cluster to be provisioned.")
@@ -163,14 +163,12 @@ func (flags *clusterProvisionFlags) addFlags(command *cobra.Command) {
 }
 
 type clusterUpdateFlags struct {
-	clusterFlags
+	globalFlags
 	cluster            string
 	allowInstallations bool
 }
 
 func (flags *clusterUpdateFlags) addFlags(command *cobra.Command) {
-	flags.clusterFlags.addFlags(command)
-
 	command.Flags().StringVar(&flags.cluster, "cluster", "", "The id of the cluster to be updated.")
 	command.Flags().BoolVar(&flags.allowInstallations, "allow-installations", true, "Whether the cluster will allow for new installations to be scheduled.")
 
@@ -210,7 +208,7 @@ func (flags *clusterUpgradeFlagChanged) addFlags(command *cobra.Command) {
 }
 
 type clusterUpgradeFlags struct {
-	clusterFlags
+	globalFlags
 	rotatorConfig
 	clusterUpgradeFlagChanged
 	cluster        string
@@ -220,7 +218,6 @@ type clusterUpgradeFlags struct {
 }
 
 func (flags *clusterUpgradeFlags) addFlags(command *cobra.Command) {
-	flags.clusterFlags.addFlags(command)
 	flags.rotatorConfig.addFlags(command)
 
 	command.Flags().StringVar(&flags.cluster, "cluster", "", "The id of the cluster to be upgraded.")
@@ -232,7 +229,7 @@ func (flags *clusterUpgradeFlags) addFlags(command *cobra.Command) {
 }
 
 type clusterResizeFlags struct {
-	clusterFlags
+	globalFlags
 	rotatorConfig
 	cluster          string
 	size             string
@@ -242,7 +239,6 @@ type clusterResizeFlags struct {
 }
 
 func (flags *clusterResizeFlags) addFlags(command *cobra.Command) {
-	flags.clusterFlags.addFlags(command)
 	flags.rotatorConfig.addFlags(command)
 
 	command.Flags().StringVar(&flags.cluster, "cluster", "", "The id of the cluster to be resized.")
@@ -255,23 +251,21 @@ func (flags *clusterResizeFlags) addFlags(command *cobra.Command) {
 }
 
 type clusterDeleteFlags struct {
-	clusterFlags
+	globalFlags
 	cluster string
 }
 
 func (flags *clusterDeleteFlags) addFlags(command *cobra.Command) {
-	flags.clusterFlags.addFlags(command)
 	command.Flags().StringVar(&flags.cluster, "cluster", "", "The id of the cluster to be deleted.")
 	_ = command.MarkFlagRequired("cluster")
 }
 
 type clusterGetFlags struct {
-	clusterFlags
+	globalFlags
 	cluster string
 }
 
 func (flags *clusterGetFlags) addFlags(command *cobra.Command) {
-	flags.clusterFlags.addFlags(command)
 	command.Flags().StringVar(&flags.cluster, "cluster", "", "The id of the cluster to be fetched.")
 	_ = command.MarkFlagRequired("cluster")
 }
@@ -299,24 +293,22 @@ func (flags *tableOptions) addFlags(command *cobra.Command) {
 }
 
 type clusterListFlags struct {
-	clusterFlags
+	globalFlags
 	pagingFlags
 	tableOptions
 }
 
 func (flags *clusterListFlags) addFlags(command *cobra.Command) {
-	flags.clusterFlags.addFlags(command)
 	flags.pagingFlags.addFlags(command)
 	flags.tableOptions.addFlags(command)
 }
 
 type clusterUtilitiesFlags struct {
-	clusterFlags
+	globalFlags
 	cluster string
 }
 
 func (flags *clusterUtilitiesFlags) addFlags(command *cobra.Command) {
-	flags.clusterFlags.addFlags(command)
 	command.Flags().StringVar(&flags.cluster, "cluster", "", "The id of the cluster whose utilities are to be fetched.")
 	_ = command.MarkFlagRequired("cluster")
 }

--- a/cmd/cloud/cluster_flag.go
+++ b/cmd/cloud/cluster_flag.go
@@ -4,14 +4,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type globalFlags struct {
+func setClusterFlags(command *cobra.Command) {
+	command.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
+	command.PersistentFlags().Bool("dry-run", false, "When set to true, only print the API request without sending it.")
+}
+
+type clusterFlags struct {
 	serverAddress string
 	dryRun        bool
 }
 
-func (flags *globalFlags) addFlags(command *cobra.Command) {
-	command.PersistentFlags().StringVar(&flags.serverAddress, "server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
-	command.PersistentFlags().BoolVar(&flags.dryRun, "dry-run", false, "When set to true, only print the API request without sending it.")
+func (flags *clusterFlags) addFlags(command *cobra.Command) {
+	flags.serverAddress, _ = command.Flags().GetString("server")
+	flags.dryRun, _ = command.Flags().GetBool("dry-run")
 }
 
 type createRequestOptions struct {
@@ -129,7 +134,7 @@ func (flags *sizeOptions) addFlags(command *cobra.Command) {
 }
 
 type clusterCreateFlags struct {
-	globalFlags
+	clusterFlags
 	createRequestOptions
 	eksFlags
 	utilityFlags
@@ -147,7 +152,7 @@ func (flags *clusterCreateFlags) addFlags(command *cobra.Command) {
 }
 
 type clusterProvisionFlags struct {
-	globalFlags
+	clusterFlags
 	utilityFlags
 	cluster                 string
 	reprovisionAllUtilities bool
@@ -163,7 +168,7 @@ func (flags *clusterProvisionFlags) addFlags(command *cobra.Command) {
 }
 
 type clusterUpdateFlags struct {
-	globalFlags
+	clusterFlags
 	cluster            string
 	allowInstallations bool
 }
@@ -208,7 +213,7 @@ func (flags *clusterUpgradeFlagChanged) addFlags(command *cobra.Command) {
 }
 
 type clusterUpgradeFlags struct {
-	globalFlags
+	clusterFlags
 	rotatorConfig
 	clusterUpgradeFlagChanged
 	cluster        string
@@ -229,7 +234,7 @@ func (flags *clusterUpgradeFlags) addFlags(command *cobra.Command) {
 }
 
 type clusterResizeFlags struct {
-	globalFlags
+	clusterFlags
 	rotatorConfig
 	cluster          string
 	size             string
@@ -251,7 +256,7 @@ func (flags *clusterResizeFlags) addFlags(command *cobra.Command) {
 }
 
 type clusterDeleteFlags struct {
-	globalFlags
+	clusterFlags
 	cluster string
 }
 
@@ -261,7 +266,7 @@ func (flags *clusterDeleteFlags) addFlags(command *cobra.Command) {
 }
 
 type clusterGetFlags struct {
-	globalFlags
+	clusterFlags
 	cluster string
 }
 
@@ -293,7 +298,7 @@ func (flags *tableOptions) addFlags(command *cobra.Command) {
 }
 
 type clusterListFlags struct {
-	globalFlags
+	clusterFlags
 	pagingFlags
 	tableOptions
 }
@@ -304,7 +309,7 @@ func (flags *clusterListFlags) addFlags(command *cobra.Command) {
 }
 
 type clusterUtilitiesFlags struct {
-	globalFlags
+	clusterFlags
 	cluster string
 }
 

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -56,10 +56,10 @@ func newCmdServer() *cobra.Command {
 		Use:   "server",
 		Short: "Run the provisioning server.",
 		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
 			return executeServerCmd(sf)
 		},
 		PreRun: func(command *cobra.Command, args []string) {
-			command.SilenceUsage = true
 			sf.serverFlagChanged.addFlags(command) // To populate flag change variables.
 			deprecationWarnings(logger, command)
 		},

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -50,49 +50,49 @@ type Provisioner interface {
 }
 
 func newCmdServer() *cobra.Command {
-	var sf serverFlags
+	var flags serverFlags
 
 	cmd := &cobra.Command{
 		Use:   "server",
 		Short: "Run the provisioning server.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			return executeServerCmd(sf)
+			return executeServerCmd(flags)
 		},
 		PreRun: func(command *cobra.Command, args []string) {
-			sf.serverFlagChanged.addFlags(command) // To populate flag change variables.
+			flags.serverFlagChanged.addFlags(command) // To populate flag change variables.
 			deprecationWarnings(logger, command)
 		},
 	}
-	sf.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }
 
-func executeServerCmd(sf serverFlags) error {
+func executeServerCmd(flags serverFlags) error {
 
-	debugMode := sf.debug || (sf.devMode && !sf.isDebugChanged)
+	debugMode := flags.debug || (flags.devMode && !flags.isDebugChanged)
 	if debugMode {
 		logger.SetLevel(logrus.DebugLevel)
 	}
 
-	helm.SetVerboseHelmLogging(sf.debugHelm)
+	helm.SetVerboseHelmLogging(flags.debugHelm)
 
-	if err := model.SetDefaultProxyDatabaseMaxInstallationsPerLogicalDatabase(sf.maxSchemas); err != nil {
+	if err := model.SetDefaultProxyDatabaseMaxInstallationsPerLogicalDatabase(flags.maxSchemas); err != nil {
 		return err
 	}
 
 	pgbouncerConfig := provisioner.NewPGBouncerConfig(
-		sf.minPoolSize, sf.defaultPoolSize, sf.reservePoolSize,
-		sf.maxClientConnections, sf.maxDatabaseConnectionsPerPool,
-		sf.serverIdleTimeout, sf.serverLifetime, sf.serverResetQueryAlways,
+		flags.minPoolSize, flags.defaultPoolSize, flags.reservePoolSize,
+		flags.maxClientConnections, flags.maxDatabaseConnectionsPerPool,
+		flags.serverIdleTimeout, flags.serverLifetime, flags.serverResetQueryAlways,
 	)
 
 	if err := pgbouncerConfig.Validate(); err != nil {
 		return errors.Wrap(err, "pgbouncer config failed validation")
 	}
 
-	gitlabOAuthToken := sf.gitlabOAuthToken
+	gitlabOAuthToken := flags.gitlabOAuthToken
 	if len(gitlabOAuthToken) == 0 {
 		gitlabOAuthToken = os.Getenv(model.GitlabOAuthTokenKey)
 	}
@@ -101,40 +101,40 @@ func executeServerCmd(sf serverFlags) error {
 		logger.Warnf("The gitlab-oauth flag and %s were empty; using local helm charts", model.GitlabOAuthTokenKey)
 	}
 
-	if sf.machineLogs {
+	if flags.machineLogs {
 		logger.SetFormatter(&logrus.JSONFormatter{})
 	}
 
-	model.SetRequireAnnotatedInstallations(sf.requireAnnotatedInstallations)
+	model.SetRequireAnnotatedInstallations(flags.requireAnnotatedInstallations)
 
-	if len(sf.allowListCIDRRange) == 0 {
+	if len(flags.allowListCIDRRange) == 0 {
 		return errors.New("allow-list-cidr-range must have at least one value")
 	}
 
-	if len(sf.vpnListCIDR) == 0 {
+	if len(flags.vpnListCIDR) == 0 {
 		return errors.New("vpn-list-cidr must have at least one value")
 	}
 
-	if sf.mattermostWebHook != "" {
-		_ = os.Setenv(model.MattermostWebhook, sf.mattermostWebHook)
+	if flags.mattermostWebHook != "" {
+		_ = os.Setenv(model.MattermostWebhook, flags.mattermostWebHook)
 	}
 
-	if sf.mattermostChannel != "" {
-		_ = os.Setenv(model.MattermostChannel, sf.mattermostChannel)
+	if flags.mattermostChannel != "" {
+		_ = os.Setenv(model.MattermostChannel, flags.mattermostChannel)
 	}
 
-	if sf.utilitiesGitURL == "" {
+	if flags.utilitiesGitURL == "" {
 		return errors.New("utilities-git-url must be set")
 	}
-	model.SetUtilityDefaults(sf.utilitiesGitURL)
+	model.SetUtilityDefaults(flags.utilitiesGitURL)
 
-	if sf.kubecostToken != "" {
-		_ = os.Setenv(model.KubecostToken, sf.kubecostToken)
+	if flags.kubecostToken != "" {
+		_ = os.Setenv(model.KubecostToken, flags.kubecostToken)
 	}
 
 	logger := logger.WithField("instance", instanceID)
 
-	sqlStore, err := sqlStore(sf.database)
+	sqlStore, err := sqlStore(flags.database)
 	if err != nil {
 		return err
 	}
@@ -153,20 +153,20 @@ func executeServerCmd(sf serverFlags) error {
 
 	// TODO: move these cluster threshold values to cluster configuration.
 	installationScheduling := supervisor.NewInstallationSupervisorSchedulingOptions(
-		sf.balancedInstallationScheduling,
-		sf.clusterResourceThreshold,
-		sf.thresholdCPUOverride,
-		sf.thresholdMemoryOverride,
-		sf.thresholdPodCountOverride,
-		sf.clusterResourceThresholdScaleValue,
+		flags.balancedInstallationScheduling,
+		flags.clusterResourceThreshold,
+		flags.thresholdCPUOverride,
+		flags.thresholdMemoryOverride,
+		flags.thresholdPodCountOverride,
+		flags.clusterResourceThresholdScaleValue,
 	)
 
 	if err := installationScheduling.Validate(); err != nil {
 		return errors.Wrap(err, "invalid installation scheduling options")
 	}
 
-	supervisorsEnabled := sf.supervisorOptions
-	if sf.disableAllSupervisors {
+	supervisorsEnabled := flags.supervisorOptions
+	if flags.disableAllSupervisors {
 		supervisorsEnabled = supervisorOptions{} // reset to zero
 	}
 
@@ -174,7 +174,7 @@ func executeServerCmd(sf serverFlags) error {
 		logger.Warn("Server will be running with no supervisors. Only API functionality will work.")
 	}
 
-	model.SetDeployOperators(sf.deployMySQLOperator, sf.deployMinioOperator)
+	model.SetDeployOperators(flags.deployMySQLOperator, flags.deployMinioOperator)
 
 	wd, err := os.Getwd()
 	if err != nil {
@@ -182,18 +182,18 @@ func executeServerCmd(sf serverFlags) error {
 		logger.WithError(err).Error("Unable to get current working directory")
 	}
 
-	keepDatabaseData := sf.keepDatabaseData
-	keepFileStoreData := sf.keepFileStoreData
-	if sf.devMode {
-		if !sf.isKeepDatabaseDataChanged {
+	keepDatabaseData := flags.keepDatabaseData
+	keepFileStoreData := flags.keepFileStoreData
+	if flags.devMode {
+		if !flags.isKeepDatabaseDataChanged {
 			keepDatabaseData = false
 		}
-		if !sf.isKeepFileStoreDataChanged {
+		if !flags.isKeepFileStoreDataChanged {
 			keepFileStoreData = false
 		}
 	}
 
-	provisionerFlag := sf.provisioner
+	provisionerFlag := flags.provisioner
 
 	logger.WithFields(logrus.Fields{
 		"build-hash":                                    model.BuildHash,
@@ -207,39 +207,39 @@ func executeServerCmd(sf serverFlags) error {
 		"installation-db-restoration-supervisor":        supervisorsEnabled.installationDBRestorationSupervisor,
 		"installation-db-migration-supervisor":          supervisorsEnabled.installationDBMigrationSupervisor,
 		"store-version":                                 currentVersion,
-		"state-store":                                   sf.s3StateStore,
+		"state-store":                                   flags.s3StateStore,
 		"working-directory":                             wd,
-		"installation-deletion-pending-time":            sf.installationDeletionPendingTime,
-		"installation-deletion-max-updating":            sf.installationDeletionMaxUpdating,
-		"balanced-installation-scheduling":              sf.balancedInstallationScheduling,
-		"cluster-resource-threshold":                    sf.clusterResourceThreshold,
-		"cluster-resource-threshold-cpu-override":       sf.thresholdCPUOverride,
-		"cluster-resource-threshold-memory-override":    sf.thresholdMemoryOverride,
-		"cluster-resource-threshold-pod-count-override": sf.thresholdPodCountOverride,
-		"cluster-resource-threshold-scale-value":        sf.clusterResourceThresholdScaleValue,
-		"use-existing-aws-resources":                    sf.useExistingResources,
+		"installation-deletion-pending-time":            flags.installationDeletionPendingTime,
+		"installation-deletion-max-updating":            flags.installationDeletionMaxUpdating,
+		"balanced-installation-scheduling":              flags.balancedInstallationScheduling,
+		"cluster-resource-threshold":                    flags.clusterResourceThreshold,
+		"cluster-resource-threshold-cpu-override":       flags.thresholdCPUOverride,
+		"cluster-resource-threshold-memory-override":    flags.thresholdMemoryOverride,
+		"cluster-resource-threshold-pod-count-override": flags.thresholdPodCountOverride,
+		"cluster-resource-threshold-scale-value":        flags.clusterResourceThresholdScaleValue,
+		"use-existing-aws-resources":                    flags.useExistingResources,
 		"keep-database-data":                            keepDatabaseData,
 		"keep-filestore-data":                           keepFileStoreData,
-		"force-cr-upgrade":                              sf.forceCRUpgrade,
-		"backup-restore-tool-image":                     sf.backupRestoreToolImage,
-		"backup-job-ttl-seconds":                        sf.backupJobTTL,
+		"force-cr-upgrade":                              flags.forceCRUpgrade,
+		"backup-restore-tool-image":                     flags.backupRestoreToolImage,
+		"backup-job-ttl-seconds":                        flags.backupJobTTL,
 		"debug":                                         debugMode,
-		"dev-mode":                                      sf.devMode,
-		"deploy-mysql-operator":                         sf.deployMySQLOperator,
-		"deploy-minio-operator":                         sf.deployMinioOperator,
-		"ndots-value":                                   sf.ndotsDefaultValue,
-		"maxDatabaseConnectionsPerPool":                 sf.maxDatabaseConnectionsPerPool,
-		"defaultPoolSize":                               sf.defaultPoolSize,
-		"minPoolSize":                                   sf.minPoolSize,
-		"maxClientConnections":                          sf.maxClientConnections,
-		"disable-db-init-check":                         sf.disableDBInitCheck,
-		"enable-route53":                                sf.enableRoute53,
-		"disable-dns-updates":                           sf.disableDNSUpdates,
+		"dev-mode":                                      flags.devMode,
+		"deploy-mysql-operator":                         flags.deployMySQLOperator,
+		"deploy-minio-operator":                         flags.deployMinioOperator,
+		"ndots-value":                                   flags.ndotsDefaultValue,
+		"maxDatabaseConnectionsPerPool":                 flags.maxDatabaseConnectionsPerPool,
+		"defaultPoolSize":                               flags.defaultPoolSize,
+		"minPoolSize":                                   flags.minPoolSize,
+		"maxClientConnections":                          flags.maxClientConnections,
+		"disable-db-init-check":                         flags.disableDBInitCheck,
+		"enable-route53":                                flags.enableRoute53,
+		"disable-dns-updates":                           flags.disableDNSUpdates,
 		"provisioner":                                   provisionerFlag,
 	}).Info("Starting Mattermost Provisioning Server")
 
 	// Warn on settings we consider to be non-production.
-	if !sf.useExistingResources {
+	if !flags.useExistingResources {
 		logger.Warn("[DEV] Server is configured to not use cluster VPC claim functionality")
 	}
 
@@ -266,25 +266,25 @@ func executeServerCmd(sf serverFlags) error {
 	owner := getHumanReadableID()
 
 	etcdManagerEnv := map[string]string{
-		"ETCD_QUOTA_BACKEND_BYTES": fmt.Sprintf("%v", sf.etcdQuotaBackendBytes),
-		"ETCD_LISTEN_METRICS_URLS": sf.etcdListenMetricsURL,
+		"ETCD_QUOTA_BACKEND_BYTES": fmt.Sprintf("%v", flags.etcdQuotaBackendBytes),
+		"ETCD_LISTEN_METRICS_URLS": flags.etcdListenMetricsURL,
 	}
 
 	provisioningParams := provisioner.ProvisioningParams{
-		S3StateStore:            sf.s3StateStore,
-		AllowCIDRRangeList:      sf.allowListCIDRRange,
-		VpnCIDRList:             sf.vpnListCIDR,
+		S3StateStore:            flags.s3StateStore,
+		AllowCIDRRangeList:      flags.allowListCIDRRange,
+		VpnCIDRList:             flags.vpnListCIDR,
 		Owner:                   owner,
-		UseExistingAWSResources: sf.useExistingResources,
-		DeployMysqlOperator:     sf.deployMySQLOperator,
-		DeployMinioOperator:     sf.deployMinioOperator,
-		NdotsValue:              sf.ndotsDefaultValue,
+		UseExistingAWSResources: flags.useExistingResources,
+		DeployMysqlOperator:     flags.deployMySQLOperator,
+		DeployMinioOperator:     flags.deployMinioOperator,
+		NdotsValue:              flags.ndotsDefaultValue,
 		PGBouncerConfig:         pgbouncerConfig,
-		SLOInstallationGroups:   sf.sloInstallationGroups,
+		SLOInstallationGroups:   flags.sloInstallationGroups,
 		EtcdManagerEnv:          etcdManagerEnv,
 	}
 
-	resourceUtil := utils.NewResourceUtil(instanceID, awsClient, dbClusterUtilizationSettingsFromFlags(sf), sf.disableDBInitCheck)
+	resourceUtil := utils.NewResourceUtil(instanceID, awsClient, dbClusterUtilizationSettingsFromFlags(flags), flags.disableDBInitCheck)
 
 	// TODO: In the future we can support both provisioners running
 	// at the same time, and the correct one should be chosen based
@@ -298,7 +298,7 @@ func executeServerCmd(sf serverFlags) error {
 			resourceUtil,
 			logger,
 			sqlStore,
-			provisioner.NewBackupOperator(sf.backupRestoreToolImage, awsRegion, sf.backupJobTTL),
+			provisioner.NewBackupOperator(flags.backupRestoreToolImage, awsRegion, flags.backupJobTTL),
 		)
 		defer kopsProvisioner.Teardown()
 		clusterProvisioner = kopsProvisioner
@@ -330,7 +330,7 @@ func executeServerCmd(sf serverFlags) error {
 
 	// DNS configuration
 	dnsManager := supervisor.NewDNSManager()
-	if sf.enableRoute53 {
+	if flags.enableRoute53 {
 		dnsManager.AddProvider(supervisor.NewRoute53DNSProvider(awsClient))
 	} else {
 		logger.Warn("Route53 disabled for Installation, Route53 CNAME records will not be created")
@@ -358,7 +358,7 @@ func executeServerCmd(sf serverFlags) error {
 		multiDoer = append(multiDoer, supervisor.NewGroupSupervisor(sqlStore, eventsProducer, instanceID, logger))
 	}
 	if supervisorsEnabled.installationSupervisor {
-		multiDoer = append(multiDoer, supervisor.NewInstallationSupervisor(sqlStore, clusterProvisioner, awsClient, instanceID, keepDatabaseData, keepFileStoreData, installationScheduling, resourceUtil, logger, cloudMetrics, eventsProducer, sf.forceCRUpgrade, dnsManager, sf.disableDNSUpdates))
+		multiDoer = append(multiDoer, supervisor.NewInstallationSupervisor(sqlStore, clusterProvisioner, awsClient, instanceID, keepDatabaseData, keepFileStoreData, installationScheduling, resourceUtil, logger, cloudMetrics, eventsProducer, flags.forceCRUpgrade, dnsManager, flags.disableDNSUpdates))
 	}
 	if supervisorsEnabled.clusterInstallationSupervisor {
 		multiDoer = append(multiDoer, supervisor.NewClusterInstallationSupervisor(sqlStore, clusterProvisioner, awsClient, eventsProducer, instanceID, logger, cloudMetrics))
@@ -367,10 +367,10 @@ func executeServerCmd(sf serverFlags) error {
 		multiDoer = append(multiDoer, supervisor.NewBackupSupervisor(sqlStore, clusterProvisioner, awsClient, instanceID, logger))
 	}
 	if supervisorsEnabled.importSupervisor {
-		if sf.awatAddress == "" {
+		if flags.awatAddress == "" {
 			return errors.New("--awat flag must be provided when --import-supervisor flag is provided")
 		}
-		multiDoer = append(multiDoer, supervisor.NewImportSupervisor(awsClient, awat.NewClient(sf.awatAddress), sqlStore, clusterProvisioner, eventsProducer, logger))
+		multiDoer = append(multiDoer, supervisor.NewImportSupervisor(awsClient, awat.NewClient(flags.awatAddress), sqlStore, clusterProvisioner, eventsProducer, logger))
 	}
 	if supervisorsEnabled.installationDBRestorationSupervisor {
 		multiDoer = append(multiDoer, supervisor.NewInstallationDBRestorationSupervisor(sqlStore, awsClient, clusterProvisioner, eventsProducer, instanceID, logger))
@@ -382,20 +382,20 @@ func executeServerCmd(sf serverFlags) error {
 	// Setup the supervisor to effect any requested changes. It is wrapped in a
 	// scheduler to trigger it periodically in addition to being poked by the API
 	// layer.
-	if sf.poll == 0 {
-		logger.WithField("poll", sf.poll).Info("Scheduler is disabled")
+	if flags.poll == 0 {
+		logger.WithField("poll", flags.poll).Info("Scheduler is disabled")
 	}
 
-	standardSupervisor := supervisor.NewScheduler(multiDoer, time.Duration(sf.poll)*time.Second)
+	standardSupervisor := supervisor.NewScheduler(multiDoer, time.Duration(flags.poll)*time.Second)
 	defer standardSupervisor.Close()
 
-	if sf.slowPoll == 0 {
-		logger.WithField("slow-poll", sf.slowPoll).Info("Slow scheduler is disabled")
+	if flags.slowPoll == 0 {
+		logger.WithField("slow-poll", flags.slowPoll).Info("Slow scheduler is disabled")
 	}
 	if supervisorsEnabled.installationDeletionSupervisor {
 		var slowMultiDoer supervisor.MultiDoer
-		slowMultiDoer = append(slowMultiDoer, supervisor.NewInstallationDeletionSupervisor(instanceID, sf.installationDeletionPendingTime, sf.installationDeletionMaxUpdating, sqlStore, eventsProducer, logger))
-		slowSupervisor := supervisor.NewScheduler(slowMultiDoer, time.Duration(sf.slowPoll)*time.Second)
+		slowMultiDoer = append(slowMultiDoer, supervisor.NewInstallationDeletionSupervisor(instanceID, flags.installationDeletionPendingTime, flags.installationDeletionMaxUpdating, sqlStore, eventsProducer, logger))
+		slowSupervisor := supervisor.NewScheduler(slowMultiDoer, time.Duration(flags.slowPoll)*time.Second)
 		defer slowSupervisor.Close()
 	}
 
@@ -403,7 +403,7 @@ func executeServerCmd(sf serverFlags) error {
 	metricsRouter.Handle("/metrics", promhttp.Handler())
 
 	metricsServer := &http.Server{
-		Addr:           fmt.Sprintf(":%d", sf.metricsPort),
+		Addr:           fmt.Sprintf(":%d", flags.metricsPort),
 		Handler:        metricsRouter,
 		ReadTimeout:    180 * time.Second,
 		WriteTimeout:   180 * time.Second,
@@ -434,7 +434,7 @@ func executeServerCmd(sf serverFlags) error {
 	})
 
 	srv := &http.Server{
-		Addr:           sf.listen,
+		Addr:           flags.listen,
 		Handler:        router,
 		ReadTimeout:    180 * time.Second,
 		WriteTimeout:   180 * time.Second,


### PR DESCRIPTION
#### Summary

moved `server` & `dry-run` flags to global flagset.

```
Global Flags:
      --dry-run         When set to true, only print the API request without sending it.
      --server string   The provisioning server whose API will be queried. (default "http://localhost:8075")
```

Missed in this [Pull Request](https://github.com/mattermost/mattermost-cloud/pull/774).

Also, updated variable names to a common name `flags`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
