### PR TITLE
Add Grafana Annotations

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/supervisor"
 	awsTools "github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/internal/tools/cloudflare"
+	"github.com/mattermost/mattermost-cloud/internal/tools/grafana"
 	"github.com/mattermost/mattermost-cloud/internal/tools/helm"
 	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
 	"github.com/mattermost/mattermost-cloud/internal/tools/terraform"
@@ -245,9 +246,16 @@ func executeServerCmd(flags serverFlags) error {
 		return errors.Wrap(err, "failed to build AWS client")
 	}
 
-	if err := checkRequirements(logger); err != nil {
+	if err = checkRequirements(logger); err != nil {
 		return errors.Wrap(err, "failed health check")
 	}
+
+	// Build a new optional Grafana client and log config.
+	grafanaClient, err := grafana.NewGrafanaClient(awsClient.GetCloudEnvironmentName(), flags.grafanaURL, flags.grafanaTokens)
+	if err != nil {
+		logger.WithError(err).Debug("Optional Grafana client could not be configured")
+	}
+	grafanaClient.LogConfiguration(logger)
 
 	// best-effort attempt to tag the VPC with a human's identity for dev purposes
 	owner := getHumanReadableID()
@@ -335,7 +343,7 @@ func executeServerCmd(flags serverFlags) error {
 
 	var multiDoer supervisor.MultiDoer
 	if supervisorsEnabled.clusterSupervisor {
-		multiDoer = append(multiDoer, supervisor.NewClusterSupervisor(sqlStore, provisionerObj.ClusterProvisionerOption, eventsProducer, instanceID, logger, cloudMetrics))
+		multiDoer = append(multiDoer, supervisor.NewClusterSupervisor(sqlStore, provisionerObj.ClusterProvisionerOption, eventsProducer, instanceID, grafanaClient, cloudMetrics, logger))
 	}
 	if supervisorsEnabled.groupSupervisor {
 		multiDoer = append(multiDoer, supervisor.NewGroupSupervisor(sqlStore, eventsProducer, instanceID, logger))

--- a/cmd/cloud/server_flag.go
+++ b/cmd/cloud/server_flag.go
@@ -193,6 +193,8 @@ type serverFlags struct {
 	enableLogStacktrace      bool
 	enableLogFilesPerCluster bool
 	logFilesPerClusterPath   string
+	grafanaURL               string
+	grafanaTokens            []string
 
 	database      string
 	maxSchemas    int64
@@ -220,6 +222,8 @@ func (flags *serverFlags) addFlags(command *cobra.Command) {
 	command.Flags().BoolVar(&flags.enableLogStacktrace, "enable-log-stacktrace", false, "Add stacktrace in error logs.")
 	command.Flags().BoolVar(&flags.enableLogFilesPerCluster, "enable-log-files-per-cluster", false, "Store individual log files per cluster.")
 	command.Flags().StringVar(&flags.logFilesPerClusterPath, "log-files-per-cluster-path", "", "Where to store the cluster log files.")
+	command.Flags().StringVar(&flags.grafanaURL, "grafana-url", "", "The URL of a Grafana endpoint to send annotations to.")
+	command.Flags().StringSliceVar(&flags.grafanaTokens, "grafana-tokens", []string{""}, "Grafana tokens which will be used with the provided URL")
 	command.MarkFlagsRequiredTogether("enable-log-files-per-cluster", "log-files-per-cluster-path")
 
 	command.Flags().StringVar(&flags.database, "database", "", "The database backing the provisioning server.")

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/grafana/grafana-api-golang-client v0.23.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -594,6 +594,7 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/go-zookeeper/zk v1.0.2/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
+github.com/gobs/pretty v0.0.0-20180724170744-09732c25a95b/go.mod h1:Xo4aNUOrJnVruqWQJBtW6+bTBDTniY8yZum5rF3b5jw=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=
@@ -772,6 +773,8 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosuri/uilive v0.0.4 h1:hUEBpQDj8D8jXgtCdBu7sWsy5sbW/5GhuO8KBwJ2jyY=
 github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tfZ74VI=
+github.com/grafana/grafana-api-golang-client v0.23.0 h1:Uta0dSkxWYf1D83/E7MRLCG69387FiUc+k9U/35nMhY=
+github.com/grafana/grafana-api-golang-client v0.23.0/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/supervisor"
 	"github.com/mattermost/mattermost-cloud/internal/testlib"
 	"github.com/mattermost/mattermost-cloud/internal/testutil"
+	"github.com/mattermost/mattermost-cloud/internal/tools/grafana"
 	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -136,6 +138,9 @@ func (p *mockClusterProvisioner) RefreshKopsMetadata(cluster *model.Cluster) err
 }
 
 func TestClusterSupervisorDo(t *testing.T) {
+	grafanaClient, err := grafana.NewGrafanaClient("", "", []string{})
+	assert.Error(t, err)
+
 	t.Run("no clusters pending work", func(t *testing.T) {
 		logger := testlib.MakeLogger(t)
 		mockStore := &mockClusterStore{}
@@ -145,8 +150,9 @@ func TestClusterSupervisorDo(t *testing.T) {
 			&mockClusterProvisionerOption{},
 			&mockEventProducer{},
 			"instanceID",
-			logger,
+			grafanaClient,
 			cloudMetrics,
+			logger,
 		)
 		err := supervisor.Do()
 		require.NoError(t, err)
@@ -170,8 +176,9 @@ func TestClusterSupervisorDo(t *testing.T) {
 			&mockClusterProvisionerOption{},
 			&mockEventProducer{},
 			"instanceID",
-			logger,
+			grafanaClient,
 			cloudMetrics,
+			logger,
 		)
 
 		err := supervisor.Do()
@@ -222,8 +229,9 @@ func TestClusterSupervisorDo(t *testing.T) {
 			&mockClusterProvisionerOption{},
 			mockEventProducer,
 			"instanceID",
-			logger,
+			grafanaClient,
 			cloudMetrics,
+			logger,
 		)
 		err := supervisor.Do()
 		require.NoError(t, err)
@@ -249,6 +257,9 @@ func TestClusterSupervisorSupervise(t *testing.T) {
 		{"refresh metadata", model.ClusterStateRefreshMetadata, model.ClusterStateStable},
 	}
 
+	grafanaClient, err := grafana.NewGrafanaClient("", "", []string{})
+	assert.Error(t, err)
+
 	for _, tc := range testCases {
 		t.Run(tc.Description, func(t *testing.T) {
 			logger := testlib.MakeLogger(t)
@@ -259,8 +270,9 @@ func TestClusterSupervisorSupervise(t *testing.T) {
 				&mockClusterProvisionerOption{},
 				testutil.SetupTestEventsProducer(sqlStore, logger),
 				"instanceID",
-				logger,
+				grafanaClient,
 				cloudMetrics,
+				logger,
 			)
 
 			cluster := &model.Cluster{
@@ -288,8 +300,9 @@ func TestClusterSupervisorSupervise(t *testing.T) {
 			&mockClusterProvisionerOption{},
 			testutil.SetupTestEventsProducer(sqlStore, logger),
 			"instanceID",
-			logger,
+			grafanaClient,
 			cloudMetrics,
+			logger,
 		)
 
 		cluster := &model.Cluster{

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -249,7 +249,7 @@ func (c *Client) GetCloudEnvironmentName() string {
 }
 
 // buildCloudEnvironmentNameCache looks for a standard cloud account environment
-// name and chacnes it in the AWS client.
+// name and caches it in the AWS client.
 func (c *Client) buildCloudEnvironmentNameCache() error {
 	accountAliases, err := c.GetAccountAliases()
 	if err != nil {

--- a/internal/tools/grafana/client.go
+++ b/internal/tools/grafana/client.go
@@ -1,0 +1,46 @@
+package grafana
+
+import (
+	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// Client is an interface for interacting with a Grafana instance.
+type Client interface {
+	LogConfiguration(logger log.FieldLogger)
+
+	AddGrafanaClusterProvisionAnnotation(clusterID string, logger log.FieldLogger)
+	UpdateGrafanaClusterProvisionAnnotation(clusterID string, logger log.FieldLogger)
+
+	AddGrafanaClusterUpgradeAnnotation(clusterID string, logger log.FieldLogger)
+	UpdateGrafanaClusterUpgradeAnnotation(clusterID string, logger log.FieldLogger)
+
+	AddGrafanaClusterResizeAnnotation(clusterID string, logger log.FieldLogger)
+	UpdateGrafanaClusterResizeAnnotation(clusterID string, logger log.FieldLogger)
+}
+
+// NewGrafanaClient returns a GrafanaClient interface. If any errors are
+// encountered a noop client is returned instead.
+func NewGrafanaClient(cloudEnvironmentName, url string, tokens []string) (Client, error) {
+	if len(cloudEnvironmentName) == 0 {
+		return &noopClient{}, errors.New("cloudEnvironmentName is empty")
+	}
+	if len(url) == 0 {
+		return &noopClient{}, errors.New("grafana URL is empty")
+	}
+	if len(tokens) == 0 {
+		return &noopClient{}, errors.New("no grafana API tokens provided")
+	}
+
+	grafana := &Grafana{cloudEnvironmentName: cloudEnvironmentName}
+	for i, token := range tokens {
+		c, err := gapi.New(url, gapi.Config{APIKey: token})
+		if err != nil {
+			return &noopClient{}, errors.Wrapf(err, "failed to initiate Grafana client %d", i)
+		}
+		grafana.clients = append(grafana.clients, c)
+	}
+
+	return grafana, nil
+}

--- a/internal/tools/grafana/grafana_client.go
+++ b/internal/tools/grafana/grafana_client.go
@@ -1,0 +1,140 @@
+package grafana
+
+import (
+	"net/url"
+
+	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// Grafana is a wrapper for one or more Grafana clients which can be used to
+// easily make API calls to a Grafana backend.
+type Grafana struct {
+	cloudEnvironmentName string
+	clients              []*gapi.Client
+}
+
+// LogConfiguration logs client configuration.
+func (gc *Grafana) LogConfiguration(logger log.FieldLogger) {
+	logger.Infof("Grafana client configured for %s account with %d API token(s)", gc.cloudEnvironmentName, len(gc.clients))
+}
+
+// AddGrafanaClusterProvisionAnnotation adds a new cluster provision annotation.
+func (gc *Grafana) AddGrafanaClusterProvisionAnnotation(clusterID string, logger log.FieldLogger) {
+	gc.addAllAnnoationsAndLogErrors(
+		"Cluster Provisioning",
+		[]string{newKVTag("cluster", clusterID), clusterProvisionTag},
+		logger,
+	)
+}
+
+// UpdateGrafanaClusterProvisionAnnotation updates an existing cluster provision
+// annotation.
+func (gc *Grafana) UpdateGrafanaClusterProvisionAnnotation(clusterID string, logger log.FieldLogger) {
+	gc.updateAllAnnotationsAndLogErrors(
+		[]string{newKVTag("cluster", clusterID), clusterProvisionTag},
+		logger,
+	)
+}
+
+// AddGrafanaClusterUpgradeAnnotation adds a new cluster upgrade annotation.
+func (gc *Grafana) AddGrafanaClusterUpgradeAnnotation(clusterID string, logger log.FieldLogger) {
+	gc.addAllAnnoationsAndLogErrors(
+		"Cluster Upgrade",
+		[]string{newKVTag("cluster", clusterID), clusterUpgradeTag},
+		logger,
+	)
+}
+
+// UpdateGrafanaClusterUpgradeAnnotation updates an existing cluster upgrade
+// annotation.
+func (gc *Grafana) UpdateGrafanaClusterUpgradeAnnotation(clusterID string, logger log.FieldLogger) {
+	gc.updateAllAnnotationsAndLogErrors(
+		[]string{newKVTag("cluster", clusterID), clusterUpgradeTag},
+		logger,
+	)
+}
+
+// AddGrafanaClusterResizeAnnotation adds a new cluster resize annotation.
+func (gc *Grafana) AddGrafanaClusterResizeAnnotation(clusterID string, logger log.FieldLogger) {
+	gc.addAllAnnoationsAndLogErrors(
+		"Cluster Resize",
+		[]string{newKVTag("cluster", clusterID), clusterResizeTag},
+		logger,
+	)
+}
+
+// UpdateGrafanaClusterResizeAnnotation updates an existing cluster resize
+// annotation.
+func (gc *Grafana) UpdateGrafanaClusterResizeAnnotation(clusterID string, logger log.FieldLogger) {
+	gc.updateAllAnnotationsAndLogErrors(
+		[]string{newKVTag("cluster", clusterID), clusterResizeTag},
+		logger,
+	)
+}
+
+// addAllAnnoationsAndLogErrors attempts to create a given annoation for all
+// configured grafana clients and logs any errors encountered.
+func (gc *Grafana) addAllAnnoationsAndLogErrors(text string, extraTags []string, logger log.FieldLogger) {
+	for i, client := range gc.clients {
+		err := gc.addGrafanaAnnotation(client, text, extraTags, logger)
+		if err != nil {
+			logger.WithError(err).Errorf("Failed to create annotation for grafana token %d of %d", i+1, len(gc.clients))
+		}
+	}
+}
+
+// addGrafanaAnnotation adds an annotation via the Grafana API.
+func (gc *Grafana) addGrafanaAnnotation(client *gapi.Client, text string, extraTags []string, logger log.FieldLogger) error {
+	tags := append(extraTags, newKVTag("environment", gc.cloudEnvironmentName), provisionerTag)
+	id, err := client.NewAnnotation(&gapi.Annotation{
+		Text: text,
+		Tags: tags,
+		Time: model.GetMillis(),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to create Grafana annotation")
+	}
+	logger.Debugf("Annotation created successfully with ID %d", id)
+
+	return nil
+}
+
+// updateAllAnnotationsAndLogErrors attempts to update a given annoation for all
+// configured grafana clients and logs any errors encountered.
+func (gc *Grafana) updateAllAnnotationsAndLogErrors(tagFilters []string, logger log.FieldLogger) {
+	for i, client := range gc.clients {
+		err := updateGrafanaAnnotation(client, tagFilters, logger)
+		if err != nil {
+			logger.WithError(err).Errorf("Failed to create annotation for grafana token %d of %d", i+1, len(gc.clients))
+		}
+	}
+}
+
+// updateGrafanaAnnotation updates the end time of an existing Grafana annoation.
+func updateGrafanaAnnotation(client *gapi.Client, tagFilters []string, logger log.FieldLogger) error {
+	values := url.Values{}
+	for _, filter := range tagFilters {
+		values.Add("tags", filter)
+	}
+	annotations, err := client.Annotations(values)
+	if err != nil {
+		return errors.Wrap(err, "failed to query grafana annotations")
+	}
+	if len(annotations) == 0 {
+		return errors.New("failed to find grafana annotation to update")
+	}
+
+	annotation := annotations[0]
+	annotation.TimeEnd = model.GetMillis()
+
+	logger.Debugf("Updating grafana annotation %d end time", annotation.ID)
+	_, err = client.UpdateAnnotation(annotation.ID, &annotation)
+	if err != nil {
+		return errors.Wrapf(err, "failed to update grafana annotation %d", annotation.ID)
+	}
+
+	return nil
+}

--- a/internal/tools/grafana/noop_client.go
+++ b/internal/tools/grafana/noop_client.go
@@ -1,0 +1,37 @@
+package grafana
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+// noopClient is a Grafana Client that is not configured.
+type noopClient struct{}
+
+// LogConfiguration logs client configuration.
+func (gc *noopClient) LogConfiguration(logger log.FieldLogger) {
+	logger.Info("Grafana client is not configured")
+}
+
+func (gc *noopClient) AddGrafanaClusterProvisionAnnotation(clusterID string, logger log.FieldLogger) {
+	logger.Debug("Grafana client is not configured; skipping cluster provision annoation creation")
+}
+
+func (gc *noopClient) UpdateGrafanaClusterProvisionAnnotation(clusterID string, logger log.FieldLogger) {
+	logger.Debug("Grafana client is not configured; skipping cluster provision annoation update")
+}
+
+func (gc *noopClient) AddGrafanaClusterUpgradeAnnotation(clusterID string, logger log.FieldLogger) {
+	logger.Debug("Grafana client is not configured; skipping cluster provision annoation creation")
+}
+
+func (gc *noopClient) UpdateGrafanaClusterUpgradeAnnotation(clusterID string, logger log.FieldLogger) {
+	logger.Debug("Grafana client is not configured; skipping cluster provision annoation update")
+}
+
+func (gc *noopClient) AddGrafanaClusterResizeAnnotation(clusterID string, logger log.FieldLogger) {
+	logger.Debug("Grafana client is not configured; skipping cluster provision annoation creation")
+}
+
+func (gc *noopClient) UpdateGrafanaClusterResizeAnnotation(clusterID string, logger log.FieldLogger) {
+	logger.Debug("Grafana client is not configured; skipping cluster provision annoation update")
+}

--- a/internal/tools/grafana/tags.go
+++ b/internal/tools/grafana/tags.go
@@ -1,0 +1,14 @@
+package grafana
+
+import "fmt"
+
+const (
+	provisionerTag      = "provisioner"
+	clusterProvisionTag = "cluster-provision"
+	clusterUpgradeTag   = "cluster-upgrade"
+	clusterResizeTag    = "cluster-resize"
+)
+
+func newKVTag(k, v string) string {
+	return fmt.Sprintf("%s:%s", k, v)
+}


### PR DESCRIPTION
The provisioner will now create and manage Grafana annotations for cluster resize, cluster upgrade, and cluster provision flows. The annotations are updated after these processes complete with an end time so that they provide a nice overlay on the metrics.

<img width="563" alt="Screenshot 2023-08-07 at 2 52 37 PM" src="https://github.com/mattermost/mattermost-cloud/assets/3694686/f1c6ea1b-f65f-4f8a-9532-e14a939f0939">

Fixes https://mattermost.atlassian.net/browse/CLD-6026

```release-note
Add Grafana Annotations
```
