### PR TITLE
[MM-48880] Added a flag for showing tags while listing

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -535,6 +535,10 @@ func executeClusterListCmd(flags clusterListFlags) error {
 			keys, vals = defaultClustersTableData(clusters)
 		}
 
+		if flags.showTags {
+			keys, vals = enhanceTableWithAnnotations(clusters, keys, vals)
+		}
+
 		printTable(keys, vals)
 		return nil
 	}
@@ -569,6 +573,24 @@ func defaultClustersTableData(clusters []*model.ClusterDTO) ([]string, [][]strin
 		})
 	}
 	return keys, values
+}
+
+func enhanceTableWithAnnotations(clusters []*model.ClusterDTO, keys []string, vals [][]string) ([]string, [][]string) {
+	var tags [][]string
+	for _, cluster := range clusters {
+		var list []string
+		for _, annotation := range cluster.Annotations {
+			list = append(list, annotation.Name)
+		}
+		tags = append(tags, list)
+	}
+	keys = append(keys, "TAG")
+	for i, v := range vals {
+		v = append(v, strings.Join(tags[i], ","))
+		vals[i] = v
+	}
+
+	return keys, vals
 }
 
 func newCmdClusterUtilities() *cobra.Command {

--- a/cmd/cloud/cluster_flag.go
+++ b/cmd/cloud/cluster_flag.go
@@ -301,11 +301,13 @@ type clusterListFlags struct {
 	clusterFlags
 	pagingFlags
 	tableOptions
+	showTags bool
 }
 
 func (flags *clusterListFlags) addFlags(command *cobra.Command) {
 	flags.pagingFlags.addFlags(command)
 	flags.tableOptions.addFlags(command)
+	command.Flags().BoolVar(&flags.showTags, "show-tags", false, "When printing, show all tags as the last column")
 }
 
 type clusterUtilitiesFlags struct {


### PR DESCRIPTION
#### Summary

In `cloud cluster list`, a new flag is introduced.

```
Flags:
      --show-tags                When printing, show all tags as the last column.
      --table                    Whether to display the returned output list as a table or not.
```

Currently, we are considering cluster annotations as **tags**

This flag `--show-tags` can only be used with `--table` and `--custom-columns`.
 
#### Ticket Link

Jira [Link](https://mattermost.atlassian.net/browse/MM-48880).

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added a flag for showing tags while listing
```
