### PR TITLE
[MM-49377] Fix bucket not being sent in batch delete

### DIFF
--- a/internal/tools/aws/s3.go
+++ b/internal/tools/aws/s3.go
@@ -75,6 +75,7 @@ func (a *Client) S3BatchDelete(bucketName string, prefix *string) error {
 	paginator := s3.NewListObjectsV2Paginator(
 		a.service.s3,
 		&s3.ListObjectsV2Input{
+			Bucket:  &bucketName,
 			MaxKeys: 1000, // The maximum number of objects we can retrieve on a single request
 			Prefix:  prefix,
 		},


### PR DESCRIPTION
#### Summary

In the batch delete operation, the bucket was not being set in order to list all items from a bucket, resulting in a validation error from AWS API.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49377

#### Release Note
```release-note
None
```
