### PR TITLE
Support arbitrary domain creation for installations

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -694,11 +694,6 @@ func executeInstallationDeploymentReportCmd(flags installationDeploymentReportFl
 		return nil
 	}
 
-	var dnsName string
-	if len(installation.DNSRecords) > 0 {
-		dnsName = installation.DNSRecords[0].DomainName
-	}
-
 	output := fmt.Sprintf("Installation: %s\n", installation.ID)
 	output += fmt.Sprintf(" ├ Created: %s\n", installation.CreationDateString())
 	output += fmt.Sprintf(" ├ State: %s\n", installation.State)
@@ -708,7 +703,16 @@ func executeInstallationDeploymentReportCmd(flags installationDeploymentReportFl
 	case model.InstallationStateDeletionPending:
 		output += fmt.Sprintf(" │ └ Scheduled Deletion: %s\n", installation.DeletionPendingExpiryCompleteTimeString())
 	}
-	output += fmt.Sprintf(" ├ DNS: %s\n", dnsName)
+	output += fmt.Sprintf(" ├ DNS: %s (primary)\n", installation.DNS) //nolint
+	if len(installation.DNSRecords) > 1 {
+		var alternateDNS []string
+		for _, record := range installation.DNSRecords {
+			if !record.IsPrimary {
+				alternateDNS = append(alternateDNS, record.DomainName)
+			}
+		}
+		output += fmt.Sprintf(" │ └ Alternate Domains: %s\n", strings.Join(alternateDNS, ", "))
+	}
 	output += fmt.Sprintf(" ├ Version: %s:%s\n", installation.Image, installation.Version)
 	output += fmt.Sprintf(" ├ Size: %s\n", installation.Size)
 	output += fmt.Sprintf(" ├ Affinity: %s\n", installation.Affinity)

--- a/cmd/cloud/installation_dns.go
+++ b/cmd/cloud/installation_dns.go
@@ -18,6 +18,7 @@ func newCmdInstallationDNS() *cobra.Command {
 
 	cmd.AddCommand(newCmdInstallationDNSAdd())
 	cmd.AddCommand(newCmdInstallationDNSSetPrimary())
+	cmd.AddCommand(newCmdInstallationDNSDelete())
 
 	return cmd
 }
