### PR TITLE
[MM-51737] Cluster Installation Status endpoint

### DIFF
--- a/cmd/cloud/cluster_installation.go
+++ b/cmd/cloud/cluster_installation.go
@@ -22,6 +22,7 @@ func newCmdClusterInstallation() *cobra.Command {
 	cmd.AddCommand(newCmdClusterInstallationGet())
 	cmd.AddCommand(newCmdClusterInstallationList())
 	cmd.AddCommand(newCmdClusterInstallationConfig())
+	cmd.AddCommand(newCmdClusterInstallationStatus())
 	cmd.AddCommand(newCmdClusterInstallationMMCTL())
 	cmd.AddCommand(newCmdClusterInstallationMattermostCLI())
 	cmd.AddCommand(newCmdClusterInstallationMigration())
@@ -197,6 +198,36 @@ func newCmdClusterInstallationConfigSet() *cobra.Command {
 				return errors.Wrap(err, "failed to modify cluster installation config")
 			}
 			return nil
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.clusterFlags.addFlags(cmd)
+		},
+	}
+	flags.addFlags(cmd)
+
+	return cmd
+}
+
+func newCmdClusterInstallationStatus() *cobra.Command {
+	var flags clusterInstallationStatusFlags
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Get the status of a particular cluster installation.",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+
+			client := model.NewClient(flags.serverAddress)
+
+			clusterInstallation, err := client.GetClusterInstallationStatus(flags.clusterInstallationID)
+			if err != nil {
+				return errors.Wrap(err, "failed to query cluster installation")
+			}
+			if clusterInstallation == nil {
+				return nil
+			}
+
+			return printJSON(clusterInstallation)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			flags.clusterFlags.addFlags(cmd)

--- a/cmd/cloud/cluster_installation_flag.go
+++ b/cmd/cloud/cluster_installation_flag.go
@@ -42,6 +42,16 @@ func (flags *clusterInstallationConfigGetFlags) addFlags(command *cobra.Command)
 	_ = command.MarkFlagRequired("cluster-installation")
 }
 
