### PR TITLE
tests: added more info to e2e webhook data

### DIFF
--- a/e2e/tests/state/state.go
+++ b/e2e/tests/state/state.go
@@ -7,8 +7,9 @@ package state
 import "time"
 
 var (
-	ClusterID string
-	TestID    string
-	StartTime time.Time
-	EndTime   time.Time
+	ClusterID      string
+	InstallationID string
+	TestID         string
+	StartTime      time.Time
+	EndTime        time.Time
 )

--- a/e2e/workflow/installation.go
+++ b/e2e/workflow/installation.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mattermost/mattermost-cloud/e2e/pkg"
 	"github.com/mattermost/mattermost-cloud/e2e/pkg/eventstest"
+	"github.com/mattermost/mattermost-cloud/e2e/tests/state"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -75,12 +76,14 @@ func (w *InstallationSuite) CreateInstallation(ctx context.Context) error {
 		w.logger.Infof("Installation created: %s", installation.ID)
 		w.Meta.InstallationID = installation.ID
 		w.Meta.InstallationDNS = installation.DNS
+		state.InstallationID = installation.ID
 	} else {
 		installation, err := w.client.GetInstallation(w.Meta.InstallationID, nil)
 		if err != nil {
 			return errors.Wrap(err, "failed to get installation")
 		}
 		w.Meta.InstallationDNS = installation.DNS
+		state.InstallationID = w.Meta.InstallationID
 
 		if installation.State == model.InstallationStateStable {
 			return nil
@@ -88,7 +91,6 @@ func (w *InstallationSuite) CreateInstallation(ctx context.Context) error {
 		if installation.State == model.InstallationStateCreationFailed {
 			return errors.Errorf("installation creation failed: %s", installation.State)
 		}
-
 	}
 
 	err := pkg.WaitForInstallationToBeStable(ctx, w.Meta.InstallationID, w.whChan, w.logger)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

- Added `InstallationID` field to test result attachment.
- Added links to each ID (test, cluster, installation) pointing directly to filtered grafana logs.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-50968

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
test: more information on end to end webhook results
```
