### PR TITLE
Helm client refactor and local chart install support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin/*
 build/kops
 build/kubectl
 vendor/
+helm-charts/mattermost-operator

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -124,10 +124,10 @@ func executeServerCmd(flags serverFlags) error {
 	}
 	model.SetUtilityDefaults(flags.utilitiesGitURL)
 
-	if flags.deployLocalMattermostOperator {
-		_, err := os.Stat(helm.LocalMattermostOperatorHelmDir)
+	if flags.mattermostOperatorHelmDir != "" {
+		_, err := os.Stat(flags.mattermostOperatorHelmDir)
 		if err != nil {
-			return errors.Wrapf(err, "failed to ensure directory %s exists; disable server flag deploy-local-mattermost-operator or ensure directory exists", helm.LocalMattermostOperatorHelmDir)
+			return errors.Wrap(err, "failed to ensure local operator helm directory exists; check your mattermost-operator-helm-dir flag value")
 		}
 	}
 
@@ -268,20 +268,20 @@ func executeServerCmd(flags serverFlags) error {
 	}
 
 	provisioningParams := provisioner.ProvisioningParams{
-		S3StateStore:                  flags.s3StateStore,
-		AllowCIDRRangeList:            flags.allowListCIDRRange,
-		VpnCIDRList:                   flags.vpnListCIDR,
-		Owner:                         owner,
-		UseExistingAWSResources:       flags.useExistingResources,
-		DeployMysqlOperator:           flags.deployMySQLOperator,
-		DeployMinioOperator:           flags.deployMinioOperator,
-		DeployLocalMattermostOperator: flags.deployLocalMattermostOperator,
-		NdotsValue:                    flags.ndotsDefaultValue,
-		InternalIPRanges:              flags.internalIPRanges,
-		PGBouncerConfig:               pgbouncerConfig,
-		SLOInstallationGroups:         flags.sloInstallationGroups,
-		SLOEnterpriseGroups:           flags.sloEnterpriseGroups,
-		EtcdManagerEnv:                etcdManagerEnv,
+		S3StateStore:              flags.s3StateStore,
+		AllowCIDRRangeList:        flags.allowListCIDRRange,
+		VpnCIDRList:               flags.vpnListCIDR,
+		Owner:                     owner,
+		UseExistingAWSResources:   flags.useExistingResources,
+		DeployMysqlOperator:       flags.deployMySQLOperator,
+		DeployMinioOperator:       flags.deployMinioOperator,
+		MattermostOperatorHelmDir: flags.mattermostOperatorHelmDir,
+		NdotsValue:                flags.ndotsDefaultValue,
+		InternalIPRanges:          flags.internalIPRanges,
+		PGBouncerConfig:           pgbouncerConfig,
+		SLOInstallationGroups:     flags.sloInstallationGroups,
+		SLOEnterpriseGroups:       flags.sloEnterpriseGroups,
+		EtcdManagerEnv:            etcdManagerEnv,
 	}
 
 	resourceUtil := utils.NewResourceUtil(instanceID, awsClient, dbClusterUtilizationSettingsFromFlags(flags), flags.disableDBInitCheck, flags.enableS3Versioning)

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -57,7 +57,7 @@ func newCmdServer() *cobra.Command {
 		},
 		PreRun: func(command *cobra.Command, args []string) {
 			flags.serverFlagChanged.addFlags(command) // To populate flag change variables.
-			deprecationWarnings(logger, command)
+			deprecationWarnings(logger, flags)
 
 			if flags.enableLogStacktrace {
 				enableLogStacktrace()
@@ -74,14 +74,8 @@ func newCmdServer() *cobra.Command {
 }
 
 func executeServerCmd(flags serverFlags) error {
-	if flags.devMode {
+	if flags.devMode || flags.debug {
 		logger.SetLevel(logrus.DebugLevel)
-		helm.SetVerboseHelmLogging(true)
-	} else {
-		if flags.debug {
-			logger.SetLevel(logrus.DebugLevel)
-		}
-		helm.SetVerboseHelmLogging(flags.debugHelm)
 	}
 
 	if flags.enableLogFilesPerCluster && flags.logFilesPerClusterPath == "" {
@@ -129,6 +123,13 @@ func executeServerCmd(flags serverFlags) error {
 		return errors.New("utilities-git-url must be set")
 	}
 	model.SetUtilityDefaults(flags.utilitiesGitURL)
+
+	if flags.deployLocalMattermostOperator {
+		_, err := os.Stat(helm.LocalMattermostOperatorHelmDir)
+		if err != nil {
+			return errors.Wrapf(err, "failed to ensure directory %s exists; disable server flag deploy-local-mattermost-operator or ensure directory exists", helm.LocalMattermostOperatorHelmDir)
+		}
+	}
 
 	logger := logger.WithField("instance", instanceID)
 
@@ -267,19 +268,20 @@ func executeServerCmd(flags serverFlags) error {
 	}
 
 	provisioningParams := provisioner.ProvisioningParams{
-		S3StateStore:            flags.s3StateStore,
-		AllowCIDRRangeList:      flags.allowListCIDRRange,
-		VpnCIDRList:             flags.vpnListCIDR,
-		Owner:                   owner,
-		UseExistingAWSResources: flags.useExistingResources,
-		DeployMysqlOperator:     flags.deployMySQLOperator,
-		DeployMinioOperator:     flags.deployMinioOperator,
-		NdotsValue:              flags.ndotsDefaultValue,
-		InternalIPRanges:        flags.internalIPRanges,
-		PGBouncerConfig:         pgbouncerConfig,
-		SLOInstallationGroups:   flags.sloInstallationGroups,
-		SLOEnterpriseGroups:     flags.sloEnterpriseGroups,
-		EtcdManagerEnv:          etcdManagerEnv,
+		S3StateStore:                  flags.s3StateStore,
+		AllowCIDRRangeList:            flags.allowListCIDRRange,
+		VpnCIDRList:                   flags.vpnListCIDR,
+		Owner:                         owner,
+		UseExistingAWSResources:       flags.useExistingResources,
+		DeployMysqlOperator:           flags.deployMySQLOperator,
+		DeployMinioOperator:           flags.deployMinioOperator,
+		DeployLocalMattermostOperator: flags.deployLocalMattermostOperator,
+		NdotsValue:                    flags.ndotsDefaultValue,
+		InternalIPRanges:              flags.internalIPRanges,
+		PGBouncerConfig:               pgbouncerConfig,
+		SLOInstallationGroups:         flags.sloInstallationGroups,
+		SLOEnterpriseGroups:           flags.sloEnterpriseGroups,
+		EtcdManagerEnv:                etcdManagerEnv,
 	}
 
 	resourceUtil := utils.NewResourceUtil(instanceID, awsClient, dbClusterUtilizationSettingsFromFlags(flags), flags.disableDBInitCheck, flags.enableS3Versioning)
@@ -504,7 +506,7 @@ func checkRequirements(logger logrus.FieldLogger) error {
 	}
 	logger.Infof("[startup-check] Using kops: %s", version)
 
-	helmClient, err := helm.New(silentLogger)
+	helmClient, err := helm.New("dummy-config-path", silentLogger)
 	if err != nil {
 		return errors.Wrap(err, "failed helm client health check")
 	}
@@ -514,7 +516,7 @@ func checkRequirements(logger logrus.FieldLogger) error {
 	}
 	logger.Infof("[startup-check] Using helm: %s", version)
 
-	kubectlClient, err := kubectl.New(silentLogger)
+	kubectlClient, err := kubectl.New("dummy-config-path", silentLogger)
 	if err != nil {
 		return errors.Wrap(err, "failed kubectl client health check")
 	}
@@ -564,8 +566,10 @@ func checkRequirements(logger logrus.FieldLogger) error {
 
 // deprecationWarnings performs all checks for deprecated settings and warns if
 // any are found.
-func deprecationWarnings(logger logrus.FieldLogger, cmd *cobra.Command) {
-	// Add deprecation logic here.
+func deprecationWarnings(logger logrus.FieldLogger, flags serverFlags) {
+	if flags.debugHelm {
+		logger.Warn("The debug-helm flag has been deprecated")
+	}
 }
 
 // getHumanReadableID  represents  a  best  effort  attempt  to  retrieve  an

--- a/cmd/cloud/server_flag.go
+++ b/cmd/cloud/server_flag.go
@@ -68,15 +68,16 @@ func (flags *schedulingOptions) addFlags(command *cobra.Command) {
 }
 
 type provisioningParams struct {
-	s3StateStore          string
-	allowListCIDRRange    []string
-	sloInstallationGroups []string
-	sloEnterpriseGroups   []string
-	vpnListCIDR           []string
-	useExistingResources  bool
-	deployMySQLOperator   bool
-	deployMinioOperator   bool
-	ndotsDefaultValue     string
+	s3StateStore                  string
+	allowListCIDRRange            []string
+	sloInstallationGroups         []string
+	sloEnterpriseGroups           []string
+	vpnListCIDR                   []string
+	useExistingResources          bool
+	deployMySQLOperator           bool
+	deployMinioOperator           bool
+	deployLocalMattermostOperator bool
+	ndotsDefaultValue             string
 
 	backupJobTTL           int32
 	backupRestoreToolImage string
@@ -94,6 +95,7 @@ func (flags *provisioningParams) addFlags(command *cobra.Command) {
 	command.Flags().BoolVar(&flags.useExistingResources, "use-existing-aws-resources", true, "Whether to use existing AWS resources (VPCs, subnets, etc.) or not.")
 	command.Flags().BoolVar(&flags.deployMySQLOperator, "deploy-mysql-operator", false, "Whether to deploy the mysql operator.")
 	command.Flags().BoolVar(&flags.deployMinioOperator, "deploy-minio-operator", false, "Whether to deploy the minio operator.")
+	command.Flags().BoolVar(&flags.deployLocalMattermostOperator, "deploy-local-mattermost-operator", false, "Whether to deploy the mattermost operator helm chart locally from helm-charts/mattermost-operator.")
 	command.Flags().StringVar(&flags.ndotsDefaultValue, "ndots-value", "5", "The default ndots value for installations.")
 
 	command.Flags().Int32Var(&flags.backupJobTTL, "backup-job-ttl-seconds", 3600, "Number of seconds after which finished backup jobs will be cleaned up. Set to negative value to not cleanup or 0 to cleanup immediately.")

--- a/cmd/cloud/server_flag.go
+++ b/cmd/cloud/server_flag.go
@@ -68,16 +68,16 @@ func (flags *schedulingOptions) addFlags(command *cobra.Command) {
 }
 
 type provisioningParams struct {
-	s3StateStore                  string
-	allowListCIDRRange            []string
-	sloInstallationGroups         []string
-	sloEnterpriseGroups           []string
-	vpnListCIDR                   []string
-	useExistingResources          bool
-	deployMySQLOperator           bool
-	deployMinioOperator           bool
-	deployLocalMattermostOperator bool
-	ndotsDefaultValue             string
+	s3StateStore              string
+	allowListCIDRRange        []string
+	sloInstallationGroups     []string
+	sloEnterpriseGroups       []string
+	vpnListCIDR               []string
+	useExistingResources      bool
+	deployMySQLOperator       bool
+	deployMinioOperator       bool
+	mattermostOperatorHelmDir string
+	ndotsDefaultValue         string
 
 	backupJobTTL           int32
 	backupRestoreToolImage string
@@ -95,7 +95,7 @@ func (flags *provisioningParams) addFlags(command *cobra.Command) {
 	command.Flags().BoolVar(&flags.useExistingResources, "use-existing-aws-resources", true, "Whether to use existing AWS resources (VPCs, subnets, etc.) or not.")
 	command.Flags().BoolVar(&flags.deployMySQLOperator, "deploy-mysql-operator", false, "Whether to deploy the mysql operator.")
 	command.Flags().BoolVar(&flags.deployMinioOperator, "deploy-minio-operator", false, "Whether to deploy the minio operator.")
-	command.Flags().BoolVar(&flags.deployLocalMattermostOperator, "deploy-local-mattermost-operator", false, "Whether to deploy the mattermost operator helm chart locally from helm-charts/mattermost-operator.")
+	command.Flags().StringVar(&flags.mattermostOperatorHelmDir, "mattermost-operator-helm-dir", "", "Provide a directory location where a local mattermost operator helm chart will be deployed instead of from the standard repo")
 	command.Flags().StringVar(&flags.ndotsDefaultValue, "ndots-value", "5", "The default ndots value for installations.")
 
 	command.Flags().Int32Var(&flags.backupJobTTL, "backup-job-ttl-seconds", 3600, "Number of seconds after which finished backup jobs will be cleaned up. Set to negative value to not cleanup or 0 to cleanup immediately.")

--- a/internal/provisioner/cluster_provisioning.go
+++ b/internal/provisioner/cluster_provisioning.go
@@ -249,10 +249,10 @@ func provisionCluster(
 		return err
 	}
 
-	if params.DeployLocalMattermostOperator {
-		logger.Debugf("Upgrading Mattermost Operator helm chart from local chart %s", helm.LocalMattermostOperatorHelmDir)
+	if params.MattermostOperatorHelmDir != "" {
+		logger.Debugf("Upgrading Mattermost Operator helm chart from local chart %s", params.MattermostOperatorHelmDir)
 
-		err = helmClient.FullyUpgradeLocalChart("mattermost-operator", helm.LocalMattermostOperatorHelmDir, "mattermost-operator", "helm-charts/mattermost-operator.yaml")
+		err = helmClient.FullyUpgradeLocalChart("mattermost-operator", params.MattermostOperatorHelmDir, "mattermost-operator", "helm-charts/mattermost-operator.yaml")
 		if err != nil {
 			return errors.Wrap(err, "failed to upgrade local mattermost helm chart")
 		}

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -29,19 +29,20 @@ func (c ClusterProvisionerOption) GetClusterProvisioner(provisioner string) supe
 
 // ProvisioningParams represent configuration used during various provisioning operations.
 type ProvisioningParams struct {
-	S3StateStore            string
-	AllowCIDRRangeList      []string
-	VpnCIDRList             []string
-	Owner                   string
-	UseExistingAWSResources bool
-	DeployMysqlOperator     bool
-	DeployMinioOperator     bool
-	NdotsValue              string
-	InternalIPRanges        []string
-	PGBouncerConfig         *model.PGBouncerConfig
-	SLOInstallationGroups   []string
-	SLOEnterpriseGroups     []string
-	EtcdManagerEnv          map[string]string
+	S3StateStore                  string
+	AllowCIDRRangeList            []string
+	VpnCIDRList                   []string
+	Owner                         string
+	UseExistingAWSResources       bool
+	DeployMysqlOperator           bool
+	DeployMinioOperator           bool
+	DeployLocalMattermostOperator bool
+	NdotsValue                    string
+	InternalIPRanges              []string
+	PGBouncerConfig               *model.PGBouncerConfig
+	SLOInstallationGroups         []string
+	SLOEnterpriseGroups           []string
+	EtcdManagerEnv                map[string]string
 }
 
 type Provisioner struct {

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -29,20 +29,20 @@ func (c ClusterProvisionerOption) GetClusterProvisioner(provisioner string) supe
 
 // ProvisioningParams represent configuration used during various provisioning operations.
 type ProvisioningParams struct {
-	S3StateStore                  string
-	AllowCIDRRangeList            []string
-	VpnCIDRList                   []string
-	Owner                         string
-	UseExistingAWSResources       bool
-	DeployMysqlOperator           bool
-	DeployMinioOperator           bool
-	DeployLocalMattermostOperator bool
-	NdotsValue                    string
-	InternalIPRanges              []string
-	PGBouncerConfig               *model.PGBouncerConfig
-	SLOInstallationGroups         []string
-	SLOEnterpriseGroups           []string
-	EtcdManagerEnv                map[string]string
+	S3StateStore              string
+	AllowCIDRRangeList        []string
+	VpnCIDRList               []string
+	Owner                     string
+	UseExistingAWSResources   bool
+	DeployMysqlOperator       bool
+	DeployMinioOperator       bool
+	MattermostOperatorHelmDir string
+	NdotsValue                string
+	InternalIPRanges          []string
+	PGBouncerConfig           *model.PGBouncerConfig
+	SLOInstallationGroups     []string
+	SLOEnterpriseGroups       []string
+	EtcdManagerEnv            map[string]string
 }
 
 type Provisioner struct {

--- a/internal/tools/helm/cmd.go
+++ b/internal/tools/helm/cmd.go
@@ -11,22 +11,28 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// LocalMattermostOperatorHelmDir is the directory used for local helm chart
+// lookup for the Mattermost Operator. Primary use is helm chart testing.
+const LocalMattermostOperatorHelmDir = "helm-charts/mattermost-operator"
+
 // Cmd is the helm command to execute.
 type Cmd struct {
-	helmPath string
-	logger   log.FieldLogger
+	helmPath   string
+	kubeconfig string
+	logger     log.FieldLogger
 }
 
 // New creates a new instance of Cmd through which to execute helm.
-func New(logger log.FieldLogger) (*Cmd, error) {
+func New(kubeconfigPath string, logger log.FieldLogger) (*Cmd, error) {
 	helmPath, err := exec.LookPath("helm")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find helm installed on your PATH")
 	}
 
 	return &Cmd{
-		helmPath: helmPath,
-		logger:   logger,
+		helmPath:   helmPath,
+		kubeconfig: kubeconfigPath,
+		logger:     logger.WithField("kubeconfig", kubeconfigPath),
 	}, nil
 }
 

--- a/internal/tools/helm/cmd.go
+++ b/internal/tools/helm/cmd.go
@@ -11,10 +11,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// LocalMattermostOperatorHelmDir is the directory used for local helm chart
-// lookup for the Mattermost Operator. Primary use is helm chart testing.
-const LocalMattermostOperatorHelmDir = "helm-charts/mattermost-operator"
-
 // Cmd is the helm command to execute.
 type Cmd struct {
 	helmPath   string

--- a/internal/tools/helm/commands.go
+++ b/internal/tools/helm/commands.go
@@ -6,8 +6,10 @@ package helm
 
 import (
 	"os/exec"
+	"path/filepath"
 	"strings"
 
+	"github.com/mattermost/mattermost-cloud/internal/tools/kubectl"
 	"github.com/pkg/errors"
 )
 
@@ -27,6 +29,26 @@ func (c *Cmd) RunCommandRaw(arg ...string) ([]byte, error) {
 	return cmd.Output()
 }
 
+// RepoAdd invokes helm repo add to add a repo.
+func (c *Cmd) RepoAdd(repoName, repoURL string) error {
+	_, _, err := c.run("repo", "add", repoName, repoURL)
+	if err != nil {
+		return errors.Wrap(err, "failed to invoke helm repo add")
+	}
+
+	return nil
+}
+
+// RepoUpdate invokes helm repo update to update all repo charts.
+func (c *Cmd) RepoUpdate() error {
+	_, _, err := c.run("repo", "update")
+	if err != nil {
+		return errors.Wrap(err, "failed to invoke helm repo update")
+	}
+
+	return nil
+}
+
 // Version invokes helm version and returns the value.
 func (c *Cmd) Version() (string, error) {
 	stdout, _, err := c.run("version")
@@ -38,10 +60,30 @@ func (c *Cmd) Version() (string, error) {
 	return trimmed, nil
 }
 
+// FullyUpgradeLocalChart takes in the arguements necessary to fully upgrade a
+// local helm chart. This includes using the kubctl client to apply CRDS.
+func (c *Cmd) FullyUpgradeLocalChart(chartName, chartDirectory, namespace, valuesLocation string) error {
+	kubectlClient, err := kubectl.New(c.kubeconfig, c.logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to create kubectl client")
+	}
+	err = kubectlClient.RunGenericCommand("apply", "-f", filepath.Join(chartDirectory, "crds/"))
+	if err != nil {
+		return errors.Wrap(err, "failed to apply crds from unpacked helm chart")
+	}
+
+	_, _, err = c.run("upgrade", chartName, chartDirectory, "--namespace", namespace, "-f", valuesLocation)
+	if err != nil {
+		return errors.Wrap(err, "failed to invoke helm upgrade")
+	}
+
+	return nil
+}
+
 // HelmChartFoundAndDeployed is a helper func that attempts to determine if a
 // given chart exists in the cluster and if it was successfully deployed.
-func (c *Cmd) HelmChartFoundAndDeployed(releaseName, kubeconfigPath string) (bool, bool) {
-	out, _, err := c.runSilent("status", releaseName, "--kubeconfig", kubeconfigPath)
+func (c *Cmd) HelmChartFoundAndDeployed(releaseName, namespace string) (bool, bool) {
+	out, _, err := c.runSilent("status", releaseName, "--namespace", namespace)
 	if err == nil {
 		if strings.Contains(string(out), "STATUS: deployed") {
 			// found and deployed

--- a/internal/tools/kubectl/cmd.go
+++ b/internal/tools/kubectl/cmd.go
@@ -14,11 +14,12 @@ import (
 // Cmd is the kubectl command to execute.
 type Cmd struct {
 	kubectlPath string
+	kubeconfig  string
 	logger      log.FieldLogger
 }
 
 // New creates a new instance of Cmd through which to execute kubectl.
-func New(logger log.FieldLogger) (*Cmd, error) {
+func New(kubeconfigPath string, logger log.FieldLogger) (*Cmd, error) {
 	kubectlPath, err := exec.LookPath("kubectl")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find kubectl installed on your PATH")
@@ -26,7 +27,8 @@ func New(logger log.FieldLogger) (*Cmd, error) {
 
 	return &Cmd{
 		kubectlPath: kubectlPath,
-		logger:      logger,
+		kubeconfig:  kubeconfigPath,
+		logger:      logger.WithField("kubeconfig", kubeconfigPath),
 	}, nil
 }
 

--- a/internal/tools/kubectl/run.go
+++ b/internal/tools/kubectl/run.go
@@ -5,6 +5,8 @@
 package kubectl
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -22,5 +24,10 @@ func outputLogger(line string, logger log.FieldLogger) {
 
 func (c *Cmd) run(arg ...string) ([]byte, []byte, error) {
 	cmd := exec.Command(c.kubectlPath, arg...)
+	cmd.Env = append(
+		os.Environ(),
+		fmt.Sprintf("KUBECONFIG=%s", c.kubeconfig),
+	)
+
 	return exechelper.RunWithEnv(cmd, c.logger, outputLogger)
 }


### PR DESCRIPTION
Even with the migration of utilities away from being managed by the provisioner, there is still a need to be able to test charts locally. This change attempts to support that use-case while also refactoring the helm client. As a result, provisioning speed is now also improved. This change does the following:

 - Adds server flag for deploying the mattermost operator helm chart locally from 'helm-charts/mattermost-operator'
 - Removes a redundant helm debug flag and instead relies on the debug log flag.
 - Cleans up helm repo add and repo update and moves them inside the helm package.
 - Removes previous logic where every helm repo added also caused a complete update of all configured repos. Instead, repos are now only updated once per cluster provision which reduces log noise and speeds up the process.
 - Adds helm client logic to install local charts.
 - Refactors the helm and kubectl clients to take in a kubecfg path on creation which is used for all commands. Passing in `--kubeconfig` flags is no longer needed for each command.

Fixes https://mattermost.atlassian.net/browse/CLD-7009

```release-note
Helm client refactor and local chart install support
```
