### PR TITLE
Fix to set values in Calico

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -154,7 +154,8 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 			return errors.Wrapf(err, "failed to set %s", setValue)
 		}
 	}
-	if cluster.ProvisionerMetadataKops != nil && cluster.ProvisionerMetadataKops.Networking == "calico" {
+
+	if kopsMetadata.ChangeRequest.Networking == "calico" {
 		logger.Info("Updating calico options")
 		setValue = "spec.networking.calico.prometheusMetricsEnabled=true"
 		err = kops.SetCluster(kopsMetadata.Name, setValue)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This fix will set values for Calico

```
  networking:
    calico:
      prometheusMetricsEnabled: true
      prometheusMetricsPort: 9091
      typhaPrometheusMetricsEnabled: true
      typhaPrometheusMetricsPort: 9093
      typhaReplicas: 2
```

#### Ticket Link

Issue [Ticket](https://mattermost.atlassian.net/browse/MM-48914)

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