@@ -76,6 +77,38 @@ func newCmdInstallationDNSSetPrimary() *cobra.Command {
 			installation, err := client.SetInstallationDomainPrimary(flags.installationID, flags.domainNameID)
 			if err != nil {
 				return errors.Wrap(err, "failed to set installation domain primary")
+			}
+
+			if err = printJSON(installation); err != nil {
+				return errors.Wrap(err, "failed to print response")
+			}
+
+			return nil
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.clusterFlags.addFlags(cmd)
+		},
+	}
+
+	flags.addFlags(cmd)
+
+	return cmd
+}
+
+func newCmdInstallationDNSDelete() *cobra.Command {
+	var flags installationDNSDeleteFlags
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete an existing installation domain name.",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+
+			client := model.NewClient(flags.serverAddress)
+
+			installation, err := client.DeleteInstallationDNS(flags.installationID, flags.domainNameID)
+			if err != nil {
+				return errors.Wrap(err, "failed to set delete installation DNS record")
 			}
 
 			if err = printJSON(installation); err != nil {

--- a/cmd/cloud/installation_dns_flags.go
+++ b/cmd/cloud/installation_dns_flags.go
@@ -13,7 +13,7 @@ type installationDNSAddFlags struct {
 }
 
 func (flags *installationDNSAddFlags) addFlags(command *cobra.Command) {
-	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to add domain to.")
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to add domain record to.")
 	command.Flags().StringVar(&flags.dnsName, "domain", "", "Domain name to map to the installation.")
 	_ = command.MarkFlagRequired("installation")
 	_ = command.MarkFlagRequired("domain")
@@ -30,5 +30,17 @@ func (flags *installationDNSSetPrimaryFlags) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.domainNameID, "domain-id", "", "The id of domain name to set as primary.")
 	_ = command.MarkFlagRequired("installation")
 	_ = command.MarkFlagRequired("domain-id")
+}
 
+type installationDNSDeleteFlags struct {
+	clusterFlags
+	installationID string
+	domainNameID   string
+}
+
+func (flags *installationDNSDeleteFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to delete domain record from.")
+	command.Flags().StringVar(&flags.domainNameID, "domain-id", "", "The id of domain name to delete.")
+	_ = command.MarkFlagRequired("installation")
+	_ = command.MarkFlagRequired("domain-id")
 }

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -421,6 +421,7 @@ func executeServerCmd(flags serverFlags) error {
 		EventProducer:                     eventsProducer,
 		Environment:                       awsClient.GetCloudEnvironmentName(),
 		AwsClient:                         awsClient,
+		DNSProvider:                       dnsManager,
 		Metrics:                           cloudMetrics,
 		InstallationDeletionExpiryDefault: flags.installationDeletionPendingTime,
 		Logger:                            logger,

--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -16,6 +16,12 @@ func (s *mockSupervisor) Do() error {
 	return nil
 }
 
+type mockDNSProvider struct{}
+
+func (s *mockDNSProvider) DeleteDNSRecords(customerDNSName []string, logger log.FieldLogger) error {
+	return nil
+}
+
 type mockMetrics struct{}
 
 func (m *mockMetrics) IncrementAPIRequest() {}

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -127,6 +127,7 @@ type Store interface {
 	GetInstallationDNS(id string) (*model.InstallationDNS, error)
 	SwitchPrimaryInstallationDomain(installationID string, installationDNSID string) error
 	GetDNSRecordsForInstallation(installationID string) ([]*model.InstallationDNS, error)
+	DeleteInstallationDNS(installationID, dnsName string) error
 }
 
 // Provisioner describes the interface required to communicate with the Kubernetes cluster.
@@ -156,6 +157,11 @@ type EventProducer interface {
 	ProduceClusterStateChangeEvent(cluster *model.Cluster, oldState string, extraDataFields ...events.DataField) error
 }
 
+// InstallationDNSProvider allows for domain name management of installations.
+type InstallationDNSProvider interface {
+	DeleteDNSRecords(customerDNSName []string, logger log.FieldLogger) error
+}
+
 // Metrics exposes metrics from API usage.
 type Metrics interface {
 	IncrementAPIRequest()
@@ -172,6 +178,7 @@ type Context struct {
 	DBProvider                        DBProvider
 	EventProducer                     EventProducer
 	AwsClient                         AwsClient
+	DNSProvider                       InstallationDNSProvider
 	Metrics                           Metrics
 	Logger                            log.FieldLogger
 	InstallationDeletionExpiryDefault time.Duration
@@ -188,6 +195,7 @@ func (c *Context) Clone() *Context {
 		DBProvider:                        c.DBProvider,
 		EventProducer:                     c.EventProducer,
 		AwsClient:                         c.AwsClient,
+		DNSProvider:                       c.DNSProvider,
 		Metrics:                           c.Metrics,
 		Logger:                            c.Logger,
 		InstallationDeletionExpiryDefault: c.InstallationDeletionExpiryDefault,

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -52,6 +52,7 @@ func initInstallation(apiRouter *mux.Router, context *Context) {
 	// DNS manipulation
 	installationRouter.Handle("/dns", addContext(handleAddDNSRecord)).Methods("POST")
 	installationRouter.Handle("/dns/{installationDNS}/set-primary", addContext(handleSetDomainNamePrimary)).Methods("POST")
+	installationRouter.Handle("/dns/{installationDNS}", addContext(handleDeleteDNSRecord)).Methods("DELETE")
 }
 
 // handleGetInstallation responds to GET /api/installation/{installation}, returning the installation in question.

--- a/internal/api/installation_dns.go
+++ b/internal/api/installation_dns.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-cloud/model"
@@ -35,7 +36,7 @@ func handleAddDNSRecord(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	defer unlockOnce()
 
-	err = addDNSRecordRequest.Validate(installationDTO.Name)
+	err = addDNSRecordRequest.Validate(installationDTO.Name, false)
 	if err != nil {
 		c.Logger.WithError(err).Error("Invalid request")
 		w.WriteHeader(http.StatusBadRequest)
@@ -86,8 +87,6 @@ func handleSetDomainNamePrimary(c *Context, w http.ResponseWriter, r *http.Reque
 		WithField("installationDNS", installationDNSID).
 		WithField("action", "set-domain-name-primary")
 
-	// Make sure the domain name with provided ID exists, otherwise we would
-	// just set all 'IsPrimary' to false.
 	installationDNS, err := c.Store.GetInstallationDNS(installationDNSID)
 	if err != nil {
 		c.Logger.WithError(err).Error("Failed to get installation domain")
@@ -95,8 +94,13 @@ func handleSetDomainNamePrimary(c *Context, w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if installationDNS == nil {
-		c.Logger.WithError(err).Error("Installation domain not found")
+		c.Logger.Error("Installation domain not found")
 		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	if installationDNS.IsPrimary {
+		c.Logger.WithError(err).Error("Installation domain is already primary")
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -110,16 +114,17 @@ func handleSetDomainNamePrimary(c *Context, w http.ResponseWriter, r *http.Reque
 
 	oldState := installationDTO.State
 	installationDTO.State = newState
+	installationDTO.Name = strings.ToLower(strings.Split(installationDNS.DomainName, ".")[0])
 
 	err = c.Store.SwitchPrimaryInstallationDomain(installationDTO.ID, installationDNSID)
 	if err != nil {
-		c.Logger.WithError(err).Error("Failed to add installation domain")
+		c.Logger.WithError(err).Error("Failed to switch primary installation domain")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	err = c.Store.UpdateInstallationState(installationDTO.Installation)
+	err = c.Store.UpdateInstallation(installationDTO.Installation)
 	if err != nil {
-		c.Logger.WithError(err).Error("Failed to update installation state when adding domain name")
+		c.Logger.WithError(err).Error("Failed to update installation state when switching primary domain name")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -131,9 +136,96 @@ func handleSetDomainNamePrimary(c *Context, w http.ResponseWriter, r *http.Reque
 	unlockOnce()
 
 	// Refresh whole Installation after switch.
-	installationDTO, err = c.Store.GetInstallationDTO(installationDTO.ID, false, false)
+	installationDTO, err = c.Store.GetInstallationDTO(installationDTO.ID, true, false)
 	if err != nil {
 		c.Logger.WithError(err).Error("Failed to get Installation DTO after primary switch")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	c.Supervisor.Do()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	outputJSON(c, w, installationDTO)
+}
+
+func handleDeleteDNSRecord(c *Context, w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	installationID := vars["installation"]
+	installationDNSID := vars["installationDNS"]
+
+	c.Logger = c.Logger.
+		WithField("installation", installationID).
+		WithField("installationDNS", installationDNSID).
+		WithField("action", "delete-installation-dns")
+
+	newState := model.InstallationStateUpdateRequested
+	installationDTO, status, unlockOnce := getInstallationForTransition(c, installationID, newState)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockOnce()
+
+	installationDNS, err := c.Store.GetInstallationDNS(installationDNSID)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to get installation domain")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if installationDNS == nil {
+		c.Logger.Error("Installation domain not found")
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	if installationDNS.IsDeleted() {
+		c.Logger.WithError(err).Error("Installation domain is already deleted")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if installationDNS.IsPrimary {
+		c.Logger.WithError(err).Error("Deleting primary installation domain record is not permitted")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	oldState := installationDTO.State
+	installationDTO.State = newState
+
+	// TODO: deleting DNS records on the API layer is out of sync with creating
+	// records which happens in the supervisor. There is no good way currently
+	// to mark records for deletion in the supervisor so we can handle it here
+	// for now. Later we should standardize this logic.
+	err = c.DNSProvider.DeleteDNSRecords([]string{installationDNS.DomainName}, c.Logger)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to delete DNS record")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	err = c.Store.DeleteInstallationDNS(installationID, installationDNS.DomainName)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to delete installation DNS record from database")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	err = c.Store.UpdateInstallation(installationDTO.Installation)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to update installation state when switching primary domain name")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	err = c.EventProducer.ProduceInstallationStateChangeEvent(installationDTO.Installation, oldState)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to create installation state change event")
+	}
+
+	unlockOnce()
+
+	// Refresh whole Installation after deletion.
+	installationDTO, err = c.Store.GetInstallationDTO(installationDTO.ID, true, false)
+	if err != nil {
+		c.Logger.WithError(err).Error("Failed to get Installation DTO after DNS deletion")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/internal/store/installation_dns_test.go
+++ b/internal/store/installation_dns_test.go
@@ -177,6 +177,17 @@ func TestInstallationDNS(t *testing.T) {
 	assert.Equal(t, true, records[2].IsPrimary)
 	assert.Equal(t, thirdRecord.ID, records[2].ID) // Sanity check
 
+	t.Run("no change when setting invalid DNS as primary", func(t *testing.T) {
+		err = sqlStore.SwitchPrimaryInstallationDomain(installation.ID, "invalid")
+		require.Error(t, err)
+		records, err = sqlStore.GetDNSRecordsForInstallation(installation.ID)
+		require.NoError(t, err)
+		assert.Equal(t, false, records[0].IsPrimary)
+		assert.Equal(t, false, records[1].IsPrimary)
+		assert.Equal(t, true, records[2].IsPrimary)
+		assert.Equal(t, thirdRecord.ID, records[2].ID) // Sanity check
+	})
+
 	record, err := sqlStore.GetInstallationDNS(thirdRecord.ID)
 	require.NoError(t, err)
 	assert.True(t, record.IsPrimary)

--- a/internal/testutil/dns.go
+++ b/internal/testutil/dns.go
@@ -9,6 +9,10 @@ import "github.com/mattermost/mattermost-cloud/model"
 // DNSForInstallation creates slice of DNSRecords for ease of use in tests.
 func DNSForInstallation(dns string) []*model.InstallationDNS {
 	return []*model.InstallationDNS{
-		{DomainName: dns},
+		{
+			DomainName: dns,
+			IsPrimary:  true,
+			CreateAt:   model.GetMillis(),
+		},
 	}
 }

--- a/internal/tools/cloudflare/dns.go
+++ b/internal/tools/cloudflare/dns.go
@@ -101,7 +101,7 @@ func (c *Client) upsertDNS(zoneNameList []string, dnsName, dnsEndpoint string, l
 		return errors.Wrap(err, "failed to fetch Zone ID from Cloudflare")
 	}
 
-	log := logger.WithFields(logrus.Fields{
+	logger = logger.WithFields(logrus.Fields{
 		"cloudflare-dns-value":    dnsName,
 		"cloudflare-dns-endpoint": dnsEndpoint,
 		"cloudflare-zone-id":      zoneID,
@@ -137,7 +137,7 @@ func (c *Client) upsertDNS(zoneNameList []string, dnsName, dnsEndpoint string, l
 			return errors.Wrap(err, "failed to create DNS Record at Cloudflare")
 		}
 
-		log.Debugf("Cloudflare create DNS record response: %v", recordResp)
+		logger.WithField("cloudflare-response", recordResp).Debugf("New Cloudflare DNS record created for %s", dnsName)
 		return nil
 	}
 
@@ -156,7 +156,7 @@ func (c *Client) upsertDNS(zoneNameList []string, dnsName, dnsEndpoint string, l
 	}
 
 	if doUpdate {
-		err = c.updateDNSRecord(zoneID, recordToUpdate.ID, record, log)
+		err = c.updateDNSRecord(zoneID, recordToUpdate.ID, record, logger)
 		if err != nil {
 			return errors.Wrap(err, "failed to update existing DNS record at Cloudflare")
 		}

--- a/model/client.go
+++ b/model/client.go
@@ -652,6 +652,22 @@ func (c *Client) SetInstallationDomainPrimary(installationID, installationDNSID 
 	}
 }
 
+// DeleteInstallationDNS deletes an existing DNS record for an installation.
+func (c *Client) DeleteInstallationDNS(installationID, installationDNSID string) (*InstallationDTO, error) {
+	resp, err := c.doDelete(c.buildURL("/api/installation/%s/dns/%s", installationID, installationDNSID))
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return DTOFromReader[InstallationDTO](resp.Body)
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // RestoreInstallationDatabase requests installation db restoration from the configured provisioning server.
 func (c *Client) RestoreInstallationDatabase(installationID, backupID string) (*InstallationDBRestorationOperation, error) {
 	resp, err := c.doPost(c.buildURL("/api/installations/operations/database/restorations"),

--- a/model/installation.go
+++ b/model/installation.go
@@ -208,10 +208,14 @@ func (i *Installation) Clone() *Installation {
 
 // ToDTO expands installation to InstallationDTO.
 func (i *Installation) ToDTO(annotations []*Annotation, dnsRecords []*InstallationDNS) *InstallationDTO {
-	dns := ""
-	if len(dnsRecords) > 0 {
-		dns = dnsRecords[0].DomainName
+	var dns string
+	for _, record := range dnsRecords {
+		if record.IsPrimary {
+			dns = record.DomainName
+			break
+		}
 	}
+
 	return &InstallationDTO{
 		Installation: i,
 		Annotations:  annotations,

--- a/model/installation_dns.go
+++ b/model/installation_dns.go
@@ -21,19 +21,26 @@ type InstallationDNS struct {
 	DeleteAt       int64
 }
 
+func (dns *InstallationDNS) IsDeleted() bool {
+	return dns.DeleteAt != 0
+}
+
 // AddDNSRecordRequest represents request body for adding domain name to Installation.
 type AddDNSRecordRequest struct {
 	DNS string
 }
 
 // Validate validates AddDNSRecordRequest.
-func (request *AddDNSRecordRequest) Validate(installationName string) error {
+func (request *AddDNSRecordRequest) Validate(installationName string, requireNameMatch bool) error {
 	err := isValidDNS(request.DNS)
 	if err != nil {
 		return errors.Wrap(err, "dns is invalid")
 	}
+	if requireNameMatch {
+		return ensureDNSMatchesName(request.DNS, installationName)
+	}
 
-	return ensureDNSMatchesName(request.DNS, installationName)
+	return nil
 }
 
 // NewAddDNSRecordRequestFromReader will create a AddDNSRecordRequest from an io.Reader with JSON data.

--- a/model/installation_dns_test.go
+++ b/model/installation_dns_test.go
@@ -16,29 +16,40 @@ func TestAddInstallationDNS_Validate(t *testing.T) {
 		description      string
 		isError          bool
 		installationName string
+		nameMatch        bool
 		request          *AddDNSRecordRequest
 	}{
 		{
 			description:      "valid DNS",
 			isError:          false,
 			installationName: "my-installation",
+			nameMatch:        true,
 			request:          &AddDNSRecordRequest{DNS: "my-installation.dns.com"},
 		},
 		{
 			description:      "invalid DNS",
 			isError:          true,
 			installationName: "my-installation",
+			nameMatch:        true,
 			request:          &AddDNSRecordRequest{DNS: "my-installation. dns.com"},
 		},
 		{
-			description:      "DNS does not start with installation name",
+			description:      "DNS does not start with installation name, but required",
 			isError:          true,
 			installationName: "my-installation",
+			nameMatch:        true,
+			request:          &AddDNSRecordRequest{DNS: "not-my-installation.dns.com"},
+		},
+		{
+			description:      "DNS does not start with installation name and not required",
+			isError:          false,
+			installationName: "my-installation",
+			nameMatch:        false,
 			request:          &AddDNSRecordRequest{DNS: "not-my-installation.dns.com"},
 		},
 	} {
 		t.Run(testCase.description, func(t *testing.T) {
-			err := testCase.request.Validate(testCase.installationName)
+			err := testCase.request.Validate(testCase.installationName, testCase.nameMatch)
 			if testCase.isError {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
We were previously blocking all domain additions for installations that didn't have a subdomain that matched the `name` value. There were many reasons for this, but it was inflexible and needed to be improved. There is more work to do in supporting custom domains, but this allows for completely switching an installation's domain after creation.

This change does the following:
 - Allows for creating any new installation domain assuming the provisioner has access to the zone.
 - Allows for deleting domains for an installation after they are no longer marked as primary.
 - Fixes a bug where certain domains couldn't be selected as primary.
 - Improves domain management logging.

Fixes https://mattermost.atlassian.net/browse/CLD-6663

```release-note
Support arbitrary domain creation for installations
```
