### PR TITLE
Refinement of flag parsing (cloud installation) 2/2

### DIFF
--- a/cmd/cloud/backup_flag.go
+++ b/cmd/cloud/backup_flag.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import "github.com/spf13/cobra"
+
+type installationBackupCreateFlags struct {
+	clusterFlags
+	installationID string
+}
+
+func (flags *installationBackupCreateFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The installation id to be backed up.")
+	_ = command.MarkFlagRequired("installation")
+}
+
+type installationBackupListFlags struct {
+	clusterFlags
+	pagingFlags
+	tableOptions
+	installationID string
+	state          string
+}
+
+func (flags *installationBackupListFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The installation id for which the backups should be listed.")
+	command.Flags().StringVar(&flags.state, "state", "", "The state to filter backups by.")
+	flags.pagingFlags.addFlags(command)
+	flags.tableOptions.addFlags(command)
+}
+
+type installationBackupGetFlags struct {
+	clusterFlags
+	backupID string
+}
+
+func (flags *installationBackupGetFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.backupID, "backup", "", "The id of the backup to get.")
+	_ = command.MarkFlagRequired("backup")
+}
+
+type installationBackupDeleteFlags struct {
+	clusterFlags
+	backupID string
+}
+
+func (flags *installationBackupDeleteFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.backupID, "backup", "", "The id of the backup to delete.")
+	_ = command.MarkFlagRequired("backup")
+}

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -39,11 +39,10 @@ func newCmdInstallation() *cobra.Command {
 	cmd.AddCommand(newCmdInstallationShowStateReport())
 	cmd.AddCommand(newCmdInstallationRecovery())
 	cmd.AddCommand(newCmdInstallationDeploymentReport())
-
-	cmd.AddCommand(installationAnnotationCmd)
-	cmd.AddCommand(backupCmd)
-	cmd.AddCommand(installationOperationCmd)
-	cmd.AddCommand(installationDNSCmd)
+	cmd.AddCommand(newCmdInstallationAnnotation())
+	cmd.AddCommand(newCmdInstallationBackup())
+	cmd.AddCommand(newCmdInstallationOperation())
+	cmd.AddCommand(newCmdInstallationDNS())
 
 	return cmd
 }

--- a/cmd/cloud/installation_annotation_flag.go
+++ b/cmd/cloud/installation_annotation_flag.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import "github.com/spf13/cobra"
+
+type installationAnnotationAddFlags struct {
+	clusterFlags
+	installationID string
+	annotations    []string
+}
+
+func (flags *installationAnnotationAddFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to be annotated.")
+	command.Flags().StringArrayVar(&flags.annotations, "annotation", []string{}, "Additional annotations for the installation. Accepts multiple values, for example: '... --annotation abc --annotation def'")
+
+	_ = command.MarkFlagRequired("installation")
+	_ = command.MarkFlagRequired("annotation")
+}
+
+type installationAnnotationDeleteFlags struct {
+	clusterFlags
+	installationID string
+	annotation     string
+}
+
+func (flags *installationAnnotationDeleteFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation from which annotations should be removed.")
+	command.Flags().StringVar(&flags.annotation, "annotation", "", "Name of the annotation to be removed from the installation.")
+
+	_ = command.MarkFlagRequired("installation")
+	_ = command.MarkFlagRequired("annotation")
+}

--- a/cmd/cloud/installation_dns_flags.go
+++ b/cmd/cloud/installation_dns_flags.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import "github.com/spf13/cobra"
+
+type installationDNSAddFlags struct {
+	clusterFlags
+	installationID string
+	dnsName        string
+}
+
+func (flags *installationDNSAddFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to add domain to.")
+	command.Flags().StringVar(&flags.dnsName, "domain", "", "Domain name to map to the installation.")
+	_ = command.MarkFlagRequired("installation")
+	_ = command.MarkFlagRequired("domain")
+}
+
+type installationDNSSetPrimaryFlags struct {
+	clusterFlags
+	installationID string
+	domainNameID   string
+}
+
+func (flags *installationDNSSetPrimaryFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation for domain switch.")
+	command.Flags().StringVar(&flags.domainNameID, "domain-id", "", "The id of domain name to set as primary.")
+	_ = command.MarkFlagRequired("installation")
+	_ = command.MarkFlagRequired("domain-id")
+
+}

--- a/cmd/cloud/installation_operation.go
+++ b/cmd/cloud/installation_operation.go
@@ -6,12 +6,14 @@ package main
 
 import "github.com/spf13/cobra"
 
-func init() {
-	installationOperationCmd.AddCommand(installationRestorationOperationCmd)
-	installationOperationCmd.AddCommand(installationDBMigrationOperationCmd)
-}
+func newCmdInstallationOperation() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "operation",
+		Short: "Manipulate installation operations managed by the provisioning server.",
+	}
 
