### PR TITLE
[MM-50538] Some logger and e2e field fixes

### DIFF
--- a/cmd/cloud/logger_hooks.go
+++ b/cmd/cloud/logger_hooks.go
@@ -36,7 +36,14 @@ func NewClusterLoggerHook(path string, levels []logrus.Level) *ClusterLoggerHook
 		path:   path,
 	}
 
-	// TODO: Ensure paths are created here rather on every write
+	// Ensure paths are created to put the logs in there
+	if err := os.MkdirAll(filepath.Join(hook.path, "cluster"), os.ModePerm); err != nil {
+		panic(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(hook.path, "installation"), os.ModePerm); err != nil {
+		panic(err)
+	}
 
 	hook.formatter = fileLogrusFormatter
 
@@ -68,11 +75,7 @@ func (hook *ClusterLoggerHook) fileWrite(entry *logrus.Entry, kind string) error
 
 	clusterID := dataClusterID.(string)
 
-	//  TODO: move this to NewClusterLoggerHook
-	dir := filepath.Dir(filepath.Join(hook.path, kind))
-	os.MkdirAll(dir, os.ModePerm)
-
-	path := filepath.Join(dir, clusterID+".log")
+	path := filepath.Join(hook.path, kind, clusterID+".log")
 
 	fd, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {

--- a/e2e/workflow/cluster.go
+++ b/e2e/workflow/cluster.go
@@ -59,6 +59,7 @@ func (w *ClusterSuite) CreateCluster(ctx context.Context) error {
 		}
 		w.logger.Infof("Cluster creation requested: %s", cluster.ID)
 		w.Meta.ClusterID = cluster.ID
+		state.ClusterID = cluster.ID
 	}
 
 	// Make sure cluster not ready or failed - otherwise we will hang on webhook
@@ -92,7 +93,6 @@ func (w *ClusterSuite) ProvisionCluster(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "while waiting for cluster provisioning")
 	}
-	state.ClusterID = cluster.ID
 
 	return nil
 }


### PR DESCRIPTION
#### Summary

- Setting the clusterID field for the notification in a different place, since it was not getting set if test failed
- Creating directories for the logrus hook once.
- Fixed the logrus hook directory creation (store installation and cluster in subfolders)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50538

#### Release Note

```release-note
fix: e2e fields and loggers
```
