### PR TITLE
[CLD-6068]Update cloub prober

### DIFF
--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -40,7 +40,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"node-problem-detector": {Chart: "2.3.5", ValuesPath: ""},
 				"metrics-server":        {Chart: "3.10.0", ValuesPath: ""},
 				"velero":                {Chart: "3.1.2", ValuesPath: ""},
-				"cloudprober":           {Chart: "0.1.1", ValuesPath: ""},
+				"cloudprober":           {Chart: "0.1.3", ValuesPath: ""},
 			},
 		}
 	}
@@ -110,7 +110,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"node-problem-detector": {Chart: "2.3.5", ValuesPath: ""},
 				"metrics-server":        {Chart: "3.10.0", ValuesPath: ""},
 				"velero":                {Chart: "3.1.2", ValuesPath: ""},
-				"cloudprober":           {Chart: "0.1.1", ValuesPath: ""},
+				"cloudprober":           {Chart: "0.1.3", ValuesPath: ""},
 			},
 		}, clusterRequest)
 	})

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -88,7 +88,7 @@ var DefaultUtilityVersions map[string]*HelmUtilityVersion = map[string]*HelmUtil
 	// VeleroCanonicalName defines the default version for the Helm chart
 	VeleroCanonicalName: {Chart: "3.1.2", ValuesPath: ""},
 	// CloudproberCanonicalName defines the default version for the Helm chart
-	CloudproberCanonicalName: {Chart: "0.1.1", ValuesPath: ""},
+	CloudproberCanonicalName: {Chart: "0.1.3", ValuesPath: ""},
 }
 
 var defaultUtilityValuesFileNames map[string]string = map[string]string{

--- a/model/cluster_utility_test.go
+++ b/model/cluster_utility_test.go
@@ -155,7 +155,7 @@ func TestGetActualVersion(t *testing.T) {
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "node-problem-detector-2.3.5"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "metrics-server-3.10.0"},
 				Velero:              &HelmUtilityVersion{Chart: "velero-3.1.2"},
-				Cloudprober:         &HelmUtilityVersion{Chart: "cloudprober-0.1.1"},
+				Cloudprober:         &HelmUtilityVersion{Chart: "cloudprober-0.1.3"},
 			},
 		},
 	}
@@ -194,7 +194,7 @@ func TestGetActualVersion(t *testing.T) {
 	assert.Equal(t, &HelmUtilityVersion{Chart: "velero-3.1.2"}, version)
 
 	version = c.ActualUtilityVersion(CloudproberCanonicalName)
-	assert.Equal(t, &HelmUtilityVersion{Chart: "cloudprober-0.1.1"}, version)
+	assert.Equal(t, &HelmUtilityVersion{Chart: "cloudprober-0.1.3"}, version)
 
 	version = c.ActualUtilityVersion("something else that doesn't exist")
 	assert.Equal(t, version, nilHuv)
@@ -229,7 +229,7 @@ func TestGetDesiredVersion(t *testing.T) {
 				NodeProblemDetector: &HelmUtilityVersion{Chart: "node-problem-detector-2.3.5"},
 				MetricsServer:       &HelmUtilityVersion{Chart: "metrics-server-3.10.0"},
 				Velero:              &HelmUtilityVersion{Chart: "velero-3.1.2"},
-				Cloudprober:         &HelmUtilityVersion{Chart: "cloudprober-0.1.1"},
+				Cloudprober:         &HelmUtilityVersion{Chart: "cloudprober-0.1.3"},
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Upgrade cloud prober helm chart to version 0.1.3 and app to 0.12.8

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/CLD-6068

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Upgrade cloud prober helm chart to version 0.1.3 and app to 0.12.8
```
