### PR TITLE
Add Kubecfg env to raw output

### DIFF
--- a/internal/tools/helm/commands.go
+++ b/internal/tools/helm/commands.go
@@ -5,6 +5,8 @@
 package helm
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -26,6 +28,11 @@ func (c *Cmd) RunGenericCommand(arg ...string) error {
 // RunCommandRaw runs any given helm command returning raw output.
 func (c *Cmd) RunCommandRaw(arg ...string) ([]byte, error) {
 	cmd := exec.Command(c.helmPath, arg...)
+	cmd.Env = append(
+		os.Environ(),
+		fmt.Sprintf("KUBECONFIG=%s", c.kubeconfig),
+	)
+
 	return cmd.Output()
 }
 


### PR DESCRIPTION
This helm client command was skipping the standard env application.

Fixes https://mattermost.atlassian.net/browse/CLD-7055

```release-note
Add Kubecfg env to raw output
```
