### PR TITLE
[MM-5945] Add support for installation deletion locks

### DIFF
--- a/cmd/cloud/security.go
+++ b/cmd/cloud/security.go
@@ -99,6 +99,8 @@ func newCmdSecurityInstallation() *cobra.Command {
 
 	cmd.AddCommand(newCmdSecurityInstallationLock())
 	cmd.AddCommand(newCmdSecurityInstallationUnlock())
+	cmd.AddCommand(newCmdSecurityInstallationDeletionLock())
+	cmd.AddCommand(newCmdSecurityInstallationDeletionUnlock())
 
 	return cmd
 }
@@ -139,6 +141,53 @@ func newCmdSecurityInstallationUnlock() *cobra.Command {
 			client := model.NewClient(flags.serverAddress)
 			if err := client.UnlockAPIForInstallation(flags.installationID); err != nil {
 				return errors.Wrap(err, "failed to unlock installation API")
+			}
+			return nil
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.securityFlags.addFlags(cmd)
+			flags.addFlags(cmd)
+		},
+	}
+
+	return cmd
+}
+
+func newCmdSecurityInstallationDeletionUnlock() *cobra.Command {
+
+	var flags securityInstallationFlags
+
+	cmd := &cobra.Command{
+		Use:   "deletion-unlock",
+		Short: "Unlock deletion lock on installation, allowing it to be deleted",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+			client := model.NewClient(flags.serverAddress)
+			if err := client.UnlockDeletionLockForInstallation(flags.installationID); err != nil {
+				return errors.Wrap(err, "failed to unlock installation deletion lock")
+			}
+			return nil
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.securityFlags.addFlags(cmd)
+			flags.addFlags(cmd)
+		},
+	}
+
+	return cmd
+}
+
+func newCmdSecurityInstallationDeletionLock() *cobra.Command {
+	var flags securityInstallationFlags
+
+	cmd := &cobra.Command{
+		Use:   "deletion-lock",
+		Short: "Lock deletion lock on installation, preventing it from being deleted until unlocked",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+			client := model.NewClient(flags.serverAddress)
+			if err := client.LockDeletionLockForInstallation(flags.installationID); err != nil {
+				return errors.Wrap(err, "failed to lock installation deletion lock")
 			}
 			return nil
 		},

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -48,6 +48,8 @@ type Store interface {
 	LockInstallationAPI(installationID string) error
 	UnlockInstallationAPI(installationID string) error
 	DeleteInstallation(installationID string) error
+	DeletionLockInstallation(installationID string) error
+	DeletionUnlockInstallation(installationID string) error
 
 	GetClusterInstallation(clusterInstallationID string) (*model.ClusterInstallation, error)
 	GetClusterInstallations(filter *model.ClusterInstallationFilter) ([]*model.ClusterInstallation, error)

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -604,6 +604,12 @@ func handleDeleteInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	if installationDTO.DeletionLocked {
+		c.Logger.WithField("deletion-lock-conflict", "installation").Warn("Attempt to delete a deletion-locked installation")
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
 	if !installationDTO.ValidTransitionState(newState) {
 		// Fall back to the deletion pending state.
 		newState = model.InstallationStateDeletionPendingRequested

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -1750,6 +1750,17 @@ func TestDeleteInstallation(t *testing.T) {
 		require.EqualError(t, errTest, "failed with status code 409")
 	})
 
+	t.Run("while deletion-locked", func(t *testing.T) {
+		errTest := sqlStore.DeletionLockInstallation(installation.ID)
+		require.NoError(t, errTest)
+
+		errTest = client.DeleteInstallation(installation.ID)
+		require.EqualError(t, errTest, "failed with status code 403")
+
+		errTest = sqlStore.DeletionUnlockInstallation(installation.ID)
+		require.NoError(t, errTest)
+	})
+
 	t.Run("while api-security-locked", func(t *testing.T) {
 		errTest := sqlStore.LockInstallationAPI(installation.ID)
 		require.NoError(t, errTest)

--- a/internal/api/security.go
+++ b/internal/api/security.go
@@ -180,13 +180,11 @@ func handleInstallationDeletionLockAPI(c *Context, w http.ResponseWriter, r *htt
 	}
 
 	// TODO: Should this respect the APISecurityLock?
-	if !installation.APISecurityLock {
-		err = c.Store.DeletionLockInstallation(installation.ID)
-		if err != nil {
-			c.Logger.WithError(err).Error("failed to lock deletion lock installation")
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
+	err = c.Store.DeletionLockInstallation(installation.ID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to lock deletion lock installation")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -211,13 +209,11 @@ func handleInstallationDeletionUnlockAPI(c *Context, w http.ResponseWriter, r *h
 	}
 
 	// TODO: Should this respect the APISecurityLock?
-	if !installation.APISecurityLock {
-		err = c.Store.DeletionUnlockInstallation(installation.ID)
-		if err != nil {
-			c.Logger.WithError(err).Error("failed to deletion unlock installation")
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
+	err = c.Store.DeletionUnlockInstallation(installation.ID)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to deletion unlock installation")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -2156,4 +2156,12 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.43.0"), semver.MustParse("0.44.0"), func(e execer) error {
+		_, err := e.Exec(`ALTER TABLE Installation ADD COLUMN DeletionLocked BOOLEAN NOT NULL DEFAULT 'false';`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/model/client.go
+++ b/model/client.go
@@ -1510,6 +1510,14 @@ func (c *Client) UnlockAPIForInstallation(installationID string) error {
 	return c.makeSecurityCall("installation", installationID, "api", "unlock")
 }
 
+func (c *Client) LockDeletionLockForInstallation(installationID string) error {
+	return c.makeSecurityCall("installation", installationID, "deletion", "lock")
+}
+
+func (c *Client) UnlockDeletionLockForInstallation(installationID string) error {
+	return c.makeSecurityCall("installation", installationID, "deletion", "unlock")
+}
+
 // LockAPIForClusterInstallation locks API changes for a given cluster installation.
 func (c *Client) LockAPIForClusterInstallation(clusterID string) error {
 	return c.makeSecurityCall("cluster_installation", clusterID, "api", "lock")

--- a/model/installation.go
+++ b/model/installation.go
@@ -48,6 +48,7 @@ type Installation struct {
 	DeleteAt                   int64
 	DeletionPendingExpiry      int64 `json:"DeletionPendingExpiry,omitempty"`
 	APISecurityLock            bool
+	DeletionLocked             bool
 	LockAcquiredBy             *string
 	LockAcquiredAt             int64
 	GroupOverrides             map[string]string `json:"GroupOverrides,omitempty"`

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -51,6 +51,7 @@ type CreateInstallationRequest struct {
 	Database                  string
 	Filestore                 string
 	APISecurityLock           bool
+	DeletionLocked            bool
 	MattermostEnv             EnvVarMap
 	PriorityEnv               EnvVarMap
 	Annotations               []string


### PR DESCRIPTION

#### Summary
Adds support for deletion locks, which will prevent an installation from being deleted if the lock is set. If the lock is set, the lock must be unset before deletion can occur.  Deletion locks are _not_ enabled by default and must be done so explicitly. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5945

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Support for "deletion lock", preventing an installation from being deleted if set
```
