### PR TITLE
[MM-50387] Decrease Master Instance type for sizeAlefDev & sizeAlef500

### DIFF
--- a/clusterdictionary/size.go
+++ b/clusterdictionary/size.go
@@ -41,7 +41,7 @@ var ValidSizes = map[string]size{
 
 // sizeAlefDev is a cluster sized for development and testing.
 var sizeAlefDev = size{
-	MasterInstanceType: "t3.medium",
+	MasterInstanceType: "t3.small",
 	MasterCount:        1,
 	NodeInstanceType:   "t3.medium",
 	NodeMinCount:       2,
@@ -50,7 +50,7 @@ var sizeAlefDev = size{
 
 // sizeAlef500 is a cluster sized for 500 users.
 var sizeAlef500 = size{
-	MasterInstanceType: "t3.medium",
+	MasterInstanceType: "t3.small",
 	MasterCount:        1,
 	NodeInstanceType:   "m5.large",
 	NodeMinCount:       2,

--- a/clusterdictionary/size_test.go
+++ b/clusterdictionary/size_test.go
@@ -46,7 +46,7 @@ func TestApplyToCreateClusterRequest(t *testing.T) {
 		}, {
 			SizeAlefDev,
 			&model.CreateClusterRequest{
-				MasterInstanceType: "t3.medium",
+				MasterInstanceType: "t3.small",
 				MasterCount:        1,
 				NodeInstanceType:   "t3.medium",
 				NodeMinCount:       2,
@@ -56,7 +56,7 @@ func TestApplyToCreateClusterRequest(t *testing.T) {
 		}, {
 			SizeAlef500,
 			&model.CreateClusterRequest{
-				MasterInstanceType: "t3.medium",
+				MasterInstanceType: "t3.small",
 				MasterCount:        1,
 				NodeInstanceType:   "m5.large",
 				NodeMinCount:       2,


### PR DESCRIPTION
#### Summary

According to AWS recommendations, `sizeAlefDev` and `sizeAlef500` should have `t3.small` master instances rather than `t3.medium`.

#### Ticket Link

  Issue [MM-50387](https://mattermost.atlassian.net/browse/MM-50387)

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Use t3.small Master instance for sizeAlefDev and sizeAlef500
```
