### PR TITLE
Add logic to skip AMI updates for instance groups

### DIFF
--- a/internal/tools/kops/instance_groups.go
+++ b/internal/tools/kops/instance_groups.go
@@ -15,7 +15,8 @@ import (
 
 // ResourceMetadata is the metadata of a kops resource.
 type ResourceMetadata struct {
-	Name string `json:"name"`
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels"`
 }
 
 // Cluster is the configuration of a kops cluster.


### PR DESCRIPTION
There are situations where it is ideal to not apply the standard AMI to all kops instance groups in a cluster. This change allows for setting an instance group metadata label with a key of `mattermost/cloud-provisioner-ami-skip` and any value to instruct the provisioner to skip any AMI updates on that instance group.

Fixes https://mattermost.atlassian.net/browse/CLD-7252

Example instance group snippet:

```
apiVersion: kops.k8s.io/v1alpha2
kind: InstanceGroup
metadata:
  creationTimestamp: "2024-03-04T14:44:27Z"
  generation: 3
  labels:
    kops.k8s.io/cluster: etuajy5q93ymdqj9pcb1oa4bzw-kops.k8s.local
    mattermost/cloud-provisioner-ami-skip: "true"
  name: nodes-us-east-1a
spec:
  ...
```

```release-note
Add logic to skip AMI updates for instance groups
```
