### PR TITLE
Add custom errors page support

### DIFF
--- a/model/ingress.go
+++ b/model/ingress.go
@@ -17,6 +17,7 @@ type IngressAnnotations struct {
 	ConfigurationSnippet string
 	ServerSnippets       string
 	WhitelistSourceRange []string
+	CustomHttpErrors     []string
 }
 
 func (ia *IngressAnnotations) ToMap() map[string]string {
@@ -56,6 +57,9 @@ func (ia *IngressAnnotations) ToMap() map[string]string {
 	if len(ia.WhitelistSourceRange) > 0 {
 		m["nginx.ingress.kubernetes.io/whitelist-source-range"] = strings.Join(ia.WhitelistSourceRange, ",")
 	}
+	if len(ia.CustomHttpErrors) > 0 {
+		m["nginx.ingress.kubernetes.io/custom-http-errors"] = strings.Join(ia.CustomHttpErrors, ",")
+	}
 
 	return m
 }
@@ -89,6 +93,9 @@ func (ia *IngressAnnotations) SetDefaults() {
 	}
 	if ia.ServerSnippets == "" {
 		ia.ServerSnippets = "gzip on;"
+	}
+	if len(ia.CustomHttpErrors) == 0 {
+		ia.CustomHttpErrors = []string{"403"}
 	}
 }
 

--- a/model/ingress_test.go
+++ b/model/ingress_test.go
@@ -32,6 +32,7 @@ func TestIngressAnnotationsToMap(t *testing.T) {
                   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`,
 			ServerSnippets:       "gzip on;",
 			WhitelistSourceRange: []string{"192.168.0.1/24", "10.0.0.1/16"},
+			CustomHttpErrors:     []string{"403"},
 		}
 		expected := map[string]string{
 			"kubernetes.io/tls-acme":                               "true",
@@ -46,6 +47,7 @@ func TestIngressAnnotationsToMap(t *testing.T) {
                   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`,
 			"nginx.org/server-snippets":                          "gzip on;",
 			"nginx.ingress.kubernetes.io/whitelist-source-range": "192.168.0.1/24,10.0.0.1/16",
+			"nginx.ingress.kubernetes.io/custom-http-errors":     "403",
 		}
 
 		actual := ia.ToMap()
@@ -65,6 +67,7 @@ func TestIngressAnnotationsToMap(t *testing.T) {
 			ConfigurationSnippet: "",
 			ServerSnippets:       "",
 			WhitelistSourceRange: []string{},
+			CustomHttpErrors:     []string{},
 		}
 		expected := map[string]string{}
 
@@ -87,6 +90,7 @@ func TestIngressAnnotationsToMap(t *testing.T) {
                   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`,
 			ServerSnippets:       "",
 			WhitelistSourceRange: []string{"192.168.0.1/24", "10.0.0.1/16"},
+			CustomHttpErrors:     []string{"403"},
 		}
 		expected := map[string]string{
 			"nginx.ingress.kubernetes.io/proxy-buffering":    "on",
@@ -95,6 +99,7 @@ func TestIngressAnnotationsToMap(t *testing.T) {
                   proxy_force_ranges on;
                   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`,
 			"nginx.ingress.kubernetes.io/whitelist-source-range": "192.168.0.1/24,10.0.0.1/16",
+			"nginx.ingress.kubernetes.io/custom-http-errors":     "403",
 		}
 
 		actual := ia.ToMap()
@@ -117,7 +122,8 @@ func TestIngressAnnotationsSetDefaults(t *testing.T) {
 			ConfigurationSnippet: `
                   proxy_force_ranges on;
                   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`,
-			ServerSnippets: "gzip on;",
+			ServerSnippets:   "gzip on;",
+			CustomHttpErrors: []string{"403"},
 		}
 
 		ia.SetDefaults()
@@ -136,6 +142,7 @@ func TestIngressAnnotationsSetDefaults(t *testing.T) {
 			SSLRedirect:          "false",
 			ConfigurationSnippet: "return 404;",
 			ServerSnippets:       "gzip off;",
+			CustomHttpErrors:     []string{"403"},
 		}
 		expected := &model.IngressAnnotations{
 			TLSACME:              "false",
@@ -147,6 +154,7 @@ func TestIngressAnnotationsSetDefaults(t *testing.T) {
 			SSLRedirect:          "false",
 			ConfigurationSnippet: "return 404;",
 			ServerSnippets:       "gzip off;",
+			CustomHttpErrors:     []string{"403"},
 		}
 
 		ia.SetDefaults()


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add custom errors page support as part of IP filtering feature refactor to fix 403 redirection issues

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add custom errors page support on ingresses
```
