### PR TITLE
[CLD-7079]remove thanos grpc ingress

### DIFF
--- a/internal/provisioner/utility/thanos.go
+++ b/internal/provisioner/utility/thanos.go
@@ -85,7 +85,7 @@ func (t *thanos) CreateOrUpgrade() error {
 	dns := fmt.Sprintf("%s.%s.%s", t.cluster.ID, app, privateDomainName)
 	grpcDNS := fmt.Sprintf("%s-grpc.%s.%s", t.cluster.ID, app, privateDomainName)
 
-	h := t.newHelmDeployment(dns, grpcDNS)
+	h := t.newHelmDeployment(dns)
 
 	err = h.Update()
 	if err != nil {
@@ -162,7 +162,7 @@ func (t *thanos) Destroy() error {
 
 	t.actualVersion = nil
 
-	helm := t.newHelmDeployment(dns, grpcDNS)
+	helm := t.newHelmDeployment(dns)
 	return helm.Delete()
 }
 
@@ -170,8 +170,8 @@ func (t *thanos) Migrate() error {
 	return nil
 }
 
-func (t *thanos) newHelmDeployment(thanosDNS, thanosDNSGRPC string) *helmDeployment {
-	helmValueArguments := fmt.Sprintf("query.ingress.hostname=%s,query.ingress.grpc.hostname=%s,query.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", thanosDNS, thanosDNSGRPC, strings.Join(t.allowCIDRRangeList, "\\,"))
+func (t *thanos) newHelmDeployment(thanosDNS string) *helmDeployment {
+	helmValueArguments := fmt.Sprintf("query.ingress.hostname=%s,query.ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range=%s", thanosDNS, strings.Join(t.allowCIDRRangeList, "\\,"))
 
 	return newHelmDeployment(
 		"bitnami/thanos",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Removing thanos-grpc ingress as we're creating service type loadbalancer the ingress is useless.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/CLD-7079



#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
