### PR TITLE
Add `--deletion-locked` installation list filter flag

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -366,6 +366,7 @@ func newCmdInstallationList() *cobra.Command {
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			flags.clusterFlags.addFlags(cmd)
+			flags.installationGetRequestChanges.addFlags(cmd)
 		},
 	}
 	flags.addFlags(cmd)
@@ -385,6 +386,7 @@ func executeInstallationListCmd(flags installationListFlags) error {
 		DNS:                         flags.dns,
 		IncludeGroupConfig:          flags.includeGroupConfig,
 		IncludeGroupConfigOverrides: flags.includeGroupConfigOverrides,
+		DeletionLocked:              flags.deletionLockedFilterValue(),
 		Paging:                      paging,
 	})
 	if err != nil {
@@ -428,10 +430,19 @@ func executeInstallationListCmd(flags installationListFlags) error {
 }
 
 func defaultInstallationTableData(installations []*model.InstallationDTO) ([]string, [][]string) {
-	keys := []string{"ID", "STATE", "VERSION", "DATABASE", "FILESTORE", "DNS"}
+	keys := []string{"ID", "STATE", "VERSION", "DATABASE", "FILESTORE", "DNS", "API-LOCKED", "DELETION-LOCKED"}
 	vals := make([][]string, 0, len(installations))
 	for _, installation := range installations {
-		vals = append(vals, []string{installation.ID, installation.State, installation.Version, installation.Database, installation.Filestore, dnsNames(installation.DNSRecords)})
+		vals = append(vals, []string{
+			installation.ID,
+			installation.State,
+			installation.Version,
+			installation.Database,
+			installation.Filestore,
+			dnsNames(installation.DNSRecords),
+			fmt.Sprintf("%t", installation.APISecurityLock),
+			fmt.Sprintf("%t", installation.DeletionLocked),
+		})
 	}
 	return keys, vals
 }

--- a/cmd/cloud/installation_flag.go
+++ b/cmd/cloud/installation_flag.go
@@ -308,6 +308,7 @@ type installationGetRequestOptions struct {
 	group                       string
 	state                       string
 	dns                         string
+	deletionLocked              bool
 	includeGroupConfig          bool
 	includeGroupConfigOverrides bool
 }
@@ -317,14 +318,23 @@ func (flags *installationGetRequestOptions) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.group, "group", "", "The group ID to filter installations.")
 	command.Flags().StringVar(&flags.state, "state", "", "The state to filter installations by.")
 	command.Flags().StringVar(&flags.dns, "dns", "", "The dns name to filter installations by.")
+	command.Flags().BoolVar(&flags.deletionLocked, "deletion-locked", false, "Filter installations by deletion-locked configuration.")
 	command.Flags().BoolVar(&flags.includeGroupConfig, "include-group-config", true, "Whether to include group configuration in the installations or not.")
 	command.Flags().BoolVar(&flags.includeGroupConfigOverrides, "include-group-config-overrides", true, "Whether to include a group configuration override summary in the installations or not.")
+}
 
