### PR TITLE
Set logger output to os.Stdout

### DIFF
--- a/cmd/cloud/logger.go
+++ b/cmd/cloud/logger.go
@@ -21,7 +21,7 @@ func init() {
 		FullTimestamp: true,
 	})
 	// Output to stdout instead of the default stderr.
-	log.SetOutput(os.Stdout)
+	logger.SetOutput(os.Stdout)
 }
 
 type logrusWriter struct {


### PR DESCRIPTION
#### Summary

```go
logger = log.New()
```

We use this `logger` in our code. So, to set output to stdout, we need to set it in `logger`

```
logger.SetOutput(os.Stdout)
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Set logger output to os.Stdout
```
