### PR TITLE
Fix docker push for tags

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
         run: make build-image build-image-e2e
 
       - name: cd/docker-push
-        run: COMMIT_SHA=${GITHUB_SHA:0:7} ./scripts/push-docker.sh
+        run: TAG=${GITHUB_REF_NAME} ./scripts/push-docker.sh
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: ci/docker-push
         run: |
-          COMMIT_SHA=${GITHUB_SHA:0:7} ./scripts/push-docker.sh
+          TAG=${GITHUB_SHA:0:7} ./scripts/push-docker.sh
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/scripts/push-docker.sh
+++ b/scripts/push-docker.sh
@@ -7,18 +7,18 @@ set -euox
 
 echo $DOCKERHUB_TOKEN | docker login --username $DOCKERHUB_USERNAME --password-stdin
 
-if [ "$COMMIT_SHA" = "" ]; then
-    echo "COMMIT_SHA was not provided"
+if [ "$TAG" = "" ]; then
+    echo "TAG was not provided"
     exit 1
 fi
 
-echo "Tagging images with SHA $COMMIT_SHA"
+echo "Tagging images with SHA $TAG"
 
-docker tag mattermost/mattermost-cloud:test mattermost/mattermost-cloud:$COMMIT_SHA
-docker tag mattermost/mattermost-cloud-e2e:test mattermost/mattermost-cloud-e2e:$COMMIT_SHA
+docker tag mattermost/mattermost-cloud:test mattermost/mattermost-cloud:$TAG
+docker tag mattermost/mattermost-cloud-e2e:test mattermost/mattermost-cloud-e2e:$TAG
 
-docker push mattermost/mattermost-cloud:$COMMIT_SHA
-docker push mattermost/mattermost-cloud-e2e:$COMMIT_SHA
+docker push mattermost/mattermost-cloud:$TAG
+docker push mattermost/mattermost-cloud-e2e:$TAG
 
 if [ "$REF_NAME" = "master" ] || [ "$REF_NAME" = "main" ]; then
     echo "Tagging images with 'latest' tag"


### PR DESCRIPTION
#### Summary
Changed the `COMMITA_SHA` to `TAG` to reflect the reality of the name and in CD workflow we use github ref name.

#### Release Note
```release-note
NONE
```
