### PR TITLE
[MM-51509] Upgrade helm version to support --wait flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOLANG_VERSION := $(shell cat go.mod | grep "^go " | cut -d " " -f 2)
 ALPINE_VERSION = 3.16
 TERRAFORM_VERSION=1.0.7
 KOPS_VERSION=v1.23.4
-HELM_VERSION=v3.5.3
+HELM_VERSION=v3.7.2
 KUBECTL_VERSION=v1.24.4
 
 ## Docker Build Versions


### PR DESCRIPTION
#### Summary

We added the `--wait` flag in `helm uninstall`.  But this flag is only available after `v3.7.0`.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-51509


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
