### PR TITLE
Use value-type data to fix an erroneous pointer reference. 

### DIFF
--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -488,7 +488,7 @@ func (a *Client) getHostedZonesWithTag(tag Tag, firstOnly bool) ([]*types.Hosted
 			return nil, errors.Wrapf(err, "failed to list all hosted zones")
 		}
 
-		for _, zone := range zoneList.HostedZones {
+		for i, zone := range zoneList.HostedZones {
 			id, err := parseHostedZoneResourceID(zone)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to parse hosted zone ID: %s", *zone.Name)
@@ -506,7 +506,7 @@ func (a *Client) getHostedZonesWithTag(tag Tag, firstOnly bool) ([]*types.Hosted
 
 			for _, resourceTag := range tagList.ResourceTagSet.Tags {
 				if tag.Compare(resourceTag) {
-					zones = append(zones, &zone)
+					zones = append(zones, &zoneList.HostedZones[i])
 					break
 				}
 			}

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -59,7 +59,7 @@ func (a *Client) buildRoute53Cache() error {
 	zoneMap := map[string]awsHostedZone{}
 
 	for _, zone := range zones {
-		zoneID, err := parseHostedZoneResourceID(*zone)
+		zoneID, err := parseHostedZoneResourceID(zone)
 		if err != nil {
 			return errors.Wrap(err, "failed to parse hosted zone ID")
 		}
@@ -466,11 +466,11 @@ func (a *Client) getHostedZoneIDWithTag(tag Tag) (string, error) {
 	if len(zones) == 0 {
 		return "", errors.Errorf("no hosted zone ID associated with tag: %s", tag.String())
 	}
-	return parseHostedZoneResourceID(*zones[0])
+	return parseHostedZoneResourceID(zones[0])
 }
 
 // GetHostedZonesWithTag returns R53 hosted zone for a given tag
-func (a *Client) GetHostedZonesWithTag(tag Tag) ([]*types.HostedZone, error) {
+func (a *Client) GetHostedZonesWithTag(tag Tag) ([]types.HostedZone, error) {
 	zones, err := a.getHostedZonesWithTag(tag, false)
 	if err != nil {
 		return nil, err
@@ -478,8 +478,8 @@ func (a *Client) GetHostedZonesWithTag(tag Tag) ([]*types.HostedZone, error) {
 	return zones, nil
 }
 
-func (a *Client) getHostedZonesWithTag(tag Tag, firstOnly bool) ([]*types.HostedZone, error) {
-	var zones []*types.HostedZone
+func (a *Client) getHostedZonesWithTag(tag Tag, firstOnly bool) ([]types.HostedZone, error) {
+	var zones []types.HostedZone
 	var next *string
 
 	for {
@@ -488,7 +488,7 @@ func (a *Client) getHostedZonesWithTag(tag Tag, firstOnly bool) ([]*types.Hosted
 			return nil, errors.Wrapf(err, "failed to list all hosted zones")
 		}
 
-		for i, zone := range zoneList.HostedZones {
+		for _, zone := range zoneList.HostedZones {
 			id, err := parseHostedZoneResourceID(zone)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to parse hosted zone ID: %s", *zone.Name)
@@ -506,7 +506,7 @@ func (a *Client) getHostedZonesWithTag(tag Tag, firstOnly bool) ([]*types.Hosted
 
 			for _, resourceTag := range tagList.ResourceTagSet.Tags {
 				if tag.Compare(resourceTag) {
-					zones = append(zones, &zoneList.HostedZones[i])
+					zones = append(zones, zone)
 					break
 				}
 			}


### PR DESCRIPTION
#### Summary

```go
for _, zone := range zoneList.HostedZones {
    zones = append(zones, &zone)
}
```

Here, adding _pointer of zone_ causes invalid reference. Because this variable is being updated with each list items.

#### Ticket Link

  Fixes [MM-49380](https://mattermost.atlassian.net/browse/MM-49380)


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fixed an invalid pointer reference that led to an incorrect zone name.
```
