### PR TITLE
[MM-51440] Fixes server flag parsing in installation status command

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -439,7 +439,7 @@ func dnsNames(dnsRecords []*model.InstallationDNS) string {
 }
 
 func newCmdInstallationGetStatuses() *cobra.Command {
-	var flags clusterFlags
+	var flags installationGetStatusesFlags
 
 	cmd := &cobra.Command{
 		Use:   "status",
@@ -457,6 +457,9 @@ func newCmdInstallationGetStatuses() *cobra.Command {
 			}
 
 			return printJSON(installationsStatus)
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.clusterFlags.addFlags(cmd)
 		},
 	}
 	flags.addFlags(cmd)

--- a/cmd/cloud/installation_flag.go
+++ b/cmd/cloud/installation_flag.go
@@ -318,6 +318,14 @@ func (flags *installationListFlags) addFlags(command *cobra.Command) {
 	command.Flags().BoolVar(&flags.hideEnv, "hide-env", true, "Whether to hide env vars in the output or not.")
 }
 
+type installationGetStatusesFlags struct {
+	clusterFlags
+}
+
+func (flags *installationGetStatusesFlags) addFlags(command *cobra.Command) {
+
+}
+
 type installationRecoveryFlags struct {
 	clusterFlags
 	installationID string


### PR DESCRIPTION
#### Summary

This bug occurred because we did not parse this flag in PreRun.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-51440



#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
