### PR TITLE
Wait until DeletionTimestamp has been added before finalizing namespace

### DIFF
--- a/internal/provisioner/cluster_provisioning.go
+++ b/internal/provisioner/cluster_provisioning.go
@@ -69,7 +69,7 @@ func provisionCluster(
 
 	err = k8sClient.DeleteNamespacesWithFinalizer(namespaces)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete namespacesß")
+		return errors.Wrap(err, "failed to delete namespaces")
 	}
 
 	wait := 300


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

When a finalizer is present in a k8s resource, actual deletion does not occur until we/controller delete it. We have to consider finalizer for EKS, which introduces an issue for kops. This PR will solve that bug.

Related Link: https://aws.amazon.com/premiumsupport/knowledge-center/eks-terminated-namespaces/

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
