### PR TITLE
Create Nodegroups in an EKS cluster

### DIFF
--- a/clusterdictionary/size.go
+++ b/clusterdictionary/size.go
@@ -158,3 +158,32 @@ func AddToCreateClusterRequest(sizes map[string]string, request *model.CreateClu
 
 	return nil
 }
+
+// AddToCreateNodegroupsRequest takes a map of size keywords and adds the corresponding
+// values to a CreateNodegroupsRequest.
+func AddToCreateNodegroupsRequest(sizes map[string]string, request *model.CreateNodegroupsRequest) error {
+	if len(sizes) == 0 {
+		return nil
+	}
+
+	if request.Nodegroups == nil {
+		request.Nodegroups = make(map[string]model.NodeGroupMetadata)
+	}
+
+	for ng, ngSize := range sizes {
+		if !IsValidClusterSize(ngSize) {
+			return errors.Errorf("%s is not a valid size", ngSize)
+		}
+
+		values := ValidSizes[ngSize]
+
+		request.Nodegroups[ng] = model.NodeGroupMetadata{
+			// These values are used in EKS configuration, but not in kops.
+			InstanceType: values.NodeInstanceType,
+			MinCount:     values.NodeMinCount,
+			MaxCount:     values.NodeMaxCount,
+		}
+	}
+
+	return nil
+}

--- a/clusterdictionary/size.go
+++ b/clusterdictionary/size.go
@@ -178,7 +178,6 @@ func AddToCreateNodegroupsRequest(sizes map[string]string, request *model.Create
 		values := ValidSizes[ngSize]
 
 		request.Nodegroups[ng] = model.NodeGroupMetadata{
-			// These values are used in EKS configuration, but not in kops.
 			InstanceType: values.NodeInstanceType,
 			MinCount:     values.NodeMinCount,
 			MaxCount:     values.NodeMaxCount,

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -40,6 +40,7 @@ func newCmdCluster() *cobra.Command {
 	cmd.AddCommand(newCmdClusterUpdate())
 	cmd.AddCommand(newCmdClusterUpgrade())
 	cmd.AddCommand(newCmdClusterResize())
+	cmd.AddCommand(newCmdClusterNodegroups())
 	cmd.AddCommand(newCmdClusterDelete())
 	cmd.AddCommand(newCmdClusterGet())
 	cmd.AddCommand(newCmdClusterList())

--- a/cmd/cloud/nodegroup.go
+++ b/cmd/cloud/nodegroup.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-cloud/clusterdictionary"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func newCmdClusterNodegroups() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "nodegroups",
+		Short: "Manipulate nodegroups of an existing cluster.",
+	}
+
+	cmd.AddCommand(newCmdClusterNodegroupsAdd())
+
+	return cmd
+}
+
+func newCmdClusterNodegroupsAdd() *cobra.Command {
+	var flags clusterNodegroupsAddFlags
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create new nodegroups in an existing cluster.",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+			return addNodegroup(flags)
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.clusterFlags.addFlags(cmd)
+		},
+	}
+
+	flags.addFlags(cmd)
+
+	return cmd
+}
+
+func addNodegroup(flags clusterNodegroupsAddFlags) error {
+	client := model.NewClient(flags.serverAddress)
+
+	if len(flags.nodegroups) == 0 {
+		return fmt.Errorf("nodegroups must be provided")
+	}
+
+	for _, ng := range flags.nodegroupsWithPublicSubnet {
+		if _, f := flags.nodegroups[ng]; !f {
+			return fmt.Errorf("nodegroup %s not provided in nodegroups", ng)
+		}
+	}
+
+	for _, ng := range flags.nodegroupsWithSecurityGroup {
+		if _, f := flags.nodegroups[ng]; !f {
+			return fmt.Errorf("nodegroup %s not provided in nodegroups", ng)
+		}
+	}
+
+	request := model.CreateNodegroupsRequest{
+		NodeGroupWithPublicSubnet:  flags.nodegroupsWithPublicSubnet,
+		NodeGroupWithSecurityGroup: flags.nodegroupsWithSecurityGroup,
+	}
+
+	err := clusterdictionary.AddToCreateNodegroupsRequest(flags.nodegroups, &request)
+	if err != nil {
+		return errors.Wrap(err, "failed to apply size values for nodegroups")
+	}
+
+	if flags.dryRun {
+		return runDryRun(request)
+	}
+
+	cluster, err := client.CreateNodegroups(flags.clusterID, &request)
+	if err != nil {
+		return errors.Wrap(err, "failed to create cluster")
+	}
+
+	if err = printJSON(cluster); err != nil {
+		return errors.Wrap(err, "failed to print cluster response")
+	}
+
+	return nil
+}

