### PR TITLE
[MM-49091] Refinement of flag parsing (cloud group)

### DIFF
--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -165,6 +165,7 @@ func newCmdGroupDelete() *cobra.Command {
 		Short: "Delete a group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
+
 			client := model.NewClient(flags.serverAddress)
 
 			if err := client.DeleteGroup(flags.groupID); err != nil {

--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -46,9 +46,7 @@ func newCmdGroupCreate() *cobra.Command {
 		Short: "Create a group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-
 			client := model.NewClient(flags.serverAddress)
-
 			envVarMap, err := parseEnvVarInput(flags.mattermostEnv, false)
 			if err != nil {
 				return err
@@ -165,13 +163,10 @@ func newCmdGroupDelete() *cobra.Command {
 		Short: "Delete a group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-
 			client := model.NewClient(flags.serverAddress)
-
 			if err := client.DeleteGroup(flags.groupID); err != nil {
 				return errors.Wrap(err, "failed to delete group")
 			}
-
 			return nil
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
@@ -193,9 +188,7 @@ func newCmdGroupGet() *cobra.Command {
 		Short: "Get a particular group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-
 			client := model.NewClient(flags.serverAddress)
-
 			group, err := client.GetGroup(flags.groupID)
 			if err != nil {
 				return errors.Wrap(err, "failed to query group")
@@ -276,9 +269,7 @@ func newCmdGroupGetStatus() *cobra.Command {
 		Short: "Get a particular group's status.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-
 			client := model.NewClient(flags.serverAddress)
-
 			groupStatus, err := client.GetGroupStatus(flags.groupID)
 			if err != nil {
 				return errors.Wrap(err, "failed to query group status")
@@ -308,14 +299,11 @@ func newCmdGroupJoin() *cobra.Command {
 		Short: "Join an installation to the given group, leaving any existing group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-
 			client := model.NewClient(flags.serverAddress)
-
 			err := client.JoinGroup(flags.groupID, flags.installationID)
 			if err != nil {
 				return errors.Wrap(err, "failed to join group")
 			}
-
 			return nil
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
@@ -337,9 +325,7 @@ func newCmdGroupAssign() *cobra.Command {
 		Short: "Assign an installation to the group based on annotations, leaving any existing group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-
 			client := model.NewClient(flags.serverAddress)
-
 			err := client.AssignGroup(flags.installationID, model.AssignInstallationGroupRequest{GroupSelectionAnnotations: flags.annotations})
 			if err != nil {
 				return errors.Wrap(err, "failed to assign group")
@@ -393,9 +379,7 @@ func newCmdGroupListStatus() *cobra.Command {
 		Short: "Get Status from all groups.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-
 			client := model.NewClient(flags.serverAddress)
-
 			groupStatus, err := client.GetGroupsStatus()
 			if err != nil {
 				return errors.Wrap(err, "failed to query group status")

--- a/cmd/cloud/group_annotation.go
+++ b/cmd/cloud/group_annotation.go
@@ -56,7 +56,7 @@ func newCmdGroupAnnotationAdd() *cobra.Command {
 		},
 	}
 
-	flags.clusterFlags.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }
@@ -69,6 +69,7 @@ func newCmdGroupAnnotationDelete() *cobra.Command {
 		Short: "Deletes Annotation from the group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
+
 			client := model.NewClient(flags.serverAddress)
 
 			if err := client.DeleteGroupAnnotation(flags.groupID, flags.annotation); err != nil {
@@ -82,7 +83,7 @@ func newCmdGroupAnnotationDelete() *cobra.Command {
 		},
 	}
 
-	flags.clusterFlags.addFlags(cmd)
+	flags.addFlags(cmd)
 
 	return cmd
 }

--- a/cmd/cloud/group_annotation.go
+++ b/cmd/cloud/group_annotation.go
@@ -31,9 +31,7 @@ func newCmdGroupAnnotationAdd() *cobra.Command {
 		Short: "Adds annotations to the group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-
 			client := model.NewClient(flags.serverAddress)
-
 			request := newAddAnnotationsRequest(flags.annotations)
 			if flags.dryRun {
 				return runDryRun(request)
@@ -69,9 +67,7 @@ func newCmdGroupAnnotationDelete() *cobra.Command {
 		Short: "Deletes Annotation from the group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-
 			client := model.NewClient(flags.serverAddress)
-
 			if err := client.DeleteGroupAnnotation(flags.groupID, flags.annotation); err != nil {
 				return errors.Wrap(err, "failed to delete group annotations")
 			}

--- a/cmd/cloud/group_annotation_flag.go
+++ b/cmd/cloud/group_annotation_flag.go
@@ -1,0 +1,31 @@
+package main
+
+import "github.com/spf13/cobra"
+
+type groupAnnotationAddFlags struct {
+	clusterFlags
+	groupID     string
+	annotations []string
+}
+
+func (flags *groupAnnotationAddFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.groupID, "group", "", "The id of the group to be annotated.")
+	command.Flags().StringSliceVar(&flags.annotations, "annotations", []string{}, "Additional annotations for the group. Accepts multiple values, for example: '... --annotation abc --annotation def'")
+
+	_ = command.MarkFlagRequired("group")
+	_ = command.MarkFlagRequired("annotations")
+}
+
+type groupAnnotationDeleteFlags struct {
+	clusterFlags
+	groupID    string
+	annotation string
+}
+
+func (flags *groupAnnotationDeleteFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.groupID, "group", "", "The id of the group from which annotations should be removed.")
+	command.Flags().StringVar(&flags.annotation, "annotation", "", "Name of the annotation to be removed from the group.")
+
+	_ = command.MarkFlagRequired("group")
+	_ = command.MarkFlagRequired("annotation")
+}

--- a/cmd/cloud/group_annotation_flag.go
+++ b/cmd/cloud/group_annotation_flag.go
@@ -10,10 +10,10 @@ type groupAnnotationAddFlags struct {
 
 func (flags *groupAnnotationAddFlags) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.groupID, "group", "", "The id of the group to be annotated.")
-	command.Flags().StringSliceVar(&flags.annotations, "annotations", []string{}, "Additional annotations for the group. Accepts multiple values, for example: '... --annotation abc --annotation def'")
+	command.Flags().StringArrayVar(&flags.annotations, "annotation", []string{}, "Additional annotations for the group. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 
 	_ = command.MarkFlagRequired("group")
-	_ = command.MarkFlagRequired("annotations")
+	_ = command.MarkFlagRequired("annotation")
 }
 
 type groupAnnotationDeleteFlags struct {

--- a/cmd/cloud/group_flag.go
+++ b/cmd/cloud/group_flag.go
@@ -64,7 +64,7 @@ func (flags *groupUpdateFlags) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.image, "image", "", "The Mattermost container image to use.")
 	command.Flags().Int64Var(&flags.maxRolling, "max-rolling", 0, "The maximum number of installations that can be updated at one time when a group is updated")
 	command.Flags().StringArrayVar(&flags.mattermostEnv, "mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
-	command.Flags().BoolVar(&flags.mattermostEnvClear, "mattermost-env-clear", false, "Clear all Mattermost env vars.")
+	command.Flags().BoolVar(&flags.mattermostEnvClear, "mattermost-env-clear", false, "Clears all env var data.")
 	command.Flags().BoolVar(&flags.forceSequenceUpdate, "force-sequence-update", false, "Forces the group version sequence to be increased by 1 even when no updates are present.")
 	command.Flags().BoolVar(&flags.forceInstallationRestart, "force-installation-restart", false, "Forces the restart of all installations in the group even if Mattermost CR does not change.")
 
@@ -126,7 +126,7 @@ type groupJoinFlags struct {
 
 func (flags *groupJoinFlags) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.groupID, "group", "", "The id of the group to which the installation will be added.")
-	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to join the group.")
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to add to the group.")
 
 	_ = command.MarkFlagRequired("group")
 	_ = command.MarkFlagRequired("installation")

--- a/cmd/cloud/group_flag.go
+++ b/cmd/cloud/group_flag.go
@@ -1,0 +1,160 @@
+package main
+
+import "github.com/spf13/cobra"
+
+type groupCreateFlags struct {
+	clusterFlags
+	name          string
+	description   string
+	version       string
+	image         string
+	maxRolling    int64
+	mattermostEnv []string
+	annotations   []string
+}
+
+func (flags *groupCreateFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.name, "name", "", "A unique name describing this group of installations.")
+	command.Flags().StringVar(&flags.description, "description", "", "An optional description for this group of installations.")
+	command.Flags().StringVar(&flags.version, "version", "", "The Mattermost version for installations in this group to target.")
+	command.Flags().StringVar(&flags.image, "image", "", "The Mattermost container image to use.")
+	command.Flags().Int64Var(&flags.maxRolling, "max-rolling", 1, "The maximum number of installations that can be updated at one time when a group is updated")
+	command.Flags().StringArrayVar(&flags.mattermostEnv, "mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
+	command.Flags().StringArrayVar(&flags.annotations, "annotation", []string{}, "Annotations for a group used for automatic group selection. Accepts multiple values, for example: '... --annotation abc --annotation def'")
+
+	_ = command.MarkFlagRequired("name")
+}
+
+type groupUpgradeFlagChanged struct {
+	isNameChanged        bool
+	isDescriptionChanged bool
+	isVersionChanged     bool
+	isImageChanged       bool
+	isMaxRollingChanged  bool
+}
+
+func (flags *groupUpgradeFlagChanged) addFlags(command *cobra.Command) {
+	flags.isNameChanged = command.Flags().Changed("name")
+	flags.isDescriptionChanged = command.Flags().Changed("description")
+	flags.isVersionChanged = command.Flags().Changed("version")
+	flags.isImageChanged = command.Flags().Changed("image")
+	flags.isMaxRollingChanged = command.Flags().Changed("max-rolling")
+}
+
+type groupUpdateFlags struct {
+	clusterFlags
+	groupUpgradeFlagChanged
+	groupID                  string
+	name                     string
+	description              string
+	version                  string
+	image                    string
+	maxRolling               int64
+	mattermostEnv            []string
+	mattermostEnvClear       bool
+	forceSequenceUpdate      bool
+	forceInstallationRestart bool
+}
+
+func (flags *groupUpdateFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.groupID, "group", "", "The id of the group to be updated.")
+	command.Flags().StringVar(&flags.name, "name", "", "A unique name describing this group of installations.")
+	command.Flags().StringVar(&flags.description, "description", "", "An optional description for this group of installations.")
+	command.Flags().StringVar(&flags.version, "version", "", "The Mattermost version for installations in this group to target.")
+	command.Flags().StringVar(&flags.image, "image", "", "The Mattermost container image to use.")
+	command.Flags().Int64Var(&flags.maxRolling, "max-rolling", 0, "The maximum number of installations that can be updated at one time when a group is updated")
+	command.Flags().StringArrayVar(&flags.mattermostEnv, "mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
+	command.Flags().BoolVar(&flags.mattermostEnvClear, "mattermost-env-clear", false, "Clear all Mattermost env vars.")
+	command.Flags().BoolVar(&flags.forceSequenceUpdate, "force-sequence-update", false, "Forces the group version sequence to be increased by 1 even when no updates are present.")
+	command.Flags().BoolVar(&flags.forceInstallationRestart, "force-installation-restart", false, "Forces the restart of all installations in the group even if Mattermost CR does not change.")
+
+	_ = command.MarkFlagRequired("group")
+}
+
+type groupDeleteFlags struct {
+	clusterFlags
+	groupID string
+}
+
+func (flags *groupDeleteFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.groupID, "group", "", "The id of the group to be deleted.")
+
+	_ = command.MarkFlagRequired("group")
+}
+
+type groupGetFlags struct {
+	clusterFlags
+	groupID string
+}
+
+func (flags *groupGetFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.groupID, "group", "", "The id of the group to be fetched.")
+
+	_ = command.MarkFlagRequired("group")
+}
+
+type groupListFlags struct {
+	clusterFlags
+	pagingFlags
+	outputToTable         bool
+	withInstallationCount bool
+}
+
+func (flags *groupListFlags) addFlags(command *cobra.Command) {
+	flags.pagingFlags.addFlags(command)
+
+	command.Flags().BoolVar(&flags.outputToTable, "table", false, "Whether to display the returned group list in a table or not")
+	command.Flags().BoolVar(&flags.withInstallationCount, "include-installation-count", false, "Whether to retrieve the installation count for the groups")
+}
+
+type groupGetStatusFlags struct {
+	clusterFlags
+	groupID string
+}
+
+func (flags *groupGetStatusFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.groupID, "group", "", "The id of the group of which the status should be fetched.")
+
+	_ = command.MarkFlagRequired("group")
+}
+
+type groupJoinFlags struct {
+	clusterFlags
+	groupID        string
+	installationID string
+}
+
+func (flags *groupJoinFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.groupID, "group", "", "The id of the group to which the installation will be added.")
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to join the group.")
+
+	_ = command.MarkFlagRequired("group")
+	_ = command.MarkFlagRequired("installation")
+}
+
+type groupAssignFlags struct {
+	clusterFlags
+	installationID string
+	annotations    []string
+}
+
+func (flags *groupAssignFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to assign to the group.")
+	command.Flags().StringArrayVar(&flags.annotations, "group-selection-annotation", []string{}, "Group annotations based on which the installation should be assigned.")
+
+	_ = command.MarkFlagRequired("installation")
+	_ = command.MarkFlagRequired("group-selection-annotation")
+}
+
+type groupLeaveFlags struct {
+	clusterFlags
+	installationID string
+	retainConfig   bool
+}
+
+func (flags *groupLeaveFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to leave its currently configured group.")
+	command.Flags().BoolVar(&flags.retainConfig, "retain-config", true, "Whether to retain the group configuration values or not.")
+
+	_ = command.MarkFlagRequired("installation")
+}

--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -32,7 +32,7 @@ func init() {
 	rootCmd.AddCommand(newCmdServer())
 	rootCmd.AddCommand(newCmdCluster())
 	rootCmd.AddCommand(newCmdInstallation())
-	rootCmd.AddCommand(groupCmd)
+	rootCmd.AddCommand(newCmdGroup())
 	rootCmd.AddCommand(databaseCmd)
 	rootCmd.AddCommand(schemaCmd)
 	rootCmd.AddCommand(webhookCmd)


### PR DESCRIPTION

#### Summary

Modified flag parsing of the following command
```
cloud group
```

Sample
```go

type groupLeaveFlags struct {
	clusterFlags
	installationID string
	retainConfig   bool
}

func (flags *groupLeaveFlags) addFlags(command *cobra.Command) {
	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to leave its currently configured group.")
	command.Flags().BoolVar(&flags.retainConfig, "retain-config", true, "Whether to retain the group configuration values or not.")

	_ = command.MarkFlagRequired("installation")
}
```

#### Ticket Link

jira [Ticket](https://mattermost.atlassian.net/browse/MM-49091)

#### Release Note


```release-note
None
```
