### PR TITLE
[CLD-6415] Allow MSteams metrics port in network policy

### DIFF
--- a/manifests/network-policies/mm-installation-netpol.yaml
+++ b/manifests/network-policies/mm-installation-netpol.yaml
@@ -32,6 +32,8 @@ spec:
       port: 9093 # Playbooks
     - protocol: TCP
       port: 9092 # Boards
+    - protocol: TCP
+      port: 9094 # MSTeams
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
#### Summary
- Allow MSteams metrics port in network policy


#### Release Note

```release-note
- Allow MSteams metrics port in network policy
```
