### PR TITLE
[CLD-4714] Delete helm chart to clean up LB resources

### DIFF
--- a/internal/provisioner/kubecost.go
+++ b/internal/provisioner/kubecost.go
@@ -114,7 +114,7 @@ func (k *kubecost) CreateOrUpgrade() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(180)*time.Second)
 	defer cancel()
 
-	endpoint, err := getPrivateLoadBalancerEndpoint(ctx, "nginx-internal", logger, k.kubeconfigPath)
+	endpoint, err := getPrivateLoadBalancerEndpoint(ctx, namespaceNginxInternal, logger, k.kubeconfigPath)
 	if err != nil {
 		return errors.Wrap(err, "couldn't get the load balancer endpoint (nginx) for Prometheus")
 	}

--- a/internal/provisioner/prometheus_operator.go
+++ b/internal/provisioner/prometheus_operator.go
@@ -134,7 +134,7 @@ func (p *prometheusOperator) CreateOrUpgrade() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(180)*time.Second)
 	defer cancel()
 
-	endpoint, err := getPrivateLoadBalancerEndpoint(ctx, "nginx-internal", logger.WithField("prometheus-action", "create"), p.kubeconfigPath)
+	endpoint, err := getPrivateLoadBalancerEndpoint(ctx, namespaceNginxInternal, logger.WithField("prometheus-action", "create"), p.kubeconfigPath)
 	if err != nil {
 		return errors.Wrap(err, "couldn't get the load balancer endpoint (nginx) for Prometheus")
 	}

--- a/internal/provisioner/thanos.go
+++ b/internal/provisioner/thanos.go
@@ -98,7 +98,7 @@ func (t *thanos) CreateOrUpgrade() error {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(120)*time.Second)
 		defer cancel()
 
-		endpoint, err := getPrivateLoadBalancerEndpoint(ctx, "nginx-internal", logger.WithField("thanos-action", "create"), t.kubeconfigPath)
+		endpoint, err := getPrivateLoadBalancerEndpoint(ctx, namespaceNginxInternal, logger.WithField("thanos-action", "create"), t.kubeconfigPath)
 		if err != nil {
 			return errors.Wrap(err, "couldn't get the load balancer endpoint (nginx) for Thanos")
 		}


### PR DESCRIPTION
#### Summary

We are manually deleting the helm chart for Nginx. This will clean up LB resources from the cloud provider.

#### Ticket Link

  Fixes [CLD-4714](https://mattermost.atlassian.net/browse/CLD-4714)

#### Release Note

```release-note
NONE
```
