### PR TITLE
Move E2E docker entrypoint to shell script

### DIFF
--- a/build/Dockerfile.e2e
+++ b/build/Dockerfile.e2e
@@ -21,7 +21,7 @@ FROM ${DOCKER_BASE_IMAGE}
 RUN addgroup -S app-group && adduser -S app-user -G app-group
 USER app-user
 
-LABEL name="Mattermost Cloud E2e" \
+LABEL name="Mattermost Cloud E2E" \
   maintainer="cloud-team@mattermost.com" \
   vendor="Mattermost" \
   distribution-scope="public" \
@@ -31,5 +31,6 @@ LABEL name="Mattermost Cloud E2e" \
 WORKDIR /mattermost-cloud-e2e/
 COPY --from=build /mattermost-cloud-e2e/mattermost-cloud-e2e-cluster-tests /mattermost-cloud-e2e
 COPY --from=build /mattermost-cloud-e2e/mattermost-cloud-e2e-installation-tests /mattermost-cloud-e2e
+COPY --from=build /mattermost-cloud-e2e/build/bin-e2e /mattermost-cloud-e2e
 
-ENTRYPOINT ["/mattermost-cloud-e2e/mattermost-cloud-e2e-cluster-tests", "&&", "/mattermost-cloud-e2e/mattermost-cloud-e2e-installation-tests"]
+ENTRYPOINT ["/mattermost-cloud-e2e/entrypoint"]

--- a/build/bin-e2e/entrypoint
+++ b/build/bin-e2e/entrypoint
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Don't exit on test failures, but capture them for final return.
+failures=0
+
+echo "Running Cluster E2E Tests"
+/mattermost-cloud-e2e/mattermost-cloud-e2e-cluster-tests || failures=$(($failures+1))
+
+echo "Running Installation E2E Tests"
+/mattermost-cloud-e2e/mattermost-cloud-e2e-installation-tests || failures=$(($failures+1))
+
+echo "\n$failures tests failed"
+if [ $failures -ne 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
This allows for better logging and fixes an issue where the second test didn't run.

Fixes https://mattermost.atlassian.net/browse/CLD-5995

```release-note
Move E2E docker entrypoint to shell script
```
