### PR TITLE
fix: set up common provisioner logger

### DIFF
--- a/internal/provisioner/eks_provisioner_cluster.go
+++ b/internal/provisioner/eks_provisioner_cluster.go
@@ -63,6 +63,7 @@ func NewEKSProvisioner(
 			resourceUtil: resourceUtil,
 			store:        store,
 			params:       params,
+			logger:       logger,
 		},
 	}
 }

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -68,6 +68,7 @@ func NewKopsProvisioner(
 			resourceUtil: resourceUtil,
 			store:        store,
 			params:       provisioningParams,
+			logger:       logger,
 		},
 	}
 }


### PR DESCRIPTION
#### Summary

Assign logger to common provisioner to avoid panics when trying to log from it.

Error:
```
|  |    | 2023-02-16 10:15:38 |   internal/provisioner/cluster\_installation\_provisioner.go:183 +0x15b   |
|  |    | 2023-02-16 10:15:38 |   github.com/mattermost/mattermost-cloud/internal/provisioner.(\*CommonProvisioner).refreshSecrets(0xc00096e0c0, 0xc0003a22a0?, 0xc000d0a380, {0xc0008340e0, 0x1f})   |
```

Offending line:
```
	logger := provisioner.logger.WithFields(log.Fields{
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50549

#### Release Note

```release-note
fix: assign missing logger to common provisioner to avoid errors
```
