### PR TITLE
Use provisionerXL-3 size for E2E tests

### DIFF
--- a/e2e/workflow/installation.go
+++ b/e2e/workflow/installation.go
@@ -143,7 +143,7 @@ func (w *InstallationSuite) CreateInstallationWithCustomProvisionerSize(ctx cont
 		DB(w.Params.DBType).
 		FileStore(w.Params.FileStoreType).
 		Annotations(w.Params.Annotations).
-		Size("provisionerXL-6")
+		Size("provisionerXL-3")
 
 	installation, err := w.client.CreateInstallation(installationBuilder.CreateRequest())
 	if err != nil {


### PR DESCRIPTION
There is no need to use such a large size here as test clusters aren't very large.

```release-note
None
```
