### PR TITLE
Temporary solution to deploy custom error configmaps in clusters

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -237,6 +237,14 @@ func executeServerCmd(flags serverFlags) error {
 		logger.Warn("[DEV] Server is configured to not use cluster VPC claim functionality")
 	}
 
+	if flags.portalURL == "" {
+		return errors.New("portal-url must be set")
+	}
+	os.Setenv("PORTAL_URL", flags.portalURL)
+	if err != nil {
+		return errors.Wrap(err, "Error setting environment variable.")
+	}
+
 	awsConfig, err := awsTools.NewAWSConfig(context.TODO())
 	if err != nil {
 		return errors.Wrap(err, "failed to get aws configuration")
@@ -371,7 +379,7 @@ func executeServerCmd(flags serverFlags) error {
 		multiDoer = append(multiDoer, supervisor.NewInstallationDBMigrationSupervisor(sqlStore, awsClient, resourceUtil, instanceID, provisionerObj, eventsProducer, logger))
 	}
 
-	// Setup the supervisor to effect any requested changes. It is wrapped in a
+	// Set up the supervisor to effect any requested changes. It is wrapped in a
 	// scheduler to trigger it periodically in addition to being poked by the API
 	// layer.
 	if flags.poll == 0 {

--- a/cmd/cloud/server_flag.go
+++ b/cmd/cloud/server_flag.go
@@ -197,6 +197,7 @@ type serverFlags struct {
 	logFilesPerClusterPath   string
 	grafanaURL               string
 	grafanaTokens            []string
+	portalURL                string
 
 	database      string
 	maxSchemas    int64
@@ -225,6 +226,7 @@ func (flags *serverFlags) addFlags(command *cobra.Command) {
 	command.Flags().BoolVar(&flags.enableLogFilesPerCluster, "enable-log-files-per-cluster", false, "Store individual log files per cluster.")
 	command.Flags().StringVar(&flags.logFilesPerClusterPath, "log-files-per-cluster-path", "", "Where to store the cluster log files.")
 	command.Flags().StringVar(&flags.grafanaURL, "grafana-url", "", "The URL of a Grafana endpoint to send annotations to.")
+	command.Flags().StringVar(&flags.portalURL, "portal-url", "", "The URL of portal endpoint.")
 	command.Flags().StringSliceVar(&flags.grafanaTokens, "grafana-tokens", []string{""}, "Grafana tokens which will be used with the provided URL")
 	command.MarkFlagsRequiredTogether("enable-log-files-per-cluster", "log-files-per-cluster-path")
 

--- a/internal/provisioner/cluster_provisioning.go
+++ b/internal/provisioner/cluster_provisioning.go
@@ -292,9 +292,9 @@ func provisionCluster(
 		return errors.Wrap(err, "Error ensuring namespace exists")
 	}
 
-	cm, error := checkCustomErrorPagesConfigMapExists(k8sClient, nginxNamespace)
-	if error != nil {
-		return errors.Wrap(error, "Error checking custom error pages ConfigMap exists")
+	cm, err := checkCustomErrorPagesConfigMapExists(k8sClient, nginxNamespace)
+	if err != nil {
+		return errors.Wrap(err, "Error checking custom error pages ConfigMap exists")
 	}
 	if !cm {
 		err = createCustomErrorPagesConfigMap(k8sClient, nginxNamespace)

--- a/internal/provisioner/cluster_provisioning.go
+++ b/internal/provisioner/cluster_provisioning.go
@@ -286,7 +286,16 @@ func provisionCluster(
 			logger.Infof("Successfully deployed service pod %q", podRunning.GetName())
 		}
 	}
+	nginxNamespace := "nginx"
+	err = ensureNamespaceExists(k8sClient, nginxNamespace)
+	if err != nil {
+		return errors.Wrap(err, "Error ensuring namespace exists")
+	}
 
+	err = createCustomErrorPagesConfigMap(k8sClient, nginxNamespace)
+	if err != nil {
+		return errors.Wrap(err, "Error creating custom error pages ConfigMap")
+	}
 	ugh, err := utility.NewUtilityGroupHandle(params.AllowCIDRRangeList, kubeconfigPath, cluster, awsClient, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new cluster utility group handle")

--- a/internal/provisioner/cluster_provisioning.go
+++ b/internal/provisioner/cluster_provisioning.go
@@ -292,9 +292,15 @@ func provisionCluster(
 		return errors.Wrap(err, "Error ensuring namespace exists")
 	}
 
-	err = createCustomErrorPagesConfigMap(k8sClient, nginxNamespace)
-	if err != nil {
-		return errors.Wrap(err, "Error creating custom error pages ConfigMap")
+	cm, error := checkCustomErrorPagesConfigMapExists(k8sClient, nginxNamespace)
+	if error != nil {
+		return errors.Wrap(error, "Error checking custom error pages ConfigMap exists")
+	}
+	if !cm {
+		err = createCustomErrorPagesConfigMap(k8sClient, nginxNamespace)
+		if err != nil {
+			return errors.Wrap(err, "Error creating custom error pages ConfigMap")
+		}
 	}
 	ugh, err := utility.NewUtilityGroupHandle(params.AllowCIDRRangeList, kubeconfigPath, cluster, awsClient, logger)
 	if err != nil {

--- a/internal/provisioner/provisioner_utils.go
+++ b/internal/provisioner/provisioner_utils.go
@@ -245,3 +245,15 @@ func ensureNamespaceExists(k8sClient *k8s.KubeClient, namespace string) error {
 	}
 	return nil
 }
+
+// checkCustomErrorPagesConfigMapExists checks if a ConfigMap with custom error pages exists.
+func checkCustomErrorPagesConfigMapExists(k8sClient *k8s.KubeClient, namespace string) (bool, error) {
+	_, err := k8sClient.Clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), "custom-error-pages", metav1.GetOptions{})
+	if k8sErrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Wrap(err, "failed to get ConfigMap")
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Temporary solution to deploy custom error configmaps in clusters

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6718

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Temporary solution to deploy custom error configmaps in clusters
```
