### PR TITLE
[MM-38163] Retry to report AWAT with exponential backoff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.25.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.29.6
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/cloudflare/cloudflare-go v0.54.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,7 @@ github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748/go.
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v0.0.0-20181003080854-62661b46c409/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -151,7 +151,7 @@ func (s *ImportSupervisor) Do() error {
 						Error:      workError,
 					})
 				if err != nil {
-					s.logger.WithError(err).Errorf("failed to report error to AWAT for Import %s", work.ID)
+					s.logger.WithError(err).Errorf("failed retry to report error to AWAT for Import %s", work.ID)
 				}
 				return err
 			})

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -7,8 +7,6 @@ package supervisor
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/cenkalti/backoff/v4"
-	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"strconv"
 	"strings"
 	"time"
@@ -16,6 +14,7 @@ import (
 	awat "github.com/mattermost/awat/model"
 	"github.com/mattermost/mattermost-cloud/internal/events"
 	toolsAWS "github.com/mattermost/mattermost-cloud/internal/tools/aws"
+	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -143,12 +142,7 @@ func (s *ImportSupervisor) Do() error {
 		go func() {
 			completeAt := model.GetMillis()
 
-			expBackoff := utils.NewExponentialBackoff(&backoff.ExponentialBackOff{
-				InitialInterval: 5 * time.Second,
-				MaxInterval:     time.Minute * 10,
-				MaxElapsedTime:  time.Minute * 30,
-			})
-
+			expBackoff := utils.NewExponentialBackoff(time.Second*5, time.Minute*10, time.Minute*30)
 			err := expBackoff.Retry(func() error {
 				err := s.awatClient.CompleteImport(
 					&awat.ImportCompletedWorkRequest{

--- a/internal/tools/utils/backoff.go
+++ b/internal/tools/utils/backoff.go
@@ -14,16 +14,17 @@ type Backoff struct {
 // NewExponentialBackoff is used to retry a function with exponential backoff
 func NewExponentialBackoff(initialInterval, maxInterval, maxElapsedTime time.Duration) *Backoff {
 	expBackoff := backoff.NewExponentialBackOff()
-	expBackoff.InitialInterval = initialInterval
-	expBackoff.MaxInterval = maxInterval
-	expBackoff.MaxElapsedTime = maxElapsedTime
 
-	if expBackoff.InitialInterval == 0 {
-		expBackoff.InitialInterval = backoff.DefaultInitialInterval
+	if initialInterval != 0 {
+		expBackoff.InitialInterval = initialInterval
 	}
 
-	if expBackoff.MaxInterval == 0 {
-		expBackoff.MaxInterval = backoff.DefaultMaxInterval
+	if maxInterval != 0 {
+		expBackoff.MaxInterval = maxInterval
+	}
+
+	if maxElapsedTime != 0 {
+		expBackoff.MaxElapsedTime = maxElapsedTime
 	}
 
 	return &Backoff{

--- a/internal/tools/utils/backoff.go
+++ b/internal/tools/utils/backoff.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"github.com/cenkalti/backoff/v4"
+)
+
+type Backoff struct {
+	*backoff.ExponentialBackOff
+}
+
+func NewExponentialBackoff(expBackoff *backoff.ExponentialBackOff) *Backoff {
+	return &Backoff{
+		expBackoff,
+	}
+}
+
+func (b *Backoff) Retry(fn func() error) error {
+	return backoff.Retry(fn, b)
+}

--- a/internal/tools/utils/backoff.go
+++ b/internal/tools/utils/backoff.go
@@ -1,19 +1,38 @@
 package utils
 
 import (
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 )
 
+// Backoff holds exponential backoff settings
 type Backoff struct {
-	*backoff.ExponentialBackOff
+	exp *backoff.ExponentialBackOff
 }
 
-func NewExponentialBackoff(expBackoff *backoff.ExponentialBackOff) *Backoff {
+// NewExponentialBackoff is used to retry a function with exponential backoff
+func NewExponentialBackoff(initialInterval, maxInterval, maxElapsedTime time.Duration) *Backoff {
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = initialInterval
+	expBackoff.MaxInterval = maxInterval
+	expBackoff.MaxElapsedTime = maxElapsedTime
+
+	if expBackoff.InitialInterval == 0 {
+		expBackoff.InitialInterval = backoff.DefaultInitialInterval
+	}
+
+	if expBackoff.MaxInterval == 0 {
+		expBackoff.MaxInterval = backoff.DefaultMaxInterval
+	}
+
 	return &Backoff{
-		expBackoff,
+		exp: expBackoff,
 	}
 }
 
+// Retry is used to invoke a function with constant backoff
 func (b *Backoff) Retry(fn func() error) error {
-	return backoff.Retry(fn, b)
+	b.exp.Reset()
+	return backoff.Retry(fn, b.exp)
 }

--- a/internal/tools/utils/backoff.go
+++ b/internal/tools/utils/backoff.go
@@ -33,7 +33,7 @@ func NewExponentialBackoff(initialInterval, maxInterval, maxElapsedTime time.Dur
 }
 
 // Retry is used to invoke a function with constant backoff
-func (b *Backoff) Retry(fn func() error) error {
+func (b *Backoff) Retry(fn backoff.Operation) error {
 	b.exp.Reset()
 	return backoff.Retry(fn, b.exp)
 }


### PR DESCRIPTION
#### Summary

When an error occurs, the import supervisor informs the AWAT server repeatedly every 5 seconds until it succeeds. We're adding exponential backoff to terminate repeated efforts after a specific duration. 

```go
  InitialInterval: time.Second * 5,
  MaxInterval:     time.Minute * 10,
  MaxElapsedTime:  time.Minute * 30,
```

The settings above will retry for up to 30 minutes. And it will retry 15 times within this timeframe.

#### Ticket Link

  Fixes [MM-38163](https://mattermost.atlassian.net/browse/MM-38163)


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
