### PR TITLE
Fix potential panic on unsafe access of installation.AllowedIPRanges

### DIFF
--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -476,6 +476,11 @@ func (p *PatchInstallationRequest) MergeNewIngressSourceRangesWithExisting(insta
 		return installation.AllowedIPRanges, nil
 	}
 
+	// If the installation.AllowedIPRanges is nil, then we can just return the patchAllowedRanges
+	if installation.AllowedIPRanges == nil {
+		return p.AllowedIPRanges, nil
+	}
+
 	allowedRanges := *installation.AllowedIPRanges
 	patchAllowedRanges := *p.AllowedIPRanges
 

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -498,20 +498,31 @@ func TestMergeNewIngressSourceRangesWithExisting(t *testing.T) {
 	sortAllowedIPRanges(mergedRanges)
 	assert.Equal(t, expectedRanges, *mergedRanges)
 
-	// Test merging with nil patchAllowedRanges
-	patchInstallationRequest.AllowedIPRanges = nil
-	mergedRanges, err = patchInstallationRequest.MergeNewIngressSourceRangesWithExisting(installation)
-	assert.NoError(t, err)
-	sortAllowedIPRanges(&allowedRanges)
-	sortAllowedIPRanges(mergedRanges)
-	assert.Equal(t, allowedRanges, *mergedRanges)
+	t.Run("Test merging with nil patchAllowedRanges", func(t *testing.T) {
+		patchInstallationRequest.AllowedIPRanges = nil
+		mergedRanges, err = patchInstallationRequest.MergeNewIngressSourceRangesWithExisting(installation)
+		assert.NoError(t, err)
+		sortAllowedIPRanges(&allowedRanges)
+		sortAllowedIPRanges(mergedRanges)
+		assert.Equal(t, allowedRanges, *mergedRanges)
+	})
 
-	// Test merging with invalid CIDR block
-	patchAllowedRanges[0].CIDRBlock = "invalid"
-	patchInstallationRequest.AllowedIPRanges = &patchAllowedRanges
-	mergedRanges, err = patchInstallationRequest.MergeNewIngressSourceRangesWithExisting(installation)
-	assert.Error(t, err)
-	assert.Nil(t, mergedRanges)
+	t.Run("Test merging with invalid CIDR block", func(t *testing.T) {
+		patchAllowedRanges[0].CIDRBlock = "invalid"
+		patchInstallationRequest.AllowedIPRanges = &patchAllowedRanges
+		mergedRanges, err = patchInstallationRequest.MergeNewIngressSourceRangesWithExisting(installation)
+		assert.Error(t, err)
+		assert.Nil(t, mergedRanges)
+	})
+
+	t.Run("Test merging with nil installation.AllowedIPRanges", func(t *testing.T) {
+		installation.AllowedIPRanges = nil
+		mergedRanges, err = patchInstallationRequest.MergeNewIngressSourceRangesWithExisting(installation)
+		assert.NoError(t, err)
+		sortAllowedIPRanges(&patchAllowedRanges)
+		sortAllowedIPRanges(mergedRanges)
+		assert.Equal(t, patchAllowedRanges, *mergedRanges)
+	})
 }
 
 func TestPatchInstallationRequestApply(t *testing.T) {


### PR DESCRIPTION
#### Summary
Prevents a panic when setting AllowedIPRanges for the first time on a new installation without using the --override-ip-ranges flag

The Mattermost instances are passing --override-ip-ranges since it sends the entire payload of ranges to be applied each time they're updated, so it was not affected by this panic. 
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
