### PR TITLE
Onboarding adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,10 @@ goformat:
 	done
 	@echo "gofmt success"; \
 
+.PHONY: dev-start
+dev-start:
+	docker-compose up -d
+
 ## Checks if imports are formatted correctly.
 .PHONY: goimports
 goimports: $(GOIMPORTS)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ region = us-east-1
 export GITLAB_OAUTH_TOKEN=YOURTOKEN
 ```
 This is the option when a remote git repo is used for utility values. In case you want to use local values for local testing you can export an empty token value and add the values in the relevant file in `helm-charts` directory and pass it in the cluster creation step.
+6. Get a CloudFlare API Key, and export it with `export CLOUDFLARE_API_KEY=<key>`
 
 Also:
 - Make sure you have a key in your ~/.ssh/
@@ -88,7 +89,10 @@ alias cloud='$HOME/go/bin/cloud'
 
 ### Running
 Before running the server the first time you must set up the DB with:
-
+```bash
+make dev-start
+```
+Then run the database migrations with:
 ```bash
 $ cloud schema migrate
 ```

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ tip: if you want to debug, enable `--dev` flag
 
 In a different terminal/window, to create a cluster:
 ```bash
-cloud cluster create --zones <availabiity-zone> --size SizeAlef500
+cloud cluster create --zones <availabiity-zone> --size SizeAlef500 --networking calico
 i.e.
-cloud cluster create --zones us-east-1c --size SizeAlef500
+cloud cluster create --zones=us-east-1a --networking calico
 ```
 Note: Provisioner's default network provider is **amazon-vpc-routed-eni** which can be overridden using `--networking` flag. Supported network providers are weave, canal, calico, amazon-vpc-routed-eni.e.g
 ```bash

--- a/build/localdev/create-database.sql
+++ b/build/localdev/create-database.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE cloud;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+services:
+  postgres:
+    image: "postgres:12.5"
+    container_name: "cloud-postgres"
+    restart: on-failure
+    networks:
+    - cloud
+    ports:
+    - "5430:5432"
+    environment:
+      POSTGRES_USER: provisioner
+      POSTGRES_PASSWORD: provisionerdev
+    volumes:
+    - "./build/localdev/create-database.sql:/docker-entrypoint-initdb.d/create-database.sql"
+networks:
+  cloud:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        # Range chosen to avoid conflicting with some of the # 10.*.*.* addresses
+        # used by Tailscale on Linux. Tailscale's use of these addresses
+        # meant no traffic reached the local container.
+        - subnet: 192.168.255.0/24
+          ip_range: 192.168.255.0/24


### PR DESCRIPTION
#### Summary
Having gone through the onboarding I've made a few adjustments to the README for first timers. This PR also includes a docker-compose file to spin up a postgres database, since the recent deprecation of sqlite requires a postgres instance of some kind. The postgres db can be spun up with either `docker-compose up` (optionally passing `-d`), or with `make dev-start`. The postgres db will create the `cloud` database on first start, so all that's required is to run the schema migrations against it.

#### Ticket Link
N/a

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
