### PR TITLE
fix: Upgrade actions and use clean Makefile commands to push tags

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -6,8 +6,9 @@ runs:
   steps:
     - name: ci/prepare-docker-environment
       uses: ./.github/actions/docker-prepare
+
     - name: cd/scan-docker-security
-      uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5 # v0.8.0
+      uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # v0.18.0
       with:
         image-ref: "mattermost/mattermost-cloud"
         format: "table"
@@ -26,7 +27,7 @@ runs:
       if: github.event_name != 'pull_request'
 
     - name: cd/scan-docker-security-e2e
-      uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5 # v0.8.0
+      uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # v0.18.0
       with:
         image-ref: "mattermost/mattermost-cloud-e2e"
         format: "table"
@@ -38,6 +39,7 @@ runs:
       run: "make push-image-pr"
       shell: bash
       if: github.event_name == 'pull_request'
+
     - name: cd/push-image
       run: "make push-image"
       shell: bash

--- a/.github/actions/docker-prepare/action.yml
+++ b/.github/actions/docker-prepare/action.yml
@@ -1,11 +1,11 @@
 ---
-name: 'docker-prepare'
-description: 'Install docker requirements'
+name: "docker-prepare"
+description: "Install docker requirements"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-  - name: ci/setup-buildx
-    uses: docker/setup-buildx-action@v3
-    with:
-      version: v0.12.0
+    - name: ci/setup-buildx
+      uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # v3.1.0
+      with:
+        version: v0.12.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: go.mod
-          cache: true
+
       - name: ci/check-style
         run: make check-style
 
@@ -33,15 +33,14 @@ jobs:
     runs-on: ubuntu-20.04 # TODO: move check-mocks back to the newest Ubuntu release
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: ci/check-mocks
         run: make verify-mocks
@@ -64,21 +63,20 @@ jobs:
 
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          cache: true
           go-version-file: go.mod
 
       - name: ci/test-postgres
         run: make unittest goverall
         env:
           CLOUD_DATABASE: postgres://cloud_test@localhost:5432/cloud_test?sslmode=disable
-      
+
       - name: ci/test-testwick
         run: make unittest
         working-directory: ./cmd/tools/testwick
@@ -90,23 +88,12 @@ jobs:
       - lint
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 
-      - name: ci/generate-tag
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]
-          then
-            SHA=${{ github.event.pull_request.head.sha }}
-          else [ "${{ github.event_name }}"  == 'push' ]
-            SHA=${GITHUB_SHA}
-          fi
-          echo "TAG=${SHA:0:7}" >> $GITHUB_ENV
-
       - name: ci/build-docker
         env:
-          REF_NAME: ${{ github.ref_name }}
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         uses: ./.github/actions/docker-build

--- a/scripts/push-image.sh
+++ b/scripts/push-image.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
 set -e
-set -u
 
-: ${GITHUB_REF_TYPE:?}
-: ${GITHUB_REF_NAME:?}
-
-if [ "${GITHUB_REF_TYPE:-}" = "branch" ]; then
-  echo "Pushing latest for $GITHUB_REF_NAME..."
-  export TAG=latest
+if [ -n "${TAG}" ]
+  then
+    echo "Pushing ${TAG} for release ..."
 else
-  echo "Pushing release $GITHUB_REF_NAME..."
-  export TAG="$GITHUB_REF_NAME"
+  echo "Pushing latest for ${GITHUB_REF_NAME} ..."
+  export TAG="latest"
 fi
+
 make build-image-with-tag


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Create Makefile commands to bump patch/minor/major versions
- Upgrade all reusable Github Actions
- Modified push-image script to properly push TAG
- Removed unused code
- Remove cache directive from golang action as it is enabled by default 

As per @gabrieljackson 
> After we merge this I will remove v0.81.3 tag/release and create a new minor one 0.82.0 🚀 
 
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-7292

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
