### PR TITLE
fix: incorrect RDS secret name

### DIFF
--- a/internal/tools/aws/database.go
+++ b/internal/tools/aws/database.go
@@ -149,7 +149,7 @@ func (d *RDSDatabase) GenerateDatabaseSecret(store model.InstallationDatabaseSto
 		"database-type":   d.databaseType,
 	})
 
-	installationSecret, err := d.client.secretsManagerGetRDSSecret(awsID, logger)
+	installationSecret, err := d.client.secretsManagerGetRDSSecret(RDSSecretName(awsID), logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tools/aws/secrets_manager.go
+++ b/internal/tools/aws/secrets_manager.go
@@ -207,8 +207,7 @@ func (a *Client) secretsManagerGetIAMAccessKeyFromSecretName(secretName string) 
 	return iamAccessKey, nil
 }
 
-func (a *Client) secretsManagerGetRDSSecret(awsID string, logger log.FieldLogger) (*RDSSecret, error) {
-	secretName := RDSSecretName(awsID)
+func (a *Client) secretsManagerGetRDSSecret(secretName string, logger log.FieldLogger) (*RDSSecret, error) {
 	result, err := a.Service().secretsManager.GetSecretValue(
 		context.TODO(),
 		&secretsmanager.GetSecretValueInput{


### PR DESCRIPTION
#### Summary

This fixes trying to retrieve an incorrect secret name for pgbouncer and multitenant databases.

Relates to: #802 

#### Ticket Link

---

#### Release Note
```release-note
None
```