+type clusterInstallationStatusFlags struct {
+	clusterFlags
+	clusterInstallationID string
+}
+
+func (flags *clusterInstallationStatusFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.clusterInstallationID, "cluster-installation", "", "The id of the cluster installation.")
+	_ = command.MarkFlagRequired("cluster-installation")
+}
+
 type clusterInstallationConfigSetFlags struct {
 	clusterFlags
 	clusterInstallationID string

--- a/e2e/pkg/installation.go
+++ b/e2e/pkg/installation.go
@@ -134,12 +134,12 @@ func WaitForClusterInstallationReadyStatus(client *model.Client, clusterInstalla
 			return false, errors.Wrap(err, "while waiting for cluster installation to be ready")
 		}
 
-		if status.Replicas != nil && status.MmctlSuccessCount != nil {
-			if *status.Replicas == *status.MmctlSuccessCount {
+		if status.Replicas != nil && status.MMCTLSuccessCount != nil {
+			if *status.Replicas == *status.MMCTLSuccessCount {
 				return true, nil
 			}
 
-			log.Infof("Cluster installation %s not ready: %d/%d", clusterInstallationID, *status.MmctlSuccessCount, *status.Replicas)
+			log.Infof("Cluster installation %s not ready: %d/%d", clusterInstallationID, *status.MMCTLSuccessCount, *status.Replicas)
 			statusByte, _ := json.Marshal(status)
 			log.Debug(string(statusByte))
 		}

--- a/e2e/pkg/installation.go
+++ b/e2e/pkg/installation.go
@@ -134,12 +134,12 @@ func WaitForClusterInstallationReadyStatus(client *model.Client, clusterInstalla
 			return false, errors.Wrap(err, "while waiting for cluster installation to be ready")
 		}
 
-		if status.Replicas != nil && status.MMCTLSuccessCount != nil {
-			if *status.Replicas == *status.MMCTLSuccessCount {
+		if status.Replicas != nil && status.ReadyLocalServer != nil {
+			if *status.Replicas == *status.ReadyLocalServer {
 				return true, nil
 			}
 
-			log.Infof("Cluster installation %s not ready: %d/%d", clusterInstallationID, *status.MMCTLSuccessCount, *status.Replicas)
+			log.Infof("Cluster installation %s not ready: %d/%d", clusterInstallationID, *status.ReadyLocalServer, *status.Replicas)
 			statusByte, _ := json.Marshal(status)
 			log.Debug(string(statusByte))
 		}

--- a/e2e/pkg/installation.go
+++ b/e2e/pkg/installation.go
@@ -9,6 +9,7 @@ package pkg
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -123,6 +124,30 @@ func WaitForInstallationToBeDeleted(ctx context.Context, installationID string, 
 	}
 
 	return whWaiter.waitForState(waitCtx, installationID)
+}
+
+// WaitForClusterInstallationReadyStatus pings installation until it responds successfully.
+func WaitForClusterInstallationReadyStatus(client *model.Client, clusterInstallationID string, log logrus.FieldLogger) error {
+	err := WaitForFunc(NewWaitConfig(5*time.Minute, 20*time.Second, 0, log), func() (bool, error) {
+		status, err := client.GetClusterInstallationStatus(clusterInstallationID)
+		if err != nil {
+			return false, errors.Wrap(err, "while waiting for cluster installation to be ready")
+		}
+
+		if status.Replicas != nil && status.MmctlSuccessCount != nil {
+			if *status.Replicas == *status.MmctlSuccessCount {
+				return true, nil
+			}
+
+			log.Infof("Cluster installation %s not ready: %d/%d", clusterInstallationID, *status.MmctlSuccessCount, *status.Replicas)
+			statusByte, _ := json.Marshal(status)
+			log.Debug(string(statusByte))
+		}
+
+		return false, nil
+	})
+
+	return err
 }
 
 // PingInstallation hits Mattermost ping endpoint.

--- a/e2e/tests/cluster/steps.go
+++ b/e2e/tests/cluster/steps.go
@@ -31,9 +31,14 @@ func clusterLifecycleSteps(clusterSuite *workflow.ClusterSuite, installationSuit
 			DependsOn: []string{"CreateInstallation"},
 		},
 		{
+			Name:      "CheckClusterInstallationStatus",
+			Func:      installationSuite.CheckClusterInstallationStatus,
+			DependsOn: []string{"GetCI"},
+		},
+		{
 			Name:      "PopulateSampleData",
 			Func:      installationSuite.PopulateSampleData,
-			DependsOn: []string{"GetCI"},
+			DependsOn: []string{"CheckClusterInstallationStatus"},
 		},
 		{
 			Name:              "ProvisionCluster",

--- a/e2e/workflow/installation.go
+++ b/e2e/workflow/installation.go
@@ -117,6 +117,10 @@ func (w *InstallationSuite) GetCI(ctx context.Context) error {
 	return nil
 }
 
+func (w *InstallationSuite) CheckClusterInstallationStatus(ctx context.Context) error {
+	return pkg.WaitForClusterInstallationReadyStatus(w.client, w.Meta.ClusterInstallationID, w.logger)
+}
+
 // GetConnectionStrAndExport saves db connection string currently configured for installation and export statistics.
 func (w *InstallationSuite) GetConnectionStrAndExport(ctx context.Context) error {
 	connectionString, err := pkg.GetConnectionString(w.client, w.Meta.ClusterInstallationID)

--- a/e2e/workflow/installation.go
+++ b/e2e/workflow/installation.go
@@ -117,6 +117,7 @@ func (w *InstallationSuite) GetCI(ctx context.Context) error {
 	return nil
 }
 
+// CheckClusterInstallationStatus checks if ClusterInstallation is in a good condition.
 func (w *InstallationSuite) CheckClusterInstallationStatus(ctx context.Context) error {
 	return pkg.WaitForClusterInstallationReadyStatus(w.client, w.Meta.ClusterInstallationID, w.logger)
 }

--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -5,7 +5,6 @@
 package api_test
 
 import (
-	"github.com/aws/smithy-go/ptr"
 	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/mattermost/mattermost-cloud/model"
 	log "github.com/sirupsen/logrus"
@@ -35,7 +34,7 @@ func (s *mockProvisioner) ProvisionerType() string {
 }
 
 func (s *mockProvisioner) GetClusterInstallationStatus(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation) (*model.ClusterInstallationStatus, error) {
-	return &model.ClusterInstallationStatus{InstallationFound: ptr.Bool(true)}, nil
+	return &model.ClusterInstallationStatus{}, nil
 }
 
 func (s *mockProvisioner) ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error, error) {

--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -5,6 +5,7 @@
 package api_test
 
 import (
+	"github.com/aws/smithy-go/ptr"
 	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/mattermost/mattermost-cloud/model"
 	log "github.com/sirupsen/logrus"
@@ -31,6 +32,10 @@ type mockProvisioner struct {
 
 func (s *mockProvisioner) ProvisionerType() string {
 	return "kops"
+}
+
+func (s *mockProvisioner) GetClusterInstallationStatus(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation) (*model.ClusterInstallationStatus, error) {
+	return &model.ClusterInstallationStatus{InstallationFound: ptr.Bool(true)}, nil
 }
 
 func (s *mockProvisioner) ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error, error) {

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -131,6 +131,7 @@ type Provisioner interface {
 	ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error, error)
 	ExecMMCTL(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
 	ExecMattermostCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
+	GetClusterInstallationStatus(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation) (*model.ClusterInstallationStatus, error)
 }
 
 // AwsClient describes the interface required to communicate with the AWS

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -538,7 +538,6 @@ func (provisioner Provisioner) GetClusterInstallationStatus(cluster *model.Clust
 			return nil, errors.Wrap(err, "failed to query mattermost deployment")
 		}
 
-		status.InstallationFound = false
 		return &status, nil
 	}
 

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -538,11 +538,11 @@ func (provisioner Provisioner) GetClusterInstallationStatus(cluster *model.Clust
 			return nil, errors.Wrap(err, "failed to query mattermost deployment")
 		}
 
-		status.InstallationFound = ptr.Bool(false)
+		status.InstallationFound = false
 		return &status, nil
 	}
 
-	status.InstallationFound = ptr.Bool(true)
+	status.InstallationFound = true
 	status.Replicas = deployment.Spec.Replicas
 
 	if status.Replicas == nil || *status.Replicas == 0 {
@@ -556,7 +556,7 @@ func (provisioner Provisioner) GetClusterInstallationStatus(cluster *model.Clust
 		return nil, errors.Wrap(err, "failed to query mattermost pods")
 	}
 
-	status.PodCount = ptr.Int32(int32(len(podList.Items)))
+	status.TotalPod = ptr.Int32(int32(len(podList.Items)))
 
 	args := []string{"./bin/mmctl", "--local", "system", "status", "--json"}
 
@@ -596,10 +596,10 @@ func (provisioner Provisioner) GetClusterInstallationStatus(cluster *model.Clust
 
 	wg.Wait()
 
-	status.PodRunningCount = &podRunningCount
-	status.PodReadyCount = &podReadyCount
-	status.PodStartedCount = &podStartedCount
-	status.MMCTLSuccessCount = mmctlSuccessCount
+	status.RunningPod = &podRunningCount
+	status.ReadyPod = &podReadyCount
+	status.StartedPod = &podStartedCount
+	status.ReadyLocalServer = mmctlSuccessCount
 
 	return &status, nil
 }

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -599,7 +599,7 @@ func (provisioner Provisioner) GetClusterInstallationStatus(cluster *model.Clust
 	status.PodRunningCount = &podRunningCount
 	status.PodReadyCount = &podReadyCount
 	status.PodStartedCount = &podStartedCount
-	status.MmctlSuccessCount = mmctlSuccessCount
+	status.MMCTLSuccessCount = mmctlSuccessCount
 
 	return &status, nil
 }

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -9,6 +9,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/smithy-go/ptr"
@@ -520,6 +522,86 @@ func (provisioner Provisioner) getMattermostCustomResource(cluster *model.Cluste
 	}
 
 	return getMattermostCustomResource(clusterInstallation, configLocation, logger)
+}
+
+func (provisioner Provisioner) GetClusterInstallationStatus(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation) (*model.ClusterInstallationStatus, error) {
+	k8sClient, err := provisioner.k8sClient(cluster)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get kube client")
+	}
+
+	var status model.ClusterInstallationStatus
+
+	deployment, err := k8sClient.Clientset.AppsV1().Deployments(clusterInstallation.Namespace).Get(context.TODO(), makeClusterInstallationName(clusterInstallation), metav1.GetOptions{})
+	if err != nil {
+		if !k8sErrors.IsNotFound(err) {
+			return nil, errors.Wrap(err, "failed to query mattermost deployment")
+		}
+
+		status.InstallationFound = ptr.Bool(false)
+		return &status, nil
+	}
+
+	status.InstallationFound = ptr.Bool(true)
+	status.Replicas = deployment.Spec.Replicas
+
+	if status.Replicas == nil || *status.Replicas == 0 {
+		return &status, nil
+	}
+
+	podList, err := k8sClient.Clientset.CoreV1().Pods(clusterInstallation.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app=mattermost",
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query mattermost pods")
+	}
+
+	status.PodCount = ptr.Int32(int32(len(podList.Items)))
+
+	args := []string{"./bin/mmctl", "--local", "system", "status", "--json"}
+
+	var podRunningCount int32
+	var podReadyCount int32
+	var podStartedCount int32
+	var mmctlSuccessCount = new(int32)
+	var wg sync.WaitGroup
+
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			podRunningCount++
+		}
+
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.Name == "mattermost" {
+				if containerStatus.Ready {
+					podReadyCount++
+				}
+				if containerStatus.Started != nil && *containerStatus.Started {
+					podStartedCount++
+
+					wg.Add(1)
+					go func(podName string) {
+						defer wg.Done()
+						_, execErr := execCLI(k8sClient, clusterInstallation.Namespace, podName, "mattermost", args...)
+						if execErr == nil {
+							atomic.AddInt32(mmctlSuccessCount, 1)
+						}
+					}(pod.Name)
+
+				}
+				break
+			}
+		}
+	}
+
+	wg.Wait()
+
+	status.PodRunningCount = &podRunningCount
+	status.PodReadyCount = &podReadyCount
+	status.PodStartedCount = &podStartedCount
+	status.MmctlSuccessCount = mmctlSuccessCount
+
+	return &status, nil
 }
 
 func deleteMMSecrets(ns string, mattermost *mmv1beta1.Mattermost, kubeClient *k8s.KubeClient, logger log.FieldLogger) error {

--- a/model/client.go
+++ b/model/client.go
@@ -1710,3 +1710,18 @@ func (c *Client) DeleteSubscription(subID string) error {
 		return errors.Errorf("failed with status code %d", resp.StatusCode)
 	}
 }
+
+func (c *Client) GetClusterInstallationStatus(clusterInstallationID string) (*ClusterInstallationStatus, error) {
+	resp, err := c.doGet(c.buildURL("/api/cluster_installation/%s/status", clusterInstallationID))
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return NewClusterInstallationStatusFromReader(resp.Body)
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}

--- a/model/cluster_installation.go
+++ b/model/cluster_installation.go
@@ -7,6 +7,8 @@ package model
 import (
 	"encoding/json"
 	"io"
+
+	"github.com/pkg/errors"
 )
 
 // ClusterInstallation is a single namespace within a cluster composing a potentially larger installation.
@@ -31,6 +33,16 @@ type ClusterInstallationFilter struct {
 	InstallationID string
 	ClusterID      string
 	IsActive       *bool
+}
+
+type ClusterInstallationStatus struct {
+	InstallationFound *bool  `json:"installation_found,omitempty"`
+	Replicas          *int32 `json:"replicas,omitempty"`
+	PodCount          *int32 `json:"pod_count,omitempty"`
+	PodRunningCount   *int32 `json:"pod_running_count,omitempty"`
+	PodReadyCount     *int32 `json:"pod_ready_count,omitempty"`
+	PodStartedCount   *int32 `json:"pod_started_count,omitempty"`
+	MmctlSuccessCount *int32 `json:"mmctl_success_count,omitempty"`
 }
 
 // MigrateClusterInstallationRequest describes the parameters used to compose migration request between two clusters.
@@ -123,4 +135,14 @@ func MigrateClusterInstallationResponseFromReader(reader io.Reader) (*MigrateClu
 	}
 
 	return &migrateClusterInstallationResponse, nil
+}
+
+func NewClusterInstallationStatusFromReader(reader io.Reader) (*ClusterInstallationStatus, error) {
+	var status ClusterInstallationStatus
+	err := json.NewDecoder(reader).Decode(&status)
+	if err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "failed to decode ClusterInstallationStatus")
+	}
+
+	return &status, nil
 }

