### PR TITLE
[MM-49890] Make e2e tests KopsAMI parameter optional

### DIFF
--- a/e2e/tests/cluster/suite.go
+++ b/e2e/tests/cluster/suite.go
@@ -33,8 +33,8 @@ type TestConfig struct {
 	WebhookAddress            string `envconfig:"default=http://localhost:11111"`
 	EventListenerAddress      string `envconfig:"default=http://localhost:11112"`
 	FetchAMI                  bool   `envconfig:"default=true"`
-	KopsAMI                   string
-	Cleanup                   bool `envconfig:"default=true"`
+	KopsAMI                   string `envconfig:"optional"`
+	Cleanup                   bool   `envconfig:"default=true"`
 }
 
 // Test holds all data required for a db migration test.


### PR DESCRIPTION
#### Summary

Fixed the new KopsAMI parameter in tests and made it optional, since `envconfig` owns it even if no annotation is set.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49890

#### Release Note

```release-note
None
```
