### PR TITLE
Warn and continue if it fails to destroy utilities

### DIFF
--- a/internal/provisioner/utility_group.go
+++ b/internal/provisioner/utility_group.go
@@ -189,7 +189,7 @@ func (group utilityGroup) DestroyUtilityGroup() error {
 	for _, utility := range group.utilities {
 		err := utility.Destroy()
 		if err != nil {
-			return errors.Wrap(err, "failed to destroy one of the cluster utilities")
+			group.logger.WithError(err).Warnf("failed to destroy utility `%s`", utility.Name())
 		}
 
 		err = group.cluster.SetUtilityActualVersion(utility.Name(), utility.ActualVersion())


### PR DESCRIPTION
#### Summary

There are a few reasons it may not be able to delete utilities, thereby failing to delete the cluster. As part of destroying a cluster, we must proceed despite this error.

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
