### PR TITLE
Refactor helm IsEmpty()

### DIFF
--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -341,13 +341,15 @@ func (u *HelmUtilityVersion) Values() string {
 // values inside are undefined. If HelmUtilityVersion is "unmanaged" then false
 // is returned instead.
 func (u *HelmUtilityVersion) IsEmpty() bool {
+	if u == nil {
+		return true
+	}
+
 	if u.Chart == UnmanagedUtilityVersion {
 		return false
 	}
 
-	return u == nil ||
-		u.ValuesPath == "" ||
-		u.Chart == ""
+	return u.ValuesPath == "" || u.Chart == ""
 }
 
 // UtilityIsUnmanaged returns true if the desired version of a utility is set to

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -351,3 +351,25 @@ func TestUtilityIsUnmanaged(t *testing.T) {
 		})
 	}
 }
+
+func TestUtilityIsEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		helm  *HelmUtilityVersion
+		empty bool
+	}{
+		{"nil", nil, true},
+		{"chart unmanaged, values empty", &HelmUtilityVersion{Chart: UnmanagedUtilityVersion}, false},
+		{"chart unmanaged, values not empty", &HelmUtilityVersion{Chart: UnmanagedUtilityVersion, ValuesPath: "test"}, false},
+		{"chart empty, values empty", &HelmUtilityVersion{}, true},
+		{"chart not empty, values empty", &HelmUtilityVersion{Chart: "test"}, true},
+		{"chart empty, values not empty", &HelmUtilityVersion{ValuesPath: "test"}, true},
+		{"chart not empty, values not empty", &HelmUtilityVersion{Chart: "test", ValuesPath: "test"}, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.empty, test.helm.IsEmpty())
+		})
+	}
+}


### PR DESCRIPTION
This refactor handles nil helm chart objects earlier to prevent panics.

Fixes https://mattermost.atlassian.net/browse/CLD-5767

```release-note
Refactor helm IsEmpty() to handle nil values earlier
```
