### PR TITLE
Add logging to S3LargeCopy

### DIFF
--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -300,17 +300,17 @@ func (mr *MockAWSMockRecorder) S3EnsureObjectDeleted(bucketName, path interface{
 }
 
 // S3LargeCopy mocks base method
-func (m *MockAWS) S3LargeCopy(srcBucketName, srcKey, destBucketName, destKey *string) error {
+func (m *MockAWS) S3LargeCopy(srcBucketName, srcKey, destBucketName, destKey *string, logger logrus.FieldLogger) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "S3LargeCopy", srcBucketName, srcKey, destBucketName, destKey)
+	ret := m.ctrl.Call(m, "S3LargeCopy", srcBucketName, srcKey, destBucketName, destKey, logger)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // S3LargeCopy indicates an expected call of S3LargeCopy
-func (mr *MockAWSMockRecorder) S3LargeCopy(srcBucketName, srcKey, destBucketName, destKey interface{}) *gomock.Call {
+func (mr *MockAWSMockRecorder) S3LargeCopy(srcBucketName, srcKey, destBucketName, destKey, logger interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "S3LargeCopy", reflect.TypeOf((*MockAWS)(nil).S3LargeCopy), srcBucketName, srcKey, destBucketName, destKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "S3LargeCopy", reflect.TypeOf((*MockAWS)(nil).S3LargeCopy), srcBucketName, srcKey, destBucketName, destKey, logger)
 }
 
 // GetMultitenantBucketNameForInstallation mocks base method

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -372,7 +372,7 @@ func (s *ImportSupervisor) copyImportToWorkspaceFilestore(imprt *awat.ImportStat
 	}
 
 	logger.Debugf("Copying %s/%s to %s/%s", srcBucket, srcKey, destBucket, destKey)
-	err = s.awsClient.S3LargeCopy(&srcBucket, &srcKey, &destBucket, &destKey)
+	err = s.awsClient.S3LargeCopy(&srcBucket, &srcKey, &destBucket, &destKey, logger)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to copy archive to Installation %s", installation.ID)
 	}

--- a/internal/supervisor/import_test.go
+++ b/internal/supervisor/import_test.go
@@ -81,8 +81,7 @@ func TestImportSupervisor(t *testing.T) {
 			Return(destBucket, nil)
 
 		aws.EXPECT().
-			S3LargeCopy(&sourceBucket, &inputArchive, &destBucket,
-				gomock.Any())
+			S3LargeCopy(&sourceBucket, &inputArchive, &destBucket, gomock.Any(), gomock.Any())
 
 		err := importSupervisor.Do()
 		assert.NoError(t, err, "error supervising")
@@ -138,8 +137,7 @@ func TestImportSupervisor(t *testing.T) {
 			Return(destBucket, nil)
 
 		aws.EXPECT().
-			S3LargeCopy(&sourceBucket, &inputArchive, &destBucket,
-				gomock.Any())
+			S3LargeCopy(&sourceBucket, &inputArchive, &destBucket, gomock.Any(), gomock.Any())
 
 		err := importSupervisor.Do()
 		assert.Error(t, err, "no error supervising")
@@ -237,8 +235,7 @@ func TestImportSupervisor(t *testing.T) {
 			Return(destBucket, nil)
 
 		aws.EXPECT().
-			S3LargeCopy(&sourceBucket, &inputArchive, &destBucket,
-				gomock.Any()).
+			S3LargeCopy(&sourceBucket, &inputArchive, &destBucket, gomock.Any(), gomock.Any()).
 			Return(errors.New("some AWS error"))
 
 		awatClient.EXPECT().

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -597,7 +597,7 @@ func (a *mockAWS) GenerateBifrostUtilitySecret(clusterID string, logger log.Fiel
 func (a *mockAWS) GetCIDRByVPCTag(vpcTagName string, logger log.FieldLogger) (string, error) {
 	return "", nil
 }
-func (a *mockAWS) S3LargeCopy(srcBucketName, srcKey, destBucketName, destKey *string) error {
+func (a *mockAWS) S3LargeCopy(srcBucketName, srcKey, destBucketName, destKey *string, logger log.FieldLogger) error {
 	return nil
 }
 

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -55,7 +55,7 @@ type AWS interface {
 
 	S3EnsureBucketDeleted(bucketName string, logger log.FieldLogger) error
 	S3EnsureObjectDeleted(bucketName, path string) error
-	S3LargeCopy(srcBucketName, srcKey, destBucketName, destKey *string) error
+	S3LargeCopy(srcBucketName, srcKey, destBucketName, destKey *string, logger log.FieldLogger) error
 	GetMultitenantBucketNameForInstallation(installationID string, store model.InstallationDatabaseStoreInterface) (string, error)
 	GetS3RegionURL() string
 

--- a/internal/tools/aws/s3.go
+++ b/internal/tools/aws/s3.go
@@ -344,7 +344,10 @@ func (a *Client) S3LargeCopy(srcBucketName, srcBucketKey, destBucketName, destBu
 		lastByte := int(math.Min(float64(bytePosition+partSize-1), float64(objectSize-1)))
 		bytesRange := fmt.Sprintf("bytes=%d-%d", bytePosition, lastByte)
 
-		logger.WithField("s3-copy-source-bytes-range", bytesRange).Debugf("Copying S3 object part %d", partNum)
+		logger.WithFields(log.Fields{
+			"s3-copy-source-bytes-range": bytesRange,
+			"s3-copy-part-num":           partNum,
+		}).Debug("Copying S3 object part")
 
 		var resp *s3.UploadPartCopyOutput
 		resp, err = a.service.s3.UploadPartCopy(


### PR DESCRIPTION
Multipart S3 object copying can take a while. This change adds logging so that progress can be reviewed if needed.

Fixes https://mattermost.atlassian.net/browse/CLD-7253

```release-note
Add logging to S3LargeCopy
```
