### PR TITLE
Bump helm to v3.11.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOLANG_VERSION := $(shell cat go.mod | grep "^go " | cut -d " " -f 2)
 ALPINE_VERSION = 3.16
 TERRAFORM_VERSION=1.0.7
 KOPS_VERSION=v1.23.4
-HELM_VERSION=v3.7.2
+HELM_VERSION=v3.11.2
 KUBECTL_VERSION=v1.24.4
 
 ## Docker Build Versions

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following is required to properly run the cloud server.
 2. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) version v1.0.7
    1. Try using [tfswitch](https://warrensbox.github.io/terraform-switcher/) for switching easily between versions
 3. Install [kops](https://github.com/kubernetes/kops/blob/master/docs/install.md) version 1.23.X
-4. Install [Helm](https://helm.sh/docs/intro/install/) version 3.5.X
+4. Install [Helm](https://helm.sh/docs/intro/install/) version 3.11.X
 5. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 6. Install [golang/mock](https://github.com/golang/mock#installation) version 1.4.x
 7. (macOS only) Upgrade [diffutils](https://www.gnu.org/software/diffutils/) with `brew install diffutils`. Used by the linters.


### PR DESCRIPTION
I created, updated, and deleted a cluster to test that there were no obvious regressions.

Fixes https://mattermost.atlassian.net/browse/MM-51851

```release-note
Bump helm to v3.11.2
```
