### PR TITLE
[MM-49373] Set logger to avoid panic

### DIFF
--- a/internal/provisioner/nginx_internal.go
+++ b/internal/provisioner/nginx_internal.go
@@ -99,6 +99,9 @@ func (n *nginxInternal) Destroy() error {
 		chartDeploymentName: chartDeploymentNameNginxInternal,
 		chartName:           chartNameNginxInternal,
 		namespace:           namespaceNginxInternal,
+
+		kubeconfigPath: n.kubeconfigPath,
+		logger:         n.logger,
 	}
 	return helm.Delete()
 }


### PR DESCRIPTION
#### Summary

```go
func (d *helmDeployment) Delete() error {
  logger := d.logger.WithField("helm-delete", d.chartDeploymentName)
  return nil
}
```

`logger` was missing in `helmDeployment`

#### Ticket Link

  Fixes [MM-49373](https://mattermost.atlassian.net/browse/MM-49373)


#### Release Note

```release-note
NONE
```
