### PR TITLE
[MM-49378] Added Nginx SLO for Enterprise customer

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -278,7 +278,7 @@ func executeServerCmd(flags serverFlags) error {
 		NdotsValue:              flags.ndotsDefaultValue,
 		PGBouncerConfig:         pgbouncerConfig,
 		SLOInstallationGroups:   flags.sloInstallationGroups,
-		EnterpriseGroups:        flags.enterpriseGroups,
+		SLOEnterpriseGroups:     flags.sloEnterpriseGroups,
 		EtcdManagerEnv:          etcdManagerEnv,
 		SLOTargetAvailability:   flags.sloTargetAvailability,
 	}

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -278,6 +278,7 @@ func executeServerCmd(flags serverFlags) error {
 		NdotsValue:              flags.ndotsDefaultValue,
 		PGBouncerConfig:         pgbouncerConfig,
 		SLOInstallationGroups:   flags.sloInstallationGroups,
+		EnterpriseGroups:        flags.enterpriseGroups,
 		EtcdManagerEnv:          etcdManagerEnv,
 		SLOTargetAvailability:   flags.sloTargetAvailability,
 	}

--- a/cmd/cloud/server_flag.go
+++ b/cmd/cloud/server_flag.go
@@ -72,6 +72,7 @@ type provisioningParams struct {
 	s3StateStore          string
 	allowListCIDRRange    []string
 	sloInstallationGroups []string
+	enterpriseGroups      []string
 	vpnListCIDR           []string
 	useExistingResources  bool
 	deployMySQLOperator   bool
@@ -90,6 +91,7 @@ func (flags *provisioningParams) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.s3StateStore, "state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
 	command.Flags().StringSliceVar(&flags.allowListCIDRRange, "allow-list-cidr-range", []string{"0.0.0.0/0"}, "The list of CIDRs to allow communication with the private ingress.")
 	command.Flags().StringSliceVar(&flags.sloInstallationGroups, "slo-installation-groups", []string{}, "The list of installation group ids to create dedicated SLOs for.")
+	command.Flags().StringSliceVar(&flags.enterpriseGroups, "enterprise-groups", []string{}, "The list of enterprise group ids to create dedicated Nginx SLOs for.")
 	command.Flags().StringSliceVar(&flags.vpnListCIDR, "vpn-list-cidr", []string{"0.0.0.0/0"}, "The list of VPN CIDRs to allow communication with the clusters.")
 	command.Flags().BoolVar(&flags.useExistingResources, "use-existing-aws-resources", true, "Whether to use existing AWS resources (VPCs, subnets, etc.) or not.")
 	command.Flags().BoolVar(&flags.deployMySQLOperator, "deploy-mysql-operator", true, "Whether to deploy the mysql operator.")

--- a/cmd/cloud/server_flag.go
+++ b/cmd/cloud/server_flag.go
@@ -72,7 +72,7 @@ type provisioningParams struct {
 	s3StateStore          string
 	allowListCIDRRange    []string
 	sloInstallationGroups []string
-	enterpriseGroups      []string
+	sloEnterpriseGroups   []string
 	vpnListCIDR           []string
 	useExistingResources  bool
 	deployMySQLOperator   bool
@@ -91,7 +91,7 @@ func (flags *provisioningParams) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.s3StateStore, "state-store", "dev.cloud.mattermost.com", "The S3 bucket used to store cluster state.")
 	command.Flags().StringSliceVar(&flags.allowListCIDRRange, "allow-list-cidr-range", []string{"0.0.0.0/0"}, "The list of CIDRs to allow communication with the private ingress.")
 	command.Flags().StringSliceVar(&flags.sloInstallationGroups, "slo-installation-groups", []string{}, "The list of installation group ids to create dedicated SLOs for.")
-	command.Flags().StringSliceVar(&flags.enterpriseGroups, "enterprise-groups", []string{}, "The list of enterprise group ids to create dedicated Nginx SLOs for.")
+	command.Flags().StringSliceVar(&flags.sloEnterpriseGroups, "slo-enterprise-groups", []string{}, "The list of enterprise group ids to create dedicated Nginx SLOs for.")
 	command.Flags().StringSliceVar(&flags.vpnListCIDR, "vpn-list-cidr", []string{"0.0.0.0/0"}, "The list of VPN CIDRs to allow communication with the clusters.")
 	command.Flags().BoolVar(&flags.useExistingResources, "use-existing-aws-resources", true, "Whether to use existing AWS resources (VPCs, subnets, etc.) or not.")
 	command.Flags().BoolVar(&flags.deployMySQLOperator, "deploy-mysql-operator", true, "Whether to deploy the mysql operator.")

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -97,7 +97,7 @@ func (provisioner *CommonProvisioner) createClusterInstallation(clusterInstallat
 		}
 		if containsInstallationGroup(*installation.GroupID, provisioner.params.EnterpriseGroups) {
 			logger.Debug("Installation belongs in the approved enterprise installation group list. Adding Nginx SLI")
-			err = createOrUpdateNginxSLIs(clusterInstallation, k8sClient, logger)
+			err = createOrUpdateNginxSLI(clusterInstallation, k8sClient, logger)
 			if err != nil {
 				return errors.Wrap(err, "failed to create Nginx SLI")
 			}
@@ -184,7 +184,7 @@ func hibernateInstallation(configLocation string, logger *log.Entry, clusterInst
 		return errors.Wrap(err, "failed to delete installation SLI")
 	}
 
-	if err = deleteNginxSLI(clusterInstallation, k8sClient, logger); err != nil {
+	if err = ensureNginxSLIDeleted(clusterInstallation, k8sClient, logger); err != nil {
 		return errors.Wrap(err, "failed to delete nginx SLI")
 	}
 
@@ -345,12 +345,12 @@ func (provisioner *CommonProvisioner) updateClusterInstallation(
 
 	if installation.GroupID != nil && *installation.GroupID != "" && containsInstallationGroup(*installation.GroupID, provisioner.params.EnterpriseGroups) {
 		logger.Debug("Creating or updating Mattermost Enterprise Nginx SLI")
-		if err = createOrUpdateNginxSLIs(clusterInstallation, k8sClient, logger); err != nil {
+		if err = createOrUpdateNginxSLI(clusterInstallation, k8sClient, logger); err != nil {
 			return errors.Wrapf(err, "failed to create enterprise Nginx SLI %s", clusterInstallation.InstallationID)
 		}
 	} else {
 		logger.Debug("Removing Mattermost Enterprise Nginx SLI")
-		if err := deleteNginxSLI(clusterInstallation, k8sClient, logger); err != nil {
+		if err := ensureNginxSLIDeleted(clusterInstallation, k8sClient, logger); err != nil {
 			return errors.Wrapf(err, "failed to delete cluster installation SLI %s", clusterInstallation.InstallationID)
 		}
 	}
@@ -426,7 +426,7 @@ func deleteClusterInstallation(
 		return errors.Wrap(err, "failed to delete installation SLI")
 	}
 
-	if err = deleteNginxSLI(clusterInstallation, k8sClient, logger); err != nil {
+	if err = ensureNginxSLIDeleted(clusterInstallation, k8sClient, logger); err != nil {
 		return errors.Wrap(err, "failed to delete nginx SLI")
 	}
 

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -95,7 +95,7 @@ func (provisioner *CommonProvisioner) createClusterInstallation(clusterInstallat
 				return errors.Wrap(err, "failed to create installation SLI")
 			}
 		}
-		if containsInstallationGroup(*installation.GroupID, provisioner.params.EnterpriseGroups) {
+		if containsInstallationGroup(*installation.GroupID, provisioner.params.SLOEnterpriseGroups) {
 			logger.Debug("Installation belongs in the approved enterprise installation group list. Adding Nginx SLI")
 			err = createOrUpdateNginxSLI(clusterInstallation, k8sClient, logger)
 			if err != nil {
@@ -343,7 +343,7 @@ func (provisioner *CommonProvisioner) updateClusterInstallation(
 		}
 	}
 
-	if installation.GroupID != nil && *installation.GroupID != "" && containsInstallationGroup(*installation.GroupID, provisioner.params.EnterpriseGroups) {
+	if installation.GroupID != nil && *installation.GroupID != "" && containsInstallationGroup(*installation.GroupID, provisioner.params.SLOEnterpriseGroups) {
 		logger.Debug("Creating or updating Mattermost Enterprise Nginx SLI")
 		if err = createOrUpdateNginxSLI(clusterInstallation, k8sClient, logger); err != nil {
 			return errors.Wrapf(err, "failed to create enterprise nginx SLI %s", getNginxSlothObjectName(clusterInstallation))

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -99,7 +99,7 @@ func (provisioner *CommonProvisioner) createClusterInstallation(clusterInstallat
 			logger.Debug("Installation belongs in the approved enterprise installation group list. Adding Nginx SLI")
 			err = createOrUpdateNginxSLI(clusterInstallation, k8sClient, logger)
 			if err != nil {
-				return errors.Wrap(err, "failed to create Nginx SLI")
+				return errors.Wrap(err, "failed to create enterprise nginx SLI")
 			}
 		}
 	}
@@ -185,7 +185,7 @@ func hibernateInstallation(configLocation string, logger *log.Entry, clusterInst
 	}
 
 	if err = ensureNginxSLIDeleted(clusterInstallation, k8sClient, logger); err != nil {
-		return errors.Wrap(err, "failed to delete nginx SLI")
+		return errors.Wrap(err, "failed to delete enterprise nginx SLI")
 	}
 
 	logger.Info("Updated cluster installation")
@@ -346,12 +346,12 @@ func (provisioner *CommonProvisioner) updateClusterInstallation(
 	if installation.GroupID != nil && *installation.GroupID != "" && containsInstallationGroup(*installation.GroupID, provisioner.params.EnterpriseGroups) {
 		logger.Debug("Creating or updating Mattermost Enterprise Nginx SLI")
 		if err = createOrUpdateNginxSLI(clusterInstallation, k8sClient, logger); err != nil {
-			return errors.Wrapf(err, "failed to create enterprise Nginx SLI %s", clusterInstallation.InstallationID)
+			return errors.Wrapf(err, "failed to create enterprise nginx SLI %s", getNginxSlothObjectName(clusterInstallation))
 		}
 	} else {
 		logger.Debug("Removing Mattermost Enterprise Nginx SLI")
 		if err := ensureNginxSLIDeleted(clusterInstallation, k8sClient, logger); err != nil {
-			return errors.Wrapf(err, "failed to delete cluster installation SLI %s", clusterInstallation.InstallationID)
+			return errors.Wrapf(err, "failed to delete enterprise nginx SLI %s", getNginxSlothObjectName(clusterInstallation))
 		}
 	}
 
@@ -427,7 +427,7 @@ func deleteClusterInstallation(
 	}
 
 	if err = ensureNginxSLIDeleted(clusterInstallation, k8sClient, logger); err != nil {
-		return errors.Wrap(err, "failed to delete nginx SLI")
+		return errors.Wrap(err, "failed to delete enterprise nginx SLI")
 	}
 
 	logger.Info("Successfully deleted cluster installation")

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -32,7 +32,7 @@ type ProvisioningParams struct {
 	NdotsValue              string
 	PGBouncerConfig         *PGBouncerConfig
 	SLOInstallationGroups   []string
-	EnterpriseGroups        []string
+	SLOEnterpriseGroups     []string
 	EtcdManagerEnv          map[string]string
 	SLOTargetAvailability   float64
 }

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -32,6 +32,7 @@ type ProvisioningParams struct {
 	NdotsValue              string
 	PGBouncerConfig         *PGBouncerConfig
 	SLOInstallationGroups   []string
+	EnterpriseGroups        []string
 	EtcdManagerEnv          map[string]string
 	SLOTargetAvailability   float64
 }

--- a/internal/provisioner/nginx_sli.go
+++ b/internal/provisioner/nginx_sli.go
@@ -22,7 +22,7 @@ func getNginxSlothObjectName(clusterInstallation *model.ClusterInstallation) str
 	return fmt.Sprintf("slo-nginx-my-enterpise-%s", clusterInstallation.InstallationID)
 }
 
-func makeNginxSLIs(clusterInstallation *model.ClusterInstallation) slothv1.PrometheusServiceLevel {
+func makeNginxSLI(clusterInstallation *model.ClusterInstallation) slothv1.PrometheusServiceLevel {
 	pslName := getNginxSlothObjectName(clusterInstallation)
 	serviceName := makeClusterInstallationName(clusterInstallation)
 
@@ -60,12 +60,12 @@ func makeNginxSLIs(clusterInstallation *model.ClusterInstallation) slothv1.Prome
 	return sli
 }
 
-func createOrUpdateNginxSLIs(clusterInstallation *model.ClusterInstallation, k8sClient *k8s.KubeClient, logger log.FieldLogger) error {
-	sli := makeNginxSLIs(clusterInstallation)
+func createOrUpdateNginxSLI(clusterInstallation *model.ClusterInstallation, k8sClient *k8s.KubeClient, logger log.FieldLogger) error {
+	sli := makeNginxSLI(clusterInstallation)
 	return createOrUpdateClusterPrometheusServiceLevel(sli, k8sClient, logger)
 }
 
-func deleteNginxSLI(clusterInstallation *model.ClusterInstallation, k8sClient *k8s.KubeClient, logger log.FieldLogger) error {
+func ensureNginxSLIDeleted(clusterInstallation *model.ClusterInstallation, k8sClient *k8s.KubeClient, logger log.FieldLogger) error {
 	pslName := getNginxSlothObjectName(clusterInstallation)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 	defer cancel()

--- a/internal/provisioner/nginx_sli.go
+++ b/internal/provisioner/nginx_sli.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/k8s"
+	"github.com/mattermost/mattermost-cloud/model"
+	log "github.com/sirupsen/logrus"
+	slothv1 "github.com/slok/sloth/pkg/kubernetes/api/sloth/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getNginxSlothObjectName(clusterInstallation *model.ClusterInstallation) string {
+	return fmt.Sprintf("slo-nginx-my-enterpise-%s", clusterInstallation.InstallationID)
+}
+
+func makeNginxSLIs(clusterInstallation *model.ClusterInstallation) slothv1.PrometheusServiceLevel {
+	pslName := getNginxSlothObjectName(clusterInstallation)
+	serviceName := makeClusterInstallationName(clusterInstallation)
+
+	sli := slothv1.PrometheusServiceLevel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pslName,
+			Labels: map[string]string{
+				"app":     "kube-prometheus-stack",
+				"release": "prometheus-operator",
+			},
+			Namespace: prometheusNamespace,
+		},
+		Spec: slothv1.PrometheusServiceLevelSpec{
+			Service: fmt.Sprintf("nginx-%s-service", clusterInstallation.InstallationID),
+			Labels: map[string]string{
+				"owner": "sre-team",
+			},
+			SLOs: []slothv1.SLO{
+				{
+					Name:        "requests-availability",
+					Objective:   99.9,
+					Description: "Common SLO based on availability for HTTP request responses measured on ingress layer.",
+					SLI: slothv1.SLI{Events: &slothv1.SLIEvents{
+						ErrorQuery: "sum(rate(nginx_ingress_controller_request_duration_seconds_count{exported_service='" + serviceName + "',status=~'(5..|429|499)'}[{{.window}}]))",
+						TotalQuery: "sum(rate(nginx_ingress_controller_request_duration_seconds_count{exported_service='" + serviceName + "'}[{{.window}}]))",
+					}},
+					Alerting: slothv1.Alerting{
+						PageAlert:   slothv1.Alert{Disable: true},
+						TicketAlert: slothv1.Alert{Disable: true},
+					},
+				}},
+		},
+	}
+
+	return sli
+}
+
+func createOrUpdateNginxSLIs(clusterInstallation *model.ClusterInstallation, k8sClient *k8s.KubeClient, logger log.FieldLogger) error {
+	sli := makeNginxSLIs(clusterInstallation)
+	return createOrUpdateClusterPrometheusServiceLevel(sli, k8sClient, logger)
+}
+
+func deleteNginxSLI(clusterInstallation *model.ClusterInstallation, k8sClient *k8s.KubeClient, logger log.FieldLogger) error {
+	pslName := getNginxSlothObjectName(clusterInstallation)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel()
+	_, err := k8sClient.SlothClientsetV1.SlothV1().PrometheusServiceLevels(prometheusNamespace).Get(ctx, pslName, metav1.GetOptions{})
+	if err != nil && k8sErrors.IsNotFound(err) {
+		logger.Debugf("sloth CRD doesn't exist on cluster: %s", err)
+		return nil
+	}
+	err = k8sClient.SlothClientsetV1.SlothV1().PrometheusServiceLevels(prometheusNamespace).Delete(ctx, pslName, metav1.DeleteOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to delete enterprise nginx sli")
+	}
+	return nil
+}

--- a/internal/provisioner/nginx_sli.go
+++ b/internal/provisioner/nginx_sli.go
@@ -7,14 +7,14 @@ package provisioner
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"time"
 
 	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	slothv1 "github.com/slok/sloth/pkg/kubernetes/api/sloth/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/provisioner/nginx_sli.go
+++ b/internal/provisioner/nginx_sli.go
@@ -43,7 +43,7 @@ func makeNginxSLI(clusterInstallation *model.ClusterInstallation) slothv1.Promet
 			SLOs: []slothv1.SLO{
 				{
 					Name:        "requests-availability",
-					Objective:   99.9,
+					Objective:   99.5,
 					Description: "Common SLO based on availability for HTTP request responses measured on ingress layer.",
 					SLI: slothv1.SLI{Events: &slothv1.SLIEvents{
 						ErrorQuery: "sum(rate(nginx_ingress_controller_request_duration_seconds_count{exported_service='" + serviceName + "',status=~'(5..|429|499)'}[{{.window}}]))",


### PR DESCRIPTION
#### Summary

We need to provide list of enterprise group while running provisioner.

```bash
$ cloud server [flags]

Flags:
      --enterprise-groups strings.       The list of enterprise group ids to create dedicated Nginx SLOs for.
```

Sample SLO
```yaml
objective: 99.9
sli:
  events:
    errorQuery: sum(rate(nginx_ingress_controller_request_duration_seconds_count{exported_service='mm-d5wh',status=~'(5..|429|499)'}[{{.window}}]))
    totalQuery: sum(rate(nginx_ingress_controller_request_duration_seconds_count{exported_service='mm-d5wh'}[{{.window}}]))
```

#### Ticket Link

  Fixes [MM-49378](https://mattermost.atlassian.net/browse/MM-49378)

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added Nginx SLO for enterprise customer
```