--- a/model/cluster_installation.go
+++ b/model/cluster_installation.go
@@ -42,7 +42,7 @@ type ClusterInstallationStatus struct {
 	PodRunningCount   *int32 `json:"pod_running_count,omitempty"`
 	PodReadyCount     *int32 `json:"pod_ready_count,omitempty"`
 	PodStartedCount   *int32 `json:"pod_started_count,omitempty"`
-	MmctlSuccessCount *int32 `json:"mmctl_success_count,omitempty"`
+	MMCTLSuccessCount *int32 `json:"mmctl_success_count,omitempty"`
 }
 
 // MigrateClusterInstallationRequest describes the parameters used to compose migration request between two clusters.

--- a/model/cluster_installation.go
+++ b/model/cluster_installation.go
@@ -36,13 +36,13 @@ type ClusterInstallationFilter struct {
 }
 
 type ClusterInstallationStatus struct {
-	InstallationFound bool   `json:"installation_found"`
-	Replicas          *int32 `json:"replicas,omitempty"`
-	TotalPod          *int32 `json:"total_pod,omitempty"`
-	RunningPod        *int32 `json:"running_pod,omitempty"`
-	ReadyPod          *int32 `json:"ready_pod,omitempty"`
-	StartedPod        *int32 `json:"started_pod,omitempty"`
-	ReadyLocalServer  *int32 `json:"ready_local_server,omitempty"`
+	InstallationFound bool   `json:"InstallationFound,omitempty"`
+	Replicas          *int32 `json:"Replicas,omitempty"`
+	TotalPod          *int32 `json:"TotalPod,omitempty"`
+	RunningPod        *int32 `json:"RunningPod,omitempty"`
+	ReadyPod          *int32 `json:"ReadyPod,omitempty"`
+	StartedPod        *int32 `json:"StartedPod,omitempty"`
+	ReadyLocalServer  *int32 `json:"ReadyLocalServer,omitempty"`
 }
 
 // MigrateClusterInstallationRequest describes the parameters used to compose migration request between two clusters.

