### PR TITLE
Add webhook header counts to table output

### DIFF
--- a/cmd/cloud/webhook.go
+++ b/cmd/cloud/webhook.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/mattermost/mattermost-cloud/model"
@@ -146,10 +147,10 @@ func executeWebhookListCmd(flags webhookListFlag) error {
 	if flags.outputToTable {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetAlignment(tablewriter.ALIGN_LEFT)
-		table.SetHeader([]string{"ID", "OWNER", "URL"})
+		table.SetHeader([]string{"ID", "OWNER", "URL", "HEADERS"})
 
 		for _, webhook := range webhooks {
-			table.Append([]string{webhook.ID, webhook.OwnerID, webhook.URL})
+			table.Append([]string{webhook.ID, webhook.OwnerID, webhook.URL, fmt.Sprintf("%d", webhook.Headers.Count())})
 		}
 		table.Render()
 

--- a/cmd/cloud/webhook.go
+++ b/cmd/cloud/webhook.go
@@ -147,7 +147,7 @@ func executeWebhookListCmd(flags webhookListFlag) error {
 	if flags.outputToTable {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetAlignment(tablewriter.ALIGN_LEFT)
-		table.SetHeader([]string{"ID", "OWNER", "URL", "HEADERS"})
+		table.SetHeader([]string{"ID", "OWNER", "URL", "HTTP HEADERS"})
 
 		for _, webhook := range webhooks {
 			table.Append([]string{webhook.ID, webhook.OwnerID, webhook.URL, fmt.Sprintf("%d", webhook.Headers.Count())})

--- a/model/types.go
+++ b/model/types.go
@@ -19,6 +19,10 @@ type WebhookHeader struct {
 
 type Headers []WebhookHeader
 
+func (wh Headers) Count() int {
+	return len(wh)
+}
+
 func (wh Headers) Value() (driver.Value, error) {
 	return json.Marshal(wh)
 }


### PR DESCRIPTION
The number of headers for each webhook is now displayed in the standard table when listing webhooks.

```release-note
Add webhook header counts to table output
```
