### PR TITLE
[CLD-5774] Update S3 bucket cleanup logic to handle versioning

### DIFF
--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -52,7 +52,7 @@ const (
 
 	// DefaultDatabasePostgresVersion is the default version of PostgreSQL used
 	// when creating databases.
-	DefaultDatabasePostgresVersion = "11.13"
+	DefaultDatabasePostgresVersion = "13.10"
 
 	// DefaultDBSubnetGroupName is the default DB subnet group name used when
 	// creating DB clusters. This group name is defined by the owner of the AWS

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -52,7 +52,7 @@ const (
 
 	// DefaultDatabasePostgresVersion is the default version of PostgreSQL used
 	// when creating databases.
-	DefaultDatabasePostgresVersion = "13.10"
+	DefaultDatabasePostgresVersion = "11.13"
 
 	// DefaultDBSubnetGroupName is the default DB subnet group name used when
 	// creating DB clusters. This group name is defined by the owner of the AWS

--- a/internal/tools/aws/s3.go
+++ b/internal/tools/aws/s3.go
@@ -79,6 +79,59 @@ func (a *Client) s3EnsureBucketCreated(bucketName string, logger log.FieldLogger
 	return nil
 }
 
+func (a *Client) S3BatchDeleteVersions(bucketName string, prefix *string) error {
+	ctx := context.TODO()
+
+	versionsPaginator := s3.NewListObjectVersionsPaginator(
+		a.service.s3,
+		&s3.ListObjectVersionsInput{
+			Bucket:  aws.String(bucketName),
+			MaxKeys: 1000, // The maximum number of objects we can retrieve on a single request
+			Prefix:  prefix,
+		},
+	)
+
+	for versionsPaginator.HasMorePages() {
+		versionsPage, err := versionsPaginator.NextPage(ctx)
+		if err != nil {
+			return errors.Wrap(err, "couldn't get object versions page")
+		}
+
+		if versionsPage == nil {
+			break
+		}
+
+		var objectVersions []types.ObjectIdentifier
+		for _, obj := range versionsPage.Versions {
+			objectVersions = append(objectVersions, types.ObjectIdentifier{
+				Key:       obj.Key,
+				VersionId: obj.VersionId,
+			})
+		}
+
+		// Ensure we have object versions, otherwise there's nothing to do
+		if len(objectVersions) == 0 {
+			a.logger.Warnf("received empty page while emptying bucket versions %s, assuming finished", bucketName)
+			break
+		}
+
+		_, err = a.service.s3.DeleteObjects(
+			ctx,
+			&s3.DeleteObjectsInput{
+				Bucket: aws.String(bucketName),
+				Delete: &types.Delete{
+					Objects: objectVersions,
+				},
+			},
+		)
+		if err != nil {
+			return errors.Wrap(err, "couldn't delete object versions from bucket")
+		}
+	}
+
+	return nil
+}
+
 // S3BatchDelete delete objects from a bucket in batches
 func (a *Client) S3BatchDelete(bucketName string, prefix *string) error {
 	ctx := context.TODO()
@@ -128,6 +181,37 @@ func (a *Client) S3BatchDelete(bucketName string, prefix *string) error {
 			return errors.Wrap(err, "couldn't delete objects from bucket")
 		}
 	}
+
+	return nil
+}
+
+func (a *Client) S3IsVersioningEnabled(bucketName string) (bool, error) {
+	ctx := context.TODO()
+	result, err := a.Service().s3.GetBucketVersioning(
+		ctx,
+		&s3.GetBucketVersioningInput{
+			Bucket: aws.String(bucketName),
+		})
+	if err != nil {
+		return false, errors.Wrap(err, "unable to get bucket versioning")
+	}
+
+	return result.Status == types.BucketVersioningStatusEnabled, nil
+}
+
+func (a *Client) S3DisableVersioning(bucketName string) error {
+	ctx := context.TODO()
+
+	_, err := a.Service().s3.PutBucketVersioning(ctx, &s3.PutBucketVersioningInput{
+		Bucket: aws.String(bucketName),
+		VersioningConfiguration: &types.VersioningConfiguration{
+			Status: types.BucketVersioningStatusSuspended,
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to disable versioning")
+	}
+
 	return nil
 }
 
@@ -148,6 +232,25 @@ func (a *Client) S3EnsureBucketDeleted(bucketName string, logger log.FieldLogger
 			return nil
 		}
 		logger.WithField("s3-bucket-name", bucketName).WithError(err).Warn("Could not determine if S3 bucket exists")
+	}
+
+	isVersioned, err := a.S3IsVersioningEnabled(bucketName)
+
+	if err != nil {
+		logger.WithField("s3-bucket-name", bucketName).WithError(err).Warn("Could not determine if S3 bucket is versioned")
+		// TODO: Continue anyways?
+		return err
+	}
+
+	if isVersioned {
+		if err = a.S3DisableVersioning(bucketName); err != nil {
+			logger.WithField("s3-bucket-name", bucketName).WithError(err).Warn("Could not disable versioning on bucket")
+			return err
+		}
+	}
+
+	if err = a.S3BatchDeleteVersions(bucketName, nil); err != nil {
+		return errors.Wrap(err, "can't empty bucket versions")
 	}
 
 	if err = a.S3BatchDelete(bucketName, nil); err != nil {

--- a/internal/tools/aws/s3_types.go
+++ b/internal/tools/aws/s3_types.go
@@ -30,4 +30,7 @@ type S3API interface {
 	PutBucketEncryption(ctx context.Context, params *s3.PutBucketEncryptionInput, optFns ...func(*s3.Options)) (*s3.PutBucketEncryptionOutput, error)
 
 	GetBucketTagging(ctx context.Context, params *s3.GetBucketTaggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error)
+	GetBucketVersioning(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
+	PutBucketVersioning(ctx context.Context, params *s3.PutBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.PutBucketVersioningOutput, error)
+	ListObjectVersions(ctx context.Context, params *s3.ListObjectVersionsInput, optFns ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error)
 }


### PR DESCRIPTION
#### Summary
Adds logic to S3 storage cleanup that will suspend versioning, then iterate through all versions and delete them before then deleting all objects and the bucket itself. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5774
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Updated S3 bucket cleanup logic to handle versioned objects
```
