### PR TITLE
[MM-41914] Added metrics for cluster change

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -354,7 +354,7 @@ func executeServerCmd(flags serverFlags) error {
 
 	var multiDoer supervisor.MultiDoer
 	if supervisorsEnabled.clusterSupervisor {
-		multiDoer = append(multiDoer, supervisor.NewClusterSupervisor(sqlStore, clusterProvisioner, awsClient, eventsProducer, instanceID, logger))
+		multiDoer = append(multiDoer, supervisor.NewClusterSupervisor(sqlStore, clusterProvisioner, awsClient, eventsProducer, instanceID, logger, cloudMetrics))
 	}
 	if supervisorsEnabled.groupSupervisor {
 		multiDoer = append(multiDoer, supervisor.NewGroupSupervisor(sqlStore, eventsProducer, instanceID, logger))

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -34,6 +34,13 @@ type CloudMetrics struct {
 	// ClusterInstallation
 	ClusterInstallationReconcilingDurationHist *prometheus.HistogramVec
 	ClusterInstallationDeletionDurationHist    *prometheus.HistogramVec
+
+	// Cluster
+	ClusterCreationDurationHist     *prometheus.HistogramVec
+	ClusterUpgradeDurationHist      *prometheus.HistogramVec
+	ClusterProvisioningDurationHist *prometheus.HistogramVec
+	ClusterResizeDurationHist       *prometheus.HistogramVec
+	ClusterDeletionDurationHist     *prometheus.HistogramVec
 }
 
 // New creates a new Prometheus-based Metrics object to be used
@@ -133,6 +140,56 @@ func New() *CloudMetrics {
 				Buckets:   standardDurationBuckets(),
 			},
 			[]string{"cluster"},
+		),
+		ClusterCreationDurationHist: promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "cluster_creation_duration_seconds",
+				Help:      "The duration of cluster creation tasks",
+				Buckets:   standardDurationBuckets(),
+			},
+			[]string{},
+		),
+		ClusterUpgradeDurationHist: promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "cluster_upgrade_duration_seconds",
+				Help:      "The duration of cluster upgrade tasks",
+				Buckets:   standardDurationBuckets(),
+			},
+			[]string{},
+		),
+		ClusterProvisioningDurationHist: promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "cluster_provisioning_duration_seconds",
+				Help:      "The duration of cluster provisioning tasks",
+				Buckets:   standardDurationBuckets(),
+			},
+			[]string{},
+		),
+		ClusterResizeDurationHist: promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "cluster_resize_duration_seconds",
+				Help:      "The duration of cluster resize tasks",
+				Buckets:   standardDurationBuckets(),
+			},
+			[]string{},
+		),
+		ClusterDeletionDurationHist: promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: provisionerNamespace,
+				Subsystem: provisionerSubsystemApp,
+				Name:      "cluster_deletion_duration_seconds",
+				Help:      "The duration of cluster deletion tasks",
+				Buckets:   standardDurationBuckets(),
+			},
+			[]string{},
 		),
 	}
 }

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -71,6 +71,10 @@ func (s *mockClusterStore) GetWebhooks(filter *model.WebhookFilter) ([]*model.We
 	return nil, nil
 }
 
+func (s *mockClusterStore) GetStateChangeEvents(filter *model.StateChangeEventFilter) ([]*model.StateChangeEventData, error) {
+	return nil, nil
+}
+
 type mockClusterProvisioner struct{}
 
 func (p *mockClusterProvisioner) PrepareCluster(cluster *model.Cluster) bool {
@@ -117,6 +121,7 @@ func TestClusterSupervisorDo(t *testing.T) {
 			&mockEventProducer{},
 			"instanceID",
 			logger,
+			cloudMetrics,
 		)
 		err := supervisor.Do()
 		require.NoError(t, err)
@@ -142,6 +147,7 @@ func TestClusterSupervisorDo(t *testing.T) {
 			&mockEventProducer{},
 			"instanceID",
 			logger,
+			cloudMetrics,
 		)
 		err := supervisor.Do()
 		require.NoError(t, err)
@@ -193,6 +199,7 @@ func TestClusterSupervisorDo(t *testing.T) {
 			mockEventProducer,
 			"instanceID",
 			logger,
+			cloudMetrics,
 		)
 		err := supervisor.Do()
 		require.NoError(t, err)
@@ -230,6 +237,7 @@ func TestClusterSupervisorSupervise(t *testing.T) {
 				testutil.SetupTestEventsProducer(sqlStore, logger),
 				"instanceID",
 				logger,
+				cloudMetrics,
 			)
 
 			cluster := &model.Cluster{
@@ -259,6 +267,7 @@ func TestClusterSupervisorSupervise(t *testing.T) {
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			"instanceID",
 			logger,
+			cloudMetrics,
 		)
 
 		cluster := &model.Cluster{


### PR DESCRIPTION
#### Summary

Collecting metrics while state changes in cluster

- `creation-requested` -> `stable`
- `upgrade-requested` -> `stable`
- `provisioning-requested` -> `stable`
- `resize-requested` -> `stable`
- `deletion-requested` -> `deleted`


#### Ticket Link

Fixes [MM-41914](https://mattermost.atlassian.net/browse/MM-41914)


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added metrics for cluster change
```
