### PR TITLE
Add group nil check for SLI checks

### DIFF
--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -483,7 +483,7 @@ func (provisioner Provisioner) updateClusterInstallation(
 		return errors.Wrapf(err, "failed to update cluster installation %s", clusterInstallation.ID)
 	}
 
-	if *installation.GroupID != "" && containsInstallationGroup(*installation.GroupID, provisioner.params.SLOInstallationGroups) {
+	if installation.GroupID != nil && *installation.GroupID != "" && containsInstallationGroup(*installation.GroupID, provisioner.params.SLOInstallationGroups) {
 		logger.Debug("Creating or updating Mattermost installation SLI")
 		err = prometheus.CreateOrUpdateInstallationSLI(clusterInstallation, k8sClient, installationName, logger)
 		if err != nil {


### PR DESCRIPTION
This prevents a panic when an installation is removed from a group.

Fixes https://mattermost.atlassian.net/browse/CLD-6656

```release-note
Add group nil check for SLI checks
```
