### PR TITLE
[MM-50721] Provisioner: Update webhooks and subscriptions resources to store custom client header config

### DIFF
--- a/cmd/cloud/events_subscription.go
+++ b/cmd/cloud/events_subscription.go
@@ -36,13 +36,34 @@ func newCmdSubscriptionCreate() *cobra.Command {
 			cmd.SilenceUsage = true
 			client := model.NewClient(flags.serverAddress)
 
+			var headers model.Headers
+			for key, value := range flags.headers {
+				valueInner := value
+				headers = append(headers, model.WebhookHeader{
+					Key:   key,
+					Value: &valueInner,
+				})
+			}
+
+			for key, value := range flags.headersFromEnv {
+				valueInner := value
+				headers = append(headers, model.WebhookHeader{
+					Key:          key,
+					ValueFromEnv: &valueInner,
+				})
+			}
+
+			if err := headers.Validate(); err != nil {
+				return errors.Wrap(err, "failed to validate webhook headers")
+			}
+
 			request := &model.CreateSubscriptionRequest{
 				Name:             flags.name,
 				URL:              flags.url,
 				OwnerID:          flags.owner,
 				EventType:        model.EventType(flags.eventType),
 				FailureThreshold: flags.failureThreshold,
-				Headers:          flags.headers,
+				Headers:          headers,
 			}
 
 			if flags.dryRun {

--- a/cmd/cloud/events_subscription.go
+++ b/cmd/cloud/events_subscription.go
@@ -27,7 +27,6 @@ func newCmdSubscription() *cobra.Command {
 }
 
 func newCmdSubscriptionCreate() *cobra.Command {
-
 	var flags subscriptionCreateFlags
 
 	cmd := &cobra.Command{
@@ -43,6 +42,7 @@ func newCmdSubscriptionCreate() *cobra.Command {
 				OwnerID:          flags.owner,
 				EventType:        model.EventType(flags.eventType),
 				FailureThreshold: flags.failureThreshold,
+				Headers:          flags.headers,
 			}
 
 			if flags.dryRun {

--- a/cmd/cloud/events_subscription_flag.go
+++ b/cmd/cloud/events_subscription_flag.go
@@ -19,6 +19,7 @@ type subscriptionCreateFlags struct {
 	eventType        string
 	failureThreshold time.Duration
 	headers          map[string]string
+	headersFromEnv   map[string]string
 }
 
 func (flags *subscriptionCreateFlags) addFlags(command *cobra.Command) {
@@ -27,7 +28,8 @@ func (flags *subscriptionCreateFlags) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.owner, "owner", "", "OwnerID of the subscription.")
 	command.Flags().StringVar(&flags.eventType, "event-type", string(model.ResourceStateChangeEventType), "Event type of the subscription.")
 	command.Flags().DurationVar(&flags.failureThreshold, "failure-threshold", 0, "Failure threshold of the subscription.")
-	command.Flags().StringToStringVar(&flags.headers, "headers", nil, "headers that should be sent with the request")
+	command.Flags().StringToStringVar(&flags.headers, "header", nil, "a header that should be sent with the request")
+	command.Flags().StringToStringVar(&flags.headersFromEnv, "header-from-env", nil, "a header that should be sent with the request, with values read from environment variables")
 	_ = command.MarkFlagRequired("url")
 	_ = command.MarkFlagRequired("owner")
 	_ = command.MarkFlagRequired("event-type")

--- a/cmd/cloud/events_subscription_flag.go
+++ b/cmd/cloud/events_subscription_flag.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
 package main
 
 import (
@@ -14,6 +18,7 @@ type subscriptionCreateFlags struct {
 	owner            string
 	eventType        string
 	failureThreshold time.Duration
+	headers          map[string]string
 }
 
 func (flags *subscriptionCreateFlags) addFlags(command *cobra.Command) {
@@ -22,6 +27,7 @@ func (flags *subscriptionCreateFlags) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.owner, "owner", "", "OwnerID of the subscription.")
 	command.Flags().StringVar(&flags.eventType, "event-type", string(model.ResourceStateChangeEventType), "Event type of the subscription.")
 	command.Flags().DurationVar(&flags.failureThreshold, "failure-threshold", 0, "Failure threshold of the subscription.")
+	command.Flags().StringToStringVar(&flags.headers, "headers", nil, "headers that should be sent with the request")
 	_ = command.MarkFlagRequired("url")
 	_ = command.MarkFlagRequired("owner")
 	_ = command.MarkFlagRequired("event-type")

--- a/cmd/cloud/webhook.go
+++ b/cmd/cloud/webhook.go
@@ -39,10 +39,11 @@ func newCmdWebhookCreate() *cobra.Command {
 			command.SilenceUsage = true
 			client := model.NewClient(flags.serverAddress)
 
+			headers := model.StringMap(flags.headers)
 			webhook, err := client.CreateWebhook(&model.CreateWebhookRequest{
 				OwnerID: flags.ownerID,
 				URL:     flags.url,
-				Headers: flags.headers,
+				Headers: headers,
 			})
 			if err != nil {
 				return errors.Wrap(err, "failed to create webhook")

--- a/cmd/cloud/webhook.go
+++ b/cmd/cloud/webhook.go
@@ -42,6 +42,7 @@ func newCmdWebhookCreate() *cobra.Command {
 			webhook, err := client.CreateWebhook(&model.CreateWebhookRequest{
 				OwnerID: flags.ownerID,
 				URL:     flags.url,
+				Headers: flags.headers,
 			})
 			if err != nil {
 				return errors.Wrap(err, "failed to create webhook")

--- a/cmd/cloud/webhook.go
+++ b/cmd/cloud/webhook.go
@@ -39,7 +39,27 @@ func newCmdWebhookCreate() *cobra.Command {
 			command.SilenceUsage = true
 			client := model.NewClient(flags.serverAddress)
 
-			headers := model.StringMap(flags.headers)
+			var headers model.Headers
+			for key, value := range flags.headers {
+				valueInner := value
+				headers = append(headers, model.WebhookHeader{
+					Key:   key,
+					Value: &valueInner,
+				})
+			}
+
+			for key, value := range flags.headersFromEnv {
+				valueInner := value
+				headers = append(headers, model.WebhookHeader{
+					Key:          key,
+					ValueFromEnv: &valueInner,
+				})
+			}
+
+			if err := headers.Validate(); err != nil {
+				return errors.Wrap(err, "failed to validate webhook headers")
+			}
+
 			webhook, err := client.CreateWebhook(&model.CreateWebhookRequest{
 				OwnerID: flags.ownerID,
 				URL:     flags.url,

--- a/cmd/cloud/webhook_flag.go
+++ b/cmd/cloud/webhook_flag.go
@@ -22,15 +22,17 @@ func (flags *webhookFlags) addFlags(command *cobra.Command) {
 
 type webhookCreateFlag struct {
 	webhookFlags
-	ownerID string
-	url     string
-	headers map[string]string
+	ownerID        string
+	url            string
+	headers        map[string]string
+	headersFromEnv map[string]string
 }
 
 func (flags *webhookCreateFlag) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.ownerID, "owner", "", "An opaque identifier describing the owner of the webhook.")
 	command.Flags().StringVar(&flags.url, "url", "", "The callback URL of the webhook.")
-	command.Flags().StringToStringVar(&flags.headers, "headers", nil, "headers that should be sent with the request")
+	command.Flags().StringToStringVar(&flags.headers, "header", nil, "a header that should be sent with the request")
+	command.Flags().StringToStringVar(&flags.headersFromEnv, "header-from-env", nil, "a header that should be sent with the request, with values read from environment variables")
 	_ = command.MarkFlagRequired("owner")
 	_ = command.MarkFlagRequired("url")
 }

--- a/cmd/cloud/webhook_flag.go
+++ b/cmd/cloud/webhook_flag.go
@@ -4,7 +4,9 @@
 
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+)
 
 func setWebhookFlags(command *cobra.Command) {
 	command.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")

--- a/cmd/cloud/webhook_flag.go
+++ b/cmd/cloud/webhook_flag.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
 package main
 
 import "github.com/spf13/cobra"
@@ -18,11 +22,13 @@ type webhookCreateFlag struct {
 	webhookFlags
 	ownerID string
 	url     string
+	headers map[string]string
 }
 
 func (flags *webhookCreateFlag) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.ownerID, "owner", "", "An opaque identifier describing the owner of the webhook.")
 	command.Flags().StringVar(&flags.url, "url", "", "The callback URL of the webhook.")
+	command.Flags().StringToStringVar(&flags.headers, "headers", nil, "headers that should be sent with the request")
 	_ = command.MarkFlagRequired("owner")
 	_ = command.MarkFlagRequired("url")
 }

--- a/internal/api/events_subscription_test.go
+++ b/internal/api/events_subscription_test.go
@@ -5,6 +5,9 @@
 package api_test
 
 import (
+	"bytes"
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -76,6 +79,80 @@ func TestCreateGetDeleteSubscriptions(t *testing.T) {
 	fetchedSub, err = client.GetSubscription(sub.ID)
 	require.NoError(t, err)
 	assert.True(t, fetchedSub.DeleteAt > 0)
+}
+
+func TestCreateSubscription(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	ownerID := "owner"
+
+	router := mux.NewRouter()
+	api.Register(router, &api.Context{
+		Store:      sqlStore,
+		Supervisor: &mockSupervisor{},
+		Metrics:    &mockMetrics{},
+		Logger:     logger,
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	client := model.NewClient(ts.URL)
+
+	t.Run("valid headers value", func(t *testing.T) {
+		testCases := []struct {
+			createRequest model.CreateSubscriptionRequest
+		}{
+			{
+				createRequest: model.CreateSubscriptionRequest{
+					OwnerID:   ownerID,
+					EventType: model.ResourceStateChangeEventType,
+					URL:       "http://valid.com/1",
+					Headers: model.StringMap{
+						"Foo": "bar",
+					},
+				},
+			},
+			{
+				createRequest: model.CreateSubscriptionRequest{
+					OwnerID:   ownerID,
+					EventType: model.ResourceStateChangeEventType,
+					URL:       "http://valid.com/2",
+					Headers:   nil,
+				},
+			},
+		}
+
+		for _, testCase := range testCases {
+			wh, err := client.CreateSubscription(&testCase.createRequest)
+			require.NoError(t, err)
+			if testCase.createRequest.Headers == nil {
+				require.Nil(t, wh.Headers)
+			} else {
+				require.NotNil(t, wh.Headers)
+			}
+		}
+	})
+
+	t.Run("invalid headers", func(t *testing.T) {
+		testCases := []struct {
+			payload string
+		}{
+			{
+				payload: fmt.Sprintf(`{"url": "https://valid.com/1","owner":"%s","eventType": "%s", "headers":"invalid"}`, ownerID, model.ResourceStateChangeEventType),
+			},
+			{
+				payload: fmt.Sprintf(`{"url": "https://valid.com/2","owner":"%s","eventType": "%s","headers":{"valid": "header","invalid": 1}}`, ownerID, model.ResourceStateChangeEventType),
+			},
+			{
+				payload: fmt.Sprintf(`{"url": "https://valid.com/3","owner":"%s","eventType": "%s","headers": 1}`, ownerID, model.ResourceStateChangeEventType),
+			},
+		}
+		for _, testCase := range testCases {
+			resp, err := http.Post(fmt.Sprintf("%s/api/subscriptions", ts.URL), "application/json", bytes.NewReader([]byte(testCase.payload)))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		}
+	})
 }
 
 func TestListSubscriptions(t *testing.T) {

--- a/internal/api/events_subscription_test.go
+++ b/internal/api/events_subscription_test.go
@@ -98,6 +98,8 @@ func TestCreateSubscription(t *testing.T) {
 
 	client := model.NewClient(ts.URL)
 
+	headerValue := "bar"
+
 	t.Run("valid headers value", func(t *testing.T) {
 		testCases := []struct {
 			createRequest model.CreateSubscriptionRequest
@@ -107,8 +109,11 @@ func TestCreateSubscription(t *testing.T) {
 					OwnerID:   ownerID,
 					EventType: model.ResourceStateChangeEventType,
 					URL:       "http://valid.com/1",
-					Headers: model.StringMap{
-						"Foo": "bar",
+					Headers: model.Headers{
+						{
+							Key:   "foo",
+							Value: &headerValue,
+						},
 					},
 				},
 			},

--- a/internal/api/webhook.go
+++ b/internal/api/webhook.go
@@ -38,7 +38,7 @@ func handleCreateWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 	webhook := model.Webhook{
 		OwnerID: createWebhookRequest.OwnerID,
 		URL:     createWebhookRequest.URL,
-		Headers: createWebhookRequest.Headers,
+		Headers: &createWebhookRequest.Headers,
 	}
 
 	err = c.Store.CreateWebhook(&webhook)

--- a/internal/api/webhook.go
+++ b/internal/api/webhook.go
@@ -38,6 +38,7 @@ func handleCreateWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 	webhook := model.Webhook{
 		OwnerID: createWebhookRequest.OwnerID,
 		URL:     createWebhookRequest.URL,
+		Headers: createWebhookRequest.Headers,
 	}
 
 	err = c.Store.CreateWebhook(&webhook)

--- a/internal/api/webhook.go
+++ b/internal/api/webhook.go
@@ -38,7 +38,7 @@ func handleCreateWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 	webhook := model.Webhook{
 		OwnerID: createWebhookRequest.OwnerID,
 		URL:     createWebhookRequest.URL,
-		Headers: &createWebhookRequest.Headers,
+		Headers: createWebhookRequest.Headers,
 	}
 
 	err = c.Store.CreateWebhook(&webhook)

--- a/internal/api/webhook_test.go
+++ b/internal/api/webhook_test.go
@@ -71,6 +71,7 @@ func TestCreateWebhook(t *testing.T) {
 	})
 
 	t.Run("valid headers value", func(t *testing.T) {
+		value := "bar"
 		testCases := []struct {
 			createRequest model.CreateWebhookRequest
 		}{
@@ -78,8 +79,11 @@ func TestCreateWebhook(t *testing.T) {
 				createRequest: model.CreateWebhookRequest{
 					OwnerID: "owner",
 					URL:     "http://valid.com/1",
-					Headers: model.StringMap{
-						"Foo": "bar",
+					Headers: []model.WebhookHeader{
+						{
+							Key:   "foo",
+							Value: &value,
+						},
 					},
 				},
 			},

--- a/internal/api/webhook_test.go
+++ b/internal/api/webhook_test.go
@@ -70,6 +70,60 @@ func TestCreateWebhook(t *testing.T) {
 		require.EqualError(t, err, "failed with status code 400")
 	})
 
+	t.Run("valid headers value", func(t *testing.T) {
+		testCases := []struct {
+			createRequest model.CreateWebhookRequest
+		}{
+			{
+				createRequest: model.CreateWebhookRequest{
+					OwnerID: "owner",
+					URL:     "http://valid.com/1",
+					Headers: model.StringMap{
+						"Foo": "bar",
+					},
+				},
+			},
+			{
+				createRequest: model.CreateWebhookRequest{
+					OwnerID: "owner",
+					URL:     "http://valid.com/2",
+					Headers: nil,
+				},
+			},
+		}
+
+		for _, testCase := range testCases {
+			wh, err := client.CreateWebhook(&testCase.createRequest)
+			require.NoError(t, err)
+			if testCase.createRequest.Headers == nil {
+				require.Nil(t, wh.Headers)
+			} else {
+				require.NotNil(t, wh.Headers)
+			}
+		}
+	})
+
+	t.Run("invalid headers", func(t *testing.T) {
+		testCases := []struct {
+			payload string
+		}{
+			{
+				payload: `{"url": "https://valid.com/1","owner":"unittest","headers":"invalid"}`,
+			},
+			{
+				payload: `{"url": "https://valid.com/2","owner":"unittest","headers":{"valid": "header","invalid": 1}}`,
+			},
+			{
+				payload: `{"url": "https://valid.com/3","owner":"unittest","headers": 1}`,
+			},
+		}
+		for _, testCase := range testCases {
+			resp, err := http.Post(fmt.Sprintf("%s/api/webhooks", ts.URL), "application/json", bytes.NewReader([]byte(testCase.payload)))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		}
+	})
+
 	t.Run("valid", func(t *testing.T) {
 		webhook, err := client.CreateWebhook(&model.CreateWebhookRequest{
 			OwnerID: "owner",

--- a/internal/events/delivery.go
+++ b/internal/events/delivery.go
@@ -286,15 +286,7 @@ func (s *sender) sendEvent(subscription_id, url string, data *model.StateChangeE
 		return errors.Wrap(err, "unable to create request from payload")
 	}
 	req.Header.Set("Content-Type", contentTypeApplicationJSON)
-	headers, err := model.ParseHeadersFromStringMap(data.EventHeaders)
-	if err != nil {
-		// If there's an error parsing the headers, log it but continue execution so the subscription
-		// event is sent, `model.ParseHeadersFromStringMap` should take care of not disclosing any
-		// unset environment variables into resulting headers.
-		s.logger.WithFields(logrus.Fields{
-			"subscription": subscription_id,
-		}).WithError(err).Error()
-	}
+	headers := data.EventHeaders.GetHeaders()
 	for key, value := range headers {
 		req.Header.Set(key, value)
 	}

--- a/internal/events/delivery.go
+++ b/internal/events/delivery.go
@@ -248,7 +248,8 @@ func (s *sender) processDelivery(sub *model.Subscription, delivery *model.StateC
 
 	var subDeliveryStatus model.SubscriptionDeliveryStatus
 
-	err := s.sendEvent(sub.URL, delivery, log)
+	delivery.EventHeaders = sub.Headers
+	err := s.sendEvent(sub.ID, sub.URL, delivery, log)
 	if err != nil {
 		log.WithError(err).Error("Failed to deliver event")
 
@@ -273,13 +274,31 @@ func (s *sender) processDelivery(sub *model.Subscription, delivery *model.StateC
 	return subDeliveryStatus, subDeliveryStatus != model.SubscriptionDeliveryFailed
 }
 
-func (s *sender) sendEvent(url string, data *model.StateChangeEventDeliveryData, log logrus.FieldLogger) error {
+func (s *sender) sendEvent(subscription_id, url string, data *model.StateChangeEventDeliveryData, log logrus.FieldLogger) error {
 	payload, err := json.Marshal(data.EventData.ToEventPayload())
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal event payload")
 	}
 
-	resp, err := s.client.Post(url, contentTypeApplicationJSON, bytes.NewBuffer(payload))
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+	if err != nil {
+		s.logger.WithField("subscription_url", url).WithError(err).Error("Unable to create request")
+		return errors.Wrap(err, "unable to create request from payload")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	headers, err := model.ParseHeadersFromStringMap(data.EventHeaders)
+	if err != nil {
+		// If there's an error parsing the headers, log it but continue execution so the subscription
+		// event is sent, `model.ParseHeadersFromStringMap` should take care of not disclosing any
+		// unset environment variables into resulting headers.
+		s.logger.WithFields(logrus.Fields{
+			"subscription": subscription_id,
+		}).WithError(err).Error()
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "failed to deliver event")
 	}

--- a/internal/events/delivery.go
+++ b/internal/events/delivery.go
@@ -14,9 +14,9 @@ import (
 	"sync"
 	"time"
 
-	"emperror.dev/errors"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -285,7 +285,7 @@ func (s *sender) sendEvent(subscription_id, url string, data *model.StateChangeE
 		s.logger.WithField("subscription_url", url).WithError(err).Error("Unable to create request")
 		return errors.Wrap(err, "unable to create request from payload")
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentTypeApplicationJSON)
 	headers, err := model.ParseHeadersFromStringMap(data.EventHeaders)
 	if err != nil {
 		// If there's an error parsing the headers, log it but continue execution so the subscription

--- a/internal/store/events_subscription.go
+++ b/internal/store/events_subscription.go
@@ -21,6 +21,7 @@ var (
 		"Name",
 		"OwnerID",
 		"EventType",
+		"Headers",
 		"FailureThreshold",
 		"LastDeliveryStatus",
 		"LastDeliveryAttemptAt",
@@ -153,6 +154,7 @@ func (sqlStore *SQLStore) CreateSubscription(sub *model.Subscription) error {
 			"DeleteAt":              sub.DeleteAt,
 			"LockAcquiredAt":        sub.LockAcquiredAt,
 			"LockAcquiredBy":        sub.LockAcquiredBy,
+			"Headers":               sub.Headers,
 		}))
 	if err != nil {
 		return errors.Wrap(err, "failed to create subscription")

--- a/internal/store/events_subscription_test.go
+++ b/internal/store/events_subscription_test.go
@@ -21,7 +21,7 @@ func TestCountSubscriptionsForEvent(t *testing.T) {
 
 	sub1 := &model.Subscription{
 		EventType: model.ResourceStateChangeEventType,
-		Headers: model.StringMap{
+		Headers: &model.StringMap{
 			"Foo": "Bar",
 		},
 	}

--- a/internal/store/events_subscription_test.go
+++ b/internal/store/events_subscription_test.go
@@ -21,6 +21,9 @@ func TestCountSubscriptionsForEvent(t *testing.T) {
 
 	sub1 := &model.Subscription{
 		EventType: model.ResourceStateChangeEventType,
+		Headers: model.StringMap{
+			"Foo": "Bar",
+		},
 	}
 	err := sqlStore.CreateSubscription(sub1)
 	require.NoError(t, err)

--- a/internal/store/events_subscription_test.go
+++ b/internal/store/events_subscription_test.go
@@ -19,10 +19,15 @@ func TestCountSubscriptionsForEvent(t *testing.T) {
 	sqlStore := MakeTestSQLStore(t, logger)
 	defer CloseConnection(t, sqlStore)
 
+	value := "bar"
+
 	sub1 := &model.Subscription{
 		EventType: model.ResourceStateChangeEventType,
-		Headers: &model.StringMap{
-			"Foo": "Bar",
+		Headers: model.Headers{
+			{
+				Key:   "foo",
+				Value: &value,
+			},
 		},
 	}
 	err := sqlStore.CreateSubscription(sub1)

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -2136,12 +2136,12 @@ var migrations = []migration{
 			fieldType = "TEXT"
 		}
 
-		_, err := e.Exec(fmt.Sprintf(`ALTER TABLE Webhooks ADD COLUMN Headers %s;`, fieldType))
+		_, err := e.Exec(fmt.Sprintf(`ALTER TABLE Webhooks ADD COLUMN Headers %s NULL;`, fieldType))
 		if err != nil {
 			return err
 		}
 
-		_, err = e.Exec(fmt.Sprintf(`ALTER TABLE Subscription ADD COLUMN Headers %s;`, fieldType))
+		_, err = e.Exec(fmt.Sprintf(`ALTER TABLE Subscription ADD COLUMN Headers %s NULL;`, fieldType))
 		if err != nil {
 			return err
 		}

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -2130,4 +2130,22 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.41.0"), semver.MustParse("0.42.0"), func(e execer) error {
+		fieldType := "JSONB"
+		if e.DriverName() == driverSqlite {
+			fieldType = "TEXT"
+		}
+
+		_, err := e.Exec(fmt.Sprintf(`ALTER TABLE Webhooks ADD COLUMN Headers %s;`, fieldType))
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(fmt.Sprintf(`ALTER TABLE Subscription ADD COLUMN Headers %s;`, fieldType))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/internal/store/webhook.go
+++ b/internal/store/webhook.go
@@ -16,7 +16,7 @@ var webhookSelect sq.SelectBuilder
 
 func init() {
 	webhookSelect = sq.
-		Select("ID", "OwnerID", "URL", "CreateAt", "DeleteAt").From("Webhooks")
+		Select("ID", "OwnerID", "URL", "Headers", "CreateAt", "DeleteAt").From("Webhooks")
 }
 
 // GetWebhook fetches the given webhook by id.
@@ -67,6 +67,7 @@ func (sqlStore *SQLStore) CreateWebhook(webhook *model.Webhook) error {
 			"URL":      webhook.URL,
 			"CreateAt": webhook.CreateAt,
 			"DeleteAt": 0,
+			"Headers":  webhook.Headers,
 		}),
 	)
 	if err != nil {

--- a/internal/store/webhook_test.go
+++ b/internal/store/webhook_test.go
@@ -30,11 +30,17 @@ func TestWebhooks(t *testing.T) {
 		webhook1 := &model.Webhook{
 			OwnerID: "owner1",
 			URL:     "https://url1.com",
+			Headers: model.StringMap{
+				"Foo": "bar",
+			},
 		}
 
 		webhook2 := &model.Webhook{
 			OwnerID: "owner2",
 			URL:     "https://url2.com",
+			Headers: model.StringMap{
+				"Foo": "bar",
+			},
 		}
 
 		err := sqlStore.CreateWebhook(webhook1)

--- a/internal/store/webhook_test.go
+++ b/internal/store/webhook_test.go
@@ -26,20 +26,27 @@ func TestWebhooks(t *testing.T) {
 	t.Run("get webhooks", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		sqlStore := MakeTestSQLStore(t, logger)
+		value := "bar"
 
 		webhook1 := &model.Webhook{
 			OwnerID: "owner1",
 			URL:     "https://url1.com",
-			Headers: &model.StringMap{
-				"Foo": "bar",
+			Headers: []model.WebhookHeader{
+				{
+					Key:   "foo",
+					Value: &value,
+				},
 			},
 		}
 
 		webhook2 := &model.Webhook{
 			OwnerID: "owner2",
 			URL:     "https://url2.com",
-			Headers: &model.StringMap{
-				"Foo": "bar",
+			Headers: []model.WebhookHeader{
+				{
+					Key:   "foo",
+					Value: &value,
+				},
 			},
 		}
 

--- a/internal/store/webhook_test.go
+++ b/internal/store/webhook_test.go
@@ -30,7 +30,7 @@ func TestWebhooks(t *testing.T) {
 		webhook1 := &model.Webhook{
 			OwnerID: "owner1",
 			URL:     "https://url1.com",
-			Headers: model.StringMap{
+			Headers: &model.StringMap{
 				"Foo": "bar",
 			},
 		}
@@ -38,7 +38,7 @@ func TestWebhooks(t *testing.T) {
 		webhook2 := &model.Webhook{
 			OwnerID: "owner2",
 			URL:     "https://url2.com",
-			Headers: model.StringMap{
+			Headers: &model.StringMap{
 				"Foo": "bar",
 			},
 		}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -60,16 +59,7 @@ func sendWebhook(hook *model.Webhook, payload *model.WebhookPayload, logger *log
 		return errors.Wrap(err, "unable to create request from payload")
 	}
 	req.Header.Set("Content-Type", "application/json")
-	headers, err := model.ParseHeadersFromStringMap(hook.Headers)
-	if err != nil {
-		// If there's an error parsing the headers, log it but continue execution so the webhook is
-		// sent, `model.ParseHeadersFromStringMap` should take care of not disclosing any unset
-		// environment variables into resulting headers.
-		logger.WithFields(logrus.Fields{
-			"webhook": hook.ID,
-		}).WithError(err).Error()
-	}
-	for key, value := range headers {
+	for key, value := range hook.Headers.GetHeaders() {
 		req.Header.Set(key, value)
 	}
 

--- a/model/events_state_change.go
+++ b/model/events_state_change.go
@@ -30,6 +30,7 @@ type StateChangeEventData struct {
 type StateChangeEventDeliveryData struct {
 	EventDelivery EventDelivery
 	EventData     StateChangeEventData
+	EventHeaders  map[string]string
 }
 
 // StateChangeEventPayload represents payload that is sent to consumers.

--- a/model/events_state_change.go
+++ b/model/events_state_change.go
@@ -30,7 +30,7 @@ type StateChangeEventData struct {
 type StateChangeEventDeliveryData struct {
 	EventDelivery EventDelivery
 	EventData     StateChangeEventData
-	EventHeaders  map[string]string
+	EventHeaders  *StringMap
 }
 
 // StateChangeEventPayload represents payload that is sent to consumers.

--- a/model/events_state_change.go
+++ b/model/events_state_change.go
@@ -30,7 +30,7 @@ type StateChangeEventData struct {
 type StateChangeEventDeliveryData struct {
 	EventDelivery EventDelivery
 	EventData     StateChangeEventData
-	EventHeaders  *StringMap
+	EventHeaders  Headers
 }
 
 // StateChangeEventPayload represents payload that is sent to consumers.

--- a/model/events_subscription.go
+++ b/model/events_subscription.go
@@ -39,7 +39,7 @@ type Subscription struct {
 	DeleteAt         int64
 	LockAcquiredBy   *string
 	LockAcquiredAt   int64
-	Headers          StringMap
+	Headers          *StringMap
 }
 
 // IsDeleted returns true if subscription is deleted.

--- a/model/events_subscription.go
+++ b/model/events_subscription.go
@@ -39,7 +39,7 @@ type Subscription struct {
 	DeleteAt         int64
 	LockAcquiredBy   *string
 	LockAcquiredAt   int64
-	Headers          *StringMap
+	Headers          Headers
 }
 
 // IsDeleted returns true if subscription is deleted.

--- a/model/events_subscription.go
+++ b/model/events_subscription.go
@@ -39,6 +39,7 @@ type Subscription struct {
 	DeleteAt         int64
 	LockAcquiredBy   *string
 	LockAcquiredAt   int64
+	Headers          StringMap
 }
 
 // IsDeleted returns true if subscription is deleted.

--- a/model/events_subscription_request.go
+++ b/model/events_subscription_request.go
@@ -20,7 +20,7 @@ type CreateSubscriptionRequest struct {
 	OwnerID          string
 	EventType        EventType
 	FailureThreshold time.Duration
-	Headers          map[string]string
+	Headers          StringMap
 }
 
 // ToSubscription validates request and converts it to subscription
@@ -47,7 +47,7 @@ func (r CreateSubscriptionRequest) ToSubscription() (Subscription, error) {
 		LastDeliveryStatus:    SubscriptionDeliveryNone,
 		LastDeliveryAttemptAt: 0,
 		FailureThreshold:      r.FailureThreshold,
-		Headers:               r.Headers,
+		Headers:               &r.Headers,
 	}, nil
 }
 

--- a/model/events_subscription_request.go
+++ b/model/events_subscription_request.go
@@ -20,7 +20,7 @@ type CreateSubscriptionRequest struct {
 	OwnerID          string
 	EventType        EventType
 	FailureThreshold time.Duration
-	Headers          StringMap
+	Headers          Headers
 }
 
 // ToSubscription validates request and converts it to subscription
@@ -47,7 +47,7 @@ func (r CreateSubscriptionRequest) ToSubscription() (Subscription, error) {
 		LastDeliveryStatus:    SubscriptionDeliveryNone,
 		LastDeliveryAttemptAt: 0,
 		FailureThreshold:      r.FailureThreshold,
-		Headers:               &r.Headers,
+		Headers:               r.Headers,
 	}, nil
 }
 

--- a/model/events_subscription_request.go
+++ b/model/events_subscription_request.go
@@ -20,6 +20,7 @@ type CreateSubscriptionRequest struct {
 	OwnerID          string
 	EventType        EventType
 	FailureThreshold time.Duration
+	Headers          map[string]string
 }
 
 // ToSubscription validates request and converts it to subscription
@@ -28,7 +29,6 @@ func (r CreateSubscriptionRequest) ToSubscription() (Subscription, error) {
 	if err != nil {
 		return Subscription{}, errors.Wrap(err, "failed to parse subscription URL")
 	}
-
 	if r.EventType == "" {
 		return Subscription{}, errors.New("event type is required when registering subscription")
 	}
@@ -47,6 +47,7 @@ func (r CreateSubscriptionRequest) ToSubscription() (Subscription, error) {
 		LastDeliveryStatus:    SubscriptionDeliveryNone,
 		LastDeliveryAttemptAt: 0,
 		FailureThreshold:      r.FailureThreshold,
+		Headers:               r.Headers,
 	}, nil
 }
 

--- a/model/types.go
+++ b/model/types.go
@@ -51,9 +51,9 @@ func (wh Headers) Validate() error {
 	return nil
 }
 
-func (wh *Headers) GetHeaders() map[string]string {
-	headers := make(map[string]string, len(*wh))
-	for _, header := range *wh {
+func (wh Headers) GetHeaders() map[string]string {
+	headers := make(map[string]string, len(wh))
+	for _, header := range wh {
 		if header.Value != nil {
 			headers[header.Key] = *header.Value
 		} else if header.ValueFromEnv != nil {

--- a/model/types.go
+++ b/model/types.go
@@ -11,23 +11,20 @@ import (
 )
 
 // StringMap type used to have a map[string]string directly in the database in a TEXT or JSON/JSONB
-// field
+// field.
 type StringMap map[string]string
 
 func (sm StringMap) Value() (driver.Value, error) {
 	return json.Marshal(sm)
 }
 
-func (sm StringMap) Scan(v interface{}) error {
-	if v == nil {
-		return nil
-	}
-	switch data := v.(type) {
+func (sm *StringMap) Scan(databaseValue interface{}) error {
+	switch value := databaseValue.(type) {
 	case string: // sqlite's text
-		return json.Unmarshal([]byte(data), &sm)
+		return json.Unmarshal([]byte(value), sm)
 	case []byte: // psqls jsonb
-		return json.Unmarshal(data, &sm)
+		return json.Unmarshal(value, sm)
 	default:
-		return fmt.Errorf("cannot scan type %t into Map", v)
+		return fmt.Errorf("cannot scan type %t into StringMap", databaseValue)
 	}
 }

--- a/model/types.go
+++ b/model/types.go
@@ -14,19 +14,19 @@ import (
 // field
 type StringMap map[string]string
 
-func (m StringMap) Value() (driver.Value, error) {
-	return json.Marshal(m)
+func (sm StringMap) Value() (driver.Value, error) {
+	return json.Marshal(sm)
 }
 
-func (m StringMap) Scan(v interface{}) error {
+func (sm StringMap) Scan(v interface{}) error {
 	if v == nil {
 		return nil
 	}
 	switch data := v.(type) {
 	case string: // sqlite's text
-		return json.Unmarshal([]byte(data), &m)
+		return json.Unmarshal([]byte(data), &sm)
 	case []byte: // psqls jsonb
-		return json.Unmarshal(data, &m)
+		return json.Unmarshal(data, &sm)
 	default:
 		return fmt.Errorf("cannot scan type %t into Map", v)
 	}

--- a/model/types.go
+++ b/model/types.go
@@ -8,23 +8,57 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"os"
 )
 
-// StringMap type used to have a map[string]string directly in the database in a TEXT or JSON/JSONB
-// field.
-type StringMap map[string]string
-
-func (sm StringMap) Value() (driver.Value, error) {
-	return json.Marshal(sm)
+type WebhookHeader struct {
+	Key          string  `json:"key"`
+	Value        *string `json:"value,omitempty"`
+	ValueFromEnv *string `json:"value_from_env,omitempty"`
 }
 
-func (sm *StringMap) Scan(databaseValue interface{}) error {
+type Headers []WebhookHeader
+
+func (wh Headers) Value() (driver.Value, error) {
+	return json.Marshal(wh)
+}
+
+func (wh *Headers) Scan(databaseValue interface{}) error {
 	switch value := databaseValue.(type) {
 	case string: // sqlite's text
-		return json.Unmarshal([]byte(value), sm)
+		return json.Unmarshal([]byte(value), wh)
 	case []byte: // psqls jsonb
-		return json.Unmarshal(value, sm)
+		return json.Unmarshal(value, wh)
 	default:
-		return fmt.Errorf("cannot scan type %t into StringMap", databaseValue)
+		return fmt.Errorf("cannot scan type %t into Headers", databaseValue)
 	}
+}
+
+func (wh Headers) Validate() error {
+	keys := make(map[string]struct{}, len(wh))
+	for _, header := range wh {
+		if _, ok := keys[header.Key]; ok {
+			return fmt.Errorf("header %s is duplicated", header.Key)
+		}
+		keys[header.Key] = struct{}{}
+		if header.Value == nil && header.ValueFromEnv == nil {
+			return fmt.Errorf("header %s must have either a value or a value_from_env", header.Key)
+		}
+		if header.Value != nil && header.ValueFromEnv != nil {
+			return fmt.Errorf("header %s cannot have both a value and a value_from_env", header.Key)
+		}
+	}
+	return nil
+}
+
+func (wh *Headers) GetHeaders() map[string]string {
+	headers := make(map[string]string, len(*wh))
+	for _, header := range *wh {
+		if header.Value != nil {
+			headers[header.Key] = *header.Value
+		} else if header.ValueFromEnv != nil {
+			headers[header.Key] = os.Getenv(*header.ValueFromEnv)
+		}
+	}
+	return headers
 }

--- a/model/types.go
+++ b/model/types.go
@@ -29,6 +29,8 @@ func (wh *Headers) Scan(databaseValue interface{}) error {
 		return json.Unmarshal([]byte(value), wh)
 	case []byte: // psqls jsonb
 		return json.Unmarshal(value, wh)
+	case nil:
+		return nil
 	default:
 		return fmt.Errorf("cannot scan type %t into Headers", databaseValue)
 	}

--- a/model/types.go
+++ b/model/types.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+// StringMap type used to have a map[string]string directly in the database in a TEXT or JSON/JSONB
+// field
+type StringMap map[string]string
+
+func (m StringMap) Value() (driver.Value, error) {
+	return json.Marshal(m)
+}
+
+func (m StringMap) Scan(v interface{}) error {
+	if v == nil {
+		return nil
+	}
+	switch data := v.(type) {
+	case string: // sqlite's text
+		return json.Unmarshal([]byte(data), &m)
+	case []byte: // psqls jsonb
+		return json.Unmarshal(data, &m)
+	default:
+		return fmt.Errorf("cannot scan type %t into Map", v)
+	}
+}

--- a/model/types_test.go
+++ b/model/types_test.go
@@ -10,23 +10,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStringMap(t *testing.T) {
+func TestHeaders(t *testing.T) {
+	headerValue := "bar"
+
 	t.Run("value", func(t *testing.T) {
 		testCases := []struct {
-			input *StringMap
+			input *Headers
 			value any
 			err   bool
 		}{
 			{
-				input: &StringMap{
-					"foo": "bar",
-				},
-				value: []byte(`{"foo":"bar"}`),
+				input: &Headers{{
+					Key: "foo", Value: &headerValue,
+				}},
+				value: []byte(`[{"key":"foo","value":"bar"}]`),
 				err:   false,
 			},
 			{
-				input: &StringMap{},
-				value: []byte(`{}`),
+				input: &Headers{},
+				value: []byte(`[]`),
 				err:   false,
 			},
 		}
@@ -45,29 +47,29 @@ func TestStringMap(t *testing.T) {
 	t.Run("scan", func(t *testing.T) {
 		testCases := []struct {
 			input any
-			scan  StringMap
+			scan  Headers
 			err   bool
 		}{
 			{
-				input: []byte(`{"foo":"bar"}`),
-				scan: StringMap{
-					"foo": "bar",
-				},
+				input: []byte(`[{"key":"foo", "value": "bar"}]`),
+				scan: Headers{{
+					Key: "foo", Value: &headerValue,
+				}},
 				err: false,
 			},
 			{
-				input: `{"foo":"bar"}`,
-				scan: StringMap{
-					"foo": "bar",
-				},
+				input: `[{"key": "foo", "value": "bar"}]`,
+				scan: Headers{{
+					Key: "foo", Value: &headerValue,
+				}},
 				err: false,
 			},
 		}
 
 		for _, test := range testCases {
-			stringMap := StringMap{}
-			err := stringMap.Scan(test.input)
-			require.Equal(t, test.scan, stringMap)
+			headers := Headers{}
+			err := headers.Scan(test.input)
+			require.Equal(t, test.scan, headers)
 			if test.err {
 				require.Error(t, err)
 			} else {

--- a/model/types_test.go
+++ b/model/types_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringMap(t *testing.T) {
+	t.Run("value", func(t *testing.T) {
+		testCases := []struct {
+			input *StringMap
+			value any
+			err   bool
+		}{
+			{
+				input: &StringMap{
+					"foo": "bar",
+				},
+				value: []byte(`{"foo":"bar"}`),
+				err:   false,
+			},
+			{
+				input: &StringMap{},
+				value: []byte(`{}`),
+				err:   false,
+			},
+		}
+
+		for _, test := range testCases {
+			value, err := test.input.Value()
+			require.Equal(t, test.value, value)
+			if test.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		}
+	})
+
+	t.Run("scan", func(t *testing.T) {
+		testCases := []struct {
+			input any
+			scan  StringMap
+			err   bool
+		}{
+			{
+				input: []byte(`{"foo":"bar"}`),
+				scan: StringMap{
+					"foo": "bar",
+				},
+				err: false,
+			},
+			{
+				input: `{"foo":"bar"}`,
+				scan: StringMap{
+					"foo": "bar",
+				},
+				err: false,
+			},
+		}
+
+		for _, test := range testCases {
+			stringMap := StringMap{}
+			err := stringMap.Scan(test.input)
+			require.Equal(t, test.scan, stringMap)
+			if test.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		}
+	})
+}

--- a/model/types_test.go
+++ b/model/types_test.go
@@ -64,6 +64,11 @@ func TestHeaders(t *testing.T) {
 				}},
 				err: false,
 			},
+			{
+				input: nil,
+				scan:  Headers{},
+				err:   false,
+			},
 		}
 
 		for _, test := range testCases {

--- a/model/webhook.go
+++ b/model/webhook.go
@@ -6,42 +6,8 @@ package model
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
-	"os"
-	"strings"
 )
-
-const (
-	WebhookHeaderEnvironmentValuePrefix = "env:"
-)
-
-// ParseHeadersFromStringMap parses the headers from a string map, finding and returning correct
-// header values for the items that require getting values from environment variables
-// This is also used in event subscription headers
-func ParseHeadersFromStringMap(sm *StringMap) (map[string]string, error) {
-	if sm == nil {
-		return map[string]string{}, nil
-	}
-	headers := make(map[string]string, len(*sm))
-	var err error
-	for key, value := range *sm {
-		headerValue := value
-		if strings.HasPrefix(value, WebhookHeaderEnvironmentValuePrefix) {
-			headerValue = os.Getenv(strings.TrimPrefix(value, WebhookHeaderEnvironmentValuePrefix))
-			// check if the header is set first, if not, return an error that can be checked in the
-			// consumers but continue parsing headers so the webhook is sent (without this header to
-			// avoid disclosing invormation)
-			if headerValue == "" {
-				err = fmt.Errorf("header from unset environment variable")
-				continue
-			}
-		}
-		headers[key] = headerValue
-	}
-
-	return headers, err
-}
 
 // ResourceType specifies a type of Provisioners' resource.
 type ResourceType string
@@ -74,7 +40,7 @@ type Webhook struct {
 	URL      string
 	CreateAt int64
 	DeleteAt int64
-	Headers  *StringMap
+	Headers  Headers
 }
 
 // WebhookFilter describes the parameters used to constrain a set of webhooks.

--- a/model/webhook.go
+++ b/model/webhook.go
@@ -6,8 +6,38 @@ package model
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
+	"os"
+	"strings"
 )
+
+const (
+	WebhookHeaderEnvironmentValuePrefix = "env:"
+)
+
+// ParseHeadersFromStringMap parses the headers from a string map, finding and returning correct
+// header values for the items that require getting values from environment variables
+func ParseHeadersFromStringMap(sm StringMap) (map[string]string, error) {
+	headers := make(map[string]string, len(sm))
+	var err error
+	for key, value := range sm {
+		headerValue := value
+		if strings.HasPrefix(value, WebhookHeaderEnvironmentValuePrefix) {
+			headerValue = os.Getenv(strings.TrimPrefix(value, WebhookHeaderEnvironmentValuePrefix))
+			// check if the header is set first, if not, return an error that can be checked in the
+			// consumers but continue parsing headers so the webhook is sent (without this header to
+			// avoid disclosing invormation)
+			if headerValue == "" {
+				err = fmt.Errorf("header from unset environment variable")
+				continue
+			}
+		}
+		headers[key] = headerValue
+	}
+
+	return headers, err
+}
 
 // ResourceType specifies a type of Provisioners' resource.
 type ResourceType string

--- a/model/webhook.go
+++ b/model/webhook.go
@@ -40,6 +40,7 @@ type Webhook struct {
 	URL      string
 	CreateAt int64
 	DeleteAt int64
+	Headers  StringMap
 }
 
 // WebhookFilter describes the parameters used to constrain a set of webhooks.

--- a/model/webhook.go
+++ b/model/webhook.go
@@ -18,10 +18,14 @@ const (
 
 // ParseHeadersFromStringMap parses the headers from a string map, finding and returning correct
 // header values for the items that require getting values from environment variables
-func ParseHeadersFromStringMap(sm StringMap) (map[string]string, error) {
-	headers := make(map[string]string, len(sm))
+// This is also used in event subscription headers
+func ParseHeadersFromStringMap(sm *StringMap) (map[string]string, error) {
+	if sm == nil {
+		return map[string]string{}, nil
+	}
+	headers := make(map[string]string, len(*sm))
 	var err error
-	for key, value := range sm {
+	for key, value := range *sm {
 		headerValue := value
 		if strings.HasPrefix(value, WebhookHeaderEnvironmentValuePrefix) {
 			headerValue = os.Getenv(strings.TrimPrefix(value, WebhookHeaderEnvironmentValuePrefix))
@@ -70,7 +74,7 @@ type Webhook struct {
 	URL      string
 	CreateAt int64
 	DeleteAt int64
-	Headers  StringMap
+	Headers  *StringMap
 }
 
 // WebhookFilter describes the parameters used to constrain a set of webhooks.

--- a/model/webhook_request.go
+++ b/model/webhook_request.go
@@ -17,7 +17,7 @@ import (
 type CreateWebhookRequest struct {
 	OwnerID string
 	URL     string
-	Headers StringMap
+	Headers []WebhookHeader
 }
 
 // NewCreateWebhookRequestFromReader will create a CreateWebhookRequest from an io.Reader with JSON data.

--- a/model/webhook_request.go
+++ b/model/webhook_request.go
@@ -17,6 +17,7 @@ import (
 type CreateWebhookRequest struct {
 	OwnerID string
 	URL     string
+	Headers StringMap
 }
 
 // NewCreateWebhookRequestFromReader will create a CreateWebhookRequest from an io.Reader with JSON data.

--- a/model/webhook_request.go
+++ b/model/webhook_request.go
@@ -17,7 +17,7 @@ import (
 type CreateWebhookRequest struct {
 	OwnerID string
 	URL     string
-	Headers []WebhookHeader
+	Headers Headers
 }
 
 // NewCreateWebhookRequestFromReader will create a CreateWebhookRequest from an io.Reader with JSON data.

--- a/model/webhook_request.go
+++ b/model/webhook_request.go
@@ -17,7 +17,7 @@ import (
 type CreateWebhookRequest struct {
 	OwnerID string
 	URL     string
-	Headers map[string]string
+	Headers StringMap
 }
 
 // NewCreateWebhookRequestFromReader will create a CreateWebhookRequest from an io.Reader with JSON data.

--- a/model/webhook_request.go
+++ b/model/webhook_request.go
@@ -17,7 +17,7 @@ import (
 type CreateWebhookRequest struct {
 	OwnerID string
 	URL     string
-	Headers StringMap
+	Headers map[string]string
 }
 
 // NewCreateWebhookRequestFromReader will create a CreateWebhookRequest from an io.Reader with JSON data.

--- a/model/webhook_test.go
+++ b/model/webhook_test.go
@@ -20,13 +20,13 @@ func TestParseHeadersFromStringMap(t *testing.T) {
 	})
 	testCases := []struct {
 		name          string
-		input         StringMap
+		input         *StringMap
 		outputHeaders map[string]string
 		outputErr     bool
 	}{
 		{
 			name: "proper headers (plain)",
-			input: StringMap{
+			input: &StringMap{
 				"Foo": "Bar",
 			},
 			outputHeaders: map[string]string{
@@ -35,8 +35,20 @@ func TestParseHeadersFromStringMap(t *testing.T) {
 			outputErr: false,
 		},
 		{
+			name:          "no headers (empty)",
+			input:         &StringMap{},
+			outputHeaders: map[string]string{},
+			outputErr:     false,
+		},
+		{
+			name:          "no headers (nil)",
+			input:         nil,
+			outputHeaders: map[string]string{},
+			outputErr:     false,
+		},
+		{
 			name: "proper headers (with environment)",
-			input: StringMap{
+			input: &StringMap{
 				"Foo": "Bar",
 				"Env": WebhookHeaderEnvironmentValuePrefix + envName,
 			},
@@ -48,7 +60,7 @@ func TestParseHeadersFromStringMap(t *testing.T) {
 		},
 		{
 			name: "proper headers (with environment error)",
-			input: StringMap{
+			input: &StringMap{
 				"Foo": "Bar",
 				"Env": "env:NON_EXISTANT",
 			},


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Allow webhooks and subscriptions to send headers long with their requests, providing headers in the format `Key=Value`, where `Value` is the header value or an environment variable name to get the value from.

Usage: `cloud webhook create --owner xx --url xx --header Key=Value --header-from-env Key2=ENV_VAR_NAME`

Struct used in storage:

``` js
[
  {
    "key": "key",
    "value": "value", // optional
    "valueFromEnv": "ENV_VAR_NAME", //optional
  }
]
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-50721

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
feat: allow webhooks and subscriptions to send custom headers
```