+type installationGetRequestChanges struct {
+	deletionLockedChanged bool
+}
+
+func (flags *installationGetRequestChanges) addFlags(command *cobra.Command) {
+	flags.deletionLockedChanged = command.Flags().Changed("deletion-locked")
 }
 
 type installationListFlags struct {
 	clusterFlags
 	installationGetRequestOptions
+	installationGetRequestChanges
 	pagingFlags
 	tableOptions
 	hideLicense bool
@@ -338,6 +348,14 @@ func (flags *installationListFlags) addFlags(command *cobra.Command) {
 
 	command.Flags().BoolVar(&flags.hideLicense, "hide-license", true, "Whether to hide the license value in the output or not.")
 	command.Flags().BoolVar(&flags.hideEnv, "hide-env", true, "Whether to hide env vars in the output or not.")
+}
+
+func (flags *installationListFlags) deletionLockedFilterValue() *bool {
+	if flags.deletionLockedChanged {
+		return &flags.deletionLocked
+	}
+
+	return nil
 }
 
 type installationGetStatusesFlags struct {

--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -72,3 +72,7 @@ func sToP(s string) *string {
 func iToP(i int64) *int64 {
 	return &i
 }
+
+func bToP(b bool) *bool {
+	return &b
+}

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -91,3 +91,17 @@ func parseGroupConfig(u *url.URL) (bool, bool, error) {
 
 	return includeGroupConfig, includeGroupConfigOverrides, nil
 }
+
+func parseDeletionLocked(u *url.URL) (*bool, error) {
+	valueStr := u.Query().Get("deletion_locked")
+	if valueStr == "" {
+		return nil, nil
+	}
+
+	locked, err := strconv.ParseBool(valueStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to deletion_locked boolean")
+	}
+
+	return &locked, nil
+}

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -100,7 +100,7 @@ func parseDeletionLocked(u *url.URL) (*bool, error) {
 
 	locked, err := strconv.ParseBool(valueStr)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to deletion_locked boolean")
+		return nil, errors.Wrap(err, "failed to convert deletion_locked to boolean")
 	}
 
 	return &locked, nil

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -101,13 +101,21 @@ func handleGetInstallations(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	deletionLocked, err := parseDeletionLocked(r.URL)
+	if err != nil {
+		c.Logger.WithError(err).Error("failed to parse deletion_locked parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	filter := &model.InstallationFilter{
-		OwnerID: r.URL.Query().Get("owner"),
-		GroupID: r.URL.Query().Get("group"),
-		State:   r.URL.Query().Get("state"),
-		Paging:  paging,
-		DNS:     r.URL.Query().Get("dns_name"),
-		Name:    r.URL.Query().Get("name"),
+		OwnerID:        r.URL.Query().Get("owner"),
+		GroupID:        r.URL.Query().Get("group"),
+		State:          r.URL.Query().Get("state"),
+		DNS:            r.URL.Query().Get("dns_name"),
+		Name:           r.URL.Query().Get("name"),
+		DeletionLocked: deletionLocked,
+		Paging:         paging,
 	}
 
 	installations, err := c.Store.GetInstallationDTOs(filter, includeGroupConfig, includeGroupConfigOverrides)

--- a/internal/api/installation_test.go
+++ b/internal/api/installation_test.go
@@ -144,11 +144,12 @@ func TestGetInstallations(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 
 		installation2 := &model.Installation{
-			OwnerID:  ownerID2,
-			Version:  "version",
-			Name:     "dns2.example",
-			Affinity: model.InstallationAffinityIsolated,
-			State:    model.InstallationStateCreationRequested,
+			OwnerID:        ownerID2,
+			Version:        "version",
+			Name:           "dns2.example",
+			Affinity:       model.InstallationAffinityIsolated,
+			State:          model.InstallationStateCreationRequested,
+			DeletionLocked: true,
 		}
 		err = sqlStore.CreateInstallation(installation2, nil, nil)
 		require.NoError(t, err)
@@ -305,6 +306,22 @@ func TestGetInstallations(t *testing.T) {
 						Name:   "dns",
 					},
 					[]*model.Installation{installation1},
+				},
+				{
+					"filter by deletion-locked true",
+					&model.GetInstallationsRequest{
+						Paging:         model.AllPagesNotDeleted(),
+						DeletionLocked: bToP(true),
+					},
+					[]*model.Installation{installation2},
+				},
+				{
+					"filter by deletion-locked false",
+					&model.GetInstallationsRequest{
+						Paging:         model.AllPagesNotDeleted(),
+						DeletionLocked: bToP(false),
+					},
+					[]*model.Installation{installation1, installation3},
 				},
 			}
 

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -194,6 +194,9 @@ func (sqlStore *SQLStore) applyInstallationFilter(builder sq.SelectBuilder, filt
 	if filter.Name != "" {
 		builder = builder.Where("Installation.Name = ?", filter.Name)
 	}
+	if filter.DeletionLocked != nil {
+		builder = builder.Where("Installation.DeletionLocked = ?", filter.DeletionLocked)
+	}
 
 	return builder
 }

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -45,16 +45,17 @@ func TestInstallations(t *testing.T) {
 	annotations := []*model.Annotation{{Name: "annotation1"}, {Name: "annotation2"}}
 
 	installation1 := &model.Installation{
-		Name:      "test1",
-		OwnerID:   ownerID1,
-		Version:   "version",
-		Database:  model.InstallationDatabaseMysqlOperator,
-		Filestore: model.InstallationFilestoreMinioOperator,
-		Size:      mmv1alpha1.Size100String,
-		Affinity:  model.InstallationAffinityIsolated,
-		GroupID:   &groupID1,
-		CRVersion: model.V1betaCRVersion,
-		State:     model.InstallationStateCreationRequested,
+		Name:           "test1",
+		OwnerID:        ownerID1,
+		Version:        "version",
+		Database:       model.InstallationDatabaseMysqlOperator,
+		Filestore:      model.InstallationFilestoreMinioOperator,
+		Size:           mmv1alpha1.Size100String,
+		Affinity:       model.InstallationAffinityIsolated,
+		GroupID:        &groupID1,
+		CRVersion:      model.V1betaCRVersion,
+		State:          model.InstallationStateCreationRequested,
+		DeletionLocked: true,
 		PriorityEnv: model.EnvVarMap{
 			"V1": model.EnvVar{
 				Value: "test",
@@ -357,6 +358,22 @@ func TestInstallations(t *testing.T) {
 				Name:   "test1",
 			},
 			[]*model.Installation{installation1},
+		},
+		{
+			"deletion locked true",
+			&model.InstallationFilter{
+				Paging:         model.AllPagesNotDeleted(),
+				DeletionLocked: bToP(true),
+			},
+			[]*model.Installation{installation1},
+		},
+		{
+			"deletion locked falise",
+			&model.InstallationFilter{
+				Paging:         model.AllPagesNotDeleted(),
+				DeletionLocked: bToP(false),
+			},
+			[]*model.Installation{installation2, installation3},
 		},
 	}
 
@@ -1291,4 +1308,8 @@ func fixDNSRecords(num int) []*model.InstallationDNS {
 	return []*model.InstallationDNS{
 		{DomainName: fmt.Sprintf("dns-%d.example.com", num)},
 	}
+}
+
+func bToP(b bool) *bool {
+	return &b
 }

--- a/model/installation.go
+++ b/model/installation.go
@@ -83,6 +83,7 @@ type InstallationFilter struct {
 	State           string
 	DNS             string
 	Name            string
+	DeletionLocked  *bool
 }
 
 type AllowedIPRanges []AllowedIPRange

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -6,6 +6,7 @@ package model
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -296,6 +297,7 @@ type GetInstallationsRequest struct {
 	OverrideIPRanges            bool
 	IncludeGroupConfig          bool
 	IncludeGroupConfigOverrides bool
+	DeletionLocked              *bool
 }
 
 // ApplyToURL modifies the given url to include query string parameters for the request.
@@ -315,6 +317,9 @@ func (request *GetInstallationsRequest) ApplyToURL(u *url.URL) {
 	}
 	if !request.IncludeGroupConfigOverrides {
 		q.Add("include_group_config_overrides", "false")
+	}
+	if request.DeletionLocked != nil {
+		q.Add("deletion_locked", fmt.Sprintf("%t", *request.DeletionLocked))
 	}
 	request.Paging.AddToQuery(q)
 


### PR DESCRIPTION
This allows for listing installations that are either deletion locked or not. This change also adds the installation lock values to the default installation table output.

Fixes https://mattermost.atlassian.net/browse/CLD-6449

```release-note
Add `--deletion-locked` installation list filter flag
```
