### PR TITLE
Add installation deletion report command

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -7,11 +7,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	awsTools "github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -40,6 +42,7 @@ func newCmdInstallation() *cobra.Command {
 	cmd.AddCommand(newCmdInstallationShowStateReport())
 	cmd.AddCommand(newCmdInstallationRecovery())
 	cmd.AddCommand(newCmdInstallationDeploymentReport())
+	cmd.AddCommand(newCmdInstallationDeletionReport())
 	cmd.AddCommand(newCmdInstallationAnnotation())
 	cmd.AddCommand(newCmdInstallationBackup())
 	cmd.AddCommand(newCmdInstallationOperation())
@@ -835,6 +838,59 @@ func executeInstallationDeploymentReportCmd(flags installationDeploymentReportFl
 	}
 
 	fmt.Println(output)
+	return nil
+}
+
+func newCmdInstallationDeletionReport() *cobra.Command {
+	var flags installationDeletionReportFlags
+
+	cmd := &cobra.Command{
+		Use:   "deletion-report",
+		Short: "Get a report of installation deletion pending times.",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+			return executeInstallationDeletionReportCmd(flags)
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.clusterFlags.addFlags(cmd)
+		},
+	}
+	flags.addFlags(cmd)
+
+	return cmd
+}
+
+func executeInstallationDeletionReportCmd(flags installationDeletionReportFlags) error {
+	client := model.NewClient(flags.serverAddress)
+
+	installations, err := client.GetInstallations(&model.GetInstallationsRequest{
+		State:  model.InstallationStateDeletionPending,
+		Paging: model.AllPagesNotDeleted(),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to query installations")
+	}
+
+	// Prepare the time cutoffs for the report.
+	now := time.Now()
+	var report model.DeletionPendingReport
+	for i := 1; i <= flags.days; i++ {
+		report.NewCutoff(fmt.Sprintf("%d day(s)", i), now.Add(time.Duration(i)*24*time.Hour))
+	}
+
+	for _, installation := range installations {
+		report.Count(installation.DeletionPendingExpiry)
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeader([]string{"TIME TO DELETION", "COUNT"})
+	for _, cutoff := range report.Cutoffs {
+		table.Append([]string{cutoff.Name, toStr(cutoff.Count)})
+	}
+	table.Append([]string{"Sometime later", toStr(report.Overflow)})
+
+	table.Render()
 	return nil
 }
 

--- a/cmd/cloud/installation_flag.go
+++ b/cmd/cloud/installation_flag.go
@@ -354,3 +354,12 @@ func (flags *installationDeploymentReportFlags) addFlags(command *cobra.Command)
 
 	_ = command.MarkFlagRequired("installation")
 }
+
+type installationDeletionReportFlags struct {
+	clusterFlags
+	days int
+}
+
+func (flags *installationDeletionReportFlags) addFlags(command *cobra.Command) {
+	command.Flags().IntVar(&flags.days, "days", 7, "The number of days include in the deletion report.")
+}

--- a/model/installation_deletion_report.go
+++ b/model/installation_deletion_report.go
@@ -1,0 +1,44 @@
+package model
+
+import "time"
+
+// DeletionPendingReport is a collection of configurable time cutoffs that are
+// used to summarize installation deletion times. There is also an Overflow
+// value that counts installations that fall outside all provided time cutoffs.
+// Examples of DeletionPendingReport cutoffs:
+// 1. Every day for a week
+// 2, Every hour for a day
+// 3. Within 1 hour, 1 day, 1 month, 1 year
+type DeletionPendingReport struct {
+	Cutoffs  []*DeletionPendingTimeCutoff
+	Overflow int
+}
+
+// DeletionPendingTimeCutoff is a single deletion time cutoff.
+type DeletionPendingTimeCutoff struct {
+	Name   string
+	Millis int64
+	Count  int
+}
+
+// NewCutoff adds a new deletion time cutoff.
+func (dpr *DeletionPendingReport) NewCutoff(name string, cutoffTime time.Time) {
+	dpr.Cutoffs = append(dpr.Cutoffs, &DeletionPendingTimeCutoff{
+		Name:   name,
+		Millis: GetMillisAtTime(cutoffTime),
+	})
+}
+
+// Count increases the Count value of the first Cutoff that is greater than the
+// provided Millis.
+func (dpr *DeletionPendingReport) Count(millis int64) {
+	for _, cutoff := range dpr.Cutoffs {
+		if cutoff.Millis > millis {
+			cutoff.Count++
+			return
+		}
+	}
+
+	// The time passed in is greater than all cutoffs so add it to the overflow.
+	dpr.Overflow++
+}

--- a/model/installation_deletion_report_test.go
+++ b/model/installation_deletion_report_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeletionPendingReport(t *testing.T) {
+	now := time.Now()
+	var report model.DeletionPendingReport
+	report.NewCutoff("6 hours", now.Add(6*time.Hour))
+	report.NewCutoff("12 hours", now.Add(12*time.Hour))
+
+	t.Run("no counts", func(t *testing.T) {
+		assert.Zero(t, report.Cutoffs[0].Count)
+		assert.Zero(t, report.Cutoffs[1].Count)
+		assert.Zero(t, report.Overflow)
+	})
+
+	t.Run("count 3 hours", func(t *testing.T) {
+		report.Count(model.GetMillisAtTime(now.Add(3 * time.Hour)))
+		assert.Equal(t, 1, report.Cutoffs[0].Count)
+		assert.Zero(t, report.Cutoffs[1].Count)
+		assert.Zero(t, report.Overflow)
+	})
+
+	t.Run("count 5 hours", func(t *testing.T) {
+		report.Count(model.GetMillisAtTime(now.Add(5 * time.Hour)))
+		assert.Equal(t, 2, report.Cutoffs[0].Count)
+		assert.Zero(t, report.Cutoffs[1].Count)
+		assert.Zero(t, report.Overflow)
+	})
+
+	t.Run("count 10 hours", func(t *testing.T) {
+		report.Count(model.GetMillisAtTime(now.Add(10 * time.Hour)))
+		assert.Equal(t, 2, report.Cutoffs[0].Count)
+		assert.Equal(t, 1, report.Cutoffs[1].Count)
+		assert.Zero(t, report.Overflow)
+	})
+
+	t.Run("count 24 hours", func(t *testing.T) {
+		report.Count(model.GetMillisAtTime(now.Add(24 * time.Hour)))
+		assert.Equal(t, 2, report.Cutoffs[0].Count)
+		assert.Equal(t, 1, report.Cutoffs[1].Count)
+		assert.Equal(t, 1, report.Overflow)
+	})
+}


### PR DESCRIPTION
This new command is used to summarize installation deletion times that are upcoming for all installations. Installations are counted in configurable groups with the cutoff time being any time in the future.

Fixes https://mattermost.atlassian.net/browse/CLD-5779

```release-note
Add installation deletion report command
```
