### PR TITLE
[Mm 49246] Refinement of flag parsing (cloud database)

### DIFF
--- a/cmd/cloud/databases_flag.go
+++ b/cmd/cloud/databases_flag.go
@@ -14,8 +14,8 @@ type databaseMultiTenantListFlag struct {
 func (flags *databaseMultiTenantListFlag) addFlags(command *cobra.Command) {
 	flags.pagingFlags.addFlags(command)
 	flags.tableOptions.addFlags(command)
-	command.Flags().StringVar(&flags.vpcID, "vpc-id", "", "The VPC ID by which to filter mulitenant databases.")
-	command.Flags().StringVar(&flags.databaseType, "database-type", "", "The database type by which to filter mulitenant databases.")
+	command.Flags().StringVar(&flags.vpcID, "vpc-id", "", "The VPC ID by which to filter multitenant databases.")
+	command.Flags().StringVar(&flags.databaseType, "database-type", "", "The database type by which to filter multitenant databases.")
 }
 
 type databaseMultiTenantGetFlag struct {
@@ -24,7 +24,7 @@ type databaseMultiTenantGetFlag struct {
 }
 
 func (flags *databaseMultiTenantGetFlag) addFlags(command *cobra.Command) {
-	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the mulitenant database to be fetched.")
+	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the multitenant database to be fetched.")
 	_ = command.MarkFlagRequired("multitenant-database")
 }
 
@@ -45,7 +45,7 @@ type databaseMultiTenantUpdateFlag struct {
 }
 
 func (flags *databaseMultiTenantUpdateFlag) addFlags(command *cobra.Command) {
-	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the mulitenant database to be updated.")
+	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the multitenant database to be updated.")
 	command.Flags().Int64Var(&flags.maxInstallations, "max-installations-per-logical-db", 10, "The maximum number of installations permitted in a single logical database (only applies to proxy databases).")
 	_ = command.MarkFlagRequired("multitenant-database")
 }
@@ -57,7 +57,7 @@ type databaseMultiTenantDeleteFlag struct {
 }
 
 func (flags *databaseMultiTenantDeleteFlag) addFlags(command *cobra.Command) {
-	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the mulitenant database to delete.")
+	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the multitenant database to delete.")
 	command.Flags().BoolVar(&flags.force, "force", false, "Specifies whether to delete record even if database cluster exists.")
 	_ = command.MarkFlagRequired("multitenant-database")
 }
@@ -68,7 +68,7 @@ type databaseMultiTenantReportFlag struct {
 }
 
 func (flags *databaseMultiTenantReportFlag) addFlags(command *cobra.Command) {
-	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the mulitenant database to be fetched.")
+	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the multitenant database to be fetched.")
 	_ = command.MarkFlagRequired("multitenant-database")
 }
 

--- a/cmd/cloud/databases_flag.go
+++ b/cmd/cloud/databases_flag.go
@@ -1,0 +1,121 @@
+package main
+
+import "github.com/spf13/cobra"
+
+type databaseMultiTenantListFlag struct {
+	clusterFlags
+	pagingFlags
+	tableOptions
+
+	vpcID        string
+	databaseType string
+}
+
+func (flags *databaseMultiTenantListFlag) addFlags(command *cobra.Command) {
+	flags.pagingFlags.addFlags(command)
+	flags.tableOptions.addFlags(command)
+	command.Flags().StringVar(&flags.vpcID, "vpc-id", "", "The VPC ID by which to filter mulitenant databases.")
+	command.Flags().StringVar(&flags.databaseType, "database-type", "", "The database type by which to filter mulitenant databases.")
+}
+
+type databaseMultiTenantGetFlag struct {
+	clusterFlags
+	multitenantDatabaseID string
+}
+
+func (flags *databaseMultiTenantGetFlag) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the mulitenant database to be fetched.")
+	_ = command.MarkFlagRequired("multitenant-database")
+}
+
+type databaseMultiTenantUpdateFlagChanged struct {
+	isMaxInstallationsChanged bool
+}
+
+func (flags *databaseMultiTenantUpdateFlagChanged) addFlags(command *cobra.Command) {
+	flags.isMaxInstallationsChanged = command.Flags().Changed("max-installations-per-logical-db")
+}
+
+type databaseMultiTenantUpdateFlag struct {
+	clusterFlags
+	databaseMultiTenantUpdateFlagChanged
+	multitenantDatabaseID             string
+	maxInstallations                  int64
+	isMaxInstallationsPerLogicalDBSet bool
+}
+
+func (flags *databaseMultiTenantUpdateFlag) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the mulitenant database to be updated.")
+	command.Flags().Int64Var(&flags.maxInstallations, "max-installations-per-logical-db", 10, "The maximum number of installations permitted in a single logical database (only applies to proxy databases).")
+	_ = command.MarkFlagRequired("multitenant-database")
+}
+
+type databaseMultiTenantDeleteFlag struct {
+	clusterFlags
+	multitenantDatabaseID string
+	force                 bool
+}
+
+func (flags *databaseMultiTenantDeleteFlag) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the mulitenant database to delete.")
+	command.Flags().BoolVar(&flags.force, "force", false, "Specifies whether to delete record even if database cluster exists.")
+	_ = command.MarkFlagRequired("multitenant-database")
+}
+
+type databaseMultiTenantReportFlag struct {
+	clusterFlags
+	multitenantDatabaseID string
+}
+
+func (flags *databaseMultiTenantReportFlag) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the mulitenant database to be fetched.")
+	_ = command.MarkFlagRequired("multitenant-database")
+}
+
+type databaseLogicalListFlag struct {
+	clusterFlags
+	pagingFlags
+	tableOptions
+	multitenantDatabaseID string
+}
+
+func (flags *databaseLogicalListFlag) addFlags(command *cobra.Command) {
+	flags.pagingFlags.addFlags(command)
+	flags.tableOptions.addFlags(command)
+	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database-id", "", "The multitenant database ID by which to filter logical databases.")
+}
+
+type databaseLogicalGetFlag struct {
+	clusterFlags
+	logicalDatabaseID string
+}
+
+func (flags *databaseLogicalGetFlag) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.logicalDatabaseID, "logical-database", "", "The id of the logical database to be fetched.")
+	_ = command.MarkFlagRequired("logical-database")
+}
+
+type databaseSchemaListFlag struct {
+	clusterFlags
+	pagingFlags
+	tableOptions
+	logicalDatabaseID string
+	installationID    string
+}
+
+func (flags *databaseSchemaListFlag) addFlags(command *cobra.Command) {
+	flags.pagingFlags.addFlags(command)
+	flags.tableOptions.addFlags(command)
+	command.Flags().StringVar(&flags.logicalDatabaseID, "logical-database-id", "", "The logical database ID by which to filter database schemas.")
+	command.Flags().StringVar(&flags.installationID, "installation-id", "", "The installation ID by which to filter database schemas.")
+}
+
+type databaseSchemaGetFlag struct {
+	clusterFlags
+	databaseSchemaID string
+}
+
+func (flags *databaseSchemaGetFlag) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.databaseSchemaID, "database-schema", "", "The id of the database schema to be fetched.")
+	_ = command.MarkFlagRequired("database-schema")
+}

