### PR TITLE
[MM-49778] Fix kops creating a temporary file instead of a directory for the kops cache

### DIFF
--- a/internal/tools/kops/cmd.go
+++ b/internal/tools/kops/cmd.go
@@ -33,7 +33,7 @@ func New(s3StateStore string, logger log.FieldLogger) (*Cmd, error) {
 		return nil, errors.Wrap(err, "failed to find kops installed on your PATH")
 	}
 
-	tempDir, err := os.CreateTemp("", "kops-")
+	tempDir, err := os.MkdirTemp("", "kops-")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create temporary kops directory")
 	}
@@ -41,7 +41,7 @@ func New(s3StateStore string, logger log.FieldLogger) (*Cmd, error) {
 	return &Cmd{
 		kopsPath:     kopsPath,
 		s3StateStore: s3StateStore,
-		tempDir:      tempDir.Name(),
+		tempDir:      tempDir,
 		logger:       logger,
 	}, nil
 }

--- a/internal/tools/kops/export.go
+++ b/internal/tools/kops/export.go
@@ -4,19 +4,24 @@
 
 package kops
 
-import "github.com/pkg/errors"
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
 
 // ExportKubecfg invokes kops export kubecfg for the named cluster in the context of the created Cmd.
 func (c *Cmd) ExportKubecfg(name string) error {
-	_, _, err := c.run(
+	_, stderr, err := c.run(
 		"export",
 		"kubecfg",
 		arg("name", name),
 		arg("state", "s3://", c.s3StateStore),
 		arg("admin", "87600h"),
 	)
+
 	if err != nil {
-		return errors.Wrap(err, "failed to invoke kops export kubecfg")
+		return errors.Wrap(err, fmt.Sprintf("failed to invoke kops export kubecfg: %s", string(stderr)))
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary

Caused by: #820 

The removal of deprecation warnings refactored a `ioutil.TempDir` into a `os.CreateTemp` by mistake, instead of using `os.MkdirTemp` as it was expected. This was causing the kops client to error all the time due to it being unable to write files into a file, instead of a directory which is the thing it expects.

I also added more verbose errors for the kops command invokation, so we can easily spot what's happening directly in the logs.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49778

#### Release Note

```release-note
Fixed kops unable to locate kubecfg files
```
