### PR TITLE
Update github ref name with context instead of env

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,12 +1,6 @@
 name: cd
-on:
-  workflow_run:
-    workflows: ["ci"]
-    types:
-      - completed
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+
+on: workflow_call
 
 permissions:
   contents: read

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,4 +28,4 @@ jobs:
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          TAG: ${GITHUB_REF_NAME}
+          TAG: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,11 @@ jobs:
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  cd:
+    needs:
+      - lint
+      - test
+      - build
+    uses: ./.github/workflows/cd.yml
+    if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
#### Summary

Fixes an incorrect environment reference on an action attribute, replacing it for a [context access](https://docs.github.com/en/actions/learn-github-actions/contexts).

From: https://github.com/mattermost/mattermost-cloud/actions/runs/3885573452/jobs/6629615255

#### Ticket Link

--

#### Release Note

```release-note
None
```
