### PR TITLE
Add provisioner installation size E2E test

### DIFF
--- a/e2e/pkg/installation_builder.go
+++ b/e2e/pkg/installation_builder.go
@@ -63,6 +63,12 @@ func (b *InstallationBuilder) Group(group string) *InstallationBuilder {
 	return b
 }
 
+// Size sets Installation's size.
+func (b *InstallationBuilder) Size(size string) *InstallationBuilder {
+	b.request.Size = size
+	return b
+}
+
 // Annotations sets Installation's annotations.
 func (b *InstallationBuilder) Annotations(annotations []string) *InstallationBuilder {
 	b.request.Annotations = annotations

--- a/e2e/pkg/webhook.go
+++ b/e2e/pkg/webhook.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/mattermost/mattermost-cloud/e2e/tests/state"
 	"github.com/pkg/errors"
@@ -141,7 +142,7 @@ func SendE2EResult(ctx context.Context, icon, text, color string) error {
 				{
 					Short: true,
 					Title: "Runtime",
-					Value: (state.EndTime.Sub(state.StartTime)).String(),
+					Value: (state.EndTime.Sub(state.StartTime)).Round(time.Second).String(),
 				},
 			},
 		}},

--- a/e2e/tests/installation/steps.go
+++ b/e2e/tests/installation/steps.go
@@ -49,6 +49,44 @@ func versionedS3BucketInstallationLifecycleSteps(clusterSuite *workflow.ClusterS
 	}
 }
 
