### PR TITLE
Add new database report tooling

### DIFF
--- a/cmd/cloud/databases.go
+++ b/cmd/cloud/databases.go
@@ -7,6 +7,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/mattermost/mattermost-cloud/internal/common"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -480,7 +481,7 @@ func executeDatabaseValidationReportCmd(flags clusterFlags) error {
 	for dbType, installationIDs := range installationDatabaseMap {
 		fmt.Printf("Database type: %s [Database=%d,Installation=%d]\n", dbType, len(databaseMap[dbType]), len(installationIDs))
 		for _, id := range installationIDs {
-			if !contains(id, databaseMap[dbType]) {
+			if !common.Contains(databaseMap[dbType], id) {
 				fmt.Printf(" - Missing: %s\n", id)
 			}
 		}
@@ -489,23 +490,13 @@ func executeDatabaseValidationReportCmd(flags clusterFlags) error {
 	for dbType, databaseIDs := range databaseMap {
 		fmt.Printf("Database type: %s [Database=%d,Installation=%d]\n", dbType, len(databaseIDs), len(installationDatabaseMap[dbType]))
 		for _, id := range databaseIDs {
-			if !contains(id, installationDatabaseMap[dbType]) {
+			if !common.Contains(installationDatabaseMap[dbType], id) {
 				fmt.Printf(" - Missing: %s\n", id)
 			}
 		}
 	}
 
 	return nil
-}
-
-func contains(val string, checkAgainst []string) bool {
-	for _, check := range checkAgainst {
-		if val == check {
-			return true
-		}
-	}
-
-	return false
 }
 
 func newCmdDatabaseMultitenantReport() *cobra.Command {

--- a/cmd/cloud/databases_flag.go
+++ b/cmd/cloud/databases_flag.go
@@ -68,10 +68,12 @@ func (flags *databaseMultiTenantDeleteFlag) addFlags(command *cobra.Command) {
 type databaseMultiTenantReportFlag struct {
 	clusterFlags
 	multitenantDatabaseID string
+	includeSchemaCounts   bool
 }
 
 func (flags *databaseMultiTenantReportFlag) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.multitenantDatabaseID, "multitenant-database", "", "The id of the multitenant database to be fetched.")
+	command.Flags().BoolVar(&flags.includeSchemaCounts, "include-schema-counts", false, "Whether to include schema counts for each logical database or not.")
 	_ = command.MarkFlagRequired("multitenant-database")
 }
 

--- a/cmd/cloud/workbench.go
+++ b/cmd/cloud/workbench.go
@@ -29,7 +29,6 @@ func newCmdWorkbench() *cobra.Command {
 }
 
 func newCmdWorkbenchCluster() *cobra.Command {
-
 	var flags workbenchClusterFlag
 
 	cmd := &cobra.Command{

--- a/model/client.go
+++ b/model/client.go
@@ -1393,8 +1393,8 @@ func (c *Client) GetDatabaseSchemas(request *GetDatabaseSchemaRequest) ([]*Datab
 }
 
 // GetDatabaseSchema fetches the database schema from the configured provisioning server.
-func (c *Client) GetDatabaseSchema(multitenantDatabaseID string) (*DatabaseSchema, error) {
-	resp, err := c.doGet(c.buildURL("/api/databases/database_schema/%s", multitenantDatabaseID))
+func (c *Client) GetDatabaseSchema(databaseSchemaID string) (*DatabaseSchema, error) {
+	resp, err := c.doGet(c.buildURL("/api/databases/database_schema/%s", databaseSchemaID))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change adds the following:
 - New flag for printing schema counts when running a multitenant database report.
 - New validation report command to run a check that database and installation records match.

Fixes https://mattermost.atlassian.net/browse/CLD-6130

```release-note
Add new database report tooling
```
