### PR TITLE
Fix latest tag docker push and ignore CD on master

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,7 @@ name: cd
 on:
   workflow_run:
     workflows: ["ci"]
+    branches-ignore: [master]
     types:
       - completed
   push:
@@ -28,4 +29,4 @@ jobs:
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          TAG: ${GITHUB_REF_NAME}
+          TAG: ${{ github.ref_name }}

--- a/scripts/push-docker.sh
+++ b/scripts/push-docker.sh
@@ -7,6 +7,10 @@ set -euox
 
 echo $DOCKERHUB_TOKEN | docker login --username $DOCKERHUB_USERNAME --password-stdin
 
+if [ "$TAG" = "master" ] || [ "$TAG" = "main" ]; then
+    TAG=latest
+fi
+
 docker tag mattermost/mattermost-cloud:test mattermost/mattermost-cloud:$TAG
 docker tag mattermost/mattermost-cloud-e2e:test mattermost/mattermost-cloud-e2e:$TAG
 


### PR DESCRIPTION
#### Summary
We removed the latest tag during the migration and now we return it back for docker images. In parallel we ignore CD during master branch.


#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-4840

#### Release Note
```release-note
NONE
```