+func largeInstallationSizeLifecycleSteps(clusterSuite *workflow.ClusterSuite, installationSuite *workflow.InstallationSuite) []*workflow.Step {
+	return []*workflow.Step{
+		{
+			Name:              "CreateCluster",
+			Func:              clusterSuite.CreateCluster,
+			DependsOn:         []string{},
+			GetExpectedEvents: clusterSuite.ClusterCreationEvents,
+		},
+		{
+			Name:              "CreateInstallationWithLargeSize",
+			Func:              installationSuite.CreateInstallationWithCustomProvisionerSize,
+			DependsOn:         []string{"CreateCluster"},
+			GetExpectedEvents: installationSuite.InstallationCreationEvents,
+		},
+		{
+			Name:      "GetLargeSizeInstallationCI",
+			Func:      installationSuite.GetCI,
+			DependsOn: []string{"CreateInstallationWithLargeSize"},
+		},
+		{
+			Name:      "CheckLargeSizeInstallationStatus",
+			Func:      installationSuite.CheckClusterInstallationStatus,
+			DependsOn: []string{"GetLargeSizeInstallationCI"},
+		},
+		{
+			Name:      "CheckLargeSizeInstallation",
+			Func:      installationSuite.CheckHealth,
+			DependsOn: []string{"CheckLargeSizeInstallationStatus"},
+		},
+		{
+			Name:              "DeleteLargeSizeInstallation",
+			Func:              installationSuite.Cleanup,
+			DependsOn:         []string{"CheckLargeSizeInstallation"},
+			GetExpectedEvents: installationSuite.InstallationDeletionEvents,
+		},
+	}
+}
+
 func basicCreateDeleteInstallationSteps(clusterSuite *workflow.ClusterSuite, installationSuite *workflow.InstallationSuite) []*workflow.Step {
 	return []*workflow.Step{
 		{

--- a/e2e/tests/shared/shared.go
+++ b/e2e/tests/shared/shared.go
@@ -44,8 +44,8 @@ const (
 type TestConfig struct {
 	Provisioner               string `envconfig:"default=kops"`
 	CloudURL                  string `envconfig:"default=http://localhost:8075"`
-	InstallationDBType        string `envconfig:"default=mysql-operator"`
-	InstallationFileStoreType string `envconfig:"default=minio-operator"`
+	InstallationDBType        string `envconfig:"default=aws-rds-postgres"`
+	InstallationFilestoreType string `envconfig:"default=bifrost"`
 	DNSSubdomain              string `envconfig:"default=dev.cloud.mattermost.com"`
 	WebhookAddress            string `envconfig:"default=http://localhost:11111"`
 	EventListenerAddress      string `envconfig:"default=http://localhost:11112"`
@@ -126,7 +126,7 @@ func SetupTestWithDefaults(testName string) (*Test, error) {
 	}
 	installationParams := workflow.InstallationSuiteParams{
 		DBType:        config.InstallationDBType,
-		FileStoreType: config.InstallationFileStoreType,
+		FileStoreType: config.InstallationFilestoreType,
 		Annotations:   testAnnotations(testID),
 	}
 

--- a/e2e/workflow/installation.go
+++ b/e2e/workflow/installation.go
@@ -136,6 +136,37 @@ func (w *InstallationSuite) CreateInstallationWithVersionedAWSS3Filestore(ctx co
 	return nil
 }
 
+// CreateInstallation creates new Installation and waits for it to reach stable state.
+func (w *InstallationSuite) CreateInstallationWithCustomProvisionerSize(ctx context.Context) error {
+	installationBuilder := pkg.NewInstallationBuilderWithDefaults().
+		DNS(pkg.GetDNS(w.dnsSubdomain)).
+		DB(w.Params.DBType).
+		FileStore(w.Params.FileStoreType).
+		Annotations(w.Params.Annotations).
+		Size("provisionerXL-6")
+
+	installation, err := w.client.CreateInstallation(installationBuilder.CreateRequest())
+	if err != nil {
+		return errors.Wrap(err, "while creating installation")
+	}
+	w.logger.Infof("Installation created: %s", installation.ID)
+	w.Meta.InstallationID = installation.ID
+	w.Meta.InstallationDNS = installation.DNS
+	state.InstallationID = installation.ID
+
+	err = pkg.WaitForInstallationToBeStable(ctx, w.Meta.InstallationID, w.whChan, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while waiting for installation creation")
+	}
+
+	err = pkg.WaitForInstallationAvailability(w.Meta.InstallationDNS, w.logger)
+	if err != nil {
+		return errors.Wrap(err, "while waiting for installation DNS")
+	}
+
+	return nil
+}
+
 // GetCI gets ClusterInstallation for an Installation being the part of test suite and saves it in metadata.
 func (w *InstallationSuite) GetCI(ctx context.Context) error {
 	ci, err := w.client.GetClusterInstallations(&model.GetClusterInstallationsRequest{InstallationID: w.Meta.InstallationID, Paging: model.AllPagesNotDeleted()})

--- a/model/mattermost_size.go
+++ b/model/mattermost_size.go
@@ -70,17 +70,18 @@ func ParseProvisionerSize(size string) (v1alpha1.ClusterInstallationSize, error)
 }
 
 // SizeProvisionerXLResources specifies resources for Installation size.
+// Size value = 25000users with 4 Replicas
 var SizeProvisionerXLResources = v1alpha1.ClusterInstallationSize{
 	App: v1alpha1.ComponentSize{
 		Replicas: 4,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("500m"),
-				corev1.ResourceMemory: resource.MustParse("500Mi"),
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("4000m"),
-				corev1.ResourceMemory: resource.MustParse("8Gi"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
 			},
 		},
 	},
@@ -88,7 +89,7 @@ var SizeProvisionerXLResources = v1alpha1.ClusterInstallationSize{
 		Replicas: 4,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceCPU:    resource.MustParse("300m"),
 				corev1.ResourceMemory: resource.MustParse("500Mi"),
 			},
 		},
@@ -98,7 +99,7 @@ var SizeProvisionerXLResources = v1alpha1.ClusterInstallationSize{
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("500m"),
-				corev1.ResourceMemory: resource.MustParse("500Mi"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 		},
 	},

--- a/model/mattermost_size_test.go
+++ b/model/mattermost_size_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestParseProvisionerSize(t *testing.T) {
-
 	provisionerXL6Replicas := SizeProvisionerXLResources
 	provisionerXL6Replicas.App.Replicas = 6
 


### PR DESCRIPTION
This change does the following:
 - Adds a new E2E test for custom provisioner sizes
 - Updates E2E test installation defaults
 - Provides more error logging when tests fail

Fixes https://mattermost.atlassian.net/browse/CLD-6229

```release-note
Add provisioner installation size E2E test
```
