### PR TITLE
Sanitize resource name for prometheus SLIs

### DIFF
--- a/internal/provisioner/cluster_sli.go
+++ b/internal/provisioner/cluster_sli.go
@@ -5,6 +5,8 @@
 package provisioner
 
 import (
+	"strings"
+
 	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/mattermost/mattermost-cloud/model"
 	log "github.com/sirupsen/logrus"
@@ -19,7 +21,7 @@ const (
 )
 
 func makeRingSLOName(group *model.GroupDTO) string {
-	return group.Name + "-ring-" + group.ID
+	return strings.ToLower(group.Name) + "-ring-" + group.ID
 }
 
 func makeRingSLOs(group *model.GroupDTO, objective float64) slothv1.PrometheusServiceLevel {

--- a/internal/provisioner/cluster_sli.go
+++ b/internal/provisioner/cluster_sli.go
@@ -5,8 +5,7 @@
 package provisioner
 
 import (
-	"strings"
-
+	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/mattermost/mattermost-cloud/model"
 	log "github.com/sirupsen/logrus"
@@ -21,7 +20,7 @@ const (
 )
 
 func makeRingSLOName(group *model.GroupDTO) string {
-	return strings.ToLower(group.Name) + "-ring-" + group.ID
+	return utils.SanitizeRFC1123String(group.Name + "-ring-" + group.ID)
 }
 
 func makeRingSLOs(group *model.GroupDTO, objective float64) slothv1.PrometheusServiceLevel {

--- a/internal/provisioner/cluster_sli.go
+++ b/internal/provisioner/cluster_sli.go
@@ -20,7 +20,7 @@ const (
 )
 
 func makeRingSLOName(group *model.GroupDTO) string {
-	return utils.SanitizeRFC1123String(group.Name + "-ring-" + group.ID)
+	return utils.SanitizeAlphaNumericString(group.Name) + "-ring-" + group.ID
 }
 
 func makeRingSLOs(group *model.GroupDTO, objective float64) slothv1.PrometheusServiceLevel {

--- a/internal/tools/utils/strings.go
+++ b/internal/tools/utils/strings.go
@@ -12,7 +12,7 @@ import (
 var rfc1123Characters = regexp.MustCompile(`[^a-z0-9-.]+`)
 
 // SanitizeRFC1123String converts a string to a valid RFC1123 representation, converting all letters to
-// lowercase and then revoming all invalid characters.
+// lowercase and then removing all invalid characters.
 func SanitizeRFC1123String(input string) string {
 	return rfc1123Characters.ReplaceAllString(strings.ToLower(input), "")
 }

--- a/internal/tools/utils/strings.go
+++ b/internal/tools/utils/strings.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 )
 
-var rfc1123Characters = regexp.MustCompile(`[^a-z0-9-.]+`)
+var alphaNumericCharacters = regexp.MustCompile(`[^a-z0-9]+`)
 
-// SanitizeRFC1123String converts a string to a valid RFC1123 representation, converting all letters to
+// SanitizeAlphaNumericString converts a string to a valid AlphaNumeric representation, converting all letters to
 // lowercase and then removing all invalid characters.
-func SanitizeRFC1123String(input string) string {
-	return rfc1123Characters.ReplaceAllString(strings.ToLower(input), "")
+func SanitizeAlphaNumericString(input string) string {
+	return alphaNumericCharacters.ReplaceAllString(strings.ToLower(input), "")
 }

--- a/internal/tools/utils/strings.go
+++ b/internal/tools/utils/strings.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+var rfc1123Characters = regexp.MustCompile(`[^a-z0-9-.]+`)
+
+// SanitizeRFC1123String converts a string to a valid RFC1123 representation, converting all letters to
+// lowercase and then revoming all invalid characters.
+func SanitizeRFC1123String(input string) string {
+	return rfc1123Characters.ReplaceAllString(strings.ToLower(input), "")
+}

--- a/internal/tools/utils/strings_test.go
+++ b/internal/tools/utils/strings_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeRFC1123String(t *testing.T) {
+	testCases := []struct {
+		Input  string
+		Output string
+	}{
+		{
+			Input:  "aabbcc",
+			Output: "aabbcc",
+		},
+		{
+			Input:  "SpinWick-thingy-123",
+			Output: "spinwick-thingy-123",
+		},
+		{
+			Input:  "sup3rR@nD#mS7t))((###-oopp<>../;[",
+			Output: "sup3rrndms7t-oopp..",
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.Output, SanitizeRFC1123String(testCase.Input))
+	}
+}

--- a/internal/tools/utils/strings_test.go
+++ b/internal/tools/utils/strings_test.go
@@ -21,15 +21,15 @@ func TestSanitizeRFC1123String(t *testing.T) {
 		},
 		{
 			Input:  "SpinWick-thingy-123",
-			Output: "spinwick-thingy-123",
+			Output: "spinwickthingy123",
 		},
 		{
 			Input:  "sup3rR@nD#mS7t))((###-oopp<>../;[",
-			Output: "sup3rrndms7t-oopp..",
+			Output: "sup3rrndms7toopp",
 		},
 	}
 
 	for _, testCase := range testCases {
-		assert.Equal(t, testCase.Output, SanitizeRFC1123String(testCase.Input))
+		assert.Equal(t, testCase.Output, SanitizeAlphaNumericString(testCase.Input))
 	}
 }


### PR DESCRIPTION
#### Summary

This PRs fixes an error where a group name contains uppercase letters, since the `PrometheusServiceLevel` objects only allows a fully qualified domain name as it's name (that is, only lowecase letters, `-` and `.`).

#### Ticket Link

#### Release Note

```release-note
NONE
```
