### PR TITLE
Fix workbench command removing workbench directory

### DIFF
--- a/cmd/cloud/workbench.go
+++ b/cmd/cloud/workbench.go
@@ -63,11 +63,6 @@ func executeWorkbenchClusterCmd(flags workbenchClusterFlag) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if errDefer := kopsClient.Close(); errDefer != nil {
-			logger.WithError(errDefer).Error("Failed to close kops client")
-		}
-	}()
 
 	if err = kopsClient.ExportKubecfg(cluster.ProvisionerMetadataKops.Name); err != nil {
 		return err


### PR DESCRIPTION
This change prevents the workbench command from silently cleaning up the workbench directory as it exits.

```release-note
Fix workbench command removing workbench directory
```