--- a/model/cluster_installation.go
+++ b/model/cluster_installation.go
@@ -36,13 +36,13 @@ type ClusterInstallationFilter struct {
 }
 
 type ClusterInstallationStatus struct {
-	InstallationFound *bool  `json:"installation_found,omitempty"`
+	InstallationFound bool   `json:"installation_found"`
 	Replicas          *int32 `json:"replicas,omitempty"`
-	PodCount          *int32 `json:"pod_count,omitempty"`
-	PodRunningCount   *int32 `json:"pod_running_count,omitempty"`
-	PodReadyCount     *int32 `json:"pod_ready_count,omitempty"`
-	PodStartedCount   *int32 `json:"pod_started_count,omitempty"`
-	MMCTLSuccessCount *int32 `json:"mmctl_success_count,omitempty"`
+	TotalPod          *int32 `json:"total_pod,omitempty"`
+	RunningPod        *int32 `json:"running_pod,omitempty"`
+	ReadyPod          *int32 `json:"ready_pod,omitempty"`
+	StartedPod        *int32 `json:"started_pod,omitempty"`
+	ReadyLocalServer  *int32 `json:"ready_local_server,omitempty"`
 }
 
 // MigrateClusterInstallationRequest describes the parameters used to compose migration request between two clusters.


### PR DESCRIPTION
#### Summary

This endpoint `/api/cluster_installation/%s/status` will return the status of running the mm servers.

```
type ClusterInstallationStatus struct {
	InstallationFound bool   `json:"installation_found"`
	Replicas          *int32 `json:"replicas,omitempty"`
	TotalPod          *int32 `json:"total_pod,omitempty"`
	RunningPod        *int32 `json:"running_pod,omitempty"`
	ReadyPod          *int32 `json:"ready_pod,omitempty"`
	StartedPod        *int32 `json:"started_pod,omitempty"`
	ReadyLocalServer  *int32 `json:"ready_local_server,omitempty"`
}
```

The `cloud` command `cloud cluster installation status --cluster-installation=` will fetch from that endpoint.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-51737


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
