### PR TITLE
Fix installation hibernation ingress config

### DIFF
--- a/internal/provisioner/cluster_installation_provisioner_test.go
+++ b/internal/provisioner/cluster_installation_provisioner_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddInternalSourceRangesToAnnotations(t *testing.T) {
+	t.Run("nil allowed ranges, blank internal ranges", func(t *testing.T) {
+		annotations := getIngressAnnotations()
+		addInternalSourceRangesToAnnotations(annotations, nil, "")
+		require.Equal(t, getIngressAnnotations(), annotations)
+	})
+
+	t.Run("nil allowed ranges, internal ranges", func(t *testing.T) {
+		annotations := getIngressAnnotations()
+		addInternalSourceRangesToAnnotations(annotations, nil, "2.2.2.2/24")
+		require.Equal(t, getIngressAnnotations(), annotations)
+	})
+
+	t.Run("allowed ranges, blank internal ranges", func(t *testing.T) {
+		annotations := getIngressAnnotations()
+		allowedRanges := &model.AllowedIPRanges{{CIDRBlock: "1.1.1.1/24"}}
+		addInternalSourceRangesToAnnotations(annotations, allowedRanges, "")
+		require.Equal(t, "1.1.1.1/24", annotations["nginx.ingress.kubernetes.io/whitelist-source-range"])
+		for k, v := range getIngressAnnotations() {
+			require.Equal(t, v, annotations[k])
+		}
+	})
+
+	t.Run("allowed ranges, blank internal ranges", func(t *testing.T) {
+		annotations := getIngressAnnotations()
+		allowedRanges := &model.AllowedIPRanges{{CIDRBlock: "1.1.1.1/24"}}
+		addInternalSourceRangesToAnnotations(annotations, allowedRanges, "2.2.2.2/24")
+		require.Equal(t, "1.1.1.1/24,2.2.2.2/24", annotations["nginx.ingress.kubernetes.io/whitelist-source-range"])
+		for k, v := range getIngressAnnotations() {
+			require.Equal(t, v, annotations[k])
+		}
+	})
+
+	t.Run("multiple of both ranges", func(t *testing.T) {
+		annotations := getIngressAnnotations()
+		allowedRanges := &model.AllowedIPRanges{
+			{CIDRBlock: "1.1.1.1/24"},
+			{CIDRBlock: "1.1.1.2/24"},
+		}
+		addInternalSourceRangesToAnnotations(annotations, allowedRanges, "2.2.2.2/24,2.2.2.3/24")
+		require.Equal(t, "1.1.1.1/24,1.1.1.2/24,2.2.2.2/24,2.2.2.3/24", annotations["nginx.ingress.kubernetes.io/whitelist-source-range"])
+		for k, v := range getIngressAnnotations() {
+			require.Equal(t, v, annotations[k])
+		}
+	})
+}


### PR DESCRIPTION
This change corrects two issues with how installation ingress configuration is generated.

When hibernating, the 410 redirect was appended to standard ingress annotations. The was hard to spot when reviewing ingress configuration, but worked as intended. This has been changed to use only the 410 redirect annotation now.

The second change was correcting an issue where installation updates were using the existing ingress annotations instead of building a fresh set with the expected defaults. This logic was a regression as the installation update logic is used to wake up installations and remove their hibernation ingress config. This has been corrected so wake-up now works as expected.

I will open a separate ticket to see if we can add E2E tests to check for this in the future.

Fixes https://mattermost.atlassian.net/browse/CLD-6511

```release-note
Fix installation hibernation ingress config
```
