### PR TITLE
[MM-49349] Refinement of flag parsing [final part]

### DIFF
--- a/cmd/cloud/completion.go
+++ b/cmd/cloud/completion.go
@@ -10,41 +10,46 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	completionCmd.AddCommand(bashCmd)
-	completionCmd.AddCommand(zshCmd)
+func newCmdCompletion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion",
+		Short: "Generates autocompletion scripts for bash and zsh",
+	}
+
+	cmd.AddCommand(newCmdCompletionBash())
+	cmd.AddCommand(newCmdZsh())
+
+	return cmd
 }
 
-var completionCmd = &cobra.Command{
-	Use:   "completion",
-	Short: "Generates autocompletion scripts for bash and zsh",
-}
-
-var bashCmd = &cobra.Command{
-	Use:   "bash",
-	Short: "Generates the bash autocompletion scripts",
-	Long: `To load completion, run
+var bashLong string = `To load completion, run
 
 . <(cloud completion bash)
 
 To configure your bash shell to load completions for each session, add the above line to your ~/.bashrc
-`,
-	Run: func(command *cobra.Command, args []string) {
-		rootCmd.GenBashCompletion(os.Stdout)
-	},
+`
+
+func newCmdCompletionBash() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bash",
+		Short: "Generates the bash autocompletion scripts",
+		Long:  bashLong,
+		Run: func(command *cobra.Command, args []string) {
+			rootCmd.GenBashCompletion(os.Stdout)
+		},
+	}
+
+	return cmd
 }
 
-var zshCmd = &cobra.Command{
-	Use:   "zsh",
-	Short: "Generates the zsh autocompletion scripts",
-	Long: `To load completion, run
+var zshLong string = `To load completion, run
 
 . <(cloud completion zsh)
 
 To configure your zsh shell to load completions for each session, add the above line to your ~/.zshrc
-`,
-	Run: func(command *cobra.Command, args []string) {
-		zshInitialization := `
+`
+
+var zshInitialization string = `
 __cloud_bash_source() {
 	alias shopt=':'
 	alias _expand=_bash_expand
@@ -176,14 +181,23 @@ __cloud_convert_bash_to_zsh() {
 	<<'BASH_COMPLETION_EOF'
 `
 
-		zshTail := `
+var zshTail string = `
 BASH_COMPLETION_EOF
 }
 __cloud_bash_source <(__cloud_convert_bash_to_zsh)
 `
 
-		os.Stdout.Write([]byte(zshInitialization))
-		rootCmd.GenBashCompletion(os.Stdout)
-		os.Stdout.Write([]byte(zshTail))
-	},
+func newCmdZsh() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "zsh",
+		Short: "Generates the zsh autocompletion scripts",
+		Long:  zshLong,
+		Run: func(command *cobra.Command, args []string) {
+			_, _ = os.Stdout.Write([]byte(zshInitialization))
+			_ = rootCmd.GenBashCompletion(os.Stdout)
+			_, _ = os.Stdout.Write([]byte(zshTail))
+		},
+	}
+
+	return cmd
 }

--- a/cmd/cloud/completion.go
+++ b/cmd/cloud/completion.go
@@ -22,7 +22,7 @@ func newCmdCompletion() *cobra.Command {
 	return cmd
 }
 
-var bashLong string = `To load completion, run
+var bashLong = `To load completion, run
 
 . <(cloud completion bash)
 
@@ -35,7 +35,7 @@ func newCmdCompletionBash() *cobra.Command {
 		Short: "Generates the bash autocompletion scripts",
 		Long:  bashLong,
 		Run: func(command *cobra.Command, args []string) {
-			rootCmd.GenBashCompletion(os.Stdout)
+			_ = rootCmd.GenBashCompletion(os.Stdout)
 		},
 	}
 
@@ -49,7 +49,7 @@ var zshLong string = `To load completion, run
 To configure your zsh shell to load completions for each session, add the above line to your ~/.zshrc
 `
 
