### PR TITLE
[MM-49747] Check installation update flags changes

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -143,23 +143,9 @@ func newCmdInstallationUpdate() *cobra.Command {
 			command.SilenceUsage = true
 			client := model.NewClient(flags.serverAddress)
 
-			envVarMap, err := parseEnvVarInput(flags.mattermostEnv, flags.mattermostEnvClear)
+			request, err := flags.GetPatchInstallationRequest()
 			if err != nil {
 				return err
-			}
-			priorityEnvVarMap, err := parseEnvVarInput(flags.priorityEnv, flags.priorityEnvClear)
-			if err != nil {
-				return err
-			}
-
-			request := &model.PatchInstallationRequest{
-				OwnerID:       &flags.ownerID,
-				Version:       &flags.version,
-				Image:         &flags.image,
-				Size:          &flags.size,
-				License:       &flags.license,
-				MattermostEnv: envVarMap,
-				PriorityEnv:   priorityEnvVarMap,
 			}
 
 			if flags.dryRun {
@@ -175,8 +161,10 @@ func newCmdInstallationUpdate() *cobra.Command {
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			flags.clusterFlags.addFlags(cmd)
+			flags.installationPatchRequestChanges.addFlags(cmd)
 		},
 	}
+
 	flags.addFlags(cmd)
 
 	return cmd
@@ -303,18 +291,9 @@ func newCmdInstallationWakeup() *cobra.Command {
 			command.SilenceUsage = true
 			client := model.NewClient(flags.serverAddress)
 
-			envVarMap, err := parseEnvVarInput(flags.mattermostEnv, flags.mattermostEnvClear)
+			request, err := flags.GetPatchInstallationRequest()
 			if err != nil {
 				return err
-			}
-
-			request := &model.PatchInstallationRequest{
-				OwnerID:       &flags.ownerID,
-				Version:       &flags.version,
-				Image:         &flags.image,
-				Size:          &flags.size,
-				License:       &flags.license,
-				MattermostEnv: envVarMap,
 			}
 
 			installation, err := client.WakeupInstallation(flags.installationID, request)
@@ -326,6 +305,7 @@ func newCmdInstallationWakeup() *cobra.Command {
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			flags.clusterFlags.addFlags(cmd)
+			flags.installationPatchRequestChanges.addFlags(cmd)
 		},
 	}
 	flags.addFlags(cmd)

--- a/cmd/cloud/installation_flag.go
+++ b/cmd/cloud/installation_flag.go
@@ -161,7 +161,7 @@ func (flags *installationUpdateFlags) addFlags(command *cobra.Command) {
 func (flags *installationUpdateFlags) GetPatchInstallationRequest() (*model.PatchInstallationRequest, error) {
 	request := flags.installationPatchRequestOptions.GetPatchInstallationRequest()
 
-	envVarMap, err := parseEnvVarInput(flags.mattermostEnv, flags.mattermostEnvClear)
+	mattermostEnv, err := parseEnvVarInput(flags.mattermostEnv, flags.mattermostEnvClear)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (flags *installationUpdateFlags) GetPatchInstallationRequest() (*model.Patc
 		return nil, err
 	}
 
-	request.MattermostEnv = envVarMap
+	request.MattermostEnv = mattermostEnv
 	request.PriorityEnv = priorityEnv
 
 	return request, nil


### PR DESCRIPTION
#### Summary

Added flag change check to installation update command.

Checked other update commands and those already check for changes except for cluster update which only accepts one change (allow installations).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49747

#### Release Note

```release-note
Check specified installation update flags before creating an update request
```
