### PR TITLE
[MM-48794] Set additional ENVs for Go & Process metrics

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -167,6 +167,16 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 		if err != nil {
 			return errors.Wrapf(err, "failed to set %s", setValue)
 		}
+		setValue = "spec.networking.calico.prometheusGoMetricsEnabled=true"
+		err = kops.SetCluster(kopsMetadata.Name, setValue)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set %s", setValue)
+		}
+		setValue = "spec.networking.calico.prometheusProcessMetricsEnabled=true"
+		err = kops.SetCluster(kopsMetadata.Name, setValue)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set %s", setValue)
+		}
 		setValue = "spec.networking.calico.typhaPrometheusMetricsEnabled=true"
 		err = kops.SetCluster(kopsMetadata.Name, setValue)
 		if err != nil {
@@ -178,16 +188,6 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 			return errors.Wrapf(err, "failed to set %s", setValue)
 		}
 		setValue = "spec.networking.calico.typhaReplicas=2"
-		err = kops.SetCluster(kopsMetadata.Name, setValue)
-		if err != nil {
-			return errors.Wrapf(err, "failed to set %s", setValue)
-		}
-		setValue = "spec.networking.calico.prometheusGoMetricsEnabled=true"
-		err = kops.SetCluster(kopsMetadata.Name, setValue)
-		if err != nil {
-			return errors.Wrapf(err, "failed to set %s", setValue)
-		}
-		setValue = "spec.networking.calico.prometheusProcessMetricsEnabled=true"
 		err = kops.SetCluster(kopsMetadata.Name, setValue)
 		if err != nil {
 			return errors.Wrapf(err, "failed to set %s", setValue)

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -182,6 +182,16 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 		if err != nil {
 			return errors.Wrapf(err, "failed to set %s", setValue)
 		}
+		setValue = "spec.networking.calico.prometheusGoMetricsEnabled=true"
+		err = kops.SetCluster(kopsMetadata.Name, setValue)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set %s", setValue)
+		}
+		setValue = "spec.networking.calico.prometheusProcessMetricsEnabled=true"
+		err = kops.SetCluster(kopsMetadata.Name, setValue)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set %s", setValue)
+		}
 	}
 
 	if len(provisioner.params.EtcdManagerEnv) > 0 {
@@ -198,7 +208,7 @@ func (provisioner *KopsProvisioner) CreateCluster(cluster *model.Cluster, awsCli
 		logger.Infof("Adding environment variables to etcd cluster manager")
 		err = kops.SetCluster(kopsMetadata.Name, strings.Join(override, ","))
 		if err != nil {
-			return errors.Wrapf(err, "failed to set %s", setValue)
+			return errors.Wrap(err, "failed to set etcd environment variables")
 		}
 	}
 


### PR DESCRIPTION
#### Summary

Set additional ENVs for Go & Process metrics

```
    FELIX_PROMETHEUSGOMETRICSENABLED = "true"
    FELIX_PROMETHEUSPROCESSMETRICSENABLED = "true"
```


#### Ticket Link

  Fixes [Issue](https://mattermost.atlassian.net/browse/MM-48794)

#### Release Note

```release-note
None
```
