### PR TITLE
[MM-49445] Added stacktrace in Error log

### DIFF
--- a/cmd/cloud/logger.go
+++ b/cmd/cloud/logger.go
@@ -5,7 +5,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"runtime"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -33,4 +36,68 @@ func (w *logrusWriter) Write(b []byte) (int, error) {
 
 	w.logger.Warning(string(b))
 	return n, nil
+}
+
+type stacktrace struct {
+}
+
+func enableLogStacktrace() {
+	logger.AddHook(&stacktrace{})
+}
+
+func (s *stacktrace) Levels() []log.Level {
+	return []log.Level{log.ErrorLevel, log.FatalLevel, log.PanicLevel}
+}
+
+func (s *stacktrace) Fire(entry *log.Entry) error {
+	files := getLogCaller(7)
+	if len(files) == 0 {
+		return nil
+	}
+	entry.Data["stacktrace"] = files
+	return nil
+}
+
+func getLogCaller(skip int) string {
+	pcs := make([]uintptr, 25)
+	depth := runtime.Callers(skip, pcs)
+	frames := runtime.CallersFrames(pcs[:depth])
+
+	var files []string
+	acceptedPrefix := "github.com/mattermost/mattermost-cloud/"
+
+	for f, again := frames.Next(); again; f, again = frames.Next() {
+		pkg := getPackageName(f.Function)
+		fileName := getFileName(f.File)
+		if strings.HasPrefix(pkg, acceptedPrefix) {
+			files = append(files, fmt.Sprintf("%s:%d", strings.TrimPrefix(fileName, acceptedPrefix), f.Line))
+		}
+	}
+
+	return strings.Join(files, "; ")
+}
+
+func getFileName(file string) string {
+	parts := strings.Split(file, "/")
+	for i := len(parts) - 1; i >= 0; i-- {
+		if strings.HasSuffix(parts[i], ".com") {
+			return strings.Join(parts[i:], "/")
+		}
+	}
+
+	return file
+}
+
+func getPackageName(f string) string {
+	for {
+		lastPeriod := strings.LastIndex(f, ".")
+		lastSlash := strings.LastIndex(f, "/")
+		if lastPeriod > lastSlash {
+			f = f[:lastPeriod]
+		} else {
+			break
+		}
+	}
+
+	return f
 }

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -62,6 +62,10 @@ func newCmdServer() *cobra.Command {
 		PreRun: func(command *cobra.Command, args []string) {
 			flags.serverFlagChanged.addFlags(command) // To populate flag change variables.
 			deprecationWarnings(logger, command)
+
+			if flags.enableLogStacktrace {
+				enableLogStacktrace()
+			}
 		},
 	}
 	flags.addFlags(cmd)

--- a/cmd/cloud/server_flag.go
+++ b/cmd/cloud/server_flag.go
@@ -186,10 +186,11 @@ type serverFlags struct {
 	listen      string
 	metricsPort int
 
-	debug       bool
-	debugHelm   bool
-	devMode     bool
-	machineLogs bool
+	debug               bool
+	debugHelm           bool
+	devMode             bool
+	machineLogs         bool
+	enableLogStacktrace bool
 
 	database      string
 	maxSchemas    int64
@@ -216,6 +217,7 @@ func (flags *serverFlags) addFlags(command *cobra.Command) {
 	command.Flags().BoolVar(&flags.debugHelm, "debug-helm", false, "Whether to include Helm output in debug logs.")
 	command.Flags().BoolVar(&flags.devMode, "dev", false, "Set sane defaults for development")
 	command.Flags().BoolVar(&flags.machineLogs, "machine-readable-logs", false, "Output the logs in machine readable format.")
+	command.Flags().BoolVar(&flags.enableLogStacktrace, "enable-log-stacktrace", false, "Add stacktrace in error logs.")
 
 	command.Flags().StringVar(&flags.database, "database", "sqlite://cloud.db", "The database backing the provisioning server.")
 	command.Flags().Int64Var(&flags.maxSchemas, "default-max-schemas-per-logical-database", 10, "When importing and creating new proxy multitenant databases, this value is used for MaxInstallationsPerLogicalDatabase.")


### PR DESCRIPTION
#### Summary

To add stacktrace to logs, we must first set the flag.
```
$ cloud server [flags]

Flags:
    --enable-log-stacktrace             Add stacktrace in error logs.
```

This will add the stacktrace if the error type is `error`, `fatal`, or `panic`.

Sample:

```
ERRO[2023-01-06T07:55:57+06:00] Failed to lock installation, status: 404      handler=handleUpdateInstallation installation=f7qjd88xpibxfpf9w63156aeuh instance=cpc81je3sp8txbmit8sse7b94a method=PUT path=/api/installation/f7qjd88xpibxfpf9w63156aeuh/mattermost request=qx4p9ppsk78rzds3ixy1bhgpje stacktrace="internal/api/installation.go:816; internal/api/installation.go:348; internal/api/handler.go:38"
```

Added stacktrace
`stacktrace="internal/api/installation.go:816; internal/api/installation.go:348; internal/api/handler.go:38"`


#### Ticket Link

Resolves [MM-49445](https://mattermost.atlassian.net/browse/MM-49445)

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
