### PR TITLE
[MM-49490] Notify E2E test result via Mattermost webhook

### DIFF
--- a/e2e/pkg/installation.go
+++ b/e2e/pkg/installation.go
@@ -2,7 +2,8 @@
 // See LICENSE.txt for license information.
 //
 
-//+build e2e
+//go:build e2e
+// +build e2e
 
 package pkg
 
@@ -67,7 +68,7 @@ func WaitForStable(client *model.Client, installationID string, log logrus.Field
 
 // WaitForInstallationDeletion waits until Installation reaches Deleted state.
 func WaitForInstallationDeletion(client *model.Client, installationID string, log logrus.FieldLogger) error {
-	err := WaitForFunc(NewWaitConfig(5*time.Minute, 10*time.Second, 2, log), func() (bool, error) {
+	err := WaitForFunc(NewWaitConfig(10*time.Minute, 10*time.Second, 2, log), func() (bool, error) {
 		installation, err := client.GetInstallation(installationID, &model.GetInstallationRequest{})
 		if err != nil {
 			return false, errors.Wrap(err, "while waiting for deletion")
@@ -100,4 +101,3 @@ func PingInstallation(dns string) error {
 func pingURL(dns string) string {
 	return fmt.Sprintf("https://%s/api/v4/system/ping", dns)
 }
-

--- a/e2e/pkg/webhook.go
+++ b/e2e/pkg/webhook.go
@@ -51,7 +51,7 @@ func sendWebhook(ctx context.Context, webhookURL string, payload *webhookPayload
 	return nil
 }
 
-// Send E2EResult sends the webhook with the provided icon and message. Errors on trying to send a
+// SendE2EResult sends the webhook with the provided icon and message. Errors on trying to send a
 // message or if the webhook URL is not provided properly.
 func SendE2EResult(ctx context.Context, icon, text string) error {
 	webhookURL := os.Getenv("WEBHOOK_URL")

--- a/e2e/pkg/webhook.go
+++ b/e2e/pkg/webhook.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package pkg
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+
+	"emperror.dev/errors"
+)
+
+type webhookPayload struct {
+	Username  string `json:"username"`
+	IconURL   string `json:"icon_url"`
+	IconEmoji string `json:"icon_emoji"`
+	Text      string `json:"text"`
+}
+
+// sendWebhook sends a Mattermost webhook to the provided URL.
+func sendWebhook(ctx context.Context, webhookURL string, payload *webhookPayload) error {
+	if len(payload.Username) == 0 {
+		return errors.New("payload username value not set")
+	}
+	if len(payload.Text) == 0 {
+		return errors.New("payload text value not set")
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal payload")
+	}
+	body := bytes.NewReader(payloadBytes)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to send webhook")
+	}
+
+	return nil
+}
+
+// Send E2EResult sends the webhook with the provided icon and message. Errors on trying to send a
+// message or if the webhook URL is not provided properly.
+func SendE2EResult(ctx context.Context, icon, text string) error {
+	webhookURL := os.Getenv("WEBHOOK_URL")
+	_, err := url.ParseRequestURI(webhookURL)
+	if err != nil {
+		return errors.New("incorrect or empty webhook url")
+	}
+
+	payload := webhookPayload{
+		Username:  "E2E",
+		IconEmoji: icon,
+		Text:      text,
+	}
+
+	if err := sendWebhook(ctx, webhookURL, &payload); err != nil {
+		return errors.Wrap(err, "error sending notification webhook")
+	}
+
+	return nil
+}

--- a/e2e/tests/cluster/suite.go
+++ b/e2e/tests/cluster/suite.go
@@ -9,6 +9,7 @@ package cluster
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/mattermost/mattermost-cloud/e2e/pkg/eventstest"
 
 	"github.com/mattermost/mattermost-cloud/clusterdictionary"
@@ -32,7 +33,8 @@ type TestConfig struct {
 	WebhookAddress            string `envconfig:"default=http://localhost:11111"`
 	EventListenerAddress      string `envconfig:"default=http://localhost:11112"`
 	FetchAMI                  bool   `envconfig:"default=true"`
-	Cleanup                   bool   `envconfig:"default=true"`
+	KopsAMI                   string
+	Cleanup                   bool `envconfig:"default=true"`
 }
 
 // Test holds all data required for a db migration test.
@@ -66,6 +68,7 @@ func SetupClusterLifecycleTest() (*Test, error) {
 	createClusterReq := &model.CreateClusterRequest{
 		AllowInstallations: true,
 		Annotations:        testAnnotations(testID),
+		KopsAMI:            config.KopsAMI,
 	}
 
 	// If specified, we fetch AMI from existing clusters.
@@ -75,6 +78,8 @@ func SetupClusterLifecycleTest() (*Test, error) {
 			return nil, errors.Wrap(err, "failed to fetch AMI")
 		}
 		createClusterReq.KopsAMI = ami
+	} else if config.KopsAMI != "" {
+		createClusterReq.KopsAMI = config.KopsAMI
 	}
 
 	err = clusterdictionary.ApplyToCreateClusterRequest("SizeAlef1000", createClusterReq)

--- a/e2e/workflow/installation.go
+++ b/e2e/workflow/installation.go
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 //
 
+//go:build e2e
 // +build e2e
 
 package workflow
@@ -276,6 +277,24 @@ func (w *InstallationSuite) InstallationDeletionEvents() []eventstest.EventOccur
 			ResourceType: model.TypeInstallation.String(),
 			ResourceID:   w.Meta.InstallationID,
 			OldState:     model.InstallationStateStable,
+			NewState:     model.InstallationStateDeletionPendingRequested,
+		},
+		{
+			ResourceType: model.TypeInstallation.String(),
+			ResourceID:   w.Meta.InstallationID,
+			OldState:     model.InstallationStateDeletionPendingRequested,
+			NewState:     model.InstallationStateDeletionPendingInProgress,
+		},
+		{
+			ResourceType: model.TypeInstallation.String(),
+			ResourceID:   w.Meta.InstallationID,
+			OldState:     model.InstallationStateDeletionPendingInProgress,
+			NewState:     model.InstallationStateDeletionPending,
+		},
+		{
+			ResourceType: model.TypeInstallation.String(),
+			ResourceID:   w.Meta.InstallationID,
+			OldState:     model.InstallationStateDeletionPending,
 			NewState:     model.InstallationStateDeletionRequested,
 		},
 		{


### PR DESCRIPTION
#### Summary

- Handle success/failure Mattermost notification directly in the E2E tests via a webhook
- Give more time to the installation deletion timeout test
- Fix the installation events (some where missing)
- Allow specifying a custom `KopsAMI` on cluster creation

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49490

#### Running locally

```
$ export FETCHAMI=false
$ export KOPSAMI=ami-03527780a0be4af06
$ export WEBHOOK_URL=<a webhook setup in a mattermost instance>
$ make e2e-cluster

--- PASS: Test_ClusterLifecycle (1931.03s)
PASS
ok      github.com/mattermost/mattermost-cloud/e2e/tests/cluster        1931.989s
```

![Screenshot 2023-01-12 at 18 43 20](https://user-images.githubusercontent.com/812088/212140373-3427fed0-41e1-492f-bf7f-7d9056a73410.png)

#### Release Note

```release-note
None
```
