### PR TITLE
[CLD-6943] Update MySQL default version to 8.0

### DIFF
--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -48,7 +48,7 @@ const (
 
 	// DefaultDatabaseMySQLVersion is the default version of MySQL used when
 	// creating databases.
-	DefaultDatabaseMySQLVersion = "5.7"
+	DefaultDatabaseMySQLVersion = "8.0"
 
 	// DefaultDatabasePostgresVersion is the default version of PostgreSQL used
 	// when creating databases.


### PR DESCRIPTION

#### Summary
Updates the default MySQL version for `aws-rds` database types in the provisioner. See `cloud-gprbnoqd43dsmbcqt3bwnwcd4c` database in the dev account (Version: `8.0.mysql_aurora.3.04.1`). 

To test: `cloud installation create --name <name> --dns <dns> --owner <owner> --affinity multitenant --database aws-rds`

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6943

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
