### PR TITLE
[MM-49713] Enable rotator on resize operations when kops require rolling-updates

### DIFF
--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -548,16 +548,23 @@ func (provisioner *KopsProvisioner) ResizeCluster(cluster *model.Cluster, awsCli
 		return err
 	}
 
-	// TODO: Find out where to put this logic correctly
-	// if cluster.ProvisionerMetadataKops.RotatorRequest.Config != nil {
-	// 	if *cluster.ProvisionerMetadataKops.RotatorRequest.Config.UseRotator {
-	// 		logger.Info("Using node rotator for node resize")
-	// 		err = provisioner.RotateClusterNodes(cluster)
-	// 		if err != nil {
-	// 			return err
-	// 		}
-	// 	}
-	// }
+	requiresRollingUpdate, err := kops.RollingUpdateClusterRequired(kopsMetadata.Name)
+	if err != nil {
+		return err
+	}
+
+	if requiresRollingUpdate {
+		logger.Info("Rolling update is required")
+		if cluster.ProvisionerMetadataKops.RotatorRequest.Config != nil {
+			if *cluster.ProvisionerMetadataKops.RotatorRequest.Config.UseRotator {
+				logger.Info("Using node rotator for node resize")
+				err = provisioner.RotateClusterNodes(cluster)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
 
 	err = kops.RollingUpdateCluster(kopsMetadata.Name)
 	if err != nil {

--- a/internal/provisioner/kops_provisioner_cluster.go
+++ b/internal/provisioner/kops_provisioner_cluster.go
@@ -550,12 +550,12 @@ func (provisioner *KopsProvisioner) ResizeCluster(cluster *model.Cluster, awsCli
 		return err
 	}
 
-	requiresRollingUpdate, err := kops.RollingUpdateClusterRequired(kopsMetadata.Name)
+	requiresClusterRotation, err := kops.RollingUpdateClusterRequired(kopsMetadata.Name)
 	if err != nil {
 		return err
 	}
 
-	if requiresRollingUpdate {
+	if requiresClusterRotation {
 		logger.Info("Rolling update is required")
 		if cluster.ProvisionerMetadataKops.RotatorRequest.Config != nil {
 			if *cluster.ProvisionerMetadataKops.RotatorRequest.Config.UseRotator {

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -5,6 +5,7 @@
 package kops
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -92,15 +93,29 @@ func (c *Cmd) SetCluster(name, setValue string) error {
 	return nil
 }
 
+// RollingUpdateClusterRequired invokes kops rolling-update using the context of the cmd on the
+// provided cluster name in dry-run mode to check if a rolling update is required or not.
+// This is used to know if rotator needs to be enabled when performing cluster mutation operations.
+func (c *Cmd) RollingUpdateClusterRequired(name string) (bool, error) {
+	rollingUpdateRequired := true
+	stdout, _, err := c.rollingUpdateCluster(name, true)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to invoke kops rolling-update cluster dry-run")
+	}
+
+	for _, line := range bytes.Split(stdout, []byte("\n")) {
+		if strings.Contains(string(line), "No rolling-update required.") {
+			rollingUpdateRequired = false
+			break
+		}
+	}
+
+	return rollingUpdateRequired, nil
+}
+
 // RollingUpdateCluster invokes kops rolling-update cluster, using the context of the created Cmd.
 func (c *Cmd) RollingUpdateCluster(name string) error {
-	_, _, err := c.run(
-		"rolling-update",
-		"cluster",
-		arg("name", name),
-		arg("state", "s3://", c.s3StateStore),
-		"--yes",
-	)
+	_, _, err := c.rollingUpdateCluster(name, false)
 	if err != nil {
 		return errors.Wrap(err, "failed to invoke kops rolling-update cluster")
 	}
@@ -108,9 +123,23 @@ func (c *Cmd) RollingUpdateCluster(name string) error {
 	return nil
 }
 
+func (c *Cmd) rollingUpdateCluster(name string, dryRun bool) ([]byte, []byte, error) {
+	args := []string{
+		"rolling-update",
+		"cluster",
+		arg("name", name),
+		arg("state", "s3://", c.s3StateStore),
+	}
+	if !dryRun {
+		args = append(args, "--yes")
+	}
+
+	return c.run(args...)
+}
+
 // UpdateCluster invokes kops update cluster, using the context of the created Cmd.
 func (c *Cmd) UpdateCluster(name, dir string) error {
-	_, _, err := c.run(
+	stdout, _, err := c.run(
 		"update",
 		"cluster",
 		arg("name", name),
@@ -122,6 +151,12 @@ func (c *Cmd) UpdateCluster(name, dir string) error {
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to invoke kops update cluster")
+	}
+
+	for _, line := range bytes.Split(stdout, []byte("\n")) {
+		if bytes.Contains(line, []byte("Apply complete!")) {
+			c.logger.Warnf("%s", string(line))
+		}
 	}
 
 	return nil

--- a/internal/tools/kops/cluster.go
+++ b/internal/tools/kops/cluster.go
@@ -139,7 +139,7 @@ func (c *Cmd) rollingUpdateCluster(name string, dryRun bool) ([]byte, []byte, er
 
 // UpdateCluster invokes kops update cluster, using the context of the created Cmd.
 func (c *Cmd) UpdateCluster(name, dir string) error {
-	stdout, _, err := c.run(
+	_, _, err := c.run(
 		"update",
 		"cluster",
 		arg("name", name),
@@ -151,12 +151,6 @@ func (c *Cmd) UpdateCluster(name, dir string) error {
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to invoke kops update cluster")
-	}
-
-	for _, line := range bytes.Split(stdout, []byte("\n")) {
-		if bytes.Contains(line, []byte("Apply complete!")) {
-			c.logger.Warnf("%s", string(line))
-		}
 	}
 
 	return nil

--- a/internal/tools/kops/run.go
+++ b/internal/tools/kops/run.go
@@ -64,7 +64,7 @@ func outputLogger(line string, logger log.FieldLogger) {
 	}
 }
 
-func (c *Cmd) run(arg ...string) ([]byte, []byte, error) {
+func (c *Cmd) run(arg ...string) (stdout []byte, stderr []byte, err error) {
 	cmd := exec.Command(c.kopsPath, arg...)
 	cmd.Env = append(
 		os.Environ(),


### PR DESCRIPTION
#### Summary

Determine when to use rotator on cluster resize by performing a `kops rolling-update cluster` in dry-run mode first and analyzing the output. If the output says: "_No rolling-update required._" then we can avoid enabling and running the rotator and just invoke `kops` as usual. If that is not present, we enable and run the rotator previous to the `kops` call so the nodes are handled by the rotator instead of by kops.

This is an ugly way of checking if kops is about to rotate the nodes, but since that command doesn't support JSON output (or any machine-friendly output), this is the easiest way I found to get that information out of it.

Unsure if this also applies to [upgrade](https://github.com/mattermost/mattermost-cloud/blob/master/internal/provisioner/kops_provisioner_cluster.go#L293) as well.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49713

#### Release Note

```release-note
Fixes rotator usage on cluster resize operations
```
