### PR TITLE
[MM-50968] fix: run mmctl command on running pods only

### DIFF
--- a/internal/provisioner/exec.go
+++ b/internal/provisioner/exec.go
@@ -144,6 +144,7 @@ func execClusterInstallationCLI(k8sClient *k8s.KubeClient, clusterInstallation *
 	ctx := context.TODO()
 	podList, err := k8sClient.Clientset.CoreV1().Pods(clusterInstallation.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: "app=mattermost",
+		FieldSelector: "status.phase=Running",
 	})
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to query mattermost pods")


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Run mattermost commands on running pods only, for those situations where we want to run a command and either the installation is being created or updating and one of the pods may not be ready yet.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-50968

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
fix: run mmctl commands on running pods only
```
