### PR TITLE
[MM-50968] Small fixes for e2e tests

### DIFF
--- a/e2e/tests/cluster/cluster_test.go
+++ b/e2e/tests/cluster/cluster_test.go
@@ -73,7 +73,7 @@ func Test_ClusterLifecycle(t *testing.T) {
 			if err != nil {
 				test.Logger.WithError(err).Error("Error cleaning up installation")
 			}
-			err := test.ClusterSuite.DeleteCluster(context.Background())
+			err := test.ClusterSuite.Cleanup(context.Background())
 			if err != nil {
 				test.Logger.WithError(err).Error("Error cleaning up cluster")
 			}

--- a/e2e/tests/cluster/cluster_test.go
+++ b/e2e/tests/cluster/cluster_test.go
@@ -86,7 +86,7 @@ func Test_ClusterLifecycle(t *testing.T) {
 	err = test.Run()
 	require.NoError(t, err)
 
-	// Make sure we wait for al subscription events
+	// Make sure we wait for all subscription events
 	time.Sleep(time.Second * 1)
 
 	// Make sure that expected events occurred in correct order.

--- a/e2e/tests/cluster/cluster_test.go
+++ b/e2e/tests/cluster/cluster_test.go
@@ -86,6 +86,9 @@ func Test_ClusterLifecycle(t *testing.T) {
 	err = test.Run()
 	require.NoError(t, err)
 
+	// Make sure we wait for al subscription events
+	time.Sleep(time.Second * 1)
+
 	// Make sure that expected events occurred in correct order.
 	expectedEvents := workflow.GetExpectedEvents(test.Steps)
 	err = test.EventsRecorder.VerifyInOrder(expectedEvents)

--- a/e2e/tests/cluster/suite.go
+++ b/e2e/tests/cluster/suite.go
@@ -41,6 +41,7 @@ type TestConfig struct {
 	NodeRoleARN               string `envconfig:"optional"`
 	ClusterID                 string `envconfig:"optional"`
 	InstallationID            string `envconfig:"optional"`
+	Debug                     bool   `envconfig:"optional,default=false"`
 }
 
 // Test holds all data required for a db migration test.
@@ -68,6 +69,10 @@ func SetupClusterLifecycleTest() (*Test, error) {
 	config, err := readConfig(logger)
 	if err != nil {
 		return nil, err
+	}
+
+	if config.Debug {
+		logger.Logger.SetLevel(logrus.DebugLevel)
 	}
 
 	client := model.NewClient(config.CloudURL)

--- a/e2e/workflow/cluster.go
+++ b/e2e/workflow/cluster.go
@@ -112,6 +112,38 @@ func (w *ClusterSuite) DeleteCluster(ctx context.Context) error {
 	return nil
 }
 
+// Cleanup cleans up installation saved in suite metadata.
+func (w *ClusterSuite) Cleanup(ctx context.Context) error {
+	cluster, err := w.client.GetCluster(w.Meta.ClusterID)
+	if err != nil {
+		return errors.Wrap(err, "error getting cluster")
+	}
+	if cluster == nil {
+		return nil
+	}
+	if cluster.State == model.ClusterStateDeleted {
+		w.logger.Info("cluster already deleted")
+		return nil
+	}
+	if cluster.State == model.ClusterStateDeletionRequested ||
+		cluster.State == model.ClusterStateDeletionFailed {
+		w.logger.Info("cluster already marked for deletion")
+		return nil
+	}
+
+	err = w.client.DeleteCluster(w.Meta.ClusterID)
+	if err != nil {
+		return errors.Wrap(err, "while requesting cluster removal")
+	}
+
+	err = pkg.WaitForClusterDeletion(context.TODO(), cluster.ID, w.whChan, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while waiting for cluster deletion")
+	}
+
+	return nil
+}
+
 // ClusterCreationEvents returns expected events that should occur while creating the cluster.
 // This method should be called only after executing the workflow so that IDs are not empty.
 func (w *ClusterSuite) ClusterCreationEvents() []eventstest.EventOccurrence {


### PR DESCRIPTION
#### Summary

- Added a Debug configuration to E2E test output. `DEBUG=true`
- Refactored cluster cleanup (no more errors on trying to delete an already deleted cluster)
- Wait for subscription messages for 1 seconds before evaluating the test steps that came from subscriptions.
  - This (hopefully) fixes a race condition where the cluster has already been deleted (correctly) but the subscription message has not arrived yet, making the step-checking fail at the end of the tests.
  - I tried to switch this to a "broadcast" from the webhook (we only register the webhook, and we leave two channels, one for the suite and one for the events recorder to collect what's going on) but that added more complexity so I wanted to try this first. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50968

#### Release Note

```release-note
fix: e2e tests fixes and improvements
```
