### PR TITLE
[CLD-6421] Add support for --master-instance-type on cluster resize for KOPS

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -389,6 +389,10 @@ func executeClusterResizeCmd(flags clusterResizeFlags) error {
 		request.NodeMaxCount = &flags.nodeMaxCount
 	}
 
+	if len(flags.masterInstanceType) != 0 {
+		request.MasterInstanceType = &flags.masterInstanceType
+	}
+
 	if flags.dryRun {
 		return runDryRun(request)
 	}

--- a/cmd/cloud/cluster_flag.go
+++ b/cmd/cloud/cluster_flag.go
@@ -237,6 +237,7 @@ type clusterResizeFlags struct {
 	nodeMinCount     int64
 	nodeMaxCount     int64
 	nodegroups       []string
+	sizeOptions
 }
 
 func (flags *clusterResizeFlags) addFlags(command *cobra.Command) {
@@ -248,6 +249,7 @@ func (flags *clusterResizeFlags) addFlags(command *cobra.Command) {
 	command.Flags().Int64Var(&flags.nodeMinCount, "size-node-min-count", 0, "The minimum number of k8s worker nodes. Overwrites value from 'size'.")
 	command.Flags().Int64Var(&flags.nodeMaxCount, "size-node-max-count", 0, "The maximum number of k8s worker nodes. Overwrites value from 'size'.")
 	command.Flags().StringSliceVar(&flags.nodegroups, "nodegroups", nil, "The list of nodegroups to resize. Must specify if the cluster has multiple nodegroups.")
+	command.Flags().StringVar(&flags.masterInstanceType, "size-master-instance-type", "", "The instance type describing the k8s master nodes. Overwrites value from 'size'.")
 
 	_ = command.MarkFlagRequired("cluster")
 }

--- a/e2e/tests/cluster/steps.go
+++ b/e2e/tests/cluster/steps.go
@@ -48,9 +48,15 @@ func clusterLifecycleSteps(clusterSuite *workflow.ClusterSuite, installationSuit
 			GetExpectedEvents: clusterSuite.ClusterReprovisionEvents,
 		},
 		{
+			Name:              "ResizeCluster",
+			Func:              clusterSuite.ResizeCluster,
+			DependsOn:         []string{"ProvisionCluster"},
+			GetExpectedEvents: clusterSuite.ClusterResizeEvents,
+		},
+		{
 			Name:      "CheckInstallation",
 			Func:      installationSuite.CheckHealth,
-			DependsOn: []string{"ProvisionCluster"},
+			DependsOn: []string{"ResizeCluster"},
 		},
 		{
 			Name:              "DeleteInstallation",

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -1047,6 +1047,20 @@ func TestResizeCluster(t *testing.T) {
 		require.EqualError(t, errTest, "failed with status code 400")
 		assert.Nil(t, clusterResp)
 	})
+
+	t.Run("resize master instance type of eks cluster fails", func(t *testing.T) {
+		cluster1.Provisioner = model.ProvisionerEKS
+		errTest := sqlStore.UpdateCluster(cluster1.Cluster)
+		require.NoError(t, errTest)
+
+		clusterResp, errTest := client.ResizeCluster(cluster1.ID, &model.PatchClusterSizeRequest{
+			MasterInstanceType: sToP("test4"),
+		})
+
+		require.EqualError(t, errTest, "failed with status code 400")
+		assert.Nil(t, clusterResp)
+
+	})
 }
 
 func TestDeleteCluster(t *testing.T) {

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -320,11 +320,12 @@ func NewUpgradeClusterRequestFromReader(reader io.Reader) (*PatchUpgradeClusterR
 
 // PatchClusterSizeRequest specifies the parameters for resizing a cluster.
 type PatchClusterSizeRequest struct {
-	NodeInstanceType *string        `json:"node-instance-type,omitempty"`
-	NodeMinCount     *int64         `json:"node-min-count,omitempty"`
-	NodeMaxCount     *int64         `json:"node-max-count,omitempty"`
-	RotatorConfig    *RotatorConfig `json:"rotatorConfig,omitempty"`
-	NodeGroups       []string       `json:"nodeGroups,omitempty"`
+	NodeInstanceType   *string        `json:"node-instance-type,omitempty"`
+	NodeMinCount       *int64         `json:"node-min-count,omitempty"`
+	NodeMaxCount       *int64         `json:"node-max-count,omitempty"`
+	RotatorConfig      *RotatorConfig `json:"rotatorConfig,omitempty"`
+	NodeGroups         []string       `json:"nodeGroups,omitempty"`
+	MasterInstanceType *string        `json:"master-instance-type,omitempty"`
 }
 
 // Validate validates the values of a PatchClusterSizeRequest.

--- a/model/eks_metadata.go
+++ b/model/eks_metadata.go
@@ -208,6 +208,10 @@ func (em *EKSMetadata) ValidateClusterSizePatch(patchRequest *PatchClusterSizeRe
 		}
 	}
 
+	if patchRequest.MasterInstanceType != nil {
+		return errors.New("master instance type cannot be changed on an EKS cluster")
+	}
+
 	return nil
 }
 

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -373,6 +373,10 @@ func (km *KopsMetadata) ApplyClusterSizePatch(patchRequest *PatchClusterSizeRequ
 		applied = true
 		changes.NodeMaxCount = *patchRequest.NodeMaxCount
 	}
+	if patchRequest.MasterInstanceType != nil && *patchRequest.MasterInstanceType != km.MasterInstanceType {
+		applied = true
+		changes.MasterInstanceType = *patchRequest.MasterInstanceType
+	}
 
 	if km.RotatorRequest == nil {
 		km.RotatorRequest = &RotatorMetadata{}


### PR DESCRIPTION
#### Summary
Adds support for `--size-master-instance-type` when resizing a cluster. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6421

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
