### PR TITLE
[MM-51583] Use 7.9.1 for mattermost-server

### DIFF
--- a/e2e/pkg/installation_builder.go
+++ b/e2e/pkg/installation_builder.go
@@ -2,7 +2,8 @@
 // See LICENSE.txt for license information.
 //
 
-//+build e2e
+//go:build e2e
+// +build e2e
 
 package pkg
 
@@ -17,7 +18,7 @@ type InstallationBuilder struct {
 func NewInstallationBuilderWithDefaults() *InstallationBuilder {
 	return &InstallationBuilder{request: &model.CreateInstallationRequest{
 		OwnerID:   "e2e-test",
-		Version:   "stable",
+		Version:   "7.9.1",
 		Image:     "mattermost/mattermost-enterprise-edition",
 		Size:      "1000users",
 		Affinity:  "multitenant",


### PR DESCRIPTION

#### Summary

The provisioner E2E test sometimes fails randomly. That error comes from the `mmctl sampledata` command, which loads sample data into **mm-server**. For the E2E test, we are using `stable` aka `7.5.1`. And I can see some relevant code changes in the `7.6.1` version.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-51583



#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
