### PR TITLE
refactor: use generics for repeating code on DTO decoding

### DIFF
--- a/model/client.go
+++ b/model/client.go
@@ -122,7 +122,7 @@ func (c *Client) CreateCluster(request *CreateClusterRequest) (*ClusterDTO, erro
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return ClusterDTOFromReader(resp.Body)
+		return DTOFromReader[ClusterDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -157,7 +157,7 @@ func (c *Client) ProvisionCluster(clusterID string, request *ProvisionClusterReq
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return ClusterDTOFromReader(resp.Body)
+		return DTOFromReader[ClusterDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -174,7 +174,7 @@ func (c *Client) GetCluster(clusterID string) (*ClusterDTO, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return ClusterDTOFromReader(resp.Body)
+		return DTOFromReader[ClusterDTO](resp.Body)
 
 	case http.StatusNotFound:
 		return nil, nil
@@ -201,7 +201,7 @@ func (c *Client) GetClusters(request *GetClustersRequest) ([]*ClusterDTO, error)
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return ClusterDTOsFromReader(resp.Body)
+		return DTOsFromReader[ClusterDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -235,7 +235,7 @@ func (c *Client) UpdateCluster(clusterID string, request *UpdateClusterRequest) 
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return ClusterDTOFromReader(resp.Body)
+		return DTOFromReader[ClusterDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -252,7 +252,7 @@ func (c *Client) UpgradeCluster(clusterID string, request *PatchUpgradeClusterRe
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return ClusterDTOFromReader(resp.Body)
+		return DTOFromReader[ClusterDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -269,7 +269,7 @@ func (c *Client) ResizeCluster(clusterID string, request *PatchClusterSizeReques
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return ClusterDTOFromReader(resp.Body)
+		return DTOFromReader[ClusterDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -303,7 +303,7 @@ func (c *Client) AddClusterAnnotations(clusterID string, annotationsRequest *Add
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return ClusterDTOFromReader(resp.Body)
+		return DTOFromReader[ClusterDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -337,7 +337,7 @@ func (c *Client) CreateInstallation(request *CreateInstallationRequest) (*Instal
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return InstallationDTOFromReader(resp.Body)
+		return DTOFromReader[InstallationDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -378,7 +378,7 @@ func (c *Client) GetInstallation(installationID string, request *GetInstallation
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return InstallationDTOFromReader(resp.Body)
+		return DTOFromReader[InstallationDTO](resp.Body)
 
 	case http.StatusNotFound:
 		return nil, nil
@@ -432,7 +432,7 @@ func (c *Client) GetInstallations(request *GetInstallationsRequest) ([]*Installa
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return InstallationDTOsFromReader(resp.Body)
+		return DTOsFromReader[InstallationDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -473,7 +473,7 @@ func (c *Client) UpdateInstallation(installationID string, request *PatchInstall
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return InstallationDTOFromReader(resp.Body)
+		return DTOFromReader[InstallationDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -490,7 +490,7 @@ func (c *Client) HibernateInstallation(installationID string) (*InstallationDTO,
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return InstallationDTOFromReader(resp.Body)
+		return DTOFromReader[InstallationDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -507,7 +507,7 @@ func (c *Client) WakeupInstallation(installationID string, request *PatchInstall
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return InstallationDTOFromReader(resp.Body)
+		return DTOFromReader[InstallationDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -562,7 +562,7 @@ func (c *Client) UpdateInstallationDeletion(installationID string, request *Patc
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return InstallationDTOFromReader(resp.Body)
+		return DTOFromReader[InstallationDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -597,7 +597,7 @@ func (c *Client) AddInstallationDNS(installationID string, request *AddDNSRecord
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return InstallationDTOFromReader(resp.Body)
+		return DTOFromReader[InstallationDTO](resp.Body)
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
 	}
@@ -613,7 +613,7 @@ func (c *Client) SetInstallationDomainPrimary(installationID, installationDNSID 
 
 	switch resp.StatusCode {
 	case http.StatusAccepted:
-		return InstallationDTOFromReader(resp.Body)
+		return DTOFromReader[InstallationDTO](resp.Body)
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
 	}
@@ -779,7 +779,7 @@ func (c *Client) AddInstallationAnnotations(installationID string, annotationsRe
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return InstallationDTOFromReader(resp.Body)
+		return DTOFromReader[InstallationDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -995,7 +995,7 @@ func (c *Client) CreateGroup(request *CreateGroupRequest) (*GroupDTO, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return GroupDTOFromReader(resp.Body)
+		return DTOFromReader[GroupDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -1012,7 +1012,7 @@ func (c *Client) UpdateGroup(request *PatchGroupRequest) (*GroupDTO, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return GroupDTOFromReader(resp.Body)
+		return DTOFromReader[GroupDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -1046,7 +1046,7 @@ func (c *Client) GetGroup(groupID string) (*GroupDTO, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return GroupDTOFromReader(resp.Body)
+		return DTOFromReader[GroupDTO](resp.Body)
 
 	case http.StatusNotFound:
 		return nil, nil
@@ -1073,7 +1073,7 @@ func (c *Client) GetGroups(request *GetGroupsRequest) ([]*GroupDTO, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return GroupDTOsFromReader(resp.Body)
+		return DTOsFromReader[GroupDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -1188,7 +1188,7 @@ func (c *Client) AddGroupAnnotations(groupID string, annotationsRequest *AddAnno
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return GroupDTOFromReader(resp.Body)
+		return DTOFromReader[GroupDTO](resp.Body)
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)

--- a/model/cluster_dto.go
+++ b/model/cluster_dto.go
@@ -4,38 +4,8 @@
 
 package model
 
-import (
-	"encoding/json"
-	"io"
-)
-
 // ClusterDTO represents cluster entity with connected data. DTO stands for Data Transfer Object.
 type ClusterDTO struct {
 	*Cluster
 	Annotations []*Annotation `json:"Annotations,omitempty"`
-}
-
-// ClusterDTOFromReader decodes a json-encoded cluster DTO from the given io.Reader.
-func ClusterDTOFromReader(reader io.Reader) (*ClusterDTO, error) {
-	clusterDTO := ClusterDTO{}
-	decoder := json.NewDecoder(reader)
-	err := decoder.Decode(&clusterDTO)
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-
-	return &clusterDTO, nil
-}
-
-// ClusterDTOsFromReader decodes a json-encoded list of cluster DTOs from the given io.Reader.
-func ClusterDTOsFromReader(reader io.Reader) ([]*ClusterDTO, error) {
-	clusterDTOs := []*ClusterDTO{}
-	decoder := json.NewDecoder(reader)
-
-	err := decoder.Decode(&clusterDTOs)
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-
-	return clusterDTOs, nil
 }

--- a/model/cluster_dto_test.go
+++ b/model/cluster_dto_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestClusterDTOFromReader(t *testing.T) {
 	t.Run("empty request", func(t *testing.T) {
-		clusterDTO, err := ClusterDTOFromReader(bytes.NewReader([]byte(
+		clusterDTO, err := DTOFromReader[ClusterDTO](bytes.NewReader([]byte(
 			``,
 		)))
 		require.NoError(t, err)
@@ -21,7 +21,7 @@ func TestClusterDTOFromReader(t *testing.T) {
 	})
 
 	t.Run("invalid request", func(t *testing.T) {
-		clusterDTO, err := ClusterDTOFromReader(bytes.NewReader([]byte(
+		clusterDTO, err := DTOFromReader[ClusterDTO](bytes.NewReader([]byte(
 			`{test`,
 		)))
 		require.Error(t, err)
@@ -29,7 +29,7 @@ func TestClusterDTOFromReader(t *testing.T) {
 	})
 
 	t.Run("request", func(t *testing.T) {
-		clusterDTO, err := ClusterDTOFromReader(bytes.NewReader([]byte(
+		clusterDTO, err := DTOFromReader[ClusterDTO](bytes.NewReader([]byte(
 			`{"ID":"id","Provider":"aws","Annotations":[{"ID":"abc","Name":"efg"}]}`,
 		)))
 		require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestClusterDTOFromReader(t *testing.T) {
 
 func TestClustersDTOFromReader(t *testing.T) {
 	t.Run("empty request", func(t *testing.T) {
-		clusterDTOs, err := ClusterDTOsFromReader(bytes.NewReader([]byte(
+		clusterDTOs, err := DTOsFromReader[ClusterDTO](bytes.NewReader([]byte(
 			``,
 		)))
 		require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestClustersDTOFromReader(t *testing.T) {
 	})
 
 	t.Run("invalid request", func(t *testing.T) {
-		clusterDTOs, err := ClusterDTOsFromReader(bytes.NewReader([]byte(
+		clusterDTOs, err := DTOsFromReader[ClusterDTO](bytes.NewReader([]byte(
 			`{test`,
 		)))
 		require.Error(t, err)
@@ -57,7 +57,7 @@ func TestClustersDTOFromReader(t *testing.T) {
 	})
 
 	t.Run("request", func(t *testing.T) {
-		clusterDTOs, err := ClusterDTOsFromReader(bytes.NewReader([]byte(
+		clusterDTOs, err := DTOsFromReader[ClusterDTO](bytes.NewReader([]byte(
 			`[{"ID":"id1","Provider":"aws","Annotations":[{"ID":"abc","Name":"efg"}]},{"ID":"id2","Provider":"aws"}]`,
 		)))
 		require.NoError(t, err)

--- a/model/dtos.go
+++ b/model/dtos.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+func DTOFromReader[T any](reader io.Reader) (*T, error) {
+	var dto T
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&dto)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &dto, nil
+}
+
+func DTOsFromReader[T any](reader io.Reader) ([]*T, error) {
+	dtos := []*T{}
+	decoder := json.NewDecoder(reader)
+
+	err := decoder.Decode(&dtos)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return dtos, nil
+}

--- a/model/group_dto.go
+++ b/model/group_dto.go
@@ -4,11 +4,6 @@
 
 package model
 
-import (
-	"encoding/json"
-	"io"
-)
-
 // GroupDTO is a group with Annotations.
 type GroupDTO struct {
 	*Group
@@ -19,29 +14,4 @@ type GroupDTO struct {
 // GetInstallationCount retrieves the installation count dereferenced value
 func (g GroupDTO) GetInstallationCount() int64 {
 	return *g.InstallationCount
-}
-
-// GroupDTOFromReader decodes a json-encoded group DTO from the given io.Reader.
-func GroupDTOFromReader(reader io.Reader) (*GroupDTO, error) {
-	groupDTO := GroupDTO{}
-	decoder := json.NewDecoder(reader)
-	err := decoder.Decode(&groupDTO)
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-
-	return &groupDTO, nil
-}
-
-// GroupDTOsFromReader decodes a json-encoded list of group DTOs from the given io.Reader.
-func GroupDTOsFromReader(reader io.Reader) ([]*GroupDTO, error) {
-	groupDTOs := []*GroupDTO{}
-	decoder := json.NewDecoder(reader)
-
-	err := decoder.Decode(&groupDTOs)
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-
-	return groupDTOs, nil
 }

--- a/model/group_dto_test.go
+++ b/model/group_dto_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestGroupDTOFromReader(t *testing.T) {
 	t.Run("empty request", func(t *testing.T) {
-		groupDTO, err := GroupDTOFromReader(bytes.NewReader([]byte(
+		groupDTO, err := DTOFromReader[GroupDTO](bytes.NewReader([]byte(
 			``,
 		)))
 		require.NoError(t, err)
@@ -21,7 +21,7 @@ func TestGroupDTOFromReader(t *testing.T) {
 	})
 
 	t.Run("invalid request", func(t *testing.T) {
-		groupDTO, err := GroupDTOFromReader(bytes.NewReader([]byte(
+		groupDTO, err := DTOFromReader[GroupDTO](bytes.NewReader([]byte(
 			`{test`,
 		)))
 		require.Error(t, err)
@@ -29,7 +29,7 @@ func TestGroupDTOFromReader(t *testing.T) {
 	})
 
 	t.Run("request", func(t *testing.T) {
-		groupDTO, err := GroupDTOFromReader(bytes.NewReader([]byte(`{
+		groupDTO, err := DTOFromReader[GroupDTO](bytes.NewReader([]byte(`{
 			"ID":"id",
 			"Sequence":10,
 			"Name": "group1",
@@ -61,7 +61,7 @@ func TestGroupDTOFromReader(t *testing.T) {
 
 func TestGroupDTOsFromReader(t *testing.T) {
 	t.Run("empty request", func(t *testing.T) {
-		groupDTOs, err := GroupDTOsFromReader(bytes.NewReader([]byte(
+		groupDTOs, err := DTOsFromReader[GroupDTO](bytes.NewReader([]byte(
 			``,
 		)))
 		require.NoError(t, err)
@@ -69,7 +69,7 @@ func TestGroupDTOsFromReader(t *testing.T) {
 	})
 
 	t.Run("invalid request", func(t *testing.T) {
-		groupDTOs, err := GroupDTOsFromReader(bytes.NewReader([]byte(
+		groupDTOs, err := DTOsFromReader[GroupDTO](bytes.NewReader([]byte(
 			`{test`,
 		)))
 		require.Error(t, err)
@@ -77,7 +77,7 @@ func TestGroupDTOsFromReader(t *testing.T) {
 	})
 
 	t.Run("request", func(t *testing.T) {
-		groupDTOs, err := GroupDTOsFromReader(bytes.NewReader([]byte(`[
+		groupDTOs, err := DTOsFromReader[GroupDTO](bytes.NewReader([]byte(`[
 			{
 				"ID":"id",
 				"Sequence":10,

--- a/model/installation_dto.go
+++ b/model/installation_dto.go
@@ -4,11 +4,6 @@
 
 package model
 
-import (
-	"encoding/json"
-	"io"
-)
-
 // InstallationDTO represents a Mattermost installation. DTO stands for Data Transfer Object.
 type InstallationDTO struct {
 	*Installation
@@ -16,29 +11,4 @@ type InstallationDTO struct {
 	// Deprecated: This is for backward compatibility until we switch all clients, as DNS was removed from Installation.
 	DNS        string
 	DNSRecords []*InstallationDNS
-}
-
-// InstallationDTOFromReader decodes a json-encoded installation DTO from the given io.Reader.
-func InstallationDTOFromReader(reader io.Reader) (*InstallationDTO, error) {
-	installationDTO := InstallationDTO{}
-	decoder := json.NewDecoder(reader)
-	err := decoder.Decode(&installationDTO)
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-
-	return &installationDTO, nil
-}
-
-// InstallationDTOsFromReader decodes a json-encoded list of installation DTOs from the given io.Reader.
-func InstallationDTOsFromReader(reader io.Reader) ([]*InstallationDTO, error) {
-	installationDTOs := []*InstallationDTO{}
-	decoder := json.NewDecoder(reader)
-
-	err := decoder.Decode(&installationDTOs)
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-
-	return installationDTOs, nil
 }

--- a/model/installation_dto_test.go
+++ b/model/installation_dto_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestInstallationDTOFromReader(t *testing.T) {
 	t.Run("empty request", func(t *testing.T) {
-		installationDTO, err := InstallationDTOFromReader(bytes.NewReader([]byte(
+		installationDTO, err := DTOFromReader[InstallationDTO](bytes.NewReader([]byte(
 			``,
 		)))
 		require.NoError(t, err)
@@ -21,7 +21,7 @@ func TestInstallationDTOFromReader(t *testing.T) {
 	})
 
 	t.Run("invalid request", func(t *testing.T) {
-		installationDTO, err := InstallationDTOFromReader(bytes.NewReader([]byte(
+		installationDTO, err := DTOFromReader[InstallationDTO](bytes.NewReader([]byte(
 			`{test`,
 		)))
 		require.Error(t, err)
@@ -29,7 +29,7 @@ func TestInstallationDTOFromReader(t *testing.T) {
 	})
 
 	t.Run("request", func(t *testing.T) {
-		installationDTO, err := InstallationDTOFromReader(bytes.NewReader([]byte(`{
+		installationDTO, err := DTOFromReader[InstallationDTO](bytes.NewReader([]byte(`{
 			"ID":"id",
 			"OwnerID":"owner",
 			"GroupID":"group_id",
@@ -70,7 +70,7 @@ func TestInstallationDTOFromReader(t *testing.T) {
 
 func TestInstallationDTOsFromReader(t *testing.T) {
 	t.Run("empty request", func(t *testing.T) {
-		installationDTOs, err := InstallationDTOsFromReader(bytes.NewReader([]byte(
+		installationDTOs, err := DTOsFromReader[InstallationDTO](bytes.NewReader([]byte(
 			``,
 		)))
 		require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestInstallationDTOsFromReader(t *testing.T) {
 	})
 
 	t.Run("invalid request", func(t *testing.T) {
-		installationDTOs, err := InstallationDTOsFromReader(bytes.NewReader([]byte(
+		installationDTOs, err := DTOsFromReader[InstallationDTO](bytes.NewReader([]byte(
 			`{test`,
 		)))
 		require.Error(t, err)
@@ -86,7 +86,7 @@ func TestInstallationDTOsFromReader(t *testing.T) {
 	})
 
 	t.Run("request", func(t *testing.T) {
-		installationDTOs, err := InstallationDTOsFromReader(bytes.NewReader([]byte(`[
+		installationDTOs, err := DTOsFromReader[InstallationDTO](bytes.NewReader([]byte(`[
 			{
 				"ID":"id1",
 				"OwnerID":"owner1",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This replaces all `XXXXDTO(s)FromReader` with a generics version of it.

Already had this going of for some tests I did with #886, so why not just open a PR for it. If you consider it cool enough we can merge it.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

none

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
refactor: use generics for repeating code on DTO decoding
```
