### PR TITLE
[MM-50390] fix: keep trying to claim available VPCs

### DIFF
--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -235,13 +235,14 @@ func (a *Client) GetAndClaimVpcResources(cluster *model.Cluster, owner string, l
 	for _, vpc := range vpcs {
 		clusterResources, err := a.getClusterResourcesForVPC(*vpc.VpcId, *vpc.CidrBlock, logger)
 		if err != nil {
-			logger.Warn(err)
+			logger.WithError(err).WithField("vpc", *vpc.VpcId).Warn("Couldn't get cluster resources for VPC")
 			continue
 		}
 
 		err = a.claimVpc(clusterResources, cluster, owner, logger)
 		if err != nil {
-			return clusterResources, err
+			logger.WithError(err).WithField("vpc", *vpc.VpcId).Warn("Couldn't claim VPC")
+			continue
 		}
 
 		return clusterResources, nil

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -242,6 +242,9 @@ func (a *Client) GetAndClaimVpcResources(cluster *model.Cluster, owner string, l
 		err = a.claimVpc(clusterResources, cluster, owner, logger)
 		if err != nil {
 			logger.WithError(err).WithField("vpc", *vpc.VpcId).Warn("Couldn't claim VPC")
+			if err := a.releaseVpc(cluster, logger); err != nil {
+				return clusterResources, errors.Wrapf(err, "error when unclaiming faulty claimed vpc %s", *vpc.VpcId)
+			}
 			continue
 		}
 

--- a/internal/tools/aws/ec2.go
+++ b/internal/tools/aws/ec2.go
@@ -16,6 +16,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type TagResourceInput struct {
+	ResourceID string
+	Key        string
+	Value      string
+}
+
 // TagResource tags an AWS EC2 resource.
 func (a *Client) TagResource(resourceID, key, value string, logger log.FieldLogger) error {
 	ctx := context.TODO()

--- a/internal/tools/aws/tags.go
+++ b/internal/tools/aws/tags.go
@@ -18,6 +18,10 @@ type Tags struct {
 	tags map[string]string
 }
 
+func (t *Tags) Get(key string) string {
+	return t.tags[key]
+}
+
 // Add adds a new tag in a key,value format
 func (t *Tags) Add(key, value string) {
 	t.tags[key] = value
@@ -80,4 +84,16 @@ func NewTags(items ...string) (*Tags, error) {
 	}
 
 	return &t, nil
+}
+
+func NewTagsFromEC2Tags(tags []ec2Types.Tag) *Tags {
+	t := Tags{
+		tags: make(map[string]string),
+	}
+	for _, tag := range tags {
+		if tag.Key != nil && tag.Value != nil {
+			t.Add(*tag.Key, *tag.Value)
+		}
+	}
+	return &t
 }


### PR DESCRIPTION
#### Summary

Keep trying to Claim a VPC in case of errors.

I'm assuming this was set up like it was for a reason, so I hope @gabrieljackson knows. My only concern with this is that if something related to tagging fails in between the claiming, we will leave bogus tags on all VPCs, instead of only one. We could use some cancel function to leave everything as it was if any error happens? (making claiming somehow atomic)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50390

#### Release Note

```release-note
fix: keep trying to claim VPCs in case of errors
```
