### PR TITLE
[MM-49661] Fixed retrieval of DNS Record Sets

### DIFF
--- a/internal/provisioner/thanos.go
+++ b/internal/provisioner/thanos.go
@@ -135,14 +135,14 @@ func (t *thanos) Destroy() error {
 	app := "thanos"
 	dns := fmt.Sprintf("%s.%s.%s", t.cluster.ID, app, privateDomainName)
 
-	logger.Infof("Deleting Route53 DNS Record for %s", app)
+	logger.WithField("dns", dns).Infof("Deleting Route53 DNS Record for %s", app)
 	err = t.awsClient.DeletePrivateCNAME(dns, logger.WithField("thanos-dns-delete", dns))
 	if err != nil {
 		return errors.Wrap(err, "failed to delete Route53 DNS record")
 	}
 
 	grpcDNS := fmt.Sprintf("%s-grpc.%s.%s", t.cluster.ID, app, privateDomainName)
-	logger.Infof("Deleting GRPC Route53 DNS Record for %s", app)
+	logger.WithField("grpcDNS", grpcDNS).Infof("Deleting GRPC Route53 DNS Record for %s", app)
 	err = t.awsClient.DeletePrivateCNAME(grpcDNS, logger.WithField("thanos-dns-delete", grpcDNS))
 	if err != nil {
 		return errors.Wrap(err, "failed to delete GRPC Route53 DNS record")

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -385,12 +385,14 @@ func (a *Client) deleteCNAME(hostedZoneID, dnsName string, logger log.FieldLogge
 		return errors.Wrapf(err, "failed to get record sets for dns name %s", dnsName)
 	}
 
+	var changesLog string
 	var changes []types.Change
 	for _, recordSet := range recordSets {
 		changes = append(changes, types.Change{
 			Action:            types.ChangeActionDelete,
 			ResourceRecordSet: recordSet,
 		})
+		changesLog += fmt.Sprintf("%s(%v) ", recordSet.Type, recordSet.Name)
 	}
 	if len(changes) == 0 {
 		logger.Warn("Unable to find any DNS records; skipping...")
@@ -412,6 +414,7 @@ func (a *Client) deleteCNAME(hostedZoneID, dnsName string, logger log.FieldLogge
 		"route53-records-deleted": len(changes),
 		"route53-dns-value":       dnsName,
 		"route53-hosted-zone-id":  hostedZoneID,
+		"route53-changes":         changesLog,
 	}).Debugf("AWS route53 delete response: %s", prettyRoute53Response(resp))
 
 	return nil

--- a/internal/tools/aws/route53.go
+++ b/internal/tools/aws/route53.go
@@ -446,7 +446,8 @@ func (a *Client) getRecordSetsForDNS(hostedZoneID, dnsName string) ([]*types.Res
 
 	for _, recordSet := range recordList.ResourceRecordSets {
 		if strings.TrimRight(*recordSet.Name, ".") == dnsName {
-			recordSets = append(recordSets, &recordSet)
+			rs := recordSet
+			recordSets = append(recordSets, &rs)
 		}
 	}
 


### PR DESCRIPTION
#### Summary

Fixed an `exportloopref` in the record set DNS list from Route 53 and added some extra logging to help debugging in the future.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49661

#### Release Note

```release-note
Fixed DNS record set retrieval
```
