### PR TITLE
Add installation deletion pending expiration control

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -235,7 +235,6 @@ func newCmdInstallationUpdateDeletion() *cobra.Command {
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			flags.clusterFlags.addFlags(cmd)
-			return
 		},
 	}
 	flags.addFlags(cmd)

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -214,7 +214,6 @@ func newCmdInstallationUpdateDeletion() *cobra.Command {
 		Short: "Updates the pending deletion parameters of an installation.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			flags.installationDeletionPatchRequestOptionsChanged.addFlags(command)
 			client := model.NewClient(flags.serverAddress)
 
 			request := &model.PatchInstallationDeletionRequest{}
@@ -236,6 +235,7 @@ func newCmdInstallationUpdateDeletion() *cobra.Command {
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			flags.clusterFlags.addFlags(cmd)
+			flags.installationDeletionPatchRequestOptionsChanged.addFlags(cmd)
 		},
 	}
 	flags.addFlags(cmd)
@@ -831,7 +831,7 @@ func executeInstallationDeploymentReportCmd(flags installationDeploymentReportFl
 			return err
 		}
 		for _, event := range events {
-			output += fmt.Sprintf("%s - %s > %s\n", model.CompleteTimeStringFromMillis(event.Event.Timestamp), event.StateChange.OldState, event.StateChange.NewState)
+			output += fmt.Sprintf("%s - %s > %s\n", model.DateTimeStringFromMillis(event.Event.Timestamp), event.StateChange.OldState, event.StateChange.NewState)
 		}
 	}
 

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -214,10 +214,11 @@ func newCmdInstallationUpdateDeletion() *cobra.Command {
 		Short: "Updates the pending deletion parameters of an installation.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
+			flags.installationDeletionPatchRequestOptionsChanged.addFlags(command)
 			client := model.NewClient(flags.serverAddress)
 
 			request := &model.PatchInstallationDeletionRequest{}
-			if command.Flags().Changed("future-expiry") {
+			if flags.installationDeletionPatchRequestOptionsChanged.futureDeletionTimeChanged {
 				newExpiryTimeMillis := model.GetMillisAtTime(time.Now().Add(flags.futureDeletionTime))
 				request.DeletionPendingExpiry = &newExpiryTimeMillis
 			}

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	awsTools "github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/model"
@@ -29,6 +30,7 @@ func newCmdInstallation() *cobra.Command {
 	cmd.AddCommand(newCmdInstallationCreate())
 	cmd.AddCommand(newCmdInstallationUpdate())
 	cmd.AddCommand(newCmdInstallationDelete())
+	cmd.AddCommand(newCmdInstallationUpdateDeletion())
 	cmd.AddCommand(newCmdInstallationCancelDeletion())
 	cmd.AddCommand(newCmdInstallationHibernate())
 	cmd.AddCommand(newCmdInstallationWakeup())
@@ -136,7 +138,7 @@ func newCmdInstallationUpdate() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update an installation's configuration",
+		Short: "Update an installation's configuration.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 			client := model.NewClient(flags.serverAddress)
@@ -195,6 +197,43 @@ func newCmdInstallationDelete() *cobra.Command {
 				return errors.Wrap(err, "failed to delete installation")
 			}
 			return nil
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.clusterFlags.addFlags(cmd)
+			return
+		},
+	}
+	flags.addFlags(cmd)
+
+	return cmd
+}
+
+func newCmdInstallationUpdateDeletion() *cobra.Command {
+	var flags installationUpdateDeletionFlags
+
+	cmd := &cobra.Command{
+		Use:   "update-deletion",
+		Short: "Updates the pending deletion parameters of an installation.",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+			client := model.NewClient(flags.serverAddress)
+
+			request := &model.PatchInstallationDeletionRequest{}
+			if command.Flags().Changed("future-expiry") {
+				newExpiryTimeMillis := model.GetMillisAtTime(time.Now().Add(flags.futureDeletionTime))
+				request.DeletionPendingExpiry = &newExpiryTimeMillis
+			}
+
+			if flags.dryRun {
+				return runDryRun(request)
+			}
+
+			installation, err := client.UpdateInstallationDeletion(flags.installationID, request)
+			if err != nil {
+				return errors.Wrap(err, "failed to update installation deletion parameters")
+			}
+
+			return printJSON(installation)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			flags.clusterFlags.addFlags(cmd)
@@ -670,8 +709,11 @@ func executeInstallationDeploymentReportCmd(flags installationDeploymentReportFl
 	output := fmt.Sprintf("Installation: %s\n", installation.ID)
 	output += fmt.Sprintf(" ├ Created: %s\n", installation.CreationDateString())
 	output += fmt.Sprintf(" ├ State: %s\n", installation.State)
-	if installation.State == model.InstallationStateDeleted {
+	switch installation.State {
+	case model.InstallationStateDeleted:
 		output += fmt.Sprintf(" │ └ Deleted: %s\n", installation.DeletionDateString())
+	case model.InstallationStateDeletionPending:
+		output += fmt.Sprintf(" │ └ Scheduled Deletion: %s\n", installation.DeletionPendingExpiryCompleteTimeString())
 	}
 	output += fmt.Sprintf(" ├ DNS: %s\n", installation.DNS)
 	output += fmt.Sprintf(" ├ Version: %s:%s\n", installation.Image, installation.Version)
@@ -793,7 +835,7 @@ func executeInstallationDeploymentReportCmd(flags installationDeploymentReportFl
 			return err
 		}
 		for _, event := range events {
-			output += fmt.Sprintf("%s - %s > %s\n", model.TimeFromMillis(event.Event.Timestamp).Format("2006-01-02 15:04:05 MST"), event.StateChange.OldState, event.StateChange.NewState)
+			output += fmt.Sprintf("%s - %s > %s\n", model.CompleteTimeStringFromMillis(event.Event.Timestamp), event.StateChange.OldState, event.StateChange.NewState)
 		}
 	}
 

--- a/cmd/cloud/installation_flag.go
+++ b/cmd/cloud/installation_flag.go
@@ -131,9 +131,18 @@ func (flags *installationDeletionPatchRequestOptions) addFlags(command *cobra.Co
 	command.Flags().DurationVar(&flags.futureDeletionTime, "future-expiry", 0, "The amount of time from now when the installation can be deleted (0s for immediate deletion)")
 }
 
+type installationDeletionPatchRequestOptionsChanged struct {
+	futureDeletionTimeChanged bool
+}
+
+func (flags *installationDeletionPatchRequestOptionsChanged) addFlags(command *cobra.Command) {
+	flags.futureDeletionTimeChanged = command.Flags().Changed("future-expiry")
+}
+
 type installationUpdateDeletionFlags struct {
 	clusterFlags
 	installationDeletionPatchRequestOptions
+	installationDeletionPatchRequestOptionsChanged
 	installationID string
 }
 

--- a/cmd/cloud/installation_flag.go
+++ b/cmd/cloud/installation_flag.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/spf13/cobra"
 )
@@ -118,6 +120,26 @@ type installationDeleteFlags struct {
 
 func (flags *installationDeleteFlags) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to be deleted.")
+	_ = command.MarkFlagRequired("installation")
+}
+
+type installationDeletionPatchRequestOptions struct {
+	futureDeletionTime time.Duration
+}
+
+func (flags *installationDeletionPatchRequestOptions) addFlags(command *cobra.Command) {
+	command.Flags().DurationVar(&flags.futureDeletionTime, "future-expiry", 0, "The amount of time from now when the installation can be deleted (0s for immediate deletion)")
+}
+
+type installationUpdateDeletionFlags struct {
+	clusterFlags
+	installationDeletionPatchRequestOptions
+	installationID string
+}
+
+func (flags *installationUpdateDeletionFlags) addFlags(command *cobra.Command) {
+	flags.installationDeletionPatchRequestOptions.addFlags(command)
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to update pending deletion parameters for.")
 	_ = command.MarkFlagRequired("installation")
 }
 

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -418,15 +418,16 @@ func executeServerCmd(flags serverFlags) error {
 	router := mux.NewRouter()
 
 	api.Register(router, &api.Context{
-		Store:         sqlStore,
-		Supervisor:    standardSupervisor,
-		Provisioner:   clusterProvisioner,
-		DBProvider:    resourceUtil,
-		EventProducer: eventsProducer,
-		Environment:   awsClient.GetCloudEnvironmentName(),
-		AwsClient:     awsClient,
-		Metrics:       cloudMetrics,
-		Logger:        logger,
+		Store:                             sqlStore,
+		Supervisor:                        standardSupervisor,
+		Provisioner:                       clusterProvisioner,
+		DBProvider:                        resourceUtil,
+		EventProducer:                     eventsProducer,
+		Environment:                       awsClient.GetCloudEnvironmentName(),
+		AwsClient:                         awsClient,
+		Metrics:                           cloudMetrics,
+		InstallationDeletionExpiryDefault: flags.installationDeletionPendingTime,
+		Logger:                            logger,
 	})
 
 	srv := &http.Server{

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -5,6 +5,8 @@
 package api
 
 import (
+	"time"
+
 	"github.com/mattermost/mattermost-cloud/internal/events"
 	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/mattermost/mattermost-cloud/model"
@@ -162,28 +164,30 @@ type Metrics interface {
 //
 // It is cloned before each request, allowing per-request changes such as logger annotations.
 type Context struct {
-	Store         Store
-	Supervisor    Supervisor
-	Provisioner   Provisioner
-	DBProvider    DBProvider
-	EventProducer EventProducer
-	AwsClient     AwsClient
-	Metrics       Metrics
-	Logger        log.FieldLogger
-	RequestID     string
-	Environment   string
+	Store                             Store
+	Supervisor                        Supervisor
+	Provisioner                       Provisioner
+	DBProvider                        DBProvider
+	EventProducer                     EventProducer
+	AwsClient                         AwsClient
+	Metrics                           Metrics
+	Logger                            log.FieldLogger
+	InstallationDeletionExpiryDefault time.Duration
+	RequestID                         string
+	Environment                       string
 }
 
 // Clone creates a shallow copy of context, allowing clones to apply per-request changes.
 func (c *Context) Clone() *Context {
 	return &Context{
-		Store:         c.Store,
-		Supervisor:    c.Supervisor,
-		Provisioner:   c.Provisioner,
-		DBProvider:    c.DBProvider,
-		EventProducer: c.EventProducer,
-		AwsClient:     c.AwsClient,
-		Metrics:       c.Metrics,
-		Logger:        c.Logger,
+		Store:                             c.Store,
+		Supervisor:                        c.Supervisor,
+		Provisioner:                       c.Provisioner,
+		DBProvider:                        c.DBProvider,
+		EventProducer:                     c.EventProducer,
+		AwsClient:                         c.AwsClient,
+		Metrics:                           c.Metrics,
+		Logger:                            c.Logger,
+		InstallationDeletionExpiryDefault: c.InstallationDeletionExpiryDefault,
 	}
 }

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/mattermost/mattermost-cloud/internal/common"
 
@@ -43,7 +44,8 @@ func initInstallation(apiRouter *mux.Router, context *Context) {
 	installationRouter.Handle("/hibernate", addContext(handleHibernateInstallation)).Methods("POST")
 	installationRouter.Handle("/wakeup", addContext(handleWakeupInstallation)).Methods("POST")
 	installationRouter.Handle("", addContext(handleDeleteInstallation)).Methods("DELETE")
-	installationRouter.Handle("/cancel_deletion", addContext(handleCancelDeletion)).Methods("POST")
+	installationRouter.Handle("/deletion", addContext(handleUpdateInstallationDeletion)).Methods("PUT")
+	installationRouter.Handle("/deletion/cancel", addContext(handleCancelInstallationDeletion)).Methods("POST")
 	installationRouter.Handle("/annotations", addContext(handleAddInstallationAnnotations)).Methods("POST")
 	installationRouter.Handle("/annotation/{annotation-name}", addContext(handleDeleteInstallationAnnotation)).Methods("DELETE")
 
@@ -629,11 +631,23 @@ func handleDeleteInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	err = updateInstallationState(c, installationDTO, newState)
+	if newState == model.InstallationStateDeletionPendingRequested {
+		// Set DeletionPendingExpiry to now+InstallationDeletionExpiryDefault
+		installationDTO.DeletionPendingExpiry = model.GetMillisAtTime(time.Now().Add(c.InstallationDeletionExpiryDefault))
+	}
+
+	oldState := installationDTO.State
+	installationDTO.State = newState
+	err = c.Store.UpdateInstallation(installationDTO.Installation)
 	if err != nil {
-		c.Logger.WithError(err).Errorf("failed to update installation state to %q", newState)
+		c.Logger.WithError(err).Error("failed to update installation")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
+	}
+
+	err = c.EventProducer.ProduceInstallationStateChangeEvent(installationDTO.Installation, oldState)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to create installation state change event")
 	}
 
 	unlockOnce()
@@ -642,9 +656,46 @@ func handleDeleteInstallation(c *Context, w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusAccepted)
 }
 
-// handleCancelDeletion responds to POST /api/installation/{installation}/cancel_deletion,
+// handleUpdateInstallationDeletion responds to PUT /api/installation/{installation}/deletion,
+// beginning the process of updating the configuration of an upcoming deletion.
+func handleUpdateInstallationDeletion(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	installationID := vars["installation"]
+	c.Logger = c.Logger.WithField("installation", installationID)
+
+	patchInstallationDeletionRequest, err := model.NewPatchInstallationDeletionRequestFromReader(r.Body)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to decode request")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	newState := model.InstallationStateDeletionCancellationRequested
+
+	installationDTO, status, unlockOnce := getInstallationForTransition(c, installationID, newState)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	if patchInstallationDeletionRequest.Apply(installationDTO.Installation) {
+		err := c.Store.UpdateInstallation(installationDTO.Installation)
+		if err != nil {
+			c.Logger.WithError(err).Error("failed to update installation")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	outputJSON(c, w, installationDTO)
+}
+
+// handleCancelInstallationDeletion responds to POST /api/installation/{installation}/deletion/cancel,
 // beginning the process of cancelling the pending deletion of the installation.
-func handleCancelDeletion(c *Context, w http.ResponseWriter, r *http.Request) {
+func handleCancelInstallationDeletion(c *Context, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	installationID := vars["installation"]
 	c.Logger = c.Logger.WithField("installation", installationID)

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -670,7 +670,8 @@ func handleUpdateInstallationDeletion(c *Context, w http.ResponseWriter, r *http
 		return
 	}
 
-	newState := model.InstallationStateDeletionCancellationRequested
+	// State won't change for this type of update.
+	newState := model.InstallationStateDeletionPending
 
 	installationDTO, status, unlockOnce := getInstallationForTransition(c, installationID, newState)
 	if status != 0 {

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -1727,49 +1727,49 @@ func TestDeleteInstallation(t *testing.T) {
 	})
 
 	t.Run("while locked", func(t *testing.T) {
-		installation1.State = model.InstallationStateStable
-		err2 := sqlStore.UpdateInstallation(installation1.Installation)
+		installation.State = model.InstallationStateStable
+		err2 := sqlStore.UpdateInstallation(installation.Installation)
 		require.NoError(t, err2)
 
 		lockerID := model.NewID()
 
-		locked, err3 := sqlStore.LockInstallation(installation1.ID, lockerID)
+		locked, err3 := sqlStore.LockInstallation(installation.ID, lockerID)
 		require.NoError(t, err3)
 		require.True(t, locked)
 		defer func() {
-			unlocked, err4 := sqlStore.UnlockInstallation(installation1.ID, lockerID, false)
+			unlocked, err4 := sqlStore.UnlockInstallation(installation.ID, lockerID, false)
 			require.NoError(t, err4)
 			require.True(t, unlocked)
 
-			installation2, err5 := client.GetInstallation(installation1.ID, nil)
+			installation2, err5 := client.GetInstallation(installation.ID, nil)
 			require.NoError(t, err5)
 			require.Equal(t, int64(0), installation2.LockAcquiredAt)
 		}()
 
-		err6 := client.DeleteInstallation(installation1.ID)
+		err6 := client.DeleteInstallation(installation.ID)
 		require.EqualError(t, err6, "failed with status code 409")
 	})
 
 	t.Run("while api-security-locked", func(t *testing.T) {
-		err2 := sqlStore.LockInstallationAPI(installation1.ID)
+		err2 := sqlStore.LockInstallationAPI(installation.ID)
 		require.NoError(t, err2)
 
-		err3 := client.DeleteInstallation(installation1.ID)
+		err3 := client.DeleteInstallation(installation.ID)
 		require.EqualError(t, err3, "failed with status code 403")
 
-		err4 := sqlStore.UnlockInstallationAPI(installation1.ID)
+		err4 := sqlStore.UnlockInstallationAPI(installation.ID)
 		require.NoError(t, err4)
 	})
 
 	t.Run("while backup is running", func(t *testing.T) {
-		backup1 := &model.InstallationBackup{InstallationID: installation1.ID, State: model.InstallationBackupStateBackupRequested}
-		backup2 := &model.InstallationBackup{InstallationID: installation1.ID, State: model.InstallationBackupStateBackupSucceeded}
+		backup1 := &model.InstallationBackup{InstallationID: installation.ID, State: model.InstallationBackupStateBackupRequested}
+		backup2 := &model.InstallationBackup{InstallationID: installation.ID, State: model.InstallationBackupStateBackupSucceeded}
 		err2 := sqlStore.CreateInstallationBackup(backup1)
 		require.NoError(t, err2)
 		err3 := sqlStore.CreateInstallationBackup(backup2)
 		require.NoError(t, err3)
 
-		err4 := client.DeleteInstallation(installation1.ID)
+		err4 := client.DeleteInstallation(installation.ID)
 		require.EqualError(t, err4, "failed with status code 400")
 
 		err5 := sqlStore.DeleteInstallationBackup(backup1.ID)
@@ -1801,9 +1801,9 @@ func TestDeleteInstallation(t *testing.T) {
 				err3 := client.DeleteInstallation(installation.ID)
 				require.NoError(t, err3)
 
-				installation, err4 := client.GetInstallation(installation.ID, nil)
+				checkedInstallation, err4 := client.GetInstallation(installation.ID, nil)
 				require.NoError(t, err4)
-				require.Equal(t, model.InstallationStateDeletionRequested, installation.State)
+				require.Equal(t, model.InstallationStateDeletionRequested, checkedInstallation.State)
 			})
 		}
 
@@ -1863,7 +1863,7 @@ func TestCancelInstallationDeletion(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("unknown installation", func(t *testing.T) {
-		err := client.CancelInstallationDeletion(model.NewID())
+		err = client.CancelInstallationDeletion(model.NewID())
 		require.EqualError(t, err, "failed with status code 404")
 	})
 
@@ -1874,17 +1874,17 @@ func TestCancelInstallationDeletion(t *testing.T) {
 
 		lockerID := model.NewID()
 
-		locked, err := sqlStore.LockInstallation(installation.ID, lockerID)
-		require.NoError(t, err)
+		locked, err2 := sqlStore.LockInstallation(installation.ID, lockerID)
+		require.NoError(t, err2)
 		require.True(t, locked)
 		defer func() {
-			unlocked, err := sqlStore.UnlockInstallation(installation.ID, lockerID, false)
-			require.NoError(t, err)
+			unlocked, err3 := sqlStore.UnlockInstallation(installation.ID, lockerID, false)
+			require.NoError(t, err3)
 			require.True(t, unlocked)
 
-			installation, err = client.GetInstallation(installation.ID, nil)
-			require.NoError(t, err)
-			require.Equal(t, int64(0), installation.LockAcquiredAt)
+			checkedInstallation, err4 := client.GetInstallation(installation.ID, nil)
+			require.NoError(t, err4)
+			require.Equal(t, int64(0), checkedInstallation.LockAcquiredAt)
 		}()
 
 		err = client.CancelInstallationDeletion(installation.ID)
@@ -1908,7 +1908,7 @@ func TestCancelInstallationDeletion(t *testing.T) {
 			err = sqlStore.UpdateInstallation(installation.Installation)
 			require.NoError(t, err)
 
-			err := client.CancelInstallationDeletion(installation.ID)
+			err = client.CancelInstallationDeletion(installation.ID)
 			require.EqualError(t, err, "failed with status code 400")
 
 			installation, err = client.GetInstallation(installation.ID, nil)
@@ -1921,7 +1921,7 @@ func TestCancelInstallationDeletion(t *testing.T) {
 			err = sqlStore.UpdateInstallation(installation.Installation)
 			require.NoError(t, err)
 
-			err := client.CancelInstallationDeletion(installation.ID)
+			err = client.CancelInstallationDeletion(installation.ID)
 			require.EqualError(t, err, "failed with status code 400")
 
 			installation, err = client.GetInstallation(installation.ID, nil)
@@ -1972,8 +1972,8 @@ func TestUpdateInstallationDeletion(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("unknown installation", func(t *testing.T) {
-		updatedInstallation, err := client.UpdateInstallationDeletion(model.NewID(), &model.PatchInstallationDeletionRequest{})
-		require.EqualError(t, err, "failed with status code 404")
+		updatedInstallation, err2 := client.UpdateInstallationDeletion(model.NewID(), &model.PatchInstallationDeletionRequest{})
+		require.EqualError(t, err2, "failed with status code 404")
 		assert.Nil(t, updatedInstallation)
 	})
 
@@ -1984,12 +1984,12 @@ func TestUpdateInstallationDeletion(t *testing.T) {
 
 		lockerID := model.NewID()
 
-		locked, err := sqlStore.LockInstallation(installation.ID, lockerID)
-		require.NoError(t, err)
+		locked, err2 := sqlStore.LockInstallation(installation.ID, lockerID)
+		require.NoError(t, err2)
 		require.True(t, locked)
 		defer func() {
-			unlocked, err := sqlStore.UnlockInstallation(installation.ID, lockerID, false)
-			require.NoError(t, err)
+			unlocked, err3 := sqlStore.UnlockInstallation(installation.ID, lockerID, false)
+			require.NoError(t, err3)
 			require.True(t, unlocked)
 
 			installation, err = client.GetInstallation(installation.ID, nil)
@@ -1997,8 +1997,8 @@ func TestUpdateInstallationDeletion(t *testing.T) {
 			require.Equal(t, int64(0), installation.LockAcquiredAt)
 		}()
 
-		updatedInstallation, err := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
-		require.EqualError(t, err, "failed with status code 409")
+		updatedInstallation, err4 := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
+		require.EqualError(t, err4, "failed with status code 409")
 		assert.Nil(t, updatedInstallation)
 	})
 
@@ -2006,8 +2006,8 @@ func TestUpdateInstallationDeletion(t *testing.T) {
 		err = sqlStore.LockInstallationAPI(installation.ID)
 		require.NoError(t, err)
 
-		updatedInstallation, err := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
-		require.EqualError(t, err, "failed with status code 403")
+		updatedInstallation, err2 := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
+		require.EqualError(t, err2, "failed with status code 403")
 		assert.Nil(t, updatedInstallation)
 
 		err = sqlStore.UnlockInstallationAPI(installation.ID)
@@ -2020,12 +2020,12 @@ func TestUpdateInstallationDeletion(t *testing.T) {
 			err = sqlStore.UpdateInstallation(installation.Installation)
 			require.NoError(t, err)
 
-			updatedInstallation, err := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
-			require.EqualError(t, err, "failed with status code 400")
+			updatedInstallation, err2 := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
+			require.EqualError(t, err2, "failed with status code 400")
 			assert.Nil(t, updatedInstallation)
 
-			installation, err = client.GetInstallation(installation.ID, nil)
-			require.NoError(t, err)
+			installation, err2 = client.GetInstallation(installation.ID, nil)
+			require.NoError(t, err2)
 			require.Equal(t, model.InstallationStateStable, installation.State)
 		})
 
@@ -2034,8 +2034,8 @@ func TestUpdateInstallationDeletion(t *testing.T) {
 			err = sqlStore.UpdateInstallation(installation.Installation)
 			require.NoError(t, err)
 
-			updatedInstallation, err := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
-			require.EqualError(t, err, "failed with status code 400")
+			updatedInstallation, err2 := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
+			require.EqualError(t, err2, "failed with status code 400")
 			assert.Nil(t, updatedInstallation)
 
 			installation, err = client.GetInstallation(installation.ID, nil)

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -1699,18 +1699,19 @@ func TestDeleteInstallation(t *testing.T) {
 
 	router := mux.NewRouter()
 	api.Register(router, &api.Context{
-		Store:         sqlStore,
-		Supervisor:    &mockSupervisor{},
-		EventProducer: testutil.SetupTestEventsProducer(sqlStore, logger),
-		Metrics:       &mockMetrics{},
-		Logger:        logger,
+		Store:                             sqlStore,
+		Supervisor:                        &mockSupervisor{},
+		EventProducer:                     testutil.SetupTestEventsProducer(sqlStore, logger),
+		Metrics:                           &mockMetrics{},
+		Logger:                            logger,
+		InstallationDeletionExpiryDefault: 3 * time.Hour,
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
 	client := model.NewClient(ts.URL)
 
-	installation1, err := client.CreateInstallation(&model.CreateInstallationRequest{
+	installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
 		OwnerID:  "owner",
 		Version:  "version",
 		DNS:      "dns.example.com",
@@ -1724,49 +1725,49 @@ func TestDeleteInstallation(t *testing.T) {
 	})
 
 	t.Run("while locked", func(t *testing.T) {
-		installation1.State = model.InstallationStateStable
-		err = sqlStore.UpdateInstallation(installation1.Installation)
+		installation.State = model.InstallationStateStable
+		err = sqlStore.UpdateInstallation(installation.Installation)
 		require.NoError(t, err)
 
 		lockerID := model.NewID()
 
-		locked, err := sqlStore.LockInstallation(installation1.ID, lockerID)
+		locked, err := sqlStore.LockInstallation(installation.ID, lockerID)
 		require.NoError(t, err)
 		require.True(t, locked)
 		defer func() {
-			unlocked, err := sqlStore.UnlockInstallation(installation1.ID, lockerID, false)
+			unlocked, err := sqlStore.UnlockInstallation(installation.ID, lockerID, false)
 			require.NoError(t, err)
 			require.True(t, unlocked)
 
-			installation1, err = client.GetInstallation(installation1.ID, nil)
+			installation, err = client.GetInstallation(installation.ID, nil)
 			require.NoError(t, err)
-			require.Equal(t, int64(0), installation1.LockAcquiredAt)
+			require.Equal(t, int64(0), installation.LockAcquiredAt)
 		}()
 
-		err = client.DeleteInstallation(installation1.ID)
+		err = client.DeleteInstallation(installation.ID)
 		require.EqualError(t, err, "failed with status code 409")
 	})
 
 	t.Run("while api-security-locked", func(t *testing.T) {
-		err = sqlStore.LockInstallationAPI(installation1.ID)
+		err = sqlStore.LockInstallationAPI(installation.ID)
 		require.NoError(t, err)
 
-		err = client.DeleteInstallation(installation1.ID)
+		err = client.DeleteInstallation(installation.ID)
 		require.EqualError(t, err, "failed with status code 403")
 
-		err = sqlStore.UnlockInstallationAPI(installation1.ID)
+		err = sqlStore.UnlockInstallationAPI(installation.ID)
 		require.NoError(t, err)
 	})
 
 	t.Run("while backup is running", func(t *testing.T) {
-		backup1 := &model.InstallationBackup{InstallationID: installation1.ID, State: model.InstallationBackupStateBackupRequested}
-		backup2 := &model.InstallationBackup{InstallationID: installation1.ID, State: model.InstallationBackupStateBackupSucceeded}
+		backup1 := &model.InstallationBackup{InstallationID: installation.ID, State: model.InstallationBackupStateBackupRequested}
+		backup2 := &model.InstallationBackup{InstallationID: installation.ID, State: model.InstallationBackupStateBackupSucceeded}
 		err = sqlStore.CreateInstallationBackup(backup1)
 		require.NoError(t, err)
 		err = sqlStore.CreateInstallationBackup(backup2)
 		require.NoError(t, err)
 
-		err = client.DeleteInstallation(installation1.ID)
+		err = client.DeleteInstallation(installation.ID)
 		require.EqualError(t, err, "failed with status code 400")
 
 		err = sqlStore.DeleteInstallationBackup(backup1.ID)
@@ -1789,16 +1790,18 @@ func TestDeleteInstallation(t *testing.T) {
 
 		for _, validDeletingState := range validDeletionRequestedStates {
 			t.Run(validDeletingState, func(t *testing.T) {
-				installation1.State = validDeletingState
-				err = sqlStore.UpdateInstallation(installation1.Installation)
+				installation.State = validDeletingState
+				installation.DeletionPendingExpiry = 0
+				err = sqlStore.UpdateInstallation(installation.Installation)
+				require.NoError(t, err)
+				require.Equal(t, int64(0), installation.DeletionPendingExpiry)
+
+				err := client.DeleteInstallation(installation.ID)
 				require.NoError(t, err)
 
-				err := client.DeleteInstallation(installation1.ID)
+				installation, err = client.GetInstallation(installation.ID, nil)
 				require.NoError(t, err)
-
-				installation1, err = client.GetInstallation(installation1.ID, nil)
-				require.NoError(t, err)
-				require.Equal(t, model.InstallationStateDeletionRequested, installation1.State)
+				require.Equal(t, model.InstallationStateDeletionRequested, installation.State)
 			})
 		}
 
@@ -1812,18 +1815,275 @@ func TestDeleteInstallation(t *testing.T) {
 
 		for _, validDeletingState := range validDeletionPendingRequestedStates {
 			t.Run(validDeletingState, func(t *testing.T) {
-				installation1.State = validDeletingState
-				err = sqlStore.UpdateInstallation(installation1.Installation)
+				installation.State = validDeletingState
+				installation.DeletionPendingExpiry = 0
+				err = sqlStore.UpdateInstallation(installation.Installation)
+				require.NoError(t, err)
+				require.Equal(t, int64(0), installation.DeletionPendingExpiry)
+
+				err := client.DeleteInstallation(installation.ID)
 				require.NoError(t, err)
 
-				err := client.DeleteInstallation(installation1.ID)
+				installation, err = client.GetInstallation(installation.ID, nil)
 				require.NoError(t, err)
-
-				installation1, err = client.GetInstallation(installation1.ID, nil)
-				require.NoError(t, err)
-				require.Equal(t, model.InstallationStateDeletionPendingRequested, installation1.State)
+				assert.Equal(t, model.InstallationStateDeletionPendingRequested, installation.State)
+				assert.Greater(t, installation.DeletionPendingExpiry, model.GetMillisAtTime(time.Now().Add(time.Hour)))
 			})
 		}
+	})
+}
+
+func TestCancelInstallationDeletion(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:                             sqlStore,
+		Supervisor:                        &mockSupervisor{},
+		EventProducer:                     testutil.SetupTestEventsProducer(sqlStore, logger),
+		Metrics:                           &mockMetrics{},
+		Logger:                            logger,
+		InstallationDeletionExpiryDefault: time.Hour,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
+		OwnerID:  "owner",
+		Version:  "version",
+		DNS:      "dns.example.com",
+		Affinity: model.InstallationAffinityIsolated,
+	})
+	require.NoError(t, err)
+
+	t.Run("unknown installation", func(t *testing.T) {
+		err := client.CancelInstallationDeletion(model.NewID())
+		require.EqualError(t, err, "failed with status code 404")
+	})
+
+	t.Run("while locked", func(t *testing.T) {
+		installation.State = model.InstallationStateStable
+		err = sqlStore.UpdateInstallation(installation.Installation)
+		require.NoError(t, err)
+
+		lockerID := model.NewID()
+
+		locked, err := sqlStore.LockInstallation(installation.ID, lockerID)
+		require.NoError(t, err)
+		require.True(t, locked)
+		defer func() {
+			unlocked, err := sqlStore.UnlockInstallation(installation.ID, lockerID, false)
+			require.NoError(t, err)
+			require.True(t, unlocked)
+
+			installation, err = client.GetInstallation(installation.ID, nil)
+			require.NoError(t, err)
+			require.Equal(t, int64(0), installation.LockAcquiredAt)
+		}()
+
+		err = client.CancelInstallationDeletion(installation.ID)
+		require.EqualError(t, err, "failed with status code 409")
+	})
+
+	t.Run("while api-security-locked", func(t *testing.T) {
+		err = sqlStore.LockInstallationAPI(installation.ID)
+		require.NoError(t, err)
+
+		err = client.CancelInstallationDeletion(installation.ID)
+		require.EqualError(t, err, "failed with status code 403")
+
+		err = sqlStore.UnlockInstallationAPI(installation.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("while", func(t *testing.T) {
+		t.Run("stable", func(t *testing.T) {
+			installation.State = model.InstallationStateStable
+			err = sqlStore.UpdateInstallation(installation.Installation)
+			require.NoError(t, err)
+
+			err := client.CancelInstallationDeletion(installation.ID)
+			require.EqualError(t, err, "failed with status code 400")
+
+			installation, err = client.GetInstallation(installation.ID, nil)
+			require.NoError(t, err)
+			require.Equal(t, model.InstallationStateStable, installation.State)
+		})
+
+		t.Run("deleted", func(t *testing.T) {
+			installation.State = model.InstallationStateDeleted
+			err = sqlStore.UpdateInstallation(installation.Installation)
+			require.NoError(t, err)
+
+			err := client.CancelInstallationDeletion(installation.ID)
+			require.EqualError(t, err, "failed with status code 400")
+
+			installation, err = client.GetInstallation(installation.ID, nil)
+			require.NoError(t, err)
+			require.Equal(t, model.InstallationStateDeleted, installation.State)
+		})
+
+		t.Run("deletion pending", func(t *testing.T) {
+			installation.State = model.InstallationStateDeletionPending
+			err = sqlStore.UpdateInstallation(installation.Installation)
+			require.NoError(t, err)
+
+			err := client.CancelInstallationDeletion(installation.ID)
+			require.NoError(t, err)
+
+			installation, err = client.GetInstallation(installation.ID, nil)
+			require.NoError(t, err)
+			require.Equal(t, model.InstallationStateDeletionCancellationRequested, installation.State)
+		})
+	})
+}
+
+func TestUpdateInstallationDeletion(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:                             sqlStore,
+		Supervisor:                        &mockSupervisor{},
+		EventProducer:                     testutil.SetupTestEventsProducer(sqlStore, logger),
+		Metrics:                           &mockMetrics{},
+		Logger:                            logger,
+		InstallationDeletionExpiryDefault: time.Hour,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	installation, err := client.CreateInstallation(&model.CreateInstallationRequest{
+		OwnerID:  "owner",
+		Version:  "version",
+		DNS:      "dns.example.com",
+		Affinity: model.InstallationAffinityIsolated,
+	})
+	require.NoError(t, err)
+
+	t.Run("unknown installation", func(t *testing.T) {
+		updatedInstallation, err := client.UpdateInstallationDeletion(model.NewID(), &model.PatchInstallationDeletionRequest{})
+		require.EqualError(t, err, "failed with status code 404")
+		assert.Nil(t, updatedInstallation)
+	})
+
+	t.Run("while locked", func(t *testing.T) {
+		installation.State = model.InstallationStateStable
+		err = sqlStore.UpdateInstallation(installation.Installation)
+		require.NoError(t, err)
+
+		lockerID := model.NewID()
+
+		locked, err := sqlStore.LockInstallation(installation.ID, lockerID)
+		require.NoError(t, err)
+		require.True(t, locked)
+		defer func() {
+			unlocked, err := sqlStore.UnlockInstallation(installation.ID, lockerID, false)
+			require.NoError(t, err)
+			require.True(t, unlocked)
+
+			installation, err = client.GetInstallation(installation.ID, nil)
+			require.NoError(t, err)
+			require.Equal(t, int64(0), installation.LockAcquiredAt)
+		}()
+
+		updatedInstallation, err := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
+		require.EqualError(t, err, "failed with status code 409")
+		assert.Nil(t, updatedInstallation)
+	})
+
+	t.Run("while api-security-locked", func(t *testing.T) {
+		err = sqlStore.LockInstallationAPI(installation.ID)
+		require.NoError(t, err)
+
+		updatedInstallation, err := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
+		require.EqualError(t, err, "failed with status code 403")
+		assert.Nil(t, updatedInstallation)
+
+		err = sqlStore.UnlockInstallationAPI(installation.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("while", func(t *testing.T) {
+		t.Run("stable", func(t *testing.T) {
+			installation.State = model.InstallationStateStable
+			err = sqlStore.UpdateInstallation(installation.Installation)
+			require.NoError(t, err)
+
+			updatedInstallation, err := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
+			require.EqualError(t, err, "failed with status code 400")
+			assert.Nil(t, updatedInstallation)
+
+			installation, err = client.GetInstallation(installation.ID, nil)
+			require.NoError(t, err)
+			require.Equal(t, model.InstallationStateStable, installation.State)
+		})
+
+		t.Run("deleted", func(t *testing.T) {
+			installation.State = model.InstallationStateDeleted
+			err = sqlStore.UpdateInstallation(installation.Installation)
+			require.NoError(t, err)
+
+			updatedInstallation, err := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
+			require.EqualError(t, err, "failed with status code 400")
+			assert.Nil(t, updatedInstallation)
+
+			installation, err = client.GetInstallation(installation.ID, nil)
+			require.NoError(t, err)
+			require.Equal(t, model.InstallationStateDeleted, installation.State)
+		})
+
+		t.Run("deletion pending", func(t *testing.T) {
+			installation.State = model.InstallationStateDeletionPending
+			err = sqlStore.UpdateInstallation(installation.Installation)
+			require.NoError(t, err)
+
+			oldExpiry := installation.DeletionPendingExpiry
+			updatedInstallation, err := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{})
+			require.NoError(t, err)
+			assert.Equal(t, oldExpiry, updatedInstallation.DeletionPendingExpiry)
+
+			installation, err = client.GetInstallation(installation.ID, nil)
+			require.NoError(t, err)
+			assert.Equal(t, model.InstallationStateDeletionPending, installation.State)
+			assert.Equal(t, oldExpiry, installation.DeletionPendingExpiry)
+
+			t.Run("with new valid expiry", func(t *testing.T) {
+				newExpiry := model.GetMillis()
+				updatedInstallation, err := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{
+					DeletionPendingExpiry: &newExpiry,
+				})
+				require.NoError(t, err)
+				assert.Equal(t, newExpiry, updatedInstallation.DeletionPendingExpiry)
+
+				installation, err = client.GetInstallation(installation.ID, nil)
+				require.NoError(t, err)
+				assert.Equal(t, model.InstallationStateDeletionPending, installation.State)
+				assert.Equal(t, newExpiry, installation.DeletionPendingExpiry)
+			})
+
+			t.Run("with new invalid expiry", func(t *testing.T) {
+				newExpiry := model.GetMillisAtTime(time.Now().Add(-time.Hour))
+				updatedInstallation, err := client.UpdateInstallationDeletion(installation.ID, &model.PatchInstallationDeletionRequest{
+					DeletionPendingExpiry: &newExpiry,
+				})
+				require.Error(t, err)
+				assert.Nil(t, updatedInstallation)
+
+				installation, err = client.GetInstallation(installation.ID, nil)
+				require.NoError(t, err)
+				assert.Equal(t, model.InstallationStateDeletionPending, installation.State)
+				assert.NotEqual(t, newExpiry, installation.DeletionPendingExpiry)
+			})
+		})
 	})
 }
 

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -26,7 +26,7 @@ func init() {
 			"Installation.ID", "Installation.Name", "OwnerID", "Version", "Image", "Database", "Filestore", "Size",
 			"Affinity", "GroupID", "GroupSequence", "Installation.State", "License",
 			"MattermostEnvRaw", "PriorityEnvRaw", "SingleTenantDatabaseConfigRaw", "ExternalDatabaseConfigRaw",
-			"Installation.CreateAt", "Installation.DeleteAt",
+			"Installation.CreateAt", "Installation.DeleteAt", "Installation.DeletionPendingExpiry",
 			"APISecurityLock", "LockAcquiredBy", "LockAcquiredAt", "CRVersion",
 		).
 		From(installationTable)
@@ -426,27 +426,28 @@ func (sqlStore *SQLStore) createInstallation(db execer, installation *model.Inst
 	}
 
 	insertsMap := map[string]interface{}{
-		"Name":             installation.Name,
-		"ID":               installation.ID,
-		"OwnerID":          installation.OwnerID,
-		"GroupID":          installation.GroupID,
-		"GroupSequence":    nil,
-		"Version":          installation.Version,
-		"Image":            installation.Image,
-		"Database":         installation.Database,
-		"Filestore":        installation.Filestore,
-		"Size":             installation.Size,
-		"Affinity":         installation.Affinity,
-		"State":            installation.State,
-		"License":          installation.License,
-		"MattermostEnvRaw": []byte(envJSON),
-		"PriorityEnvRaw":   []byte(priorityEnvJSON),
-		"CreateAt":         installation.CreateAt,
-		"DeleteAt":         0,
-		"APISecurityLock":  installation.APISecurityLock,
-		"LockAcquiredBy":   nil,
-		"LockAcquiredAt":   0,
-		"CRVersion":        installation.CRVersion,
+		"Name":                  installation.Name,
+		"ID":                    installation.ID,
+		"OwnerID":               installation.OwnerID,
+		"GroupID":               installation.GroupID,
+		"GroupSequence":         nil,
+		"Version":               installation.Version,
+		"Image":                 installation.Image,
+		"Database":              installation.Database,
+		"Filestore":             installation.Filestore,
+		"Size":                  installation.Size,
+		"Affinity":              installation.Affinity,
+		"State":                 installation.State,
+		"License":               installation.License,
+		"MattermostEnvRaw":      []byte(envJSON),
+		"PriorityEnvRaw":        []byte(priorityEnvJSON),
+		"CreateAt":              installation.CreateAt,
+		"DeleteAt":              0,
+		"DeletionPendingExpiry": 0,
+		"APISecurityLock":       installation.APISecurityLock,
+		"LockAcquiredBy":        nil,
+		"LockAcquiredAt":        0,
+		"CRVersion":             installation.CRVersion,
 	}
 
 	singleTenantDBConfJSON, err := installation.SingleTenantDatabaseConfig.ToJSON()
@@ -493,7 +494,6 @@ func (sqlStore *SQLStore) updateInstallation(db execer, installation *model.Inst
 	if err != nil {
 		return errors.Wrap(err, "unable to marshal MattermostEnv")
 	}
-
 	priorityEnvJSON, err := json.Marshal(installation.PriorityEnv)
 	if err != nil {
 		return errors.Wrap(err, "unable to marshal PriorityEnv")
@@ -502,21 +502,22 @@ func (sqlStore *SQLStore) updateInstallation(db execer, installation *model.Inst
 	_, err = sqlStore.execBuilder(db, sq.
 		Update("Installation").
 		SetMap(map[string]interface{}{
-			"Name":             installation.Name,
-			"OwnerID":          installation.OwnerID,
-			"GroupID":          installation.GroupID,
-			"GroupSequence":    installation.GroupSequence,
-			"Version":          installation.Version,
-			"Image":            installation.Image,
-			"Database":         installation.Database,
-			"Filestore":        installation.Filestore,
-			"Size":             installation.Size,
-			"Affinity":         installation.Affinity,
-			"License":          installation.License,
-			"MattermostEnvRaw": []byte(envJSON),
-			"PriorityEnvRaw":   []byte(priorityEnvJSON),
-			"State":            installation.State,
-			"CRVersion":        installation.CRVersion,
+			"Name":                  installation.Name,
+			"OwnerID":               installation.OwnerID,
+			"GroupID":               installation.GroupID,
+			"GroupSequence":         installation.GroupSequence,
+			"Version":               installation.Version,
+			"Image":                 installation.Image,
+			"Database":              installation.Database,
+			"Filestore":             installation.Filestore,
+			"Size":                  installation.Size,
+			"Affinity":              installation.Affinity,
+			"License":               installation.License,
+			"MattermostEnvRaw":      []byte(envJSON),
+			"PriorityEnvRaw":        []byte(priorityEnvJSON),
+			"State":                 installation.State,
+			"CRVersion":             installation.CRVersion,
+			"DeletionPendingExpiry": installation.DeletionPendingExpiry,
 		}).
 		Where("ID = ?", installation.ID),
 	)

--- a/model/client.go
+++ b/model/client.go
@@ -551,10 +551,28 @@ func (c *Client) DeleteInstallation(installationID string) error {
 	}
 }
 
+// UpdateInstallationDeletion updates the deletion parameters of an installation
+// that is still pending deletion.
+func (c *Client) UpdateInstallationDeletion(installationID string, request *PatchInstallationDeletionRequest) (*InstallationDTO, error) {
+	resp, err := c.doPut(c.buildURL("/api/installation/%s/deletion", installationID), request)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return InstallationDTOFromReader(resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // CancelInstallationDeletion cancels the deletion of an installation that is
-// still pending deletion
+// still pending deletion.
 func (c *Client) CancelInstallationDeletion(installationID string) error {
-	resp, err := c.doPost(c.buildURL("/api/installation/%s/cancel_deletion", installationID), nil)
+	resp, err := c.doPost(c.buildURL("/api/installation/%s/deletion/cancel", installationID), nil)
 	if err != nil {
 		return err
 	}

--- a/model/installation.go
+++ b/model/installation.go
@@ -46,6 +46,7 @@ type Installation struct {
 	CRVersion                  string
 	CreateAt                   int64
 	DeleteAt                   int64
+	DeletionPendingExpiry      int64 `json:"DeletionPendingExpiry,omitempty"`
 	APISecurityLock            bool
 	LockAcquiredBy             *string
 	LockAcquiredAt             int64
@@ -104,7 +105,7 @@ func (i *Installation) ToDTO(annotations []*Annotation, dnsRecords []*Installati
 // CreationDateString returns a standardized date string for an installation's
 // creation.
 func (i *Installation) CreationDateString() string {
-	return GetDateString(i.CreateAt)
+	return DateStringFromMillis(i.CreateAt)
 }
 
 // DeletionDateString returns a standardized date string for an installation's
@@ -114,7 +115,17 @@ func (i *Installation) DeletionDateString() string {
 		return "n/a"
 	}
 
-	return TimeFromMillis(i.DeleteAt).Format("Jan 2 2006")
+	return DateStringFromMillis(i.DeleteAt)
+}
+
+// DeletionPendingExpiryCompleteTimeString returns a standardized time string for
+// an installation's deletion or 'n/a' if not pending deletion.
+func (i *Installation) DeletionPendingExpiryCompleteTimeString() string {
+	if i.DeletionPendingExpiry == 0 {
+		return "n/a"
+	}
+
+	return CompleteTimeStringFromMillis(i.DeletionPendingExpiry)
 }
 
 // GetDatabaseWeight returns a value corresponding to the

--- a/model/installation.go
+++ b/model/installation.go
@@ -125,7 +125,7 @@ func (i *Installation) DeletionPendingExpiryCompleteTimeString() string {
 		return "n/a"
 	}
 
-	return CompleteTimeStringFromMillis(i.DeletionPendingExpiry)
+	return DateTimeStringFromMillis(i.DeletionPendingExpiry)
 }
 
 // GetDatabaseWeight returns a value corresponding to the

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -395,6 +396,56 @@ func NewPatchInstallationRequestFromReader(reader io.Reader) (*PatchInstallation
 	}
 
 	return &patchInstallationRequest, nil
+}
+
+// PatchInstallationDeletionRequest specifies the parameters for an updating
+// installation deletion parameters.
+type PatchInstallationDeletionRequest struct {
+	DeletionPendingExpiry *int64
+}
+
+// Validate validates the values of a installation deletion patch request.
+func (p *PatchInstallationDeletionRequest) Validate() error {
+	if p.DeletionPendingExpiry != nil {
+		// DeletionPendingExpiry is the new time when an installation pending
+		// deletion can be deleted. This can be any time from "now" into the
+		// future. The cuttoff for "now" will be the current time with a 5 second
+		// buffer. Any time value lower than that will be considered an error.
+		cutoffTimeMillis := GetMillisAtTime(time.Now().Add(-5 * time.Second))
+		if cutoffTimeMillis > *p.DeletionPendingExpiry {
+			return errors.Errorf("DeletionPendingExpiry must be %d or higher", cutoffTimeMillis)
+		}
+	}
+
+	return nil
+}
+
+// Apply applies the deletion patch to the given installation.
+func (p *PatchInstallationDeletionRequest) Apply(installation *Installation) bool {
+	var applied bool
+
+	if p.DeletionPendingExpiry != nil && *p.DeletionPendingExpiry != installation.DeletionPendingExpiry {
+		applied = true
+		installation.DeletionPendingExpiry = *p.DeletionPendingExpiry
+	}
+
+	return applied
+}
+
+// NewPatchInstallationDeletionRequestFromReader will create a PatchInstallationDeletionRequest from an io.Reader with JSON data.
+func NewPatchInstallationDeletionRequestFromReader(reader io.Reader) (*PatchInstallationDeletionRequest, error) {
+	var patchInstallationDeletionRequest PatchInstallationDeletionRequest
+	err := json.NewDecoder(reader).Decode(&patchInstallationDeletionRequest)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode patch installation deletion request")
+	}
+
+	err = patchInstallationDeletionRequest.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid patch installation deletion request")
+	}
+
+	return &patchInstallationDeletionRequest, nil
 }
 
 // AssignInstallationGroupRequest specifies request body for installation group assignment.

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -221,6 +221,9 @@ var (
 			InstallationStateDeletionPendingRequested,
 			InstallationStateDeletionPendingInProgress,
 		},
+		InstallationStateDeletionPending: {
+			InstallationStateDeletionPending,
+		},
 		InstallationStateDeletionCancellationRequested: {
 			InstallationStateDeletionPending,
 		},

--- a/model/multitenant_database.go
+++ b/model/multitenant_database.go
@@ -55,7 +55,7 @@ type MultitenantDatabase struct {
 // CreationDateString returns a standardized date string for a multitenant
 // database string.
 func (d *MultitenantDatabase) CreationDateString() string {
-	return GetDateString(d.CreateAt)
+	return DateStringFromMillis(d.CreateAt)
 }
 
 // LogicalDatabase represents a logical database inside a MultitenantDatabase.

--- a/model/time.go
+++ b/model/time.go
@@ -8,7 +8,12 @@ import "time"
 
 // GetMillis is a convenience method to get milliseconds since epoch.
 func GetMillis() int64 {
-	return time.Now().UnixNano() / int64(time.Millisecond)
+	return GetMillisAtTime(time.Now())
+}
+
+// GetMillisAtTime returns millis for a given time.
+func GetMillisAtTime(t time.Time) int64 {
+	return t.UnixNano() / int64(time.Millisecond)
 }
 
 // TimeFromMillis converts time in milliseconds to time.Time.
@@ -16,9 +21,14 @@ func TimeFromMillis(millis int64) time.Time {
 	return time.Unix(0, millis*int64(time.Millisecond))
 }
 
-// GetDateString returns a standard date string from millis.
-func GetDateString(millis int64) string {
+// DateStringFromMillis returns a standard date string from millis.
+func DateStringFromMillis(millis int64) string {
 	return TimeFromMillis(millis).Format("Jan 2 2006")
+}
+
+// CompleteTimeStringFromMillis returns a standard complete time string from millis.
+func CompleteTimeStringFromMillis(millis int64) string {
+	return TimeFromMillis(millis).Format("2006-01-02 15:04:05 MST")
 }
 
 // ElapsedTimeInSeconds returns time in seconds since the provided millis.

--- a/model/time.go
+++ b/model/time.go
@@ -26,8 +26,8 @@ func DateStringFromMillis(millis int64) string {
 	return TimeFromMillis(millis).Format("Jan 2 2006")
 }
 
-// CompleteTimeStringFromMillis returns a standard complete time string from millis.
-func CompleteTimeStringFromMillis(millis int64) string {
+// DateTimeStringFromMillis returns a standard complete time string from millis.
+func DateTimeStringFromMillis(millis int64) string {
 	return TimeFromMillis(millis).Format("2006-01-02 15:04:05 MST")
 }
 


### PR DESCRIPTION
This change introduces logic to control when installations that are pending deletion are fully deleted. Installations now have individual timestamps when they will exit the pending deletion state.

Installations that are currently pending deletion with no expiration value will fall back and use the existing logic based on installation change events.

When installation deletion is requested, the expiry time is set to the default future time as defined in the provisioning server. The value can then be updated if needed to happen sooner or later. As before, the installation deletion can be cancelled if it is still pending.

Fixes https://mattermost.atlassian.net/browse/MM-47409

```release-note
Add installation deletion pending expiration control
```
