### PR TITLE
[CLD-5737] Update Single Tenant PG Default Version to 13.10

### DIFF
--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -52,7 +52,7 @@ const (
 
 	// DefaultDatabasePostgresVersion is the default version of PostgreSQL used
 	// when creating databases.
-	DefaultDatabasePostgresVersion = "11.13"
+	DefaultDatabasePostgresVersion = "13.10"
 
 	// DefaultDBSubnetGroupName is the default DB subnet group name used when
 	// creating DB clusters. This group name is defined by the owner of the AWS


### PR DESCRIPTION
#### Summary
Update default PG version for single tenant db's to 13.10 from 11.13. See: `cloud-w8czjwng43nt7r3xnjfguetspc-master` RDS db in Dev account. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5737
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Single tenant Postgres databases will now be created with PostgreSQL version 13.10
```
