### PR TITLE
[MM-29718] Allow env var to set every cloud flag

### DIFF
--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -60,7 +60,7 @@ func main() {
 func populateEnv(cmd *cobra.Command) {
 	v := viper.New()
 
-	v.SetEnvPrefix("mm")
+	v.SetEnvPrefix("cp")
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
 


### PR DESCRIPTION
#### Summary

Environment variables with the prefix `CP_` can be used to set any flag.

**Some examples**

`size-node-min-count` → `CP_SIZE_NODE_MIN_COUNT`
`debug` → `CP_DEBUG`
`slo-target-availability` → `CP_SLO_TARGET_AVAILABILITY`

The following order will be used

- flag value
- env value
- default value

#### Ticket Link

  Jira [Ticket](https://mattermost.atlassian.net/browse/MM-29718)


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Allow ENV variables to set every cloud flag
```
