### PR TITLE
[CLD-6035] Fix potential for installation (and therefore cluster) to leak after E2E failure

### DIFF
--- a/e2e/tests/installation/installation_test.go
+++ b/e2e/tests/installation/installation_test.go
@@ -8,6 +8,7 @@
 package installation
 
 import (
+	"context"
 	"github.com/pkg/errors"
 	"math/rand"
 	"testing"
@@ -35,6 +36,7 @@ func SetupInstallationLifecycleTest() (*shared.Test, error) {
 }
 
 func Test_InstallationLifecycle(t *testing.T) {
+	ctx := context.Background()
 	rand.Seed(time.Now().UnixNano())
 
 	test, err := SetupInstallationLifecycleTest()
@@ -64,6 +66,7 @@ func Test_InstallationLifecycle(t *testing.T) {
 			testWorkflowSteps := c.WorkflowStepsFunc(test.ClusterSuite, test.InstallationSuite)
 			test.Workflow = workflow.NewWorkflow(testWorkflowSteps)
 			test.Steps = testWorkflowSteps
+			defer test.InstallationSuite.Cleanup(ctx)
 			err = test.Run()
 			require.NoError(t, err)
 			time.Sleep(time.Second * 1)


### PR DESCRIPTION
#### Summary
The recent refactor introduced re-using a cluster for multiple installation test suites. We ran into an issue where the first suite failed while running, but there was no logic to explicitly clean up the installation created from that test suite. This meant that an installation was still alive on the cluster when its deletion was later attempted after all tests had finished. Cluster couldn't be deleted because there was an installation on it. 

This change makes it so that after each run the installation is cleaned up, regardless of the result, so that there are no "orphaned" installations from previous suites that would prevent cluster deletion in the future. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6035
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