-var zshInitialization string = `
+var zshInitialization = `
 __cloud_bash_source() {
 	alias shopt=':'
 	alias _expand=_bash_expand
@@ -181,7 +181,7 @@ __cloud_convert_bash_to_zsh() {
 	<<'BASH_COMPLETION_EOF'
 `
 
-var zshTail string = `
+var zshTail = `
 BASH_COMPLETION_EOF
 }
 __cloud_bash_source <(__cloud_convert_bash_to_zsh)

--- a/cmd/cloud/dashboard.go
+++ b/cmd/cloud/dashboard.go
@@ -11,11 +11,10 @@ import (
 	"time"
 
 	"github.com/gosuri/uilive"
+	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-
-	"github.com/mattermost/mattermost-cloud/model"
 )
 
 func newCmdDashboard() *cobra.Command {
@@ -154,7 +153,7 @@ func executeDashboardCmd(flags dashboardFlags) error {
 		}
 
 		for i := flags.refreshSeconds; i > 0; i-- {
-			fmt.Fprintf(writer, "%s\nUpdating in %d seconds...\n", renderedDashboard, i)
+			_, _ = fmt.Fprintf(writer, "%s\nUpdating in %d seconds...\n", renderedDashboard, i)
 			time.Sleep(time.Second)
 		}
 	}

--- a/cmd/cloud/dashboard.go
+++ b/cmd/cloud/dashboard.go
@@ -18,143 +18,146 @@ import (
 	"github.com/mattermost/mattermost-cloud/model"
 )
 
-func init() {
-	dashboardCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
+func newCmdDashboard() *cobra.Command {
 
-	dashboardCmd.PersistentFlags().Int("refresh-seconds", 10, "The amount of seconds before the dashboard is refreshed with new data.")
+	var flags dashboardFlags
+
+	cmd := &cobra.Command{
+		Use:   "dashboard",
+		Short: "View an auto-refreshing dashboard of all cloud server resources.",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+			return executeDashboardCmd(flags)
+		},
+	}
+
+	flags.addFlags(cmd)
+
+	return cmd
 }
 
-var dashboardCmd = &cobra.Command{
-	Use:   "dashboard",
-	Short: "View an auto-refreshing dashboard of all cloud server resources.",
-	RunE: func(command *cobra.Command, args []string) error {
-		command.SilenceUsage = true
+func executeDashboardCmd(flags dashboardFlags) error {
+	client := model.NewClient(flags.serverAddress)
+	if flags.refreshSeconds < 1 {
+		return errors.Errorf("refresh seconds (%d) must be set to 1 or higher", flags.refreshSeconds)
+	}
 
-		serverAddress, _ := command.Flags().GetString("server")
-		client := model.NewClient(serverAddress)
+	writer := uilive.New()
+	writer.Start()
 
-		refreshSeconds, _ := command.Flags().GetInt("refresh-seconds")
-		if refreshSeconds < 1 {
-			return errors.Errorf("refresh seconds (%d) must be set to 1 or higher", refreshSeconds)
+	for {
+		tableString := &strings.Builder{}
+		table := tablewriter.NewWriter(tableString)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
+		table.SetHeader([]string{"TYPE", "TOTAL", "STABLE", "WIP"})
+
+		var unstableList []string
+
+		// Clusters
+		start := time.Now()
+		clusters, err := client.GetClusters(&model.GetClustersRequest{
+			Paging: model.AllPagesNotDeleted(),
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to query clusters")
+		}
+		clusterQueryTime := time.Since(start)
+
+		clusterCount := len(clusters)
+		var clusterStableCount int
+		for _, cluster := range clusters {
+			if cluster.State == model.ClusterStateStable {
+				clusterStableCount++
+			} else {
+				unstableList = append(unstableList, fmt.Sprintf("Cluster: %s (%s)", cluster.ID, cluster.State))
+			}
 		}
 
-		writer := uilive.New()
-		writer.Start()
+		table.Append([]string{
+			"Cluster",
+			toStr(clusterCount),
+			toStr(clusterStableCount),
+			toStr(clusterCount - clusterStableCount),
+		})
 
-		for {
-			tableString := &strings.Builder{}
-			table := tablewriter.NewWriter(tableString)
-			table.SetAlignment(tablewriter.ALIGN_LEFT)
-			table.SetHeader([]string{"TYPE", "TOTAL", "STABLE", "WIP"})
+		// Installations
+		start = time.Now()
+		installations, err := client.GetInstallations(&model.GetInstallationsRequest{
+			Paging: model.AllPagesNotDeleted(),
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to query installations")
+		}
+		installationQueryTime := time.Since(start)
 
-			var unstableList []string
-
-			// Clusters
-			start := time.Now()
-			clusters, err := client.GetClusters(&model.GetClustersRequest{
-				Paging: model.AllPagesNotDeleted(),
-			})
-			if err != nil {
-				return errors.Wrap(err, "failed to query clusters")
-			}
-			clusterQueryTime := time.Since(start)
-
-			clusterCount := len(clusters)
-			var clusterStableCount int
-			for _, cluster := range clusters {
-				if cluster.State == model.ClusterStateStable {
-					clusterStableCount++
-				} else {
-					unstableList = append(unstableList, fmt.Sprintf("Cluster: %s (%s)", cluster.ID, cluster.State))
-				}
-			}
-
-			table.Append([]string{
-				"Cluster",
-				toStr(clusterCount),
-				toStr(clusterStableCount),
-				toStr(clusterCount - clusterStableCount),
-			})
-
-			// Installations
-			start = time.Now()
-			installations, err := client.GetInstallations(&model.GetInstallationsRequest{
-				Paging: model.AllPagesNotDeleted(),
-			})
-			if err != nil {
-				return errors.Wrap(err, "failed to query installations")
-			}
-			installationQueryTime := time.Since(start)
-
-			installationCount := len(installations)
-			var installationStableCount, installationsHibernatingCount, installationsPendingDeletionCount int
-			for _, installation := range installations {
-				switch installation.State {
-				case model.ClusterInstallationStateStable:
-					installationStableCount++
-				case model.InstallationStateHibernating:
-					installationsHibernatingCount++
-				case model.InstallationStateDeletionPending:
-					installationsPendingDeletionCount++
-				default:
-					unstableList = append(unstableList, fmt.Sprintf("Installation: %s | %s (%s)", installation.ID, installation.DNS, installation.State))
-				}
-			}
-
-			table.Append([]string{
-				"Installation",
-				toStr(installationCount),
-				fmt.Sprintf("%d (H=%d, DP=%d)", installationStableCount+installationsHibernatingCount, installationsHibernatingCount, installationsPendingDeletionCount),
-				toStr(installationCount - (installationStableCount + installationsHibernatingCount + installationsPendingDeletionCount)),
-			})
-
-			// Cluster Installations
-			start = time.Now()
-			clusterInstallations, err := client.GetClusterInstallations(&model.GetClusterInstallationsRequest{
-				Paging: model.AllPagesNotDeleted(),
-			})
-			if err != nil {
-				return errors.Wrap(err, "failed to query clusters")
-			}
-			ciQueryTime := time.Since(start)
-
-			clusterInstallationCount := len(clusterInstallations)
-			var clusterInstallationStableCount int
-			for _, clusterInstallation := range clusterInstallations {
-				if clusterInstallation.State == model.ClusterInstallationStateStable {
-					clusterInstallationStableCount++
-				} else {
-					unstableList = append(unstableList, fmt.Sprintf("Cluster Installation: %s (%s)", clusterInstallation.ID, clusterInstallation.State))
-				}
-			}
-
-			table.Append([]string{
-				"Cluster Installation",
-				toStr(clusterInstallationCount),
-				toStr(clusterInstallationStableCount),
-				toStr(clusterInstallationCount - clusterInstallationStableCount),
-			})
-
-			table.Render()
-			renderedDashboard := "\n### CLOUD DASHBOARD\n"
-			renderedDashboard += fmt.Sprintf("[ Query Time Stats: CLSR=%s, INST=%s, CLIN=%s ]\n\n",
-				clusterQueryTime.Round(time.Millisecond).String(),
-				installationQueryTime.Round(time.Millisecond).String(),
-				ciQueryTime.Round(time.Millisecond).String())
-			renderedDashboard += tableString.String()
-			for _, entry := range unstableList {
-				renderedDashboard += fmt.Sprintf("%s\n", entry)
-			}
-			if len(unstableList) != 0 {
-				renderedDashboard += "\n"
-			}
-
-			for i := refreshSeconds; i > 0; i-- {
-				fmt.Fprintf(writer, "%s\nUpdating in %d seconds...\n", renderedDashboard, i)
-				time.Sleep(time.Second)
+		installationCount := len(installations)
+		var installationStableCount, installationsHibernatingCount, installationsPendingDeletionCount int
+		for _, installation := range installations {
+			switch installation.State {
+			case model.ClusterInstallationStateStable:
+				installationStableCount++
+			case model.InstallationStateHibernating:
+				installationsHibernatingCount++
+			case model.InstallationStateDeletionPending:
+				installationsPendingDeletionCount++
+			default:
+				unstableList = append(unstableList, fmt.Sprintf("Installation: %s | %s (%s)", installation.ID, installation.DNS, installation.State))
 			}
 		}
-	},
+
+		table.Append([]string{
+			"Installation",
+			toStr(installationCount),
+			fmt.Sprintf("%d (H=%d, DP=%d)", installationStableCount+installationsHibernatingCount, installationsHibernatingCount, installationsPendingDeletionCount),
+			toStr(installationCount - (installationStableCount + installationsHibernatingCount + installationsPendingDeletionCount)),
+		})
+
+		// Cluster Installations
+		start = time.Now()
+		clusterInstallations, err := client.GetClusterInstallations(&model.GetClusterInstallationsRequest{
+			Paging: model.AllPagesNotDeleted(),
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to query clusters")
+		}
+		ciQueryTime := time.Since(start)
+
+		clusterInstallationCount := len(clusterInstallations)
+		var clusterInstallationStableCount int
+		for _, clusterInstallation := range clusterInstallations {
+			if clusterInstallation.State == model.ClusterInstallationStateStable {
+				clusterInstallationStableCount++
+			} else {
+				unstableList = append(unstableList, fmt.Sprintf("Cluster Installation: %s (%s)", clusterInstallation.ID, clusterInstallation.State))
+			}
+		}
+
+		table.Append([]string{
+			"Cluster Installation",
+			toStr(clusterInstallationCount),
+			toStr(clusterInstallationStableCount),
+			toStr(clusterInstallationCount - clusterInstallationStableCount),
+		})
+
+		table.Render()
+		renderedDashboard := "\n### CLOUD DASHBOARD\n"
+		renderedDashboard += fmt.Sprintf("[ Query Time Stats: CLSR=%s, INST=%s, CLIN=%s ]\n\n",
+			clusterQueryTime.Round(time.Millisecond).String(),
+			installationQueryTime.Round(time.Millisecond).String(),
+			ciQueryTime.Round(time.Millisecond).String())
+		renderedDashboard += tableString.String()
+		for _, entry := range unstableList {
+			renderedDashboard += fmt.Sprintf("%s\n", entry)
+		}
+		if len(unstableList) != 0 {
+			renderedDashboard += "\n"
+		}
+
+		for i := flags.refreshSeconds; i > 0; i-- {
+			fmt.Fprintf(writer, "%s\nUpdating in %d seconds...\n", renderedDashboard, i)
+			time.Sleep(time.Second)
+		}
+	}
 }
 
 func toStr(i int) string {

--- a/cmd/cloud/dashboard_flag.go
+++ b/cmd/cloud/dashboard_flag.go
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/spf13/cobra"
+
+type dashboardFlags struct {
+	serverAddress  string
+	refreshSeconds int
+}
+
+func (flags *dashboardFlags) addFlags(command *cobra.Command) {
+	command.PersistentFlags().StringVar(&flags.serverAddress, "server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
+	command.PersistentFlags().IntVar(&flags.refreshSeconds, "refresh-seconds", 10, "The amount of seconds before the dashboard is refreshed with new data.")
+}

--- a/cmd/cloud/events.go
+++ b/cmd/cloud/events.go
@@ -10,75 +10,91 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	eventsCmd.AddCommand(stateChangeEventsCmd)
-	eventsCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
+func newCmdEvents() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "events",
+		Short: "Groups event commands managed by the provisioning server.",
+	}
 
-	listStateChangeEventsCmd.Flags().String("resource-type", "", "Type of a resource for which to list events.")
-	listStateChangeEventsCmd.Flags().String("resource-id", "", "ID of a resource for which to list events.")
-	registerPagingFlags(listStateChangeEventsCmd)
-	registerTableOutputFlags(listStateChangeEventsCmd)
+	setEventFlags(cmd)
 
-	stateChangeEventsCmd.AddCommand(listStateChangeEventsCmd)
+	cmd.AddCommand(newCmdStateChangeEvents())
+
+	return cmd
 }
 
-var eventsCmd = &cobra.Command{
-	Use:   "events",
-	Short: "Groups event commands managed by the provisioning server.",
+func newCmdStateChangeEvents() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "state-change",
+		Short: "Groups state change event commands managed by the provisioning server.",
+	}
+
+	cmd.AddCommand(newCmdStateChangeEventList())
+
+	return cmd
 }
 
-var stateChangeEventsCmd = &cobra.Command{
-	Use:   "state-change",
-	Short: "Groups state change event commands managed by the provisioning server.",
+func newCmdStateChangeEventList() *cobra.Command {
+	var flags stateChangeEventListFlags
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Fetch state change events managed by the provisioning server.",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+			return executeStateChangeEventListCmd(flags)
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.eventFlags.addFlags(cmd)
+			return
+		},
+	}
+
+	flags.addFlags(cmd)
+
+	return cmd
 }
 
-var listStateChangeEventsCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Fetch state change events managed by the provisioning server.",
-	RunE: func(command *cobra.Command, args []string) error {
-		command.SilenceUsage = true
+func executeStateChangeEventListCmd(flags stateChangeEventListFlags) error {
+	client := model.NewClient(flags.serverAddress)
 
-		serverAddress, _ := command.Flags().GetString("server")
-		client := model.NewClient(serverAddress)
+	paging := getPaging(flags.pagingFlags)
 
-		resourceType, _ := command.Flags().GetString("resource-type")
-		resourceID, _ := command.Flags().GetString("resource-id")
-		paging := parsePagingFlags(command)
+	req := model.ListStateChangeEventsRequest{
+		Paging:       paging,
+		ResourceType: model.ResourceType(flags.resourceType),
+		ResourceID:   flags.resourceID,
+	}
 
-		req := model.ListStateChangeEventsRequest{
-			Paging:       paging,
-			ResourceType: model.ResourceType(resourceType),
-			ResourceID:   resourceID,
-		}
+	events, err := client.ListStateChangeEvents(&req)
+	if err != nil {
+		return err
+	}
 
-		events, err := client.ListStateChangeEvents(&req)
-		if err != nil {
-			return err
-		}
+	if enabled, customCols := getTableOutputOption(flags.tableOptions); enabled {
+		var keys []string
+		var vals [][]string
 
-		if enabled, customCols := tableOutputEnabled(command); enabled {
-			var keys []string
-			var vals [][]string
-
-			if len(customCols) > 0 {
-				data := make([]interface{}, 0, len(events))
-				for _, elem := range events {
-					data = append(data, elem)
-				}
-				keys, vals, err = prepareTableData(customCols, data)
-				if err != nil {
-					return errors.Wrap(err, "failed to prepare table output")
-				}
-			} else {
-				keys, vals = defaultEventsTableData(events)
+		if len(customCols) > 0 {
+			data := make([]interface{}, 0, len(events))
+			for _, elem := range events {
+				data = append(data, elem)
 			}
-
-			printTable(keys, vals)
-			return nil
+			keys, vals, err = prepareTableData(customCols, data)
+			if err != nil {
+				return errors.Wrap(err, "failed to prepare table output")
+			}
+		} else {
+			keys, vals = defaultEventsTableData(events)
 		}
 
-		return printJSON(events)
-	},
+		printTable(keys, vals)
+		return nil
+	}
+
+	return printJSON(events)
+
 }
 
 func defaultEventsTableData(events []*model.StateChangeEventData) ([]string, [][]string) {

--- a/cmd/cloud/events_flag.go
+++ b/cmd/cloud/events_flag.go
@@ -1,0 +1,31 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func setEventFlags(command *cobra.Command) {
+	command.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
+}
+
+type eventFlags struct {
+	serverAddress string
+}
+
+func (flags *eventFlags) addFlags(command *cobra.Command) {
+	flags.serverAddress, _ = command.Flags().GetString("server")
+}
+
+type stateChangeEventListFlags struct {
+	eventFlags
+	pagingFlags
+	tableOptions
+	resourceType string
+	resourceID   string
+}
+
+func (flags *stateChangeEventListFlags) addFlags(command *cobra.Command) {
+	flags.pagingFlags.addFlags(command)
+	flags.tableOptions.addFlags(command)
+
+	command.Flags().StringVar(&flags.resourceType, "resource-type", "", "Type of a resource for which to list events.")
+	command.Flags().StringVar(&flags.resourceID, "resource-id", "", "ID of a resource for which to list events.")
+}

--- a/cmd/cloud/events_flag.go
+++ b/cmd/cloud/events_flag.go
@@ -25,7 +25,6 @@ type stateChangeEventListFlags struct {
 func (flags *stateChangeEventListFlags) addFlags(command *cobra.Command) {
 	flags.pagingFlags.addFlags(command)
 	flags.tableOptions.addFlags(command)
-
 	command.Flags().StringVar(&flags.resourceType, "resource-type", "", "Type of a resource for which to list events.")
 	command.Flags().StringVar(&flags.resourceID, "resource-id", "", "ID of a resource for which to list events.")
 }

--- a/cmd/cloud/events_subscription_flag.go
+++ b/cmd/cloud/events_subscription_flag.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/spf13/cobra"
+	"time"
+)
+
+type subscriptionCreateFlags struct {
+	clusterFlags
+	name             string
+	url              string
+	owner            string
+	eventType        string
+	failureThreshold time.Duration
+}
+
+func (flags *subscriptionCreateFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.name, "name", "", "Name of the subscription.")
+	command.Flags().StringVar(&flags.url, "url", "", "URL of the subscription.")
+	command.Flags().StringVar(&flags.owner, "owner", "", "OwnerID of the subscription.")
+	command.Flags().StringVar(&flags.eventType, "event-type", string(model.ResourceStateChangeEventType), "Event type of the subscription.")
+	command.Flags().DurationVar(&flags.failureThreshold, "failure-threshold", 0, "Failure threshold of the subscription.")
+	_ = command.MarkFlagRequired("url")
+	_ = command.MarkFlagRequired("owner")
+	_ = command.MarkFlagRequired("event-type")
+}
+
+type subscriptionListFlags struct {
+	clusterFlags
+	pagingFlags
+	tableOptions
+	owner     string
+	eventType string
+}
+
+func (flags *subscriptionListFlags) addFlags(command *cobra.Command) {
+	flags.pagingFlags.addFlags(command)
+	flags.tableOptions.addFlags(command)
+	command.Flags().StringVar(&flags.owner, "owner", "", "OwnerID of the subscription.")
+	command.Flags().StringVar(&flags.eventType, "event-type", "", "Event type of the subscription.")
+}
+
+type subscriptionGetFlags struct {
+	clusterFlags
+	subID string
+}
+
+func (flags *subscriptionGetFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.subID, "subscription", "", "ID of subscription to get")
+	_ = command.MarkFlagRequired("subscription")
+}
+
+type subscriptionDeleteFlags struct {
+	clusterFlags
+	subID string
+}
+
+func (flags *subscriptionDeleteFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.subID, "subscription", "", "ID of subscription to delete")
+	_ = command.MarkFlagRequired("subscription")
+}

--- a/cmd/cloud/events_subscription_flag.go
+++ b/cmd/cloud/events_subscription_flag.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"time"
+
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 type subscriptionCreateFlags struct {

--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -37,11 +37,11 @@ func init() {
 	rootCmd.AddCommand(newCmdSchema())
 	rootCmd.AddCommand(newCmdWebhook())
 	rootCmd.AddCommand(newCmdSecurity())
-	rootCmd.AddCommand(workbenchCmd)
-	rootCmd.AddCommand(completionCmd)
-	rootCmd.AddCommand(dashboardCmd)
-	rootCmd.AddCommand(eventsCmd)
-	rootCmd.AddCommand(subscriptionCmd)
+	rootCmd.AddCommand(newCmdWorkbench())
+	rootCmd.AddCommand(newCmdCompletion())
+	rootCmd.AddCommand(newCmdDashboard())
+	rootCmd.AddCommand(newCmdEvents())
+	rootCmd.AddCommand(newCmdSubscription())
 }
 
 func main() {

--- a/cmd/cloud/workbench.go
+++ b/cmd/cloud/workbench.go
@@ -12,77 +12,87 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	workbenchCmd.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
-	workbenchCmd.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
+func newCmdWorkbench() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workbench",
+		Short: "Tools for working with cloud resources",
+	}
 
-	workbenchClusterCmd.Flags().String("cluster", "", "The id of the cluster to work on.")
-	workbenchClusterCmd.MarkFlagRequired("cluster")
+	setWorkbenchFlags(cmd)
 
-	workbenchCmd.AddCommand(workbenchClusterCmd)
+	cmd.AddCommand(newCmdWorkbenchCluster())
+
+	return cmd
 }
 
-var workbenchCmd = &cobra.Command{
-	Use:   "workbench",
-	Short: "Tools for working with cloud resources",
+func newCmdWorkbenchCluster() *cobra.Command {
+
+	var flags workbenchClusterFlag
+
+	cmd := &cobra.Command{
+		Use:   "cluster",
+		Short: "Export kops and terraform files into a workbench directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			return executeWorkbenchClusterCmd(flags)
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.workbenchFlags.addFlags(cmd)
+		},
+	}
+
+	flags.addFlags(cmd)
+
+	return cmd
 }
 
-var workbenchClusterCmd = &cobra.Command{
-	Use:   "cluster",
-	Short: "Export kops and terraform files into a workbench directory",
-	RunE: func(command *cobra.Command, args []string) error {
-		command.SilenceUsage = true
+func executeWorkbenchClusterCmd(flags workbenchClusterFlag) error {
+	client := model.NewClient(flags.serverAddress)
+	cluster, err := client.GetCluster(flags.clusterID)
+	if err != nil {
+		return errors.Wrap(err, "failed to query cluster")
+	}
+	if cluster == nil {
+		return errors.Errorf("unable to find cluster %s", flags.clusterID)
+	}
 
-		serverAddress, _ := command.Flags().GetString("server")
-		client := model.NewClient(serverAddress)
+	logger := logger.WithField("cluster", flags.clusterID)
+	logger.Info("Setting up cluster workbench")
 
-		clusterID, _ := command.Flags().GetString("cluster")
-		cluster, err := client.GetCluster(clusterID)
-		if err != nil {
-			return errors.Wrap(err, "failed to query cluster")
+	kopsClient, err := kops.New(flags.s3StateStore, logger)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := kopsClient.Close(); err != nil {
+			logger.WithError(err).Error("Failed to close kops client")
 		}
-		if cluster == nil {
-			return errors.Errorf("unable to find cluster %s", clusterID)
+	}()
+
+	if err = kopsClient.ExportKubecfg(cluster.ProvisionerMetadataKops.Name); err != nil {
+		return err
+	}
+
+	if err = kopsClient.UpdateCluster(cluster.ProvisionerMetadataKops.Name, kopsClient.GetOutputDirectory()); err != nil {
+		return err
+	}
+
+	terraformClient, err := terraform.New(kopsClient.GetOutputDirectory(), flags.s3StateStore, logger)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := terraformClient.Close(); err != nil {
+			logger.WithError(err).Error("Failed to close terraform client")
 		}
+	}()
 
-		logger := logger.WithField("cluster", clusterID)
-		logger.Info("Setting up cluster workbench")
+	if err = terraformClient.Init(cluster.ProvisionerMetadataKops.Name); err != nil {
+		return err
+	}
 
-		s3StateStore, _ := command.Flags().GetString("state-store")
+	logger.Info("Cluster workbench setup complete")
+	logger.Infof("The workbench directory can be found at %s", kopsClient.GetTempDir())
 
-		kopsClient, err := kops.New(s3StateStore, logger)
-		if err != nil {
-			return err
-		}
-
-		err = kopsClient.ExportKubecfg(cluster.ProvisionerMetadataKops.Name)
-		if err != nil {
-			kopsClient.Close()
-			return err
-		}
-
-		err = kopsClient.UpdateCluster(cluster.ProvisionerMetadataKops.Name, kopsClient.GetOutputDirectory())
-		if err != nil {
-			kopsClient.Close()
-			return err
-		}
-
-		terraformClient, err := terraform.New(kopsClient.GetOutputDirectory(), s3StateStore, logger)
-		if err != nil {
-			kopsClient.Close()
-			return err
-		}
-
-		err = terraformClient.Init(cluster.ProvisionerMetadataKops.Name)
-		if err != nil {
-			kopsClient.Close()
-			terraformClient.Close()
-			return err
-		}
-
-		logger.Info("Cluster workbench setup complete")
-		logger.Infof("The workbench directory can be found at %s", kopsClient.GetTempDir())
-
-		return nil
-	},
+	return nil
 }

--- a/cmd/cloud/workbench_flag.go
+++ b/cmd/cloud/workbench_flag.go
@@ -1,0 +1,28 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func setWorkbenchFlags(command *cobra.Command) {
+	command.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
+	command.PersistentFlags().String("state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
+}
+
+type workbenchFlags struct {
+	serverAddress string
+	s3StateStore  string
+}
+
+func (flags *workbenchFlags) addFlags(command *cobra.Command) {
+	flags.serverAddress, _ = command.Flags().GetString("server")
+	flags.s3StateStore, _ = command.Flags().GetString("state-store")
+}
+
+type workbenchClusterFlag struct {
+	workbenchFlags
+	clusterID string
+}
+
+func (flags *workbenchClusterFlag) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.clusterID, "cluster", "", "The id of the cluster to work on.")
+	_ = command.MarkFlagRequired("cluster")
+}


### PR DESCRIPTION
#### Summary

Modified flag parsing of the following command

```bash
$ cloud workbench
$ cloud completion
$ cloud dashboard
$ cloud events
$ cloud subscription
```

Also, I've changed a flag data type to `duration`

```bash
$ cloud subscription create --help

Flags:
      --failure-threshold duration   Failure threshold of the subscription.
```

Sample
```go
func setEventFlags(command *cobra.Command) {
	command.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
}

type eventFlags struct {
	serverAddress string
}

func (flags *eventFlags) addFlags(command *cobra.Command) {
	flags.serverAddress, _ = command.Flags().GetString("server")
}

func newCmdEvents() *cobra.Command {
	cmd := &cobra.Command{
		Use:   "events",
		Short: "Groups event commands managed by the provisioning server.",
	}

	setEventFlags(cmd)

	cmd.AddCommand(newCmdStateChangeEvents())

	return cmd
}
```

#### Ticket Link

Jira [Ticket](https://mattermost.atlassian.net/browse/MM-49349)

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
