### PR TITLE
[MM-52578] Resolved panic for missing VPC

### DIFF
--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -114,6 +114,21 @@ func (mr *MockAWSMockRecorder) ReleaseVpc(cluster, logger interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseVpc", reflect.TypeOf((*MockAWS)(nil).ReleaseVpc), cluster, logger)
 }
 
+// GetClaimedVPC mocks base method
+func (m *MockAWS) GetClaimedVPC(clusterID string, logger logrus.FieldLogger) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClaimedVPC", clusterID, logger)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClaimedVPC indicates an expected call of GetClaimedVPC
+func (mr *MockAWSMockRecorder) GetClaimedVPC(clusterID, logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClaimedVPC", reflect.TypeOf((*MockAWS)(nil).GetClaimedVPC), clusterID, logger)
+}
+
 // AttachPolicyToRole mocks base method
 func (m *MockAWS) AttachPolicyToRole(roleName, policyName string, logger logrus.FieldLogger) error {
 	m.ctrl.T.Helper()

--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -8,8 +8,7 @@
 package mockawstools
 
 import (
-	types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	types0 "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	types "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	gomock "github.com/golang/mock/gomock"
 	aws "github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	model "github.com/mattermost/mattermost-cloud/model"
@@ -418,10 +417,10 @@ func (mr *MockAWSMockRecorder) SecretsManagerGetPGBouncerAuthUserPassword(vpcID 
 }
 
 // EnsureEKSCluster mocks base method
-func (m *MockAWS) EnsureEKSCluster(cluster *model.Cluster, resources aws.ClusterResources) (*types0.Cluster, error) {
+func (m *MockAWS) EnsureEKSCluster(cluster *model.Cluster, resources aws.ClusterResources) (*types.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureEKSCluster", cluster, resources)
-	ret0, _ := ret[0].(*types0.Cluster)
+	ret0, _ := ret[0].(*types.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -433,10 +432,10 @@ func (mr *MockAWSMockRecorder) EnsureEKSCluster(cluster, resources interface{}) 
 }
 
 // EnsureEKSClusterUpdated mocks base method
-func (m *MockAWS) EnsureEKSClusterUpdated(cluster *model.Cluster) (*types0.Update, error) {
+func (m *MockAWS) EnsureEKSClusterUpdated(cluster *model.Cluster) (*types.Update, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureEKSClusterUpdated", cluster)
-	ret0, _ := ret[0].(*types0.Update)
+	ret0, _ := ret[0].(*types.Update)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -448,10 +447,10 @@ func (mr *MockAWSMockRecorder) EnsureEKSClusterUpdated(cluster interface{}) *gom
 }
 
 // EnsureEKSNodeGroup mocks base method
-func (m *MockAWS) EnsureEKSNodeGroup(cluster *model.Cluster, nodeGroupPrefix string) (*types0.Nodegroup, error) {
+func (m *MockAWS) EnsureEKSNodeGroup(cluster *model.Cluster, nodeGroupPrefix string) (*types.Nodegroup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureEKSNodeGroup", cluster, nodeGroupPrefix)
-	ret0, _ := ret[0].(*types0.Nodegroup)
+	ret0, _ := ret[0].(*types.Nodegroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -477,10 +476,10 @@ func (mr *MockAWSMockRecorder) EnsureEKSNodeGroupMigrated(cluster, nodeGroupPref
 }
 
 // GetActiveEKSCluster mocks base method
-func (m *MockAWS) GetActiveEKSCluster(clusterName string) (*types0.Cluster, error) {
+func (m *MockAWS) GetActiveEKSCluster(clusterName string) (*types.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActiveEKSCluster", clusterName)
-	ret0, _ := ret[0].(*types0.Cluster)
+	ret0, _ := ret[0].(*types.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -492,10 +491,10 @@ func (mr *MockAWSMockRecorder) GetActiveEKSCluster(clusterName interface{}) *gom
 }
 
 // GetActiveEKSNodeGroup mocks base method
-func (m *MockAWS) GetActiveEKSNodeGroup(clusterName, nodeGroupName string) (*types0.Nodegroup, error) {
+func (m *MockAWS) GetActiveEKSNodeGroup(clusterName, nodeGroupName string) (*types.Nodegroup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActiveEKSNodeGroup", clusterName, nodeGroupName)
-	ret0, _ := ret[0].(*types0.Nodegroup)
+	ret0, _ := ret[0].(*types.Nodegroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -549,10 +548,10 @@ func (mr *MockAWSMockRecorder) InstallEKSAddons(cluster interface{}) *gomock.Cal
 }
 
 // WaitForActiveEKSCluster mocks base method
-func (m *MockAWS) WaitForActiveEKSCluster(clusterName string, timeout int) (*types0.Cluster, error) {
+func (m *MockAWS) WaitForActiveEKSCluster(clusterName string, timeout int) (*types.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForActiveEKSCluster", clusterName, timeout)
-	ret0, _ := ret[0].(*types0.Cluster)
+	ret0, _ := ret[0].(*types.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -564,10 +563,10 @@ func (mr *MockAWSMockRecorder) WaitForActiveEKSCluster(clusterName, timeout inte
 }
 
 // WaitForActiveEKSNodeGroup mocks base method
-func (m *MockAWS) WaitForActiveEKSNodeGroup(clusterName, nodeGroupName string, timeout int) (*types0.Nodegroup, error) {
+func (m *MockAWS) WaitForActiveEKSNodeGroup(clusterName, nodeGroupName string, timeout int) (*types.Nodegroup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForActiveEKSNodeGroup", clusterName, nodeGroupName, timeout)
-	ret0, _ := ret[0].(*types0.Nodegroup)
+	ret0, _ := ret[0].(*types.Nodegroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -718,19 +717,4 @@ func (m *MockAWS) GetLoadBalancerAPIByType(arg0 string) aws.ELB {
 func (mr *MockAWSMockRecorder) GetLoadBalancerAPIByType(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancerAPIByType", reflect.TypeOf((*MockAWS)(nil).GetLoadBalancerAPIByType), arg0)
-}
-
-// GetVpcsWithFilters mocks base method
-func (m *MockAWS) GetVpcsWithFilters(filters []types.Filter) ([]types.Vpc, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVpcsWithFilters", filters)
-	ret0, _ := ret[0].([]types.Vpc)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVpcsWithFilters indicates an expected call of GetVpcsWithFilters
-func (mr *MockAWSMockRecorder) GetVpcsWithFilters(filters interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVpcsWithFilters", reflect.TypeOf((*MockAWS)(nil).GetVpcsWithFilters), filters)
 }

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -498,6 +498,10 @@ func (a *mockAWS) ClaimVPC(vpcID string, cluster *model.Cluster, owner string, l
 	return aws.ClusterResources{}, nil
 }
 
+func (a *mockAWS) GetClaimedVPC(clusterID string, logger log.FieldLogger) (string, error) {
+	return "", nil
+}
+
 func (a *mockAWS) EnsureEKSCluster(cluster *model.Cluster, resources aws.ClusterResources) (*eksTypes.Cluster, error) {
 	return &eksTypes.Cluster{}, nil
 }

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/acm"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	eksTypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
@@ -92,8 +91,6 @@ type AWS interface {
 	GetAccountID() (string, error)
 
 	GetLoadBalancerAPIByType(string) ELB
-
-	GetVpcsWithFilters(filters []ec2Types.Filter) ([]ec2Types.Vpc, error)
 }
 
 // Client is a client for interacting with AWS resources in a single AWS account.

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -39,6 +39,7 @@ type AWS interface {
 	GetAndClaimVpcResources(cluster *model.Cluster, owner string, logger log.FieldLogger) (ClusterResources, error)
 	ClaimVPC(vpcID string, cluster *model.Cluster, owner string, logger log.FieldLogger) (ClusterResources, error)
 	ReleaseVpc(cluster *model.Cluster, logger log.FieldLogger) error
+	GetClaimedVPC(clusterID string, logger log.FieldLogger) (string, error)
 	AttachPolicyToRole(roleName, policyName string, logger log.FieldLogger) error
 	DetachPolicyFromRole(roleName, policyName string, logger log.FieldLogger) error
 	ClaimSecurityGroups(cluster *model.Cluster, ngNames string, vpcID string, logger log.FieldLogger) ([]string, error)

--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -273,6 +273,19 @@ func (a *Client) ClaimSecurityGroups(cluster *model.Cluster, nodeGroup string, v
 	return sgIDs, nil
 }
 
+func (c *Client) GetClaimedVPC(clusterID string, logger log.FieldLogger) (string, error) {
+	vpc, err := getVPCForCluster(clusterID, c)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get VPC for cluster")
+	}
+
+	if vpc == nil {
+		return "", nil
+	}
+
+	return *vpc.VpcId, nil
+}
+
 // GetAndClaimVpcResources creates ClusterResources from an available VPC and
 // tags them appropriately.
 func (a *Client) GetAndClaimVpcResources(cluster *model.Cluster, owner string, logger log.FieldLogger) (ClusterResources, error) {


### PR DESCRIPTION
#### Summary

If the VPC is claimed by the secondary cluster, deployment of the NGINX utility causes a panic.
We need to get the VPC either claimed by primary or secondary cluster.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-52578

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