-var installationOperationCmd = &cobra.Command{
-	Use:   "operation",
-	Short: "Manipulate installation operations managed by the provisioning server.",
+	cmd.AddCommand(newCmdInstallationRestorationOperation())
+	cmd.AddCommand(newCmdInstallationDBMigrationOperation())
+
+	return cmd
 }

--- a/cmd/cloud/installation_operation_db_migration_flag.go
+++ b/cmd/cloud/installation_operation_db_migration_flag.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/spf13/cobra"
+)
+
+type installationDBMigrationRequestFlags struct {
+	clusterFlags
+	installationID  string
+	destinationDB   string
+	multiTenantDBID string
+}
+
+func (flags *installationDBMigrationRequestFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to be migrated.")
+	command.Flags().StringVar(&flags.destinationDB, "destination-db", model.InstallationDatabaseMultiTenantRDSPostgres, "The destination database type.")
+	command.Flags().StringVar(&flags.multiTenantDBID, "multi-tenant-db", "", "The id of the destination multi tenant db.")
+	_ = command.MarkFlagRequired("installation")
+	_ = command.MarkFlagRequired("multi-tenant-db")
+}
+
+type installationDBMigrationsListFlags struct {
+	clusterFlags
+	pagingFlags
+	tableOptions
+	installationID string
+	state          string
+}
+
+func (flags *installationDBMigrationsListFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to query operations.")
+	command.Flags().StringVar(&flags.state, "state", "", "The state to filter operations by.")
+	flags.pagingFlags.addFlags(command)
+	flags.tableOptions.addFlags(command)
+}
+
+type installationDBMigrationGetFlags struct {
+	clusterFlags
+	dbMigrationID string
+}
+
+func (flags *installationDBMigrationGetFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.dbMigrationID, "db-migration", "", "The id of the installation db migration operation.")
+	_ = command.MarkFlagRequired("db-migration")
+}
+
+type installationDBMigrationCommitFlags struct {
+	clusterFlags
+	dbMigrationID string
+}
+
+func (flags *installationDBMigrationCommitFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.dbMigrationID, "db-migration", "", "The id of the installation db migration operation.")
+	_ = command.MarkFlagRequired("db-migration")
+}
+
+type installationDBMigrationRollbackFlags struct {
+	clusterFlags
+	dbMigrationID string
+}
+
+func (flags *installationDBMigrationRollbackFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.dbMigrationID, "db-migration", "", "The id of the installation db migration operation.")
+	_ = command.MarkFlagRequired("db-migration")
+}

--- a/cmd/cloud/installation_operation_restoration_flag.go
+++ b/cmd/cloud/installation_operation_restoration_flag.go
@@ -1,0 +1,44 @@
+package main
+
+import "github.com/spf13/cobra"
+
+type installationRestorationRequestFlags struct {
+	clusterFlags
+	installationID string
+	backupID       string
+}
+
+func (flags *installationRestorationRequestFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to be restored.")
+	command.Flags().StringVar(&flags.backupID, "backup", "", "The id of the backup to restore.")
+	_ = command.MarkFlagRequired("installation")
+	_ = command.MarkFlagRequired("backup")
+}
+
+type installationRestorationsListFlags struct {
+	clusterFlags
+	pagingFlags
+	tableOptions
+	installationID        string
+	clusterInstallationID string
+	state                 string
+}
+
+func (flags *installationRestorationsListFlags) addFlags(command *cobra.Command) {
+	flags.pagingFlags.addFlags(command)
+	flags.tableOptions.addFlags(command)
+
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to query operations.")
+	command.Flags().StringVar(&flags.clusterInstallationID, "cluster-installation", "", "The cluster installation to filter operations by.")
+	command.Flags().StringVar(&flags.state, "state", "", "The state to filter operations by.")
+}
+
+type installationRestorationGetFlags struct {
+	clusterFlags
+	restorationID string
+}
+
+func (flags *installationRestorationGetFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.restorationID, "restoration", "", "The id of restoration operation.")
+	_ = command.MarkFlagRequired("restoration")
+}


### PR DESCRIPTION
#### Summary

Modified parsing flags in the following commands.

```
$ cloud installation annotation
$ cloud installation backup
$ cloud installation operation
$ cloud installation dns
```

**Sample**

```
type installationDNSAddFlags struct {
	clusterFlags
	installationID string
	dnsName        string
}

func (flags *installationDNSAddFlags) addFlags(command *cobra.Command) {
	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to add domain to.")
	command.Flags().StringVar(&flags.dnsName, "domain", "", "Domain name to map to the installation.")
	_ = command.MarkFlagRequired("installation")
	_ = command.MarkFlagRequired("domain")
}

```


#### Ticket Link

Jira [Ticket](https://mattermost.atlassian.net/browse/MM-49074)

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
