### PR TITLE
Add network policy to disable access to metadata

### DIFF
--- a/manifests/network-policies/mm-installation-netpol.yaml
+++ b/manifests/network-policies/mm-installation-netpol.yaml
@@ -77,3 +77,20 @@ spec:
       - namespaceSelector:
           matchLabels:
             name: mysql-operator
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-metadata-access
+spec:
+  podSelector:
+     matchLabels:
+      app: mattermost 
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.169.254/32


### PR DESCRIPTION
Issue: CLD-5507

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Disable access to AWS metadata for workspaces


#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5507

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Disable access to AWS metadata for workspaces
```

