### PR TITLE
AWS multitenant database cleanup and tests

### DIFF
--- a/internal/tools/aws/database_multitenant_test.go
+++ b/internal/tools/aws/database_multitenant_test.go
@@ -35,7 +35,7 @@ func (a *AWSTestSuite) TestProvisioningMultitenantDatabase() {
 		false,
 	)
 
-	databaseType := database.DatabaseTypeTagValue()
+	databaseType := database.DatabaseEngineTypeTagValue()
 
 	var databaseID string
 
@@ -88,6 +88,18 @@ func (a *AWSTestSuite) TestProvisioningMultitenantDatabase() {
 				a.Assert().Equal(input.ResourceTypeFilters, []string{DefaultResourceTypeClusterRDS})
 				tagFilter := []gtTypes.TagFilter{
 					{
+						Key:    aws.String("DatabaseType"),
+						Values: []string{"multitenant-rds"},
+					},
+					{
+						Key:    aws.String(trimTagPrefix(CloudInstallationDatabaseTagKey)),
+						Values: []string{databaseType},
+					},
+					{
+						Key:    aws.String("VpcID"),
+						Values: []string{a.VPCa},
+					},
+					{
 						Key:    aws.String("Purpose"),
 						Values: []string{"provisioning"},
 					},
@@ -98,18 +110,6 @@ func (a *AWSTestSuite) TestProvisioningMultitenantDatabase() {
 					{
 						Key:    aws.String("Terraform"),
 						Values: []string{"true"},
-					},
-					{
-						Key:    aws.String("DatabaseType"),
-						Values: []string{"multitenant-rds"},
-					},
-					{
-						Key:    aws.String("VpcID"),
-						Values: []string{a.VPCa},
-					},
-					{
-						Key:    aws.String(trimTagPrefix(CloudInstallationDatabaseTagKey)),
-						Values: []string{databaseType},
 					},
 					{
 						Key: aws.String("Counter"),

--- a/internal/tools/aws/helpers_sql.go
+++ b/internal/tools/aws/helpers_sql.go
@@ -173,3 +173,13 @@ func dropSchemaIfExists(ctx context.Context, db SQLDatabaseManager, schemaName s
 
 	return nil
 }
+
+func ensureDefaultTextSearchConfig(ctx context.Context, db SQLDatabaseManager, databaseName string) error {
+	query := fmt.Sprintf(`ALTER DATABASE %s SET default_text_search_config TO "pg_catalog.english";`, databaseName)
+	_, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "failed to run SQL command to set default_text_search_config to pg_catalog.english")
+	}
+
+	return nil
+}

--- a/internal/tools/aws/helpers_test.go
+++ b/internal/tools/aws/helpers_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStandardMultitenantDatabaseTagFilters(t *testing.T) {
+	databaseType := DefaultRDSMultitenantDatabasePerseusTypeTagValue
+	engineType := DatabaseTypePostgresSQLAurora
+	vpcID := model.NewID()
+
+	tagFilters := standardMultitenantDatabaseTagFilters(databaseType, engineType, vpcID)
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(DefaultRDSMultitenantDatabaseTypeTagKey), databaseType, tagFilters))
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(CloudInstallationDatabaseTagKey), engineType, tagFilters))
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(VpcIDTagKey), vpcID, tagFilters))
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(RDSMultitenantPurposeTagKey), RDSMultitenantPurposeTagValueProvisioning, tagFilters))
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(RDSMultitenantOwnerTagKey), RDSMultitenantOwnerTagValueCloudTeam, tagFilters))
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(DefaultAWSTerraformProvisionedKey), DefaultAWSTerraformProvisionedValueTrue, tagFilters))
+	assert.False(t, ensureTagFilterInFilterSet(trimTagPrefix("key"), "value", tagFilters))
+
+	databaseType = DefaultRDSMultitenantDatabaseDBProxyTypeTagValue
+	vpcID = model.NewID()
+
+	tagFilters = standardMultitenantDatabaseTagFilters(databaseType, engineType, vpcID)
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(DefaultRDSMultitenantDatabaseTypeTagKey), databaseType, tagFilters))
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(CloudInstallationDatabaseTagKey), engineType, tagFilters))
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(VpcIDTagKey), vpcID, tagFilters))
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(RDSMultitenantPurposeTagKey), RDSMultitenantPurposeTagValueProvisioning, tagFilters))
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(RDSMultitenantOwnerTagKey), RDSMultitenantOwnerTagValueCloudTeam, tagFilters))
+	assert.True(t, ensureTagFilterInFilterSet(trimTagPrefix(DefaultAWSTerraformProvisionedKey), DefaultAWSTerraformProvisionedValueTrue, tagFilters))
+	assert.False(t, ensureTagFilterInFilterSet(trimTagPrefix("key"), "value", tagFilters))
+}


### PR DESCRIPTION
This change includes the following:
 - Standardizes matching SQL queries between Perseus and PGBouncer.
 - Standardizes shared tag filter logic between Perseus, PGBouncer and standard multitenant database lookup.
 - Adds tests for shared tag filter helper.

Partially fixes https://mattermost.atlassian.net/browse/MM-49699

```release-note
AWS multitenant database cleanup and tests
```
