### PR TITLE
Set priorities to 'creation-requested' and 'creation-in-progress'

### DIFF
--- a/internal/supervisor/cluster.go
+++ b/internal/supervisor/cluster.go
@@ -75,15 +75,9 @@ func (s *ClusterSupervisor) Do() error {
 		return nil
 	}
 
-	// Preference of state (high to low).
-	preferredOrder := map[string]int{
-		model.ClusterStateCreationRequested:  2,
-		model.ClusterStateCreationInProgress: 1,
-	}
-
 	// Sort the clusters by state preference. Relative order is preserved.
 	sort.SliceStable(clusters, func(i, j int) bool {
-		return preferredOrder[clusters[i].State] > preferredOrder[clusters[j].State]
+		return model.PendingWorkPriority[clusters[i].State] > model.PendingWorkPriority[clusters[j].State]
 	})
 
 	for _, cluster := range clusters {

--- a/internal/supervisor/cluster.go
+++ b/internal/supervisor/cluster.go
@@ -5,6 +5,8 @@
 package supervisor
 
 import (
+	"sort"
+
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/model"
 	log "github.com/sirupsen/logrus"
@@ -72,6 +74,17 @@ func (s *ClusterSupervisor) Do() error {
 		s.logger.WithError(err).Warn("Failed to query for clusters pending work")
 		return nil
 	}
+
+	// Preference of state (high to low).
+	preferredOrder := map[string]int{
+		model.ClusterStateCreationRequested:  2,
+		model.ClusterStateCreationInProgress: 1,
+	}
+
+	// Sort the clusters by state preference. Relative order is preserved.
+	sort.SliceStable(clusters, func(i, j int) bool {
+		return preferredOrder[clusters[i].State] > preferredOrder[clusters[j].State]
+	})
 
 	for _, cluster := range clusters {
 		s.Supervise(cluster)

--- a/internal/supervisor/cluster.go
+++ b/internal/supervisor/cluster.go
@@ -77,7 +77,7 @@ func (s *ClusterSupervisor) Do() error {
 
 	// Sort the clusters by state preference. Relative order is preserved.
 	sort.SliceStable(clusters, func(i, j int) bool {
-		return model.PendingWorkPriority[clusters[i].State] > model.PendingWorkPriority[clusters[j].State]
+		return model.ClusterStateWorkPriority[clusters[i].State] > model.ClusterStateWorkPriority[clusters[j].State]
 	})
 
 	for _, cluster := range clusters {

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -198,10 +198,7 @@ func TestClusterSupervisorDo(t *testing.T) {
 		require.NoError(t, err)
 
 		clusterListByWorkOrder := mockEventProducer.clusterListByEventOrder
-		require.Equal(t, len(preferredClusterOrder), len(clusterListByWorkOrder))
-		for i, clusterID := range clusterListByWorkOrder {
-			require.Equal(t, preferredClusterOrder[i], clusterID)
-		}
+		require.Equal(t, preferredClusterOrder, clusterListByWorkOrder)
 	})
 
 }

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -7,11 +7,10 @@ package supervisor_test
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-cloud/internal/testutil"
-
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/supervisor"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/stretchr/testify/require"
@@ -27,11 +26,21 @@ type mockClusterStore struct {
 }
 
 func (s *mockClusterStore) GetCluster(clusterID string) (*model.Cluster, error) {
-	return s.Cluster, nil
+	if s.Cluster != nil {
+		return s.Cluster, nil
+	}
+	for _, cluster := range s.Clusters {
+		if cluster.ID == clusterID {
+			return cluster, nil
+		}
+	}
+	return nil, nil
 }
 
 func (s *mockClusterStore) GetUnlockedClustersPendingWork() ([]*model.Cluster, error) {
-	return s.UnlockedClustersPendingWork, nil
+	clusters := make([]*model.Cluster, len(s.UnlockedClustersPendingWork))
+	copy(clusters, s.UnlockedClustersPendingWork)
+	return clusters, nil
 }
 
 func (s *mockClusterStore) GetClusters(clusterFilter *model.ClusterFilter) ([]*model.Cluster, error) {
@@ -140,6 +149,61 @@ func TestClusterSupervisorDo(t *testing.T) {
 		<-mockStore.UnlockChan
 		require.Equal(t, 3, mockStore.UpdateClusterCalls)
 	})
+
+	t.Run("order of pending works", func(t *testing.T) {
+		logger := testlib.MakeLogger(t)
+		mockStore := &mockClusterStore{}
+
+		clusters := []*model.Cluster{
+			{
+				ID:    "1",
+				State: model.ClusterStateDeletionRequested, // should be 4th
+			},
+			{
+				ID:    "2",
+				State: model.ClusterStateCreationRequested, // should be 1st
+			},
+			{
+				ID:    "3",
+				State: model.ClusterStateResizeRequested, // should be 5th
+			},
+			{
+				ID:    "4",
+				State: model.ClusterStateCreationInProgress, // should be 3rd
+			},
+			{
+				ID:    "5",
+				State: model.ClusterStateProvisioningRequested, // should be 6th
+			},
+			{
+				ID:    "6",
+				State: model.ClusterStateCreationRequested, // should be 2nd
+			},
+		}
+		preferredClusterOrder := []string{"2", "6", "4", "1", "3", "5"}
+
+		mockStore.UnlockedClustersPendingWork = clusters
+		mockStore.Clusters = clusters
+
+		mockEventProducer := &mockEventProducer{}
+		supervisor := supervisor.NewClusterSupervisor(
+			mockStore,
+			&mockClusterProvisioner{},
+			&mockAWS{},
+			mockEventProducer,
+			"instanceID",
+			logger,
+		)
+		err := supervisor.Do()
+		require.NoError(t, err)
+
+		clusterListByWorkOrder := mockEventProducer.clusterListByEventOrder
+		require.Equal(t, len(preferredClusterOrder), len(clusterListByWorkOrder))
+		for i, clusterID := range clusterListByWorkOrder {
+			require.Equal(t, preferredClusterOrder[i], clusterID)
+		}
+	})
+
 }
 
 func TestClusterSupervisorSupervise(t *testing.T) {

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -9,16 +9,13 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/eks"
-
 	"github.com/mattermost/mattermost-cloud/internal/events"
-	"github.com/mattermost/mattermost-cloud/internal/testutil"
-
-	"github.com/mattermost/mattermost-cloud/internal/provisioner"
-
 	"github.com/mattermost/mattermost-cloud/internal/metrics"
+	"github.com/mattermost/mattermost-cloud/internal/provisioner"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/supervisor"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/internal/testutil"
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"github.com/mattermost/mattermost-cloud/k8s"
@@ -581,12 +578,15 @@ func (a *mockAWS) SecretsManagerValidateExternalDatabaseSecret(name string) erro
 	return nil
 }
 
-type mockEventProducer struct{}
+type mockEventProducer struct {
+	clusterListByEventOrder []string
+}
 
 func (m *mockEventProducer) ProduceInstallationStateChangeEvent(installation *model.Installation, oldState string, extraDataFields ...events.DataField) error {
 	return nil
 }
 func (m *mockEventProducer) ProduceClusterStateChangeEvent(cluster *model.Cluster, oldState string, extraDataFields ...events.DataField) error {
+	m.clusterListByEventOrder = append(m.clusterListByEventOrder, cluster.ID)
 	return nil
 }
 func (m *mockEventProducer) ProduceClusterInstallationStateChangeEvent(clusterInstallation *model.ClusterInstallation, oldState string, extraDataFields ...events.DataField) error {

--- a/model/cluster_states.go
+++ b/model/cluster_states.go
@@ -71,9 +71,9 @@ var AllClusterStatesPendingWork = []string{
 	ClusterStateDeletionRequested,
 }
 
-// PendingWorkPriority is a map of states to their priority. Default priority is 0.
+// ClusterStateWorkPriority is a map of states to their priority. Default priority is 0.
 // States with higher priority will be processed first.
-var PendingWorkPriority = map[string]int{
+var ClusterStateWorkPriority = map[string]int{
 	ClusterStateCreationRequested:  2,
 	ClusterStateCreationInProgress: 1,
 }

--- a/model/cluster_states.go
+++ b/model/cluster_states.go
@@ -71,6 +71,13 @@ var AllClusterStatesPendingWork = []string{
 	ClusterStateDeletionRequested,
 }
 
+// PendingWorkPriority is a map of states to their priority. Default priority is 0.
+// States with higher priority will be processed first.
+var PendingWorkPriority = map[string]int{
+	ClusterStateCreationRequested:  2,
+	ClusterStateCreationInProgress: 1,
+}
+
 // AllClusterRequestStates is a list of all states that a cluster can be put in
 // via the API.
 // Warning:


### PR DESCRIPTION
#### Summary

We are setting priorities on the following states while executing

- creation-requested
- creation-in-progress

#### Ticket Link

  Fixes [MM-33114](https://mattermost.atlassian.net/browse/MM-33114)


#### Release Note
```release-note
Set priorities to 'creation-requested' and 'creation-in-progress'
```