--- a/cmd/cloud/nodegroup_flag.go
+++ b/cmd/cloud/nodegroup_flag.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import "github.com/spf13/cobra"
+
+type clusterNodegroupsAddFlags struct {
+	clusterFlags
+	clusterID                   string
+	nodegroups                  map[string]string
+	nodegroupsWithPublicSubnet  []string
+	nodegroupsWithSecurityGroup []string
+}
+
+func (flags *clusterNodegroupsAddFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.clusterID, "cluster", "", "The id of the cluster to be modified.")
+	command.Flags().StringToStringVar(&flags.nodegroups, "nodegroups", nil, "Additional nodegroups to create. The key is the name of the nodegroup and the value is the size constant.")
+	command.Flags().StringSliceVar(&flags.nodegroupsWithPublicSubnet, "nodegroups-with-public-subnet", nil, "Nodegroups to create with public subnet. The value is the name of the nodegroup.")
+	command.Flags().StringSliceVar(&flags.nodegroupsWithSecurityGroup, "nodegroups-with-sg", nil, "Nodegroups to create with dedicated security group. The value is the name of the nodegroup.")
+
+	_ = command.MarkFlagRequired("cluster")
+	_ = command.MarkFlagRequired("nodegroups")
+}

--- a/e2e/pkg/webhook.go
+++ b/e2e/pkg/webhook.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	e2eTestGrafanaLogsURLTmpl     = `https://grafana.internal.mattermost.com/explore?orgId=1&left={"datasource":"PFB2D5CACEC34D62E","queries":[{"refId":"A","datasource":{"type":"loki","uid":"PFB2D5CACEC34D62E"},"editorMode":"code","expr":"{cluster=\"cnc\", namespace=\"e2e-mattermost-cloud-test\"} |= %60{{.ID}}%60","queryType":"range"}],"range":{"from":"now-24h","to":"now"}}'`
+	e2eTestGrafanaLogsURLTmpl     = `https://grafana.internal.mattermost.com/explore?orgId=1&left={"datasource":"PFB2D5CACEC34D62E","queries":[{"refId":"A","datasource":{"type":"loki","uid":"PFB2D5CACEC34D62E"},"editorMode":"code","expr":"{cluster=\"cnc\", namespace=\"e2e-mattermost-cloud-test\"} |= %60{{.ID}}%60","queryType":"range"}],"range":{"from":"now-24h","to":"now"}}`
 	provisionerGrafanaLogsURLTmpl = `https://grafana.internal.mattermost.com/explore?orgId=1&left={"datasource":"PFB2D5CACEC34D62E","queries":[{"refId":"A","datasource":{"type":"loki","uid":"PFB2D5CACEC34D62E"},"editorMode":"code","expr":"{namespace=\"mattermost-cloud-test\", component=\"provisioner\"} |= %60{{.ID}}%60","queryType":"range"}],"range":{"from":"now-24h","to":"now"}}`
 )
 

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -503,7 +503,7 @@ func handleDeleteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 	clusterID := vars["cluster"]
 	c.Logger = c.Logger.WithField("cluster", clusterID)
 
-	newState := model.ClusterStateDeletionRequested
+	newState := model.ClusterInstallationStateDeletionRequested
 
 	clusterDTO, status, unlockOnce := getClusterForTransition(c, clusterID, newState)
 	if status != 0 {

--- a/internal/provisioner/eks_provisioner.go
+++ b/internal/provisioner/eks_provisioner.go
@@ -256,6 +256,9 @@ func (provisioner *EKSProvisioner) CreateNodes(cluster *model.Cluster) error {
 	if eksMetadata == nil {
 		return errors.New("error: EKS metadata not set when creating EKS NodeGroup")
 	}
+
+	eksMetadata = provisioner.setMissingChangeRequest(eksMetadata)
+
 	changeRequest := eksMetadata.ChangeRequest
 
 	var wg sync.WaitGroup
@@ -696,6 +699,28 @@ func (provisioner *EKSProvisioner) cleanupCluster(cluster *model.Cluster) error 
 
 	return nil
 
+}
+
+func (provisioner *EKSProvisioner) setMissingChangeRequest(eksMetadata *model.EKSMetadata) *model.EKSMetadata {
+	changeRequest := eksMetadata.ChangeRequest
+
+	if changeRequest.AMI == "" {
+		changeRequest.AMI = eksMetadata.AMI
+	}
+
+	if changeRequest.MaxPodsPerNode == 0 {
+		changeRequest.MaxPodsPerNode = eksMetadata.MaxPodsPerNode
+	}
+
+	if changeRequest.VPC == "" {
+		changeRequest.VPC = eksMetadata.VPC
+	}
+
+	if changeRequest.NodeRoleARN == "" {
+		changeRequest.NodeRoleARN = eksMetadata.NodeRoleARN
+	}
+
+	return eksMetadata
 }
 
 // DeleteCluster deletes EKS cluster.

--- a/model/client.go
+++ b/model/client.go
@@ -276,6 +276,23 @@ func (c *Client) ResizeCluster(clusterID string, request *PatchClusterSizeReques
 	}
 }
 
