### PR TITLE
Revert command functions to their earlier names

### DIFF
--- a/cmd/cloud/backup.go
+++ b/cmd/cloud/backup.go
@@ -10,21 +10,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdInstallationBackup() *cobra.Command {
+func installationBackupCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "backup",
 		Short: "Manipulate installation backups managed by the provisioning server.",
 	}
 
-	cmd.AddCommand(newCmdInstallationBackupCreate())
-	cmd.AddCommand(newCmdInstallationBackupList())
-	cmd.AddCommand(newCmdInstallationBackupGet())
-	cmd.AddCommand(newCmdInstallationBackupDelete())
+	cmd.AddCommand(installationBackupCreateCmd())
+	cmd.AddCommand(installationBackupListCmd())
+	cmd.AddCommand(installationBackupGetCmd())
+	cmd.AddCommand(installationBackupDeleteCmd())
 
 	return cmd
 }
 
-func newCmdInstallationBackupCreate() *cobra.Command {
+func installationBackupCreateCmd() *cobra.Command {
 	var flags installationBackupCreateFlags
 
 	cmd := &cobra.Command{
@@ -53,7 +53,7 @@ func newCmdInstallationBackupCreate() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationBackupList() *cobra.Command {
+func installationBackupListCmd() *cobra.Command {
 	var flags installationBackupListFlags
 
 	cmd := &cobra.Command{
@@ -135,7 +135,7 @@ func defaultBackupTableData(backups []*model.InstallationBackup) ([]string, [][]
 	return keys, vals
 }
 
-func newCmdInstallationBackupGet() *cobra.Command {
+func installationBackupGetCmd() *cobra.Command {
 	var flags installationBackupGetFlags
 
 	cmd := &cobra.Command{
@@ -168,7 +168,7 @@ func newCmdInstallationBackupGet() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationBackupDelete() *cobra.Command {
+func installationBackupDeleteCmd() *cobra.Command {
 	var flags installationBackupDeleteFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -27,7 +27,7 @@ const (
 	waitBetweenPodEvictionsDefault = 5    // seconds
 )
 
-func newCmdCluster() *cobra.Command {
+func clusterCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Manipulate clusters managed by the provisioning server.",
@@ -35,21 +35,21 @@ func newCmdCluster() *cobra.Command {
 
 	setClusterFlags(cmd)
 
-	cmd.AddCommand(newCmdClusterCreate())
-	cmd.AddCommand(newCmdClusterProvision())
-	cmd.AddCommand(newCmdClusterUpdate())
-	cmd.AddCommand(newCmdClusterUpgrade())
-	cmd.AddCommand(newCmdClusterResize())
-	cmd.AddCommand(newCmdClusterDelete())
-	cmd.AddCommand(newCmdClusterGet())
-	cmd.AddCommand(newCmdClusterList())
-	cmd.AddCommand(newCmdClusterUtilities())
+	cmd.AddCommand(clusterCreateCmd())
+	cmd.AddCommand(clusterProvisionCmd())
+	cmd.AddCommand(clusterUpdateCmd())
+	cmd.AddCommand(clusterUpgradeCmd())
+	cmd.AddCommand(clusterResizeCmd())
+	cmd.AddCommand(clusterDeleteCmd())
+	cmd.AddCommand(clusterGetCmd())
+	cmd.AddCommand(clusterListCmd())
+	cmd.AddCommand(clusterUtilitiesCmd())
 
-	cmd.AddCommand(newCmdClusterSizeDictionary())
-	cmd.AddCommand(newCmdClusterShowStateReport())
+	cmd.AddCommand(clusterSizeDictionaryCmd())
+	cmd.AddCommand(clusterShowStateReportCmd())
 
-	cmd.AddCommand(newCmdClusterAnnotation())
-	cmd.AddCommand(newCmdClusterInstallation())
+	cmd.AddCommand(clusterAnnotationCmd())
+	cmd.AddCommand(clusterInstallationCmd())
 
 	return cmd
 }
@@ -73,7 +73,7 @@ func getRotatorConfigFromFlags(rc rotatorConfig) model.RotatorConfig {
 	}
 }
 
-func newCmdClusterCreate() *cobra.Command {
+func clusterCreateCmd() *cobra.Command {
 	var flags clusterCreateFlags
 
 	cmd := &cobra.Command{
@@ -183,7 +183,7 @@ func executeClusterCreateCmd(flags clusterCreateFlags) error {
 
 }
 
-func newCmdClusterProvision() *cobra.Command {
+func clusterProvisionCmd() *cobra.Command {
 	var flags clusterProvisionFlags
 
 	cmd := &cobra.Command{
@@ -234,7 +234,7 @@ func executeClusterProvisionCmd(flags clusterProvisionFlags) error {
 
 }
 
-func newCmdClusterUpdate() *cobra.Command {
+func clusterUpdateCmd() *cobra.Command {
 	var flags clusterUpdateFlags
 
 	cmd := &cobra.Command{
@@ -285,7 +285,7 @@ func executeClusterUpdateCmd(flags clusterUpdateFlags) error {
 
 }
 
-func newCmdClusterUpgrade() *cobra.Command {
+func clusterUpgradeCmd() *cobra.Command {
 	var flags clusterUpgradeFlags
 
 	cmd := &cobra.Command{
@@ -347,7 +347,7 @@ func executeClusterUpgradeCmd(flags clusterUpgradeFlags) error {
 
 }
 
-func newCmdClusterResize() *cobra.Command {
+func clusterResizeCmd() *cobra.Command {
 	var flags clusterResizeFlags
 
 	cmd := &cobra.Command{
@@ -417,7 +417,7 @@ func executeClusterResizeCmd(flags clusterResizeFlags) error {
 
 }
 
-func newCmdClusterDelete() *cobra.Command {
+func clusterDeleteCmd() *cobra.Command {
 	var flags clusterDeleteFlags
 
 	cmd := &cobra.Command{
@@ -448,7 +448,7 @@ func executeClusterDeleteCmd(flags clusterDeleteFlags) error {
 	return nil
 }
 
-func newCmdClusterGet() *cobra.Command {
+func clusterGetCmd() *cobra.Command {
 	var flags clusterGetFlags
 
 	cmd := &cobra.Command{
@@ -486,7 +486,7 @@ func executeClusterGetCmd(flags clusterGetFlags) error {
 	return nil
 }
 
-func newCmdClusterList() *cobra.Command {
+func clusterListCmd() *cobra.Command {
 	var flags clusterListFlags
 
 	cmd := &cobra.Command{
@@ -593,7 +593,7 @@ func enhanceTableWithAnnotations(clusters []*model.ClusterDTO, keys []string, va
 	return keys, vals
 }
 
-func newCmdClusterUtilities() *cobra.Command {
+func clusterUtilitiesCmd() *cobra.Command {
 	var flags clusterUtilitiesFlags
 
 	cmd := &cobra.Command{
@@ -624,7 +624,7 @@ func newCmdClusterUtilities() *cobra.Command {
 	return cmd
 }
 
-func newCmdClusterSizeDictionary() *cobra.Command {
+func clusterSizeDictionaryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dictionary",
 		Short: "Shows predefined cluster size templates.",
@@ -643,7 +643,7 @@ func newCmdClusterSizeDictionary() *cobra.Command {
 // TODO:
 // Instead of showing the state data from the model of the CLI binary, add a new
 // API endpoint to return the server's state model.
-func newCmdClusterShowStateReport() *cobra.Command {
+func clusterShowStateReportCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "state-report",
 		Short: "Shows information regarding changing cluster state.",

--- a/cmd/cloud/cluster_annotation.go
+++ b/cmd/cloud/cluster_annotation.go
@@ -10,19 +10,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdClusterAnnotation() *cobra.Command {
+func clusterAnnotationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "annotation",
 		Short: "Manipulate annotations of clusters managed by the provisioning server.",
 	}
 
-	cmd.AddCommand(newCmdClusterAnnotationAdd())
-	cmd.AddCommand(newCmdClusterAnnotationDelete())
+	cmd.AddCommand(clusterAnnotationAddCmd())
+	cmd.AddCommand(clusterAnnotationDeleteCmd())
 
 	return cmd
 }
 
-func newCmdClusterAnnotationAdd() *cobra.Command {
+func clusterAnnotationAddCmd() *cobra.Command {
 	var flags clusterAnnotationAddFlags
 
 	cmd := &cobra.Command{
@@ -65,7 +65,7 @@ func executeClusterAnnotationAddCmd(flags clusterAnnotationAddFlags) error {
 	return nil
 }
 
-func newCmdClusterAnnotationDelete() *cobra.Command {
+func clusterAnnotationDeleteCmd() *cobra.Command {
 	var flags clusterAnnotationDeleteFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/cluster_installation.go
+++ b/cmd/cloud/cluster_installation.go
@@ -13,23 +13,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdClusterInstallation() *cobra.Command {
+func clusterInstallationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "installation",
 		Short: "Manipulate cluster installations managed by the provisioning server.",
 	}
 
-	cmd.AddCommand(newCmdClusterInstallationGet())
-	cmd.AddCommand(newCmdClusterInstallationList())
-	cmd.AddCommand(newCmdClusterInstallationConfig())
-	cmd.AddCommand(newCmdClusterInstallationMMCTL())
-	cmd.AddCommand(newCmdClusterInstallationMattermostCLI())
-	cmd.AddCommand(newCmdClusterInstallationMigration())
+	cmd.AddCommand(clusterInstallationGetCmd())
+	cmd.AddCommand(clusterInstallationListCmd())
+	cmd.AddCommand(clusterInstallationConfigCmd())
+	cmd.AddCommand(clusterInstallationMMCTLCmd())
+	cmd.AddCommand(clusterInstallationMattermostCLICmd())
+	cmd.AddCommand(clusterInstallationMigrationCmd())
 
 	return cmd
 }
 
-func newCmdClusterInstallationGet() *cobra.Command {
+func clusterInstallationGetCmd() *cobra.Command {
 	var flags clusterInstallationGetFlags
 
 	cmd := &cobra.Command{
@@ -63,7 +63,7 @@ func newCmdClusterInstallationGet() *cobra.Command {
 	return cmd
 }
 
-func newCmdClusterInstallationList() *cobra.Command {
+func clusterInstallationListCmd() *cobra.Command {
 	var flags clusterInstallationListFlags
 
 	cmd := &cobra.Command{
@@ -136,19 +136,19 @@ func defaultClusterInstallationTableData(cis []*model.ClusterInstallation) ([]st
 	return keys, vals
 }
 
-func newCmdClusterInstallationConfig() *cobra.Command {
+func clusterInstallationConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manipulate a particular cluster installation's config.",
 	}
 
-	cmd.AddCommand(newCmdClusterInstallationConfigGet())
-	cmd.AddCommand(newCmdClusterInstallationConfigSet())
+	cmd.AddCommand(clusterInstallationConfigGetCmd())
+	cmd.AddCommand(clusterInstallationConfigSetCmd())
 
 	return cmd
 }
 
-func newCmdClusterInstallationConfigGet() *cobra.Command {
+func clusterInstallationConfigGetCmd() *cobra.Command {
 	var flags clusterInstallationConfigGetFlags
 
 	cmd := &cobra.Command{
@@ -182,7 +182,7 @@ func newCmdClusterInstallationConfigGet() *cobra.Command {
 	return cmd
 }
 
-func newCmdClusterInstallationConfigSet() *cobra.Command {
+func clusterInstallationConfigSetCmd() *cobra.Command {
 	var flags clusterInstallationConfigSetFlags
 
 	cmd := &cobra.Command{
@@ -221,7 +221,7 @@ func newCmdClusterInstallationConfigSet() *cobra.Command {
 	return cmd
 }
 
-func newCmdClusterInstallationMMCTL() *cobra.Command {
+func clusterInstallationMMCTLCmd() *cobra.Command {
 	var flags clusterInstallationMMCTLFlags
 
 	cmd := &cobra.Command{
@@ -250,7 +250,7 @@ func newCmdClusterInstallationMMCTL() *cobra.Command {
 	return cmd
 }
 
-func newCmdClusterInstallationMattermostCLI() *cobra.Command {
+func clusterInstallationMattermostCLICmd() *cobra.Command {
 	var flags clusterInstallationMattermostCLIFlags
 
 	cmd := &cobra.Command{
@@ -278,7 +278,7 @@ func newCmdClusterInstallationMattermostCLI() *cobra.Command {
 	return cmd
 }
 
-func newCmdClusterInstallationMigration() *cobra.Command {
+func clusterInstallationMigrationCmd() *cobra.Command {
 	var flags clusterInstallationMigrationFlags
 
 	cmd := &cobra.Command{
@@ -295,9 +295,9 @@ func newCmdClusterInstallationMigration() *cobra.Command {
 		},
 	}
 	flags.addFlags(cmd)
-	cmd.AddCommand(newCmdClusterInstallationDNSMigration())
-	cmd.AddCommand(newCmdDeleteInActiveClusterInstallation())
-	cmd.AddCommand(newCmdClusterRolesPostMigrationSwitch())
+	cmd.AddCommand(clusterInstallationDNSMigrationCmd())
+	cmd.AddCommand(deleteInActiveClusterInstallationCmd())
+	cmd.AddCommand(clusterRolesPostMigrationSwitchCmd())
 
 	return cmd
 }
@@ -324,7 +324,7 @@ func executeClusterInstallationMigrationCmd(flags clusterInstallationMigrationFl
 	return nil
 }
 
-func newCmdClusterInstallationDNSMigration() *cobra.Command {
+func clusterInstallationDNSMigrationCmd() *cobra.Command {
 	var flags clusterInstallationDNSMigrationFlags
 
 	cmd := &cobra.Command{
@@ -364,7 +364,7 @@ func executeClusterInstallationDNSMigrationCmd(flags clusterInstallationDNSMigra
 	return nil
 }
 
-func newCmdDeleteInActiveClusterInstallation() *cobra.Command {
+func deleteInActiveClusterInstallationCmd() *cobra.Command {
 	var flags inActiveClusterInstallationDeleteFlags
 
 	cmd := &cobra.Command{
@@ -414,7 +414,7 @@ func executeDeleteInActiveClusterInstallationCmd(flags inActiveClusterInstallati
 	return nil
 }
 
-func newCmdClusterRolesPostMigrationSwitch() *cobra.Command {
+func clusterRolesPostMigrationSwitchCmd() *cobra.Command {
 	var flags clusterRolesPostMigrationSwitchFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/completion.go
+++ b/cmd/cloud/completion.go
@@ -10,14 +10,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdCompletion() *cobra.Command {
+func completionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completion",
 		Short: "Generates autocompletion scripts for bash and zsh",
 	}
 
-	cmd.AddCommand(newCmdCompletionBash())
-	cmd.AddCommand(newCmdZsh())
+	cmd.AddCommand(completionBashCmd())
+	cmd.AddCommand(zshCmd())
 
 	return cmd
 }
@@ -29,7 +29,7 @@ var bashLong = `To load completion, run
 To configure your bash shell to load completions for each session, add the above line to your ~/.bashrc
 `
 
-func newCmdCompletionBash() *cobra.Command {
+func completionBashCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bash",
 		Short: "Generates the bash autocompletion scripts",
@@ -187,7 +187,7 @@ BASH_COMPLETION_EOF
 __cloud_bash_source <(__cloud_convert_bash_to_zsh)
 `
 
-func newCmdZsh() *cobra.Command {
+func zshCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "zsh",
 		Short: "Generates the zsh autocompletion scripts",

--- a/cmd/cloud/dashboard.go
+++ b/cmd/cloud/dashboard.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdDashboard() *cobra.Command {
+func dashboardCmd() *cobra.Command {
 
 	var flags dashboardFlags
 

--- a/cmd/cloud/databases.go
+++ b/cmd/cloud/databases.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdDatabase() *cobra.Command {
+func databaseCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "database",
 		Short: "Manipulate database resources managed by the provisioning server.",
@@ -20,29 +20,29 @@ func newCmdDatabase() *cobra.Command {
 
 	setClusterFlags(cmd)
 
-	cmd.AddCommand(newCmdDatabaseMultitenant())
-	cmd.AddCommand(newCmdDatabaseLogical())
-	cmd.AddCommand(newCmdDatabaseSchema())
+	cmd.AddCommand(databaseMultitenantCmd())
+	cmd.AddCommand(databaseLogicalCmd())
+	cmd.AddCommand(databaseSchemaCmd())
 
 	return cmd
 }
 
-func newCmdDatabaseMultitenant() *cobra.Command {
+func databaseMultitenantCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "multitenant",
 		Short: "Manage and view multitenant database resources.",
 	}
 
-	cmd.AddCommand(newCmdDatabaseMultitenantList())
-	cmd.AddCommand(newCmdDatabaseMultitenantGet())
-	cmd.AddCommand(newCmdDatabaseMultitenantUpdate())
-	cmd.AddCommand(newCmdDatabaseMultitenantDelete())
-	cmd.AddCommand(newCmdDatabaseMultitenantReport())
+	cmd.AddCommand(databaseMultitenantListCmd())
+	cmd.AddCommand(databaseMultitenantGetCmd())
+	cmd.AddCommand(databaseMultitenantUpdateCmd())
+	cmd.AddCommand(databaseMultitenantDeleteCmd())
+	cmd.AddCommand(databaseMultitenantReportCmd())
 
 	return cmd
 }
 
-func newCmdDatabaseMultitenantList() *cobra.Command {
+func databaseMultitenantListCmd() *cobra.Command {
 
 	var flags databaseMultiTenantListFlag
 
@@ -111,7 +111,7 @@ func defaultMultitenantDatabaseTableData(multitenantDatabases []*model.Multitena
 	return keys, vals
 }
 
-func newCmdDatabaseMultitenantGet() *cobra.Command {
+func databaseMultitenantGetCmd() *cobra.Command {
 	var flags databaseMultiTenantGetFlag
 
 	cmd := &cobra.Command{
@@ -142,7 +142,7 @@ func newCmdDatabaseMultitenantGet() *cobra.Command {
 	return cmd
 }
 
-func newCmdDatabaseMultitenantUpdate() *cobra.Command {
+func databaseMultitenantUpdateCmd() *cobra.Command {
 	var flags databaseMultiTenantUpdateFlag
 
 	cmd := &cobra.Command{
@@ -183,7 +183,7 @@ func newCmdDatabaseMultitenantUpdate() *cobra.Command {
 	return cmd
 }
 
-func newCmdDatabaseMultitenantDelete() *cobra.Command {
+func databaseMultitenantDeleteCmd() *cobra.Command {
 	var flags databaseMultiTenantDeleteFlag
 
 	cmd := &cobra.Command{
@@ -209,19 +209,19 @@ func newCmdDatabaseMultitenantDelete() *cobra.Command {
 	return cmd
 }
 
-func newCmdDatabaseLogical() *cobra.Command {
+func databaseLogicalCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logical",
 		Short: "Manage and view logical database resources.",
 	}
 
-	cmd.AddCommand(newCmdDatabaseLogicalList())
-	cmd.AddCommand(newCmdDatabaseLogicalGet())
+	cmd.AddCommand(databaseLogicalListCmd())
+	cmd.AddCommand(databaseLogicalGetCmd())
 
 	return cmd
 }
 
-func newCmdDatabaseLogicalList() *cobra.Command {
+func databaseLogicalListCmd() *cobra.Command {
 	var flags databaseLogicalListFlag
 
 	cmd := &cobra.Command{
@@ -288,7 +288,7 @@ func defaultLogicalDatabaseTableData(logicalDatabases []*model.LogicalDatabase) 
 	return keys, vals
 }
 
-func newCmdDatabaseLogicalGet() *cobra.Command {
+func databaseLogicalGetCmd() *cobra.Command {
 	var flags databaseLogicalGetFlag
 
 	cmd := &cobra.Command{
@@ -319,19 +319,19 @@ func newCmdDatabaseLogicalGet() *cobra.Command {
 	return cmd
 }
 
-func newCmdDatabaseSchema() *cobra.Command {
+func databaseSchemaCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "schema",
 		Short: "Manage and view database schema resources.",
 	}
 
-	cmd.AddCommand(newCmdDatabaseSchemaList())
-	cmd.AddCommand(newCmdDatabaseSchemaGet())
+	cmd.AddCommand(databaseSchemaListCmd())
+	cmd.AddCommand(databaseSchemaGetCmd())
 
 	return cmd
 }
 
-func newCmdDatabaseSchemaList() *cobra.Command {
+func databaseSchemaListCmd() *cobra.Command {
 	var flags databaseSchemaListFlag
 
 	cmd := &cobra.Command{
@@ -399,7 +399,7 @@ func defaultDatabaseSchemaTableData(databaseSchemas []*model.DatabaseSchema) ([]
 	return keys, vals
 }
 
-func newCmdDatabaseSchemaGet() *cobra.Command {
+func databaseSchemaGetCmd() *cobra.Command {
 	var flags databaseSchemaGetFlag
 
 	cmd := &cobra.Command{
@@ -430,7 +430,7 @@ func newCmdDatabaseSchemaGet() *cobra.Command {
 	return cmd
 }
 
-func newCmdDatabaseMultitenantReport() *cobra.Command {
+func databaseMultitenantReportCmd() *cobra.Command {
 	var flags databaseMultiTenantReportFlag
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/events.go
+++ b/cmd/cloud/events.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdEvents() *cobra.Command {
+func eventsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "events",
 		Short: "Groups event commands managed by the provisioning server.",
@@ -18,24 +18,24 @@ func newCmdEvents() *cobra.Command {
 
 	setEventFlags(cmd)
 
-	cmd.AddCommand(newCmdStateChangeEvents())
+	cmd.AddCommand(stateChangeEventsCmd())
 
 	return cmd
 }
 
-func newCmdStateChangeEvents() *cobra.Command {
+func stateChangeEventsCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "state-change",
 		Short: "Groups state change event commands managed by the provisioning server.",
 	}
 
-	cmd.AddCommand(newCmdStateChangeEventList())
+	cmd.AddCommand(stateChangeEventListCmd())
 
 	return cmd
 }
 
-func newCmdStateChangeEventList() *cobra.Command {
+func stateChangeEventListCmd() *cobra.Command {
 	var flags stateChangeEventListFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/events_subscription.go
+++ b/cmd/cloud/events_subscription.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdSubscription() *cobra.Command {
+func subscriptionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "subscription",
 		Short: "Manipulate subscriptions managed by the provisioning server.",
@@ -18,15 +18,15 @@ func newCmdSubscription() *cobra.Command {
 
 	setClusterFlags(cmd)
 
-	cmd.AddCommand(newCmdSubscriptionCreate())
-	cmd.AddCommand(newCmdSubscriptionList())
-	cmd.AddCommand(newCmdSubscriptionGet())
-	cmd.AddCommand(newCmdSubscriptionDelete())
+	cmd.AddCommand(subscriptionCreateCmd())
+	cmd.AddCommand(subscriptionListCmd())
+	cmd.AddCommand(subscriptionGetCmd())
+	cmd.AddCommand(subscriptionDeleteCmd())
 
 	return cmd
 }
 
-func newCmdSubscriptionCreate() *cobra.Command {
+func subscriptionCreateCmd() *cobra.Command {
 
 	var flags subscriptionCreateFlags
 
@@ -71,7 +71,7 @@ func newCmdSubscriptionCreate() *cobra.Command {
 	return cmd
 }
 
-func newCmdSubscriptionList() *cobra.Command {
+func subscriptionListCmd() *cobra.Command {
 
 	var flags subscriptionListFlags
 
@@ -146,7 +146,7 @@ func defaultSubscriptionsTableData(subscriptions []*model.Subscription) ([]strin
 	return keys, vals
 }
 
-func newCmdSubscriptionGet() *cobra.Command {
+func subscriptionGetCmd() *cobra.Command {
 	var flags subscriptionGetFlags
 
 	cmd := &cobra.Command{
@@ -174,7 +174,7 @@ func newCmdSubscriptionGet() *cobra.Command {
 	return cmd
 }
 
-func newCmdSubscriptionDelete() *cobra.Command {
+func subscriptionDeleteCmd() *cobra.Command {
 	var flags subscriptionDeleteFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdGroup() *cobra.Command {
+func groupCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "group",
 		Short: "Manipulate groups managed by the provisioning server.",
@@ -22,22 +22,22 @@ func newCmdGroup() *cobra.Command {
 
 	setClusterFlags(cmd)
 
-	cmd.AddCommand(newCmdGroupCreate())
-	cmd.AddCommand(newCmdGroupUpdate())
-	cmd.AddCommand(newCmdGroupDelete())
-	cmd.AddCommand(newCmdGroupGet())
-	cmd.AddCommand(newCmdGroupList())
-	cmd.AddCommand(newCmdGroupGetStatus())
-	cmd.AddCommand(newCmdGroupJoin())
-	cmd.AddCommand(newCmdGroupAssign())
-	cmd.AddCommand(newCmdGroupLeave())
-	cmd.AddCommand(newCmdGroupListStatus())
-	cmd.AddCommand(newCmdGroupAnnotation())
+	cmd.AddCommand(groupCreateCmd())
+	cmd.AddCommand(groupUpdateCmd())
+	cmd.AddCommand(groupDeleteCmd())
+	cmd.AddCommand(groupGetCmd())
+	cmd.AddCommand(groupListCmd())
+	cmd.AddCommand(groupGetStatusCmd())
+	cmd.AddCommand(groupJoinCmd())
+	cmd.AddCommand(groupAssignCmd())
+	cmd.AddCommand(groupLeaveCmd())
+	cmd.AddCommand(groupListStatusCmd())
+	cmd.AddCommand(groupAnnotationCmd())
 
 	return cmd
 }
 
-func newCmdGroupCreate() *cobra.Command {
+func groupCreateCmd() *cobra.Command {
 
 	var flags groupCreateFlags
 
@@ -87,7 +87,7 @@ func newCmdGroupCreate() *cobra.Command {
 	return cmd
 }
 
-func newCmdGroupUpdate() *cobra.Command {
+func groupUpdateCmd() *cobra.Command {
 	var flags groupUpdateFlags
 
 	cmd := &cobra.Command{
@@ -155,7 +155,7 @@ func executeGroupUpdateCmd(flags groupUpdateFlags) error {
 	return printJSON(group)
 }
 
-func newCmdGroupDelete() *cobra.Command {
+func groupDeleteCmd() *cobra.Command {
 	var flags groupDeleteFlags
 
 	cmd := &cobra.Command{
@@ -180,7 +180,7 @@ func newCmdGroupDelete() *cobra.Command {
 	return cmd
 }
 
-func newCmdGroupGet() *cobra.Command {
+func groupGetCmd() *cobra.Command {
 	var flags groupGetFlags
 
 	cmd := &cobra.Command{
@@ -210,7 +210,7 @@ func newCmdGroupGet() *cobra.Command {
 	return cmd
 }
 
-func newCmdGroupList() *cobra.Command {
+func groupListCmd() *cobra.Command {
 	var flags groupListFlags
 
 	cmd := &cobra.Command{
@@ -261,7 +261,7 @@ func executeGroupListCmd(flags groupListFlags) error {
 	return printJSON(groups)
 }
 
-func newCmdGroupGetStatus() *cobra.Command {
+func groupGetStatusCmd() *cobra.Command {
 	var flags groupGetStatusFlags
 
 	cmd := &cobra.Command{
@@ -291,7 +291,7 @@ func newCmdGroupGetStatus() *cobra.Command {
 	return cmd
 }
 
-func newCmdGroupJoin() *cobra.Command {
+func groupJoinCmd() *cobra.Command {
 	var flags groupJoinFlags
 
 	cmd := &cobra.Command{
@@ -317,7 +317,7 @@ func newCmdGroupJoin() *cobra.Command {
 	return cmd
 }
 
-func newCmdGroupAssign() *cobra.Command {
+func groupAssignCmd() *cobra.Command {
 	var flags groupAssignFlags
 
 	cmd := &cobra.Command{
@@ -343,7 +343,7 @@ func newCmdGroupAssign() *cobra.Command {
 	return cmd
 }
 
-func newCmdGroupLeave() *cobra.Command {
+func groupLeaveCmd() *cobra.Command {
 	var flags groupLeaveFlags
 
 	cmd := &cobra.Command{
@@ -371,7 +371,7 @@ func newCmdGroupLeave() *cobra.Command {
 	return cmd
 }
 
-func newCmdGroupListStatus() *cobra.Command {
+func groupListStatusCmd() *cobra.Command {
 	var flags clusterFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/group_annotation.go
+++ b/cmd/cloud/group_annotation.go
@@ -10,19 +10,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdGroupAnnotation() *cobra.Command {
+func groupAnnotationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "annotation",
 		Short: "Manipulate annotations of group managed by the provisioning server.",
 	}
 
-	cmd.AddCommand(newCmdGroupAnnotationAdd())
-	cmd.AddCommand(newCmdGroupAnnotationDelete())
+	cmd.AddCommand(groupAnnotationAddCmd())
+	cmd.AddCommand(groupAnnotationDeleteCmd())
 
 	return cmd
 }
 
-func newCmdGroupAnnotationAdd() *cobra.Command {
+func groupAnnotationAddCmd() *cobra.Command {
 
 	var flags groupAnnotationAddFlags
 
@@ -59,7 +59,7 @@ func newCmdGroupAnnotationAdd() *cobra.Command {
 	return cmd
 }
 
-func newCmdGroupAnnotationDelete() *cobra.Command {
+func groupAnnotationDeleteCmd() *cobra.Command {
 	var flags groupAnnotationDeleteFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -19,7 +19,7 @@ import (
 
 const hiddenLicense = "hidden (--hide-license=true)"
 
-func newCmdInstallation() *cobra.Command {
+func installationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "installation",
 		Short: "Manipulate installations managed by the provisioning server.",
@@ -27,27 +27,27 @@ func newCmdInstallation() *cobra.Command {
 
 	setClusterFlags(cmd)
 
-	cmd.AddCommand(newCmdInstallationCreate())
-	cmd.AddCommand(newCmdInstallationUpdate())
-	cmd.AddCommand(newCmdInstallationDelete())
-	cmd.AddCommand(newCmdInstallationCancelDeletion())
-	cmd.AddCommand(newCmdInstallationHibernate())
-	cmd.AddCommand(newCmdInstallationWakeup())
-	cmd.AddCommand(newCmdInstallationGet())
-	cmd.AddCommand(newCmdInstallationList())
-	cmd.AddCommand(newCmdInstallationGetStatuses())
-	cmd.AddCommand(newCmdInstallationShowStateReport())
-	cmd.AddCommand(newCmdInstallationRecovery())
-	cmd.AddCommand(newCmdInstallationDeploymentReport())
-	cmd.AddCommand(newCmdInstallationAnnotation())
-	cmd.AddCommand(newCmdInstallationBackup())
-	cmd.AddCommand(newCmdInstallationOperation())
-	cmd.AddCommand(newCmdInstallationDNS())
+	cmd.AddCommand(installationCreateCmd())
+	cmd.AddCommand(installationUpdateCmd())
+	cmd.AddCommand(installationDeleteCmd())
+	cmd.AddCommand(installationCancelDeletionCmd())
+	cmd.AddCommand(installationHibernateCmd())
+	cmd.AddCommand(installationWakeupCmd())
+	cmd.AddCommand(installationGetCmd())
+	cmd.AddCommand(installationListCmd())
+	cmd.AddCommand(installationGetStatusesCmd())
+	cmd.AddCommand(installationShowStateReportCmd())
+	cmd.AddCommand(installationRecoveryCmd())
+	cmd.AddCommand(installationDeploymentReportCmd())
+	cmd.AddCommand(installationAnnotationCmd())
+	cmd.AddCommand(installationBackupCmd())
+	cmd.AddCommand(installationOperationCmd())
+	cmd.AddCommand(installationDNSCmd())
 
 	return cmd
 }
 
-func newCmdInstallationCreate() *cobra.Command {
+func installationCreateCmd() *cobra.Command {
 	var flags installationCreateFlags
 
 	cmd := &cobra.Command{
@@ -137,7 +137,7 @@ func executeInstallationCreateCmd(flags installationCreateFlags) error {
 	return printJSON(installation)
 }
 
-func newCmdInstallationUpdate() *cobra.Command {
+func installationUpdateCmd() *cobra.Command {
 	var flags installationUpdateFlags
 
 	cmd := &cobra.Command{
@@ -192,7 +192,7 @@ func newCmdInstallationUpdate() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationDelete() *cobra.Command {
+func installationDeleteCmd() *cobra.Command {
 	var flags installationDeleteFlags
 
 	cmd := &cobra.Command{
@@ -217,7 +217,7 @@ func newCmdInstallationDelete() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationCancelDeletion() *cobra.Command {
+func installationCancelDeletionCmd() *cobra.Command {
 	var flags installationCancelDeletionFlags
 
 	cmd := &cobra.Command{
@@ -242,7 +242,7 @@ func newCmdInstallationCancelDeletion() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationHibernate() *cobra.Command {
+func installationHibernateCmd() *cobra.Command {
 	var flags installationHibernateFlags
 
 	cmd := &cobra.Command{
@@ -273,7 +273,7 @@ func newCmdInstallationHibernate() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationWakeup() *cobra.Command {
+func installationWakeupCmd() *cobra.Command {
 	var flags installationWakeupFlags
 
 	cmd := &cobra.Command{
@@ -318,7 +318,7 @@ func newCmdInstallationWakeup() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationGet() *cobra.Command {
+func installationGetCmd() *cobra.Command {
 	var flags installationGetFlags
 
 	cmd := &cobra.Command{
@@ -361,7 +361,7 @@ func newCmdInstallationGet() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationList() *cobra.Command {
+func installationListCmd() *cobra.Command {
 	var flags installationListFlags
 
 	cmd := &cobra.Command{
@@ -454,7 +454,7 @@ func dnsNames(dnsRecords []*model.InstallationDNS) string {
 	return strings.Join(names, ", ")
 }
 
-func newCmdInstallationGetStatuses() *cobra.Command {
+func installationGetStatusesCmd() *cobra.Command {
 	var flags clusterFlags
 
 	cmd := &cobra.Command{
@@ -483,7 +483,7 @@ func newCmdInstallationGetStatuses() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationShowStateReport() *cobra.Command {
+func installationShowStateReportCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "state-report",
 		Short: "Shows information regarding changing installation state.",
@@ -502,7 +502,7 @@ func newCmdInstallationShowStateReport() *cobra.Command {
 
 // WARNING: EXPERIMENTAL
 // This command runs as a client with direct store integration.
-func newCmdInstallationRecovery() *cobra.Command {
+func installationRecoveryCmd() *cobra.Command {
 	var flags installationRecoveryFlags
 
 	cmd := &cobra.Command{
@@ -668,7 +668,7 @@ func executeInstallationRecoveryCmd(flags installationRecoveryFlags) error {
 	return nil
 }
 
-func newCmdInstallationDeploymentReport() *cobra.Command {
+func installationDeploymentReportCmd() *cobra.Command {
 	var flags installationDeploymentReportFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/installation_annotation.go
+++ b/cmd/cloud/installation_annotation.go
@@ -10,19 +10,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdInstallationAnnotation() *cobra.Command {
+func installationAnnotationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "annotation",
 		Short: "Manipulate annotations of installations managed by the provisioning server.",
 	}
 
-	cmd.AddCommand(newCmdInstallationAnnotationAdd())
-	cmd.AddCommand(newCmdInstallationAnnotationDelete())
+	cmd.AddCommand(installationAnnotationAddCmd())
+	cmd.AddCommand(installationAnnotationDeleteCmd())
 
 	return cmd
 }
 
-func newCmdInstallationAnnotationAdd() *cobra.Command {
+func installationAnnotationAddCmd() *cobra.Command {
 	var flags installationAnnotationAddFlags
 
 	cmd := &cobra.Command{
@@ -61,7 +61,7 @@ func newCmdInstallationAnnotationAdd() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationAnnotationDelete() *cobra.Command {
+func installationAnnotationDeleteCmd() *cobra.Command {
 	var flags installationAnnotationDeleteFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/installation_dns.go
+++ b/cmd/cloud/installation_dns.go
@@ -10,19 +10,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdInstallationDNS() *cobra.Command {
+func installationDNSCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dns",
 		Short: "Manipulate installation DNS records.",
 	}
 
-	cmd.AddCommand(newCmdInstallationDNSAdd())
-	cmd.AddCommand(newCmdInstallationDNSSetPrimary())
+	cmd.AddCommand(installationDNSAddCmd())
+	cmd.AddCommand(installationDNSSetPrimaryCmd())
 
 	return cmd
 }
 
-func newCmdInstallationDNSAdd() *cobra.Command {
+func installationDNSAddCmd() *cobra.Command {
 	var flags installationDNSAddFlags
 
 	cmd := &cobra.Command{
@@ -66,7 +66,7 @@ func newCmdInstallationDNSAdd() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationDNSSetPrimary() *cobra.Command {
+func installationDNSSetPrimaryCmd() *cobra.Command {
 	var flags installationDNSSetPrimaryFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/installation_operation.go
+++ b/cmd/cloud/installation_operation.go
@@ -6,14 +6,14 @@ package main
 
 import "github.com/spf13/cobra"
 
-func newCmdInstallationOperation() *cobra.Command {
+func installationOperationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "operation",
 		Short: "Manipulate installation operations managed by the provisioning server.",
 	}
 
-	cmd.AddCommand(newCmdInstallationRestorationOperation())
-	cmd.AddCommand(newCmdInstallationDBMigrationOperation())
+	cmd.AddCommand(installationRestorationOperationCmd())
+	cmd.AddCommand(installationDBMigrationOperationCmd())
 
 	return cmd
 }

--- a/cmd/cloud/installation_operation_db_migration.go
+++ b/cmd/cloud/installation_operation_db_migration.go
@@ -10,22 +10,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdInstallationDBMigrationOperation() *cobra.Command {
+func installationDBMigrationOperationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "db-migration",
 		Short: "Manipulate installation db migration operations managed by the provisioning server.",
 	}
 
-	cmd.AddCommand(newCmdInstallationDBMigrationRequest())
-	cmd.AddCommand(newCmdInstallationDBMigrationsList())
-	cmd.AddCommand(newCmdInstallationDBMigrationGet())
-	cmd.AddCommand(newCmdInstallationDBMigrationCommit())
-	cmd.AddCommand(newCmdInstallationDBMigrationRollback())
+	cmd.AddCommand(installationDBMigrationRequestCmd())
+	cmd.AddCommand(installationDBMigrationsListCmd())
+	cmd.AddCommand(installationDBMigrationGetCmd())
+	cmd.AddCommand(installationDBMigrationCommitCmd())
+	cmd.AddCommand(installationDBMigrationRollbackCmd())
 
 	return cmd
 }
 
-func newCmdInstallationDBMigrationRequest() *cobra.Command {
+func installationDBMigrationRequestCmd() *cobra.Command {
 
 	var flags installationDBMigrationRequestFlags
 
@@ -73,7 +73,7 @@ func newCmdInstallationDBMigrationRequest() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationDBMigrationsList() *cobra.Command {
+func installationDBMigrationsListCmd() *cobra.Command {
 	var flags installationDBMigrationsListFlags
 
 	cmd := &cobra.Command{
@@ -154,7 +154,7 @@ func defaultDBMigrationOperationTableData(ops []*model.InstallationDBMigrationOp
 	return keys, vals
 }
 
-func newCmdInstallationDBMigrationGet() *cobra.Command {
+func installationDBMigrationGetCmd() *cobra.Command {
 	var flags installationDBMigrationGetFlags
 
 	cmd := &cobra.Command{
@@ -186,7 +186,7 @@ func newCmdInstallationDBMigrationGet() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationDBMigrationCommit() *cobra.Command {
+func installationDBMigrationCommitCmd() *cobra.Command {
 	var flags installationDBMigrationCommitFlags
 
 	cmd := &cobra.Command{
@@ -220,7 +220,7 @@ func newCmdInstallationDBMigrationCommit() *cobra.Command {
 
 }
 
-func newCmdInstallationDBMigrationRollback() *cobra.Command {
+func installationDBMigrationRollbackCmd() *cobra.Command {
 	var flags installationDBMigrationRollbackFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/installation_operation_restoration.go
+++ b/cmd/cloud/installation_operation_restoration.go
@@ -10,20 +10,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdInstallationRestorationOperation() *cobra.Command {
+func installationRestorationOperationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restoration",
 		Short: "Manipulate installation restoration operations managed by the provisioning server.",
 	}
 
-	cmd.AddCommand(newCmdInstallationRestorationRequest())
-	cmd.AddCommand(newCmdInstallationRestorationsListCmd())
-	cmd.AddCommand(newCmdInstallationRestorationGetCmd())
+	cmd.AddCommand(installationRestorationRequestCmd())
+	cmd.AddCommand(installationRestorationsListCmd())
+	cmd.AddCommand(installationRestorationGetCmd())
 
 	return cmd
 }
 
-func newCmdInstallationRestorationRequest() *cobra.Command {
+func installationRestorationRequestCmd() *cobra.Command {
 	var flags installationRestorationRequestFlags
 
 	cmd := &cobra.Command{
@@ -56,7 +56,7 @@ func newCmdInstallationRestorationRequest() *cobra.Command {
 	return cmd
 }
 
-func newCmdInstallationRestorationsListCmd() *cobra.Command {
+func installationRestorationsListCmd() *cobra.Command {
 
 	var flags installationRestorationsListFlags
 
@@ -140,7 +140,7 @@ func defaultDBRestorationOperationTableData(ops []*model.InstallationDBRestorati
 	return keys, vals
 }
 
-func newCmdInstallationRestorationGetCmd() *cobra.Command {
+func installationRestorationGetCmd() *cobra.Command {
 	var flags installationRestorationGetFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -18,7 +18,7 @@ var rootCmd = &cobra.Command{
 	Use:   "cloud",
 	Short: "Cloud is a tool to provision, manage, and monitor Kubernetes clusters.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return newCmdServer().RunE(cmd, args)
+		return serverCmd().RunE(cmd, args)
 	},
 	// SilenceErrors allows us to explicitly log the error returned from rootCmd below.
 	SilenceErrors: true,
@@ -29,19 +29,19 @@ func init() {
 
 	_ = rootCmd.MarkFlagRequired("database")
 
-	rootCmd.AddCommand(newCmdServer())
-	rootCmd.AddCommand(newCmdCluster())
-	rootCmd.AddCommand(newCmdInstallation())
-	rootCmd.AddCommand(newCmdGroup())
-	rootCmd.AddCommand(newCmdDatabase())
-	rootCmd.AddCommand(newCmdSchema())
-	rootCmd.AddCommand(newCmdWebhook())
-	rootCmd.AddCommand(newCmdSecurity())
-	rootCmd.AddCommand(newCmdWorkbench())
-	rootCmd.AddCommand(newCmdCompletion())
-	rootCmd.AddCommand(newCmdDashboard())
-	rootCmd.AddCommand(newCmdEvents())
-	rootCmd.AddCommand(newCmdSubscription())
+	rootCmd.AddCommand(serverCmd())
+	rootCmd.AddCommand(clusterCmd())
+	rootCmd.AddCommand(installationCmd())
+	rootCmd.AddCommand(groupCmd())
+	rootCmd.AddCommand(databaseCmd())
+	rootCmd.AddCommand(schemaCmd())
+	rootCmd.AddCommand(webhookCmd())
+	rootCmd.AddCommand(securityCmd())
+	rootCmd.AddCommand(workbenchCmd())
+	rootCmd.AddCommand(completionCmd())
+	rootCmd.AddCommand(dashboardCmd())
+	rootCmd.AddCommand(eventsCmd())
+	rootCmd.AddCommand(subscriptionCmd())
 }
 
 func main() {

--- a/cmd/cloud/schema.go
+++ b/cmd/cloud/schema.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/store"
 )
 
-func newCmdSchema() *cobra.Command {
+func schemaCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "schema",
 		Short: "Manipulate the schema used by the provisioning server.",
@@ -18,7 +18,7 @@ func newCmdSchema() *cobra.Command {
 
 	setSchemaFlags(cmd)
 
-	cmd.AddCommand(newCmdSchemaMigrate())
+	cmd.AddCommand(schemaMigrateCmd())
 
 	return cmd
 }
@@ -32,7 +32,7 @@ func sqlStore(database string) (*store.SQLStore, error) {
 	return sqlStore, nil
 }
 
-func newCmdSchemaMigrate() *cobra.Command {
+func schemaMigrateCmd() *cobra.Command {
 	var flags schemaFlag
 	cmd := &cobra.Command{
 		Use:   "migrate",

--- a/cmd/cloud/security.go
+++ b/cmd/cloud/security.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdSecurity() *cobra.Command {
+func securityCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "security",
 		Short: "Manage security locks for different cloud resources.",
@@ -18,16 +18,16 @@ func newCmdSecurity() *cobra.Command {
 
 	setSecurityFlags(cmd)
 
-	cmd.AddCommand(newCmdSecurityCluster())
-	cmd.AddCommand(newCmdSecurityInstallation())
-	cmd.AddCommand(newCmdSecurityClusterInstallation())
-	cmd.AddCommand(newCmdSecurityGroup())
-	cmd.AddCommand(newCmdSecurityBackup())
+	cmd.AddCommand(securityClusterCmd())
+	cmd.AddCommand(securityInstallationCmd())
+	cmd.AddCommand(securityClusterInstallationCmd())
+	cmd.AddCommand(securityGroupCmd())
+	cmd.AddCommand(securityBackupCmd())
 
 	return cmd
 }
 
-func newCmdSecurityCluster() *cobra.Command {
+func securityClusterCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Manage security locks for cluster resources.",
@@ -35,13 +35,13 @@ func newCmdSecurityCluster() *cobra.Command {
 
 	setSecurityClusterFlags(cmd)
 
-	cmd.AddCommand(newCmdSecurityClusterLock())
-	cmd.AddCommand(newCmdSecurityClusterUnlock())
+	cmd.AddCommand(securityClusterLockCmd())
+	cmd.AddCommand(securityClusterUnlockCmd())
 
 	return cmd
 }
 
-func newCmdSecurityClusterLock() *cobra.Command {
+func securityClusterLockCmd() *cobra.Command {
 
 	var flags securityClusterFlags
 
@@ -65,7 +65,7 @@ func newCmdSecurityClusterLock() *cobra.Command {
 	return cmd
 }
 
-func newCmdSecurityClusterUnlock() *cobra.Command {
+func securityClusterUnlockCmd() *cobra.Command {
 
 	var flags securityClusterFlags
 
@@ -89,7 +89,7 @@ func newCmdSecurityClusterUnlock() *cobra.Command {
 	return cmd
 }
 
-func newCmdSecurityInstallation() *cobra.Command {
+func securityInstallationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "installation",
 		Short: "Manage security locks for installation resources.",
@@ -97,13 +97,13 @@ func newCmdSecurityInstallation() *cobra.Command {
 
 	setSecurityInstallationFlags(cmd)
 
-	cmd.AddCommand(newCmdSecurityInstallationLock())
-	cmd.AddCommand(newCmdSecurityInstallationUnlock())
+	cmd.AddCommand(securityInstallationLockCmd())
+	cmd.AddCommand(securityInstallationUnlockCmd())
 
 	return cmd
 }
 
-func newCmdSecurityInstallationLock() *cobra.Command {
+func securityInstallationLockCmd() *cobra.Command {
 
 	var flags securityInstallationFlags
 
@@ -127,7 +127,7 @@ func newCmdSecurityInstallationLock() *cobra.Command {
 	return cmd
 }
 
-func newCmdSecurityInstallationUnlock() *cobra.Command {
+func securityInstallationUnlockCmd() *cobra.Command {
 
 	var flags securityInstallationFlags
 
@@ -151,7 +151,7 @@ func newCmdSecurityInstallationUnlock() *cobra.Command {
 	return cmd
 }
 
-func newCmdSecurityClusterInstallation() *cobra.Command {
+func securityClusterInstallationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster-installation",
 		Short: "Manage security locks for cluster installation resources.",
@@ -159,13 +159,13 @@ func newCmdSecurityClusterInstallation() *cobra.Command {
 
 	setSecurityClusterInstallationFlags(cmd)
 
-	cmd.AddCommand(newCmdSecurityClusterInstallationLock())
-	cmd.AddCommand(newCmdSecurityClusterInstallationUnlock())
+	cmd.AddCommand(securityClusterInstallationLockCmd())
+	cmd.AddCommand(securityClusterInstallationUnlockCmd())
 
 	return cmd
 }
 
-func newCmdSecurityClusterInstallationLock() *cobra.Command {
+func securityClusterInstallationLockCmd() *cobra.Command {
 
 	var flags securityClusterInstallationFlags
 
@@ -189,7 +189,7 @@ func newCmdSecurityClusterInstallationLock() *cobra.Command {
 	return cmd
 }
 
-func newCmdSecurityClusterInstallationUnlock() *cobra.Command {
+func securityClusterInstallationUnlockCmd() *cobra.Command {
 
 	var flags securityClusterInstallationFlags
 
@@ -213,7 +213,7 @@ func newCmdSecurityClusterInstallationUnlock() *cobra.Command {
 	return cmd
 }
 
-func newCmdSecurityGroup() *cobra.Command {
+func securityGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "group",
 		Short: "Manage security locks for group resources.",
@@ -221,13 +221,13 @@ func newCmdSecurityGroup() *cobra.Command {
 
 	setSecurityGroupFlags(cmd)
 
-	cmd.AddCommand(newCmdSecurityGroupLock())
-	cmd.AddCommand(newCmdSecurityGroupUnlock())
+	cmd.AddCommand(securityGroupLockCmd())
+	cmd.AddCommand(securityGroupUnlockCmd())
 
 	return cmd
 }
 
-func newCmdSecurityGroupLock() *cobra.Command {
+func securityGroupLockCmd() *cobra.Command {
 
 	var flags securityGroupFlags
 
@@ -251,7 +251,7 @@ func newCmdSecurityGroupLock() *cobra.Command {
 	return cmd
 }
 
-func newCmdSecurityGroupUnlock() *cobra.Command {
+func securityGroupUnlockCmd() *cobra.Command {
 
 	var flags securityGroupFlags
 
@@ -275,7 +275,7 @@ func newCmdSecurityGroupUnlock() *cobra.Command {
 	return cmd
 }
 
-func newCmdSecurityBackup() *cobra.Command {
+func securityBackupCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "backup",
 		Short: "Manage security locks for backup resources.",
@@ -283,13 +283,13 @@ func newCmdSecurityBackup() *cobra.Command {
 
 	setSecurityBackupFlags(cmd)
 
-	cmd.AddCommand(newCmdSecurityBackupLock())
-	cmd.AddCommand(newCmdSecurityBackupUnlock())
+	cmd.AddCommand(securityBackupLockCmd())
+	cmd.AddCommand(securityBackupUnlockCmd())
 
 	return cmd
 }
 
-func newCmdSecurityBackupLock() *cobra.Command {
+func securityBackupLockCmd() *cobra.Command {
 
 	var flags securityBackupFlags
 
@@ -313,7 +313,7 @@ func newCmdSecurityBackupLock() *cobra.Command {
 	return cmd
 }
 
-func newCmdSecurityBackupUnlock() *cobra.Command {
+func securityBackupUnlockCmd() *cobra.Command {
 
 	var flags securityBackupFlags
 

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -49,7 +49,7 @@ type Provisioner interface {
 	supervisor.Provisioner
 }
 
-func newCmdServer() *cobra.Command {
+func serverCmd() *cobra.Command {
 	var flags serverFlags
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/webhook.go
+++ b/cmd/cloud/webhook.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdWebhook() *cobra.Command {
+func webhookCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "webhook",
 		Short: "Manipulate webhooks managed by the provisioning server.",
@@ -21,15 +21,15 @@ func newCmdWebhook() *cobra.Command {
 
 	setWebhookFlags(cmd)
 
-	cmd.AddCommand(newCmdWebhookCreate())
-	cmd.AddCommand(newCmdWebhookGet())
-	cmd.AddCommand(newCmdWebhookList())
-	cmd.AddCommand(newCmdWebhookDelete())
+	cmd.AddCommand(webhookCreateCmd())
+	cmd.AddCommand(webhookGetCmd())
+	cmd.AddCommand(webhookListCmd())
+	cmd.AddCommand(webhookDeleteCmd())
 
 	return cmd
 }
 
-func newCmdWebhookCreate() *cobra.Command {
+func webhookCreateCmd() *cobra.Command {
 	var flags webhookCreateFlag
 
 	cmd := &cobra.Command{
@@ -60,7 +60,7 @@ func newCmdWebhookCreate() *cobra.Command {
 	return cmd
 }
 
-func newCmdWebhookGet() *cobra.Command {
+func webhookGetCmd() *cobra.Command {
 	var flags webhookGetFlag
 
 	cmd := &cobra.Command{
@@ -91,7 +91,7 @@ func newCmdWebhookGet() *cobra.Command {
 	return cmd
 }
 
-func newCmdWebhookList() *cobra.Command {
+func webhookListCmd() *cobra.Command {
 	var flags webhookListFlag
 
 	cmd := &cobra.Command{
@@ -140,7 +140,7 @@ func executeWebhookListCmd(flags webhookListFlag) error {
 	return printJSON(webhooks)
 }
 
-func newCmdWebhookDelete() *cobra.Command {
+func webhookDeleteCmd() *cobra.Command {
 	var flags webhookDeleteFlag
 
 	cmd := &cobra.Command{

--- a/cmd/cloud/workbench.go
+++ b/cmd/cloud/workbench.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCmdWorkbench() *cobra.Command {
+func workbenchCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "workbench",
 		Short: "Tools for working with cloud resources",
@@ -20,12 +20,12 @@ func newCmdWorkbench() *cobra.Command {
 
 	setWorkbenchFlags(cmd)
 
-	cmd.AddCommand(newCmdWorkbenchCluster())
+	cmd.AddCommand(workbenchClusterCmd())
 
 	return cmd
 }
 
-func newCmdWorkbenchCluster() *cobra.Command {
+func workbenchClusterCmd() *cobra.Command {
 
 	var flags workbenchClusterFlag
 


### PR DESCRIPTION
#### Summary

Example

`newCmdCluster()` -> `clusterCmd()`

#### Ticket Link

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
