### PR TITLE
[CLD-6529] Implement Enabled Check for Allowed IP Ranges + a few refactors

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -265,7 +265,6 @@ func executeServerCmd(flags serverFlags) error {
 		"ETCD_LISTEN_METRICS_URLS": flags.etcdListenMetricsURL,
 	}
 
-	logger.Infof("%+v", flags.internalIPRanges)
 	provisioningParams := provisioner.ProvisioningParams{
 		S3StateStore:            flags.s3StateStore,
 		AllowCIDRRangeList:      flags.allowListCIDRRange,

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -265,6 +265,7 @@ func executeServerCmd(flags serverFlags) error {
 		"ETCD_LISTEN_METRICS_URLS": flags.etcdListenMetricsURL,
 	}
 
+	logger.Infof("%+v", flags.internalIPRanges)
 	provisioningParams := provisioner.ProvisioningParams{
 		S3StateStore:            flags.s3StateStore,
 		AllowCIDRRangeList:      flags.allowListCIDRRange,

--- a/cmd/cloud/server_flag.go
+++ b/cmd/cloud/server_flag.go
@@ -134,7 +134,7 @@ type installationOptions struct {
 	forceCRUpgrade                bool
 	utilitiesGitURL               string
 	enableS3Versioning            bool
-	internalIPRanges              string
+	internalIPRanges              []string
 }
 
 func (flags *installationOptions) addFlags(command *cobra.Command) {
@@ -145,7 +145,7 @@ func (flags *installationOptions) addFlags(command *cobra.Command) {
 	command.Flags().BoolVar(&flags.forceCRUpgrade, "force-cr-upgrade", false, "If specified installation CRVersions will be updated to the latest version when supervised.")
 	command.Flags().StringVar(&flags.utilitiesGitURL, "utilities-git-url", "", "The private git domain to use for utilities. For example https://gitlab.com")
 	command.Flags().BoolVar(&flags.enableS3Versioning, "enable-s3-versioning", false, "Whether to enable S3 versioning for the installation bucket or not")
-	command.Flags().StringVar(&flags.internalIPRanges, "internal-ip-ranges", "", "Some ranges that needed to be allowed for operational reasons")
+	command.Flags().StringSliceVar(&flags.internalIPRanges, "internal-ip-ranges", []string{}, "Some ranges that needed to be allowed for operational reasons")
 }
 
 type dbUtilizationSettings struct {

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -1064,7 +1064,7 @@ func getHibernatingIngressAnnotations() *model.IngressAnnotations {
 
 func addSourceRangeWhitelistToAnnotations(annotations *model.IngressAnnotations, allowedIPRanges *model.AllowedIPRanges, internalIPRanges []string) {
 	// If all allowedIPRanges are disabled we don't continue so we don't unintentionally lock the workspace to internal traffic only
-	if allowedIPRanges == nil || len(*allowedIPRanges) == 0 || allowedIPRanges.AllRulesAreDisabled() {
+	if allowedIPRanges.AllRulesAreDisabled() {
 		return
 	}
 

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -1063,7 +1063,7 @@ func getHibernatingIngressAnnotations() *model.IngressAnnotations {
 }
 
 func addSourceRangeWhitelistToAnnotations(annotations *model.IngressAnnotations, allowedIPRanges *model.AllowedIPRanges, internalIPRanges []string) {
-	// If all allowedIPRange
+	// If all allowedIPRanges are disabled we don't continue so we don't unintentionally lock the workspace to internal traffic only
 	if allowedIPRanges == nil || len(*allowedIPRanges) == 0 || allowedIPRanges.AllRulesAreDisabled() {
 		return
 	}

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -829,15 +829,15 @@ func configureInstallationForHibernation(mattermost *mmv1beta1.Mattermost, insta
 	mattermost.Spec.Replicas = int32Ptr(0)
 	mattermost.Spec.Size = ""
 	if mattermost.Spec.Ingress != nil { // In case Installation was not yet updated and still uses old Ingress spec.
-		mattermost.Spec.Ingress.Annotations = getHibernatingIngressAnnotations()
+		mattermost.Spec.Ingress.Annotations = getHibernatingIngressAnnotations().ToMap()
 	} else {
-		mattermost.Spec.IngressAnnotations = getHibernatingIngressAnnotations()
+		mattermost.Spec.IngressAnnotations = getHibernatingIngressAnnotations().ToMap()
 	}
 
 	mattermost.Spec.ResourceLabels = clusterInstallationHibernatedLabels(installation, clusterInstallation)
 }
 
-func makeIngressSpec(installationDNS []*model.InstallationDNS, annotations map[string]string) *mmv1beta1.Ingress {
+func makeIngressSpec(installationDNS []*model.InstallationDNS, annotations *model.IngressAnnotations) *mmv1beta1.Ingress {
 	primaryRecord := installationDNS[0]
 	for _, rec := range installationDNS {
 		if rec.IsPrimary {
@@ -851,7 +851,7 @@ func makeIngressSpec(installationDNS []*model.InstallationDNS, annotations map[s
 		Enabled:      true,
 		Host:         primaryRecord.DomainName,
 		Hosts:        mapDomains(installationDNS),
-		Annotations:  annotations,
+		Annotations:  annotations.ToMap(),
 		IngressClass: &ingressClass,
 	}
 }
@@ -1048,53 +1048,41 @@ func getMattermostEnvWithOverrides(installation *model.Installation) model.EnvVa
 }
 
 // getIngressAnnotations returns ingress annotations used by Mattermost installations.
-func getIngressAnnotations() map[string]string {
-	return map[string]string{
-		"kubernetes.io/tls-acme":                               "true",
-		"nginx.ingress.kubernetes.io/proxy-buffering":          "on",
-		"nginx.ingress.kubernetes.io/proxy-body-size":          "100m",
-		"nginx.ingress.kubernetes.io/proxy-send-timeout":       "600",
-		"nginx.ingress.kubernetes.io/proxy-read-timeout":       "600",
-		"nginx.ingress.kubernetes.io/proxy-max-temp-file-size": "0",
-		"nginx.ingress.kubernetes.io/ssl-redirect":             "true",
-		"nginx.ingress.kubernetes.io/configuration-snippet": `
-				  proxy_force_ranges on;
-				  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`,
-		"nginx.org/server-snippets": "gzip on;",
-	}
+func getIngressAnnotations() *model.IngressAnnotations {
+	annotations := &model.IngressAnnotations{}
+	annotations.SetDefaults()
+	return annotations
 }
 
 // getHibernatingIngressAnnotations returns ingress annotations used by
 // hibernating Mattermost installations.
-func getHibernatingIngressAnnotations() map[string]string {
-	return map[string]string{
-		"nginx.ingress.kubernetes.io/configuration-snippet": "return 410;",
-	}
+func getHibernatingIngressAnnotations() *model.IngressAnnotations {
+	annotations := &model.IngressAnnotations{}
+	annotations.SetHibernatingDefaults()
+	return annotations
 }
 
-func addInternalSourceRangesToAnnotations(annotations map[string]string, allowedIPRanges *model.AllowedIPRanges, internalIPRanges string) {
-	if allowedIPRanges == nil || len(*allowedIPRanges) == 0 {
+func addInternalSourceRangesToAnnotations(annotations *model.IngressAnnotations, allowedIPRanges *model.AllowedIPRanges, internalIPRanges []string) {
+	// If all allowedIPRange
+	if allowedIPRanges == nil || len(*allowedIPRanges) == 0 || allowedIPRanges.AllRulesAreDisabled() {
 		return
 	}
 
 	allIPRanges := make([]string, 0)
 
-	// TODO: add Enabled check via helper method.
 	for _, entry := range *allowedIPRanges {
-		if !common.Contains(allIPRanges, entry.CIDRBlock) {
+		if !common.Contains(allIPRanges, entry.CIDRBlock) && entry.Enabled {
 			allIPRanges = append(allIPRanges, entry.CIDRBlock)
 		}
 	}
 
-	if internalIPRanges != "" {
-		for _, ip := range strings.Split(internalIPRanges, ",") {
-			if !common.Contains(allIPRanges, ip) {
-				allIPRanges = append(allIPRanges, ip)
-			}
+	for _, entry := range internalIPRanges {
+		if !common.Contains(allIPRanges, entry) {
+			allIPRanges = append(allIPRanges, entry)
 		}
 	}
 
-	annotations["nginx.ingress.kubernetes.io/whitelist-source-range"] = strings.Join(allIPRanges, ",")
+	annotations.WhitelistSourceRange = allIPRanges
 }
 
 func int32Ptr(i int) *int32 {

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -475,7 +475,7 @@ func (provisioner Provisioner) updateClusterInstallation(
 	mattermost.Spec.IngressName = ""
 	mattermost.Spec.IngressAnnotations = nil
 	annotations := getIngressAnnotations()
-	addInternalSourceRangesToAnnotations(annotations, installation.AllowedIPRanges, provisioner.params.InternalIPRanges)
+	addSourceRangeWhitelistToAnnotations(annotations, installation.AllowedIPRanges, provisioner.params.InternalIPRanges)
 	mattermost.Spec.Ingress = makeIngressSpec(installationDNS, annotations)
 
 	_, err = k8sClient.MattermostClientsetV1Beta.MattermostV1beta1().Mattermosts(clusterInstallation.Namespace).Update(ctx, mattermost, metav1.UpdateOptions{})
@@ -1062,7 +1062,7 @@ func getHibernatingIngressAnnotations() *model.IngressAnnotations {
 	return annotations
 }
 
-func addInternalSourceRangesToAnnotations(annotations *model.IngressAnnotations, allowedIPRanges *model.AllowedIPRanges, internalIPRanges []string) {
+func addSourceRangeWhitelistToAnnotations(annotations *model.IngressAnnotations, allowedIPRanges *model.AllowedIPRanges, internalIPRanges []string) {
 	// If all allowedIPRange
 	if allowedIPRanges == nil || len(*allowedIPRanges) == 0 || allowedIPRanges.AllRulesAreDisabled() {
 		return

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -1068,7 +1068,7 @@ func addSourceRangeWhitelistToAnnotations(annotations *model.IngressAnnotations,
 		return
 	}
 
-	allIPRanges := make([]string, 0)
+	var allIPRanges []string
 
 	for _, entry := range *allowedIPRanges {
 		if !common.Contains(allIPRanges, entry.CIDRBlock) && entry.Enabled {

--- a/internal/provisioner/cluster_installation_provisioner_test.go
+++ b/internal/provisioner/cluster_installation_provisioner_test.go
@@ -11,37 +11,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAddInternalSourceRangesToAnnotations(t *testing.T) {
+func TestaddSourceRangeWhitelistToAnnotations(t *testing.T) {
 	t.Run("nil allowed ranges, blank internal ranges", func(t *testing.T) {
 		annotations := getIngressAnnotations()
-		addInternalSourceRangesToAnnotations(annotations, nil, "")
+		addSourceRangeWhitelistToAnnotations(annotations, nil, "")
 		require.Equal(t, getIngressAnnotations(), annotations)
 	})
 
 	t.Run("nil allowed ranges, internal ranges", func(t *testing.T) {
 		annotations := getIngressAnnotations()
-		addInternalSourceRangesToAnnotations(annotations, nil, "2.2.2.2/24")
+		addSourceRangeWhitelistToAnnotations(annotations, nil, "2.2.2.2/24")
 		require.Equal(t, getIngressAnnotations(), annotations)
 	})
 
 	t.Run("allowed ranges, blank internal ranges", func(t *testing.T) {
 		annotations := getIngressAnnotations()
 		allowedRanges := &model.AllowedIPRanges{{CIDRBlock: "1.1.1.1/24"}}
-		addInternalSourceRangesToAnnotations(annotations, allowedRanges, "")
-		require.Equal(t, "1.1.1.1/24", annotations["nginx.ingress.kubernetes.io/whitelist-source-range"])
-		for k, v := range getIngressAnnotations() {
-			require.Equal(t, v, annotations[k])
-		}
+		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, "")
+		require.Equal(t, "1.1.1.1/24", annotations.WhitelistSourceRange)
+		require.Equal(t, annotations, getIngressAnnotations())
 	})
 
 	t.Run("allowed ranges, blank internal ranges", func(t *testing.T) {
 		annotations := getIngressAnnotations()
 		allowedRanges := &model.AllowedIPRanges{{CIDRBlock: "1.1.1.1/24"}}
-		addInternalSourceRangesToAnnotations(annotations, allowedRanges, "2.2.2.2/24")
-		require.Equal(t, "1.1.1.1/24,2.2.2.2/24", annotations["nginx.ingress.kubernetes.io/whitelist-source-range"])
-		for k, v := range getIngressAnnotations() {
-			require.Equal(t, v, annotations[k])
-		}
+		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, "2.2.2.2/24")
+		require.Equal(t, "1.1.1.1/24,2.2.2.2/24", annotations.WhitelistSourceRange)
+		require.Equal(t, annotations, getIngressAnnotations())
 	})
 
 	t.Run("multiple of both ranges", func(t *testing.T) {
@@ -50,10 +46,8 @@ func TestAddInternalSourceRangesToAnnotations(t *testing.T) {
 			{CIDRBlock: "1.1.1.1/24"},
 			{CIDRBlock: "1.1.1.2/24"},
 		}
-		addInternalSourceRangesToAnnotations(annotations, allowedRanges, "2.2.2.2/24,2.2.2.3/24")
-		require.Equal(t, "1.1.1.1/24,1.1.1.2/24,2.2.2.2/24,2.2.2.3/24", annotations["nginx.ingress.kubernetes.io/whitelist-source-range"])
-		for k, v := range getIngressAnnotations() {
-			require.Equal(t, v, annotations[k])
-		}
+		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, "2.2.2.2/24,2.2.2.3/24")
+		require.Equal(t, "1.1.1.1/24,1.1.1.2/24,2.2.2.2/24,2.2.2.3/24", annotations.WhitelistSourceRange)
+		require.Equal(t, annotations, getIngressAnnotations())
 	})
 }

--- a/internal/provisioner/cluster_installation_provisioner_test.go
+++ b/internal/provisioner/cluster_installation_provisioner_test.go
@@ -26,28 +26,47 @@ func TestAddSourceRangeWhitelistToAnnotations(t *testing.T) {
 
 	t.Run("allowed ranges, blank internal ranges", func(t *testing.T) {
 		annotations := getIngressAnnotations()
-		allowedRanges := &model.AllowedIPRanges{{CIDRBlock: "1.1.1.1/24"}}
-		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, []string{""})
-		require.Equal(t, "1.1.1.1/24", annotations.WhitelistSourceRange)
-		require.Equal(t, annotations, getIngressAnnotations())
+		allowedRanges := &model.AllowedIPRanges{{CIDRBlock: "1.1.1.1/24", Enabled: true}}
+		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, nil)
+		require.Equal(t, []string{"1.1.1.1/24"}, annotations.WhitelistSourceRange)
+		expectedAnnotations := getIngressAnnotations()
+		expectedAnnotations.WhitelistSourceRange = []string{"1.1.1.1/24"}
+		require.Equal(t, annotations, expectedAnnotations)
 	})
 
-	t.Run("allowed ranges, blank internal ranges", func(t *testing.T) {
+	t.Run("allowed range, internal range", func(t *testing.T) {
 		annotations := getIngressAnnotations()
-		allowedRanges := &model.AllowedIPRanges{{CIDRBlock: "1.1.1.1/24"}}
+		allowedRanges := &model.AllowedIPRanges{{CIDRBlock: "1.1.1.1/24", Enabled: true}}
 		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, []string{"2.2.2.2/24"})
-		require.Equal(t, "1.1.1.1/24,2.2.2.2/24", annotations.WhitelistSourceRange)
-		require.Equal(t, annotations, getIngressAnnotations())
+		require.Equal(t, []string{"1.1.1.1/24", "2.2.2.2/24"}, annotations.WhitelistSourceRange)
+		expectedAnnotations := getIngressAnnotations()
+		expectedAnnotations.WhitelistSourceRange = []string{"1.1.1.1/24", "2.2.2.2/24"}
+		require.Equal(t, annotations, expectedAnnotations)
 	})
 
 	t.Run("multiple of both ranges", func(t *testing.T) {
 		annotations := getIngressAnnotations()
 		allowedRanges := &model.AllowedIPRanges{
-			{CIDRBlock: "1.1.1.1/24"},
-			{CIDRBlock: "1.1.1.2/24"},
+			{CIDRBlock: "1.1.1.1/24", Enabled: true},
+			{CIDRBlock: "1.1.1.2/24", Enabled: true},
 		}
-		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, []string{"2.2.2.2/24,2.2.2.3/24"})
-		require.Equal(t, "1.1.1.1/24,1.1.1.2/24,2.2.2.2/24,2.2.2.3/24", annotations.WhitelistSourceRange)
-		require.Equal(t, annotations, getIngressAnnotations())
+		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, []string{"2.2.2.2/24", "2.2.2.3/24"})
+		require.Equal(t, []string{"1.1.1.1/24", "1.1.1.2/24", "2.2.2.2/24", "2.2.2.3/24"}, annotations.WhitelistSourceRange)
+		expectedAnnotations := getIngressAnnotations()
+		expectedAnnotations.WhitelistSourceRange = []string{"1.1.1.1/24", "1.1.1.2/24", "2.2.2.2/24", "2.2.2.3/24"}
+		require.Equal(t, annotations, expectedAnnotations)
+	})
+
+	t.Run("multiple of both ranges, some disabled allowed ranges", func(t *testing.T) {
+		annotations := getIngressAnnotations()
+		allowedRanges := &model.AllowedIPRanges{
+			{CIDRBlock: "1.1.1.1/24", Enabled: true},
+			{CIDRBlock: "1.1.1.2/24", Enabled: false},
+		}
+		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, []string{"2.2.2.2/24", "2.2.2.3/24"})
+		require.Equal(t, []string{"1.1.1.1/24", "2.2.2.2/24", "2.2.2.3/24"}, annotations.WhitelistSourceRange)
+		expectedAnnotations := getIngressAnnotations()
+		expectedAnnotations.WhitelistSourceRange = []string{"1.1.1.1/24", "2.2.2.2/24", "2.2.2.3/24"}
+		require.Equal(t, annotations, expectedAnnotations)
 	})
 }

--- a/internal/provisioner/cluster_installation_provisioner_test.go
+++ b/internal/provisioner/cluster_installation_provisioner_test.go
@@ -11,23 +11,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestaddSourceRangeWhitelistToAnnotations(t *testing.T) {
+func TestAddSourceRangeWhitelistToAnnotations(t *testing.T) {
 	t.Run("nil allowed ranges, blank internal ranges", func(t *testing.T) {
 		annotations := getIngressAnnotations()
-		addSourceRangeWhitelistToAnnotations(annotations, nil, "")
+		addSourceRangeWhitelistToAnnotations(annotations, nil, []string{""})
 		require.Equal(t, getIngressAnnotations(), annotations)
 	})
 
 	t.Run("nil allowed ranges, internal ranges", func(t *testing.T) {
 		annotations := getIngressAnnotations()
-		addSourceRangeWhitelistToAnnotations(annotations, nil, "2.2.2.2/24")
+		addSourceRangeWhitelistToAnnotations(annotations, nil, []string{"2.2.2.2/24"})
 		require.Equal(t, getIngressAnnotations(), annotations)
 	})
 
 	t.Run("allowed ranges, blank internal ranges", func(t *testing.T) {
 		annotations := getIngressAnnotations()
 		allowedRanges := &model.AllowedIPRanges{{CIDRBlock: "1.1.1.1/24"}}
-		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, "")
+		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, []string{""})
 		require.Equal(t, "1.1.1.1/24", annotations.WhitelistSourceRange)
 		require.Equal(t, annotations, getIngressAnnotations())
 	})
@@ -35,7 +35,7 @@ func TestaddSourceRangeWhitelistToAnnotations(t *testing.T) {
 	t.Run("allowed ranges, blank internal ranges", func(t *testing.T) {
 		annotations := getIngressAnnotations()
 		allowedRanges := &model.AllowedIPRanges{{CIDRBlock: "1.1.1.1/24"}}
-		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, "2.2.2.2/24")
+		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, []string{"2.2.2.2/24"})
 		require.Equal(t, "1.1.1.1/24,2.2.2.2/24", annotations.WhitelistSourceRange)
 		require.Equal(t, annotations, getIngressAnnotations())
 	})
@@ -46,7 +46,7 @@ func TestaddSourceRangeWhitelistToAnnotations(t *testing.T) {
 			{CIDRBlock: "1.1.1.1/24"},
 			{CIDRBlock: "1.1.1.2/24"},
 		}
-		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, "2.2.2.2/24,2.2.2.3/24")
+		addSourceRangeWhitelistToAnnotations(annotations, allowedRanges, []string{"2.2.2.2/24,2.2.2.3/24"})
 		require.Equal(t, "1.1.1.1/24,1.1.1.2/24,2.2.2.2/24,2.2.2.3/24", annotations.WhitelistSourceRange)
 		require.Equal(t, annotations, getIngressAnnotations())
 	})

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -37,7 +37,7 @@ type ProvisioningParams struct {
 	DeployMysqlOperator     bool
 	DeployMinioOperator     bool
 	NdotsValue              string
-	InternalIPRanges        string
+	InternalIPRanges        []string
 	PGBouncerConfig         *model.PGBouncerConfig
 	SLOInstallationGroups   []string
 	SLOEnterpriseGroups     []string

--- a/model/ingress.go
+++ b/model/ingress.go
@@ -1,0 +1,71 @@
+package model
+
+import "strings"
+
+type IngressAnnotations struct {
+	TLSACME              string
+	ProxyBuffering       string
+	ProxyBodySize        string
+	ProxySendTimeout     string
+	ProxyReadTimeout     string
+	ProxyMaxTempFileSize string
+	SSLRedirect          string
+	ConfigurationSnippet string
+	ServerSnippets       string
+	WhitelistSourceRange []string
+}
+
+func (ia *IngressAnnotations) ToMap() map[string]string {
+	m := make(map[string]string)
+
+	if ia == nil {
+		return m
+	}
+	m["kubernetes.io/tls-acme"] = ia.TLSACME
+	m["nginx.ingress.kubernetes.io/proxy-buffering"] = ia.ProxyBuffering
+	m["nginx.ingress.kubernetes.io/proxy-body-size"] = ia.ProxyBodySize
+	m["nginx.ingress.kubernetes.io/proxy-send-timeout"] = ia.ProxySendTimeout
+	m["nginx.ingress.kubernetes.io/proxy-read-timeout"] = ia.ProxyReadTimeout
+	m["nginx.ingress.kubernetes.io/proxy-max-temp-file-size"] = ia.ProxyMaxTempFileSize
+	m["nginx.ingress.kubernetes.io/ssl-redirect"] = ia.SSLRedirect
+	m["nginx.ingress.kubernetes.io/configuration-snippet"] = ia.ConfigurationSnippet
+	m["nginx.org/server-snippets"] = ia.ServerSnippets
+	m["nginx.ingress.kubernetes.io/whitelist-source-range"] = strings.Join(ia.WhitelistSourceRange, ",")
+	return m
+}
+
+func (ia *IngressAnnotations) SetDefaults() {
+	if ia.TLSACME == "" {
+		ia.TLSACME = "true"
+	}
+	if ia.ProxyBuffering == "" {
+		ia.ProxyBuffering = "on"
+	}
+	if ia.ProxyBodySize == "" {
+		ia.ProxyBodySize = "100m"
+	}
+	if ia.ProxySendTimeout == "" {
+		ia.ProxySendTimeout = "600"
+	}
+	if ia.ProxyReadTimeout == "" {
+		ia.ProxyReadTimeout = "600"
+	}
+	if ia.ProxyMaxTempFileSize == "" {
+		ia.ProxyMaxTempFileSize = "0"
+	}
+	if ia.SSLRedirect == "" {
+		ia.SSLRedirect = "true"
+	}
+	if ia.ConfigurationSnippet == "" {
+		ia.ConfigurationSnippet = `
+                  proxy_force_ranges on;
+                  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`
+	}
+	if ia.ServerSnippets == "" {
+		ia.ServerSnippets = "gzip on;"
+	}
+}
+
+func (ia *IngressAnnotations) SetHibernatingDefaults() {
+	ia.ConfigurationSnippet = "return 410;"
+}

--- a/model/ingress.go
+++ b/model/ingress.go
@@ -25,16 +25,38 @@ func (ia *IngressAnnotations) ToMap() map[string]string {
 	if ia == nil {
 		return m
 	}
-	m["kubernetes.io/tls-acme"] = ia.TLSACME
-	m["nginx.ingress.kubernetes.io/proxy-buffering"] = ia.ProxyBuffering
-	m["nginx.ingress.kubernetes.io/proxy-body-size"] = ia.ProxyBodySize
-	m["nginx.ingress.kubernetes.io/proxy-send-timeout"] = ia.ProxySendTimeout
-	m["nginx.ingress.kubernetes.io/proxy-read-timeout"] = ia.ProxyReadTimeout
-	m["nginx.ingress.kubernetes.io/proxy-max-temp-file-size"] = ia.ProxyMaxTempFileSize
-	m["nginx.ingress.kubernetes.io/ssl-redirect"] = ia.SSLRedirect
-	m["nginx.ingress.kubernetes.io/configuration-snippet"] = ia.ConfigurationSnippet
-	m["nginx.org/server-snippets"] = ia.ServerSnippets
-	m["nginx.ingress.kubernetes.io/whitelist-source-range"] = strings.Join(ia.WhitelistSourceRange, ",")
+
+	if ia.TLSACME != "" {
+		m["kubernetes.io/tls-acme"] = ia.TLSACME
+	}
+	if ia.ProxyBuffering != "" {
+		m["nginx.ingress.kubernetes.io/proxy-buffering"] = ia.ProxyBuffering
+	}
+	if ia.ProxyBodySize != "" {
+		m["nginx.ingress.kubernetes.io/proxy-body-size"] = ia.ProxyBodySize
+	}
+	if ia.ProxySendTimeout != "" {
+		m["nginx.ingress.kubernetes.io/proxy-send-timeout"] = ia.ProxySendTimeout
+	}
+	if ia.ProxyReadTimeout != "" {
+		m["nginx.ingress.kubernetes.io/proxy-read-timeout"] = ia.ProxyReadTimeout
+	}
+	if ia.ProxyMaxTempFileSize != "" {
+		m["nginx.ingress.kubernetes.io/proxy-max-temp-file-size"] = ia.ProxyMaxTempFileSize
+	}
+	if ia.SSLRedirect != "" {
+		m["nginx.ingress.kubernetes.io/ssl-redirect"] = ia.SSLRedirect
+	}
+	if ia.ConfigurationSnippet != "" {
+		m["nginx.ingress.kubernetes.io/configuration-snippet"] = ia.ConfigurationSnippet
+	}
+	if ia.ServerSnippets != "" {
+		m["nginx.org/server-snippets"] = ia.ServerSnippets
+	}
+	if len(ia.WhitelistSourceRange) > 0 {
+		m["nginx.ingress.kubernetes.io/whitelist-source-range"] = strings.Join(ia.WhitelistSourceRange, ",")
+	}
+
 	return m
 }
 

--- a/model/ingress.go
+++ b/model/ingress.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
 package model
 
 import "strings"

--- a/model/ingress_test.go
+++ b/model/ingress_test.go
@@ -52,6 +52,55 @@ func TestIngressAnnotationsToMap(t *testing.T) {
 
 		require.Equal(t, expected, actual)
 	})
+
+	t.Run("returns expected map when some fields are empty", func(t *testing.T) {
+		ia := &model.IngressAnnotations{
+			TLSACME:              "",
+			ProxyBuffering:       "",
+			ProxyBodySize:        "",
+			ProxySendTimeout:     "",
+			ProxyReadTimeout:     "",
+			ProxyMaxTempFileSize: "",
+			SSLRedirect:          "",
+			ConfigurationSnippet: "",
+			ServerSnippets:       "",
+			WhitelistSourceRange: []string{},
+		}
+		expected := map[string]string{}
+
+		actual := ia.ToMap()
+
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("returns expected map when some fields are not empty", func(t *testing.T) {
+		ia := &model.IngressAnnotations{
+			TLSACME:              "",
+			ProxyBuffering:       "on",
+			ProxyBodySize:        "",
+			ProxySendTimeout:     "600",
+			ProxyReadTimeout:     "",
+			ProxyMaxTempFileSize: "",
+			SSLRedirect:          "",
+			ConfigurationSnippet: `
+                  proxy_force_ranges on;
+                  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`,
+			ServerSnippets:       "",
+			WhitelistSourceRange: []string{"192.168.0.1/24", "10.0.0.1/16"},
+		}
+		expected := map[string]string{
+			"nginx.ingress.kubernetes.io/proxy-buffering":    "on",
+			"nginx.ingress.kubernetes.io/proxy-send-timeout": "600",
+			"nginx.ingress.kubernetes.io/configuration-snippet": `
+                  proxy_force_ranges on;
+                  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`,
+			"nginx.ingress.kubernetes.io/whitelist-source-range": "192.168.0.1/24,10.0.0.1/16",
+		}
+
+		actual := ia.ToMap()
+
+		require.Equal(t, expected, actual)
+	})
 }
 
 func TestIngressAnnotationsSetDefaults(t *testing.T) {

--- a/model/ingress_test.go
+++ b/model/ingress_test.go
@@ -1,0 +1,122 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-cloud/model"
+)
+
+func TestIngressAnnotationsToMap(t *testing.T) {
+	t.Run("returns empty map when IngressAnnotations is nil", func(t *testing.T) {
+		var ia *model.IngressAnnotations
+		expected := make(map[string]string)
+
+		actual := ia.ToMap()
+
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("returns expected map when IngressAnnotations is not nil", func(t *testing.T) {
+		ia := &model.IngressAnnotations{
+			TLSACME:              "true",
+			ProxyBuffering:       "on",
+			ProxyBodySize:        "100m",
+			ProxySendTimeout:     "600",
+			ProxyReadTimeout:     "600",
+			ProxyMaxTempFileSize: "0",
+			SSLRedirect:          "true",
+			ConfigurationSnippet: `
+                  proxy_force_ranges on;
+                  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`,
+			ServerSnippets:       "gzip on;",
+			WhitelistSourceRange: []string{"192.168.0.1/24", "10.0.0.1/16"},
+		}
+		expected := map[string]string{
+			"kubernetes.io/tls-acme":                               "true",
+			"nginx.ingress.kubernetes.io/proxy-buffering":          "on",
+			"nginx.ingress.kubernetes.io/proxy-body-size":          "100m",
+			"nginx.ingress.kubernetes.io/proxy-send-timeout":       "600",
+			"nginx.ingress.kubernetes.io/proxy-read-timeout":       "600",
+			"nginx.ingress.kubernetes.io/proxy-max-temp-file-size": "0",
+			"nginx.ingress.kubernetes.io/ssl-redirect":             "true",
+			"nginx.ingress.kubernetes.io/configuration-snippet": `
+                  proxy_force_ranges on;
+                  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`,
+			"nginx.org/server-snippets":                          "gzip on;",
+			"nginx.ingress.kubernetes.io/whitelist-source-range": "192.168.0.1/24,10.0.0.1/16",
+		}
+
+		actual := ia.ToMap()
+
+		require.Equal(t, expected, actual)
+	})
+}
+
+func TestIngressAnnotationsSetDefaults(t *testing.T) {
+	t.Run("sets default values when fields are empty", func(t *testing.T) {
+		ia := &model.IngressAnnotations{}
+		expected := &model.IngressAnnotations{
+			TLSACME:              "true",
+			ProxyBuffering:       "on",
+			ProxyBodySize:        "100m",
+			ProxySendTimeout:     "600",
+			ProxyReadTimeout:     "600",
+			ProxyMaxTempFileSize: "0",
+			SSLRedirect:          "true",
+			ConfigurationSnippet: `
+                  proxy_force_ranges on;
+                  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`,
+			ServerSnippets: "gzip on;",
+		}
+
+		ia.SetDefaults()
+
+		require.Equal(t, expected, ia)
+	})
+
+	t.Run("does not overwrite non-empty fields", func(t *testing.T) {
+		ia := &model.IngressAnnotations{
+			TLSACME:              "false",
+			ProxyBuffering:       "off",
+			ProxyBodySize:        "50m",
+			ProxySendTimeout:     "300",
+			ProxyReadTimeout:     "300",
+			ProxyMaxTempFileSize: "10m",
+			SSLRedirect:          "false",
+			ConfigurationSnippet: "return 404;",
+			ServerSnippets:       "gzip off;",
+		}
+		expected := &model.IngressAnnotations{
+			TLSACME:              "false",
+			ProxyBuffering:       "off",
+			ProxyBodySize:        "50m",
+			ProxySendTimeout:     "300",
+			ProxyReadTimeout:     "300",
+			ProxyMaxTempFileSize: "10m",
+			SSLRedirect:          "false",
+			ConfigurationSnippet: "return 404;",
+			ServerSnippets:       "gzip off;",
+		}
+
+		ia.SetDefaults()
+
+		require.Equal(t, expected, ia)
+	})
+}
+
+func TestIngressAnnotationsSetHibernatingDefaults(t *testing.T) {
+	t.Run("sets ConfigurationSnippet to 'return 410;'", func(t *testing.T) {
+		ia := &model.IngressAnnotations{
+			ConfigurationSnippet: "return 404;",
+		}
+		expected := &model.IngressAnnotations{
+			ConfigurationSnippet: "return 410;",
+		}
+
+		ia.SetHibernatingDefaults()
+
+		require.Equal(t, expected, ia)
+	})
+}

--- a/model/installation.go
+++ b/model/installation.go
@@ -98,7 +98,7 @@ type AllowedIPRange struct {
 
 // Returns boolean true if all rules are disabled, false otherwise
 func (a *AllowedIPRanges) AllRulesAreDisabled() bool {
-	if a == nil {
+	if a == nil || len(*a) == 0 {
 		return true
 	}
 

--- a/model/installation.go
+++ b/model/installation.go
@@ -96,6 +96,21 @@ type AllowedIPRange struct {
 	OwnerID string
 }
 
+// Returns boolean true if all rules are disabled, false otherwise
+func (a *AllowedIPRanges) AllRulesAreDisabled() bool {
+	if a == nil {
+		return true
+	}
+
+	for _, allowedIPRange := range *a {
+		if allowedIPRange.Enabled {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (a AllowedIPRanges) Value() (driver.Value, error) {
 	return json.Marshal(a)
 }

--- a/model/installation_test.go
+++ b/model/installation_test.go
@@ -571,3 +571,37 @@ func TestAllowedIPRangesAreValid(t *testing.T) {
 	var nilIPRanges *AllowedIPRanges
 	assert.True(t, nilIPRanges.AreValid())
 }
+
+func TestAllowedIPRangesAllRulesAreDisabled(t *testing.T) {
+	t.Run("returns true when AllowedIPRanges is nil", func(t *testing.T) {
+		var a *AllowedIPRanges
+
+		actual := a.AllRulesAreDisabled()
+
+		require.True(t, actual)
+	})
+
+	t.Run("returns true when all rules are disabled", func(t *testing.T) {
+		a := AllowedIPRanges{
+			{Enabled: false},
+			{Enabled: false},
+			{Enabled: false},
+		}
+
+		actual := a.AllRulesAreDisabled()
+
+		require.True(t, actual)
+	})
+
+	t.Run("returns false when at least one rule is enabled", func(t *testing.T) {
+		a := AllowedIPRanges{
+			{Enabled: false},
+			{Enabled: true},
+			{Enabled: false},
+		}
+
+		actual := a.AllRulesAreDisabled()
+
+		require.False(t, actual)
+	})
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR adds logic to only add whitelist rules to ingress that are actually `Enabled: true`. I've also refactored a couple things:

Internal ranges are now parsed as a slice of strings rather than a string with csv values in it
Nginx annotations now have a struct rather than setting string keys in a map


#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6529

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