+// CreateNodegroups requests the creation of new nodegroups in the given cluster.
+func (c *Client) CreateNodegroups(clusterID string, request *CreateNodegroupsRequest) (*ClusterDTO, error) {
+	resp, err := c.doPost(c.buildURL("/api/cluster/%s/nodegroups", clusterID), request)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return DTOFromReader[ClusterDTO](resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // DeleteCluster deletes the given cluster and all resources contained therein.
 func (c *Client) DeleteCluster(clusterID string) error {
 	resp, err := c.doDelete(c.buildURL("/api/cluster/%s", clusterID))

--- a/model/cluster_states.go
+++ b/model/cluster_states.go
@@ -34,8 +34,6 @@ const (
 	ClusterStateResizeFailed = "resize-failed"
 	// ClusterStateNodegroupsCreationRequested is a cluster in the process of creating nodegroups.
 	ClusterStateNodegroupsCreationRequested = "nodegroups-creation-requested"
-	// ClusterStateNodegroupsDeletionRequested is a cluster in the process of deleting nodegroups.
-	ClusterStateNodegroupsDeletionRequested = "nodegroups-deletion-requested"
 	// ClusterStateNodegroupsCreationFailed is a cluster that failed to create nodegroups.
 	ClusterStateNodegroupsCreationFailed = "nodegroups-creation-failed"
 	// ClusterStateDeletionRequested is a cluster in the process of being deleted.
@@ -59,6 +57,8 @@ var AllClusterStates = []string{
 	ClusterStateCreationFailed,
 	ClusterStateProvisioningRequested,
 	ClusterStateProvisioningFailed,
+	ClusterStateNodegroupsCreationRequested,
+	ClusterStateNodegroupsCreationFailed,
 	ClusterStateUpgradeRequested,
 	ClusterStateUpgradeFailed,
 	ClusterStateResizeRequested,
@@ -105,6 +105,7 @@ var AllClusterRequestStates = []string{
 	ClusterStateProvisioningRequested,
 	ClusterStateUpgradeRequested,
 	ClusterStateResizeRequested,
+	ClusterStateNodegroupsCreationRequested,
 	ClusterStateDeletionRequested,
 }
 

--- a/model/cluster_states.go
+++ b/model/cluster_states.go
@@ -32,6 +32,12 @@ const (
 	ClusterStateResizeRequested = "resize-requested"
 	// ClusterStateResizeFailed is a cluster that failed to resize.
 	ClusterStateResizeFailed = "resize-failed"
+	// ClusterStateNodegroupsCreationRequested is a cluster in the process of creating nodegroups.
+	ClusterStateNodegroupsCreationRequested = "nodegroups-creation-requested"
+	// ClusterStateNodegroupsDeletionRequested is a cluster in the process of deleting nodegroups.
+	ClusterStateNodegroupsDeletionRequested = "nodegroups-deletion-requested"
+	// ClusterStateNodegroupsCreationFailed is a cluster that failed to create nodegroups.
+	ClusterStateNodegroupsCreationFailed = "nodegroups-creation-failed"
 	// ClusterStateDeletionRequested is a cluster in the process of being deleted.
 	ClusterStateDeletionRequested = "deletion-requested"
 	// ClusterStateDeletionFailed is a cluster that failed deletion.
@@ -76,6 +82,7 @@ var AllClusterStatesPendingWork = []string{
 	ClusterStateRefreshMetadata,
 	ClusterStateUpgradeRequested,
 	ClusterStateResizeRequested,
+	ClusterStateNodegroupsCreationRequested,
 	ClusterStateDeletionRequested,
 }
 
@@ -132,6 +139,11 @@ var (
 			ClusterStateStable,
 			ClusterStateResizeRequested,
 			ClusterStateResizeFailed,
+		},
+		ClusterStateNodegroupsCreationRequested: {
+			ClusterStateStable,
+			ClusterStateNodegroupsCreationRequested,
+			ClusterStateNodegroupsCreationFailed,
 		},
 		ClusterStateDeletionRequested: {
 			ClusterStateStable,


### PR DESCRIPTION
#### Summary

```bash
$ cloud cluster nodegroups create --cluster=mw3xfmepaffefbuwees6ynbqjo --nodegroups calls=SizeAlefDev
```

This command will create a new Nodegroup in an existing EKS cluster.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-51736


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
