### PR TITLE
Bump operator version to v1.20.0-rc.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/lib/pq v1.10.7
 	github.com/mattermost/awat v0.2.0
-	github.com/mattermost/mattermost-operator v1.20.0-rc.0.0.20230201161241-262f04a1080e
+	github.com/mattermost/mattermost-operator v1.20.0-rc.2
 	github.com/mattermost/rotator v0.2.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,8 @@ github.com/mattermost/mattermost-cloud v0.39.0/go.mod h1:GbWfZajyp+DvdEpoNfFeJ3Z
 github.com/mattermost/mattermost-cloud v0.48.0/go.mod h1:1u1LQsuNVMcoxo6MvKKL6sGZ+LJrGdXg8TGyyTe3yjY=
 github.com/mattermost/mattermost-operator v1.12.0/go.mod h1:a6pSJI6bDaIfO65M/Hvuqg8kUNYQQYDHLayoT5XZx5o=
 github.com/mattermost/mattermost-operator v1.15.0/go.mod h1:9esaQrOcruyyGQme3AnXGnoCDbpER7XAifDVu3HlCm8=
-github.com/mattermost/mattermost-operator v1.20.0-rc.0.0.20230201161241-262f04a1080e h1:JFzKjl6NQgxVAde1o6+2Ldn96IRywkBF/vSOpUkhz3Q=
-github.com/mattermost/mattermost-operator v1.20.0-rc.0.0.20230201161241-262f04a1080e/go.mod h1:WGxmW6iF1+cFc3sJ5uZTVAHolIMjt2/zHumeI7Xt7Hk=
+github.com/mattermost/mattermost-operator v1.20.0-rc.2 h1:crGusVBsw0zOavJWVaaYExr+ippAq+C3qZzf5VMz9nM=
+github.com/mattermost/mattermost-operator v1.20.0-rc.2/go.mod h1:WGxmW6iF1+cFc3sJ5uZTVAHolIMjt2/zHumeI7Xt7Hk=
 github.com/mattermost/mattermost-server/v5 v5.23.0/go.mod h1:nMrt08IvThjybZpXPe/nqe/oJuvJxhqKkGI+m7M0R00=
 github.com/mattermost/mmetl v0.0.2-0.20210316151859-38824e5f5efd/go.mod h1:w6GNqrudkzs/GddfgqkgUqsXVQ/4ImK5JJfNj5KJeUQ=
 github.com/mattermost/rotator v0.1.2/go.mod h1:1oxWiEhVdZRckZ0uHGd5Zqf04yynm4U/YGHUPsf4sQ8=

--- a/manifests/operator-manifests/mattermost/operator.yaml
+++ b/manifests/operator-manifests/mattermost/operator.yaml
@@ -26,7 +26,7 @@ spec:
           value: 20s
         - name: MAX_RECONCILE_CONCURRENCY
           value: "10"
-        image: mattermost/mattermost-operator:b269a84
+        image: mattermost/mattermost-operator:v1.20.0-rc.2
         imagePullPolicy: IfNotPresent
         name: mattermost-operator
         ports:


### PR DESCRIPTION
Fixes https://mattermost.atlassian.net/browse/MM-50507

```release-note
Bump operator version to v1.20.0-rc.2
```