--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -33,7 +33,7 @@ func init() {
 	rootCmd.AddCommand(newCmdCluster())
 	rootCmd.AddCommand(newCmdInstallation())
 	rootCmd.AddCommand(newCmdGroup())
-	rootCmd.AddCommand(databaseCmd)
+	rootCmd.AddCommand(newCmdDatabase())
 	rootCmd.AddCommand(schemaCmd)
 	rootCmd.AddCommand(webhookCmd)
 	rootCmd.AddCommand(securityCmd)


### PR DESCRIPTION
#### Summary

Modified flag parsing of the following command

```bash
$ cloud database
```
Sample
```go

type databaseMultiTenantListFlag struct {
	clusterFlags
	pagingFlags
	tableOptions

	vpcID        string
	databaseType string
}

func (flags *databaseMultiTenantListFlag) addFlags(command *cobra.Command) {
	flags.pagingFlags.addFlags(command)
	flags.tableOptions.addFlags(command)
	command.Flags().StringVar(&flags.vpcID, "vpc-id", "", "The VPC ID by which to filter multitenant databases.")
	command.Flags().StringVar(&flags.databaseType, "database-type", "", "The database type by which to filter multitenant databases.")
}

func newCmdDatabaseMultitenantList() *cobra.Command {

	var flags databaseMultiTenantListFlag

	cmd := &cobra.Command{
		Use:   "list",
		Short: "List known multitenant databases.",
		RunE: func(command *cobra.Command, args []string) error {},
		PreRun: func(cmd *cobra.Command, args []string) {
			flags.clusterFlags.addFlags(cmd)
			return
		},
	}

	flags.addFlags(cmd)

	return cmd
}
```

#### Ticket Link

Jira [Ticket](https://mattermost.atlassian.net/browse/MM-49246)

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
