### PR TITLE
feat: Introduce --header global variable to access provisioner with auth

### DIFF
--- a/cmd/cloud/backup.go
+++ b/cmd/cloud/backup.go
@@ -33,7 +33,7 @@ func newCmdInstallationBackupCreate() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			backup, err := client.CreateInstallationBackup(flags.installationID)
 			if err != nil {
@@ -73,7 +73,7 @@ func newCmdInstallationBackupList() *cobra.Command {
 }
 
 func executeInstallationBackupListCmd(flags installationBackupListFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 
@@ -138,7 +138,7 @@ func newCmdInstallationBackupGet() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			backup, err := client.GetInstallationBackup(flags.backupID)
 			if err != nil {
@@ -166,7 +166,7 @@ func newCmdInstallationBackupDelete() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			if err := client.DeleteInstallationBackup(flags.backupID); err != nil {
 				return errors.Wrap(err, "failed to delete backup")

--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -94,7 +94,7 @@ func newCmdClusterCreate() *cobra.Command {
 }
 
 func executeClusterCreateCmd(flags clusterCreateFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	if flags.cluster != "" {
 		err := client.RetryCreateCluster(flags.cluster)
@@ -220,7 +220,7 @@ func newCmdClusterProvision() *cobra.Command {
 }
 
 func executeClusterProvisionCmd(flags clusterProvisionFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	request := &model.ProvisionClusterRequest{
 		Force:                  flags.reprovisionAllUtilities,
@@ -266,7 +266,7 @@ func newCmdClusterUpdate() *cobra.Command {
 
 func executeClusterUpdateCmd(flags clusterUpdateFlags) error {
 
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	request := &model.UpdateClusterRequest{
 		AllowInstallations: flags.allowInstallations,
@@ -310,7 +310,7 @@ func newCmdClusterUpgrade() *cobra.Command {
 }
 
 func executeClusterUpgradeCmd(flags clusterUpgradeFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	rotatorConfig := getRotatorConfigFromFlags(flags.rotatorConfig)
 
@@ -368,7 +368,7 @@ func newCmdClusterResize() *cobra.Command {
 }
 
 func executeClusterResizeCmd(flags clusterResizeFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	rotatorConfig := getRotatorConfigFromFlags(flags.rotatorConfig)
 
@@ -436,7 +436,7 @@ func newCmdClusterDelete() *cobra.Command {
 }
 
 func executeClusterDeleteCmd(flags clusterDeleteFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	err := client.DeleteCluster(flags.cluster)
 	if err != nil {
@@ -466,7 +466,7 @@ func newCmdClusterGet() *cobra.Command {
 }
 
 func executeClusterGetCmd(flags clusterGetFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	cluster, err := client.GetCluster(flags.cluster)
 	if err != nil {
@@ -502,7 +502,7 @@ func newCmdClusterList() *cobra.Command {
 }
 
 func executeClusterListCmd(flags clusterListFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 
@@ -609,7 +609,7 @@ func newCmdClusterUtilities() *cobra.Command {
 		Short: "Show metadata regarding utility services running in a cluster.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			metadata, err := client.GetClusterUtilities(flags.cluster)
 			if err != nil {

--- a/cmd/cloud/cluster_annotation.go
+++ b/cmd/cloud/cluster_annotation.go
@@ -44,7 +44,7 @@ func newCmdClusterAnnotationAdd() *cobra.Command {
 
 func executeClusterAnnotationAddCmd(flags clusterAnnotationAddFlags) error {
 
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	request := newAddAnnotationsRequest(flags.annotations)
 
@@ -73,7 +73,7 @@ func newCmdClusterAnnotationDelete() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			if err := client.DeleteClusterAnnotation(flags.cluster, flags.annotation); err != nil {
 				return errors.Wrap(err, "failed to delete cluster annotations")

--- a/cmd/cloud/cluster_flag.go
+++ b/cmd/cloud/cluster_flag.go
@@ -6,16 +6,19 @@ import (
 
 func setClusterFlags(command *cobra.Command) {
 	command.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
+	command.PersistentFlags().String("token", "", "The auth token to access provisioning server.")
 	command.PersistentFlags().Bool("dry-run", false, "When set to true, only print the API request without sending it.")
 }
 
 type clusterFlags struct {
 	serverAddress string
+	token         string
 	dryRun        bool
 }
 
 func (flags *clusterFlags) addFlags(command *cobra.Command) {
 	flags.serverAddress, _ = command.Flags().GetString("server")
+	flags.token, _ = command.Flags().GetString("token")
 	flags.dryRun, _ = command.Flags().GetBool("dry-run")
 }
 

--- a/cmd/cloud/cluster_flag.go
+++ b/cmd/cloud/cluster_flag.go
@@ -6,19 +6,19 @@ import (
 
 func setClusterFlags(command *cobra.Command) {
 	command.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
-	command.PersistentFlags().String("token", "", "The auth token to access provisioning server.")
+	command.PersistentFlags().StringToString("header", nil, "The extra headers to sent in every API call towards the provisioning server. Accepts format: HEADER_KEY=HEADER_VALUE. Use the flag multiple times to set multiple headers.")
 	command.PersistentFlags().Bool("dry-run", false, "When set to true, only print the API request without sending it.")
 }
 
 type clusterFlags struct {
 	serverAddress string
-	token         string
+	headers       map[string]string
 	dryRun        bool
 }
 
 func (flags *clusterFlags) addFlags(command *cobra.Command) {
 	flags.serverAddress, _ = command.Flags().GetString("server")
-	flags.token, _ = command.Flags().GetString("token")
+	flags.headers, _ = command.Flags().GetStringToString("header")
 	flags.dryRun, _ = command.Flags().GetBool("dry-run")
 }
 

--- a/cmd/cloud/cluster_flag.go
+++ b/cmd/cloud/cluster_flag.go
@@ -6,7 +6,7 @@ import (
 
 func setClusterFlags(command *cobra.Command) {
 	command.PersistentFlags().String("server", defaultLocalServerAPI, "The provisioning server whose API will be queried.")
-	command.PersistentFlags().StringToString("header", nil, "The extra headers to sent in every API call towards the provisioning server. Accepts format: HEADER_KEY=HEADER_VALUE. Use the flag multiple times to set multiple headers.")
+	command.PersistentFlags().StringToString("header", nil, "The extra headers to send in every API call towards the provisioning server. Accepts format: HEADER_KEY=HEADER_VALUE. Use the flag multiple times to set multiple headers.")
 	command.PersistentFlags().Bool("dry-run", false, "When set to true, only print the API request without sending it.")
 }
 

--- a/cmd/cloud/cluster_installation.go
+++ b/cmd/cloud/cluster_installation.go
@@ -39,7 +39,7 @@ func newCmdClusterInstallationGet() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			clusterInstallation, err := client.GetClusterInstallation(flags.clusterInstallationID)
 			if err != nil {
@@ -81,7 +81,7 @@ func newCmdClusterInstallationList() *cobra.Command {
 }
 
 func executeClusterInstallationListCmd(flags clusterInstallationListFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 
@@ -149,7 +149,7 @@ func newCmdClusterInstallationConfigGet() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			clusterInstallationConfig, err := client.GetClusterInstallationConfig(flags.clusterInstallationID)
 			if err != nil {
@@ -179,7 +179,7 @@ func newCmdClusterInstallationConfigSet() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			config := make(map[string]interface{})
 			keyParts := strings.Split(flags.key, ".")
@@ -217,7 +217,7 @@ func newCmdClusterInstallationStatus() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			clusterInstallation, err := client.GetClusterInstallationStatus(flags.clusterInstallationID)
 			if err != nil {
@@ -247,7 +247,7 @@ func newCmdClusterInstallationMMCTL() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			output, err := client.ExecClusterInstallationCLI(flags.clusterInstallationID, "mmctl", strings.Split(flags.subcommand, " "))
 			fmt.Println(string(output))
@@ -275,7 +275,7 @@ func newCmdClusterInstallationMattermostCLI() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			output, err := client.RunMattermostCLICommandOnClusterInstallation(flags.clusterInstallationID, strings.Split(flags.subcommand, " "))
 			fmt.Println(string(output))
@@ -318,7 +318,7 @@ func newCmdClusterInstallationMigration() *cobra.Command {
 
 func executeClusterInstallationMigrationCmd(flags clusterInstallationMigrationFlags) error {
 
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	response, err := client.MigrateClusterInstallation(
 		&model.MigrateClusterInstallationRequest{
@@ -359,7 +359,7 @@ func newCmdClusterInstallationDNSMigration() *cobra.Command {
 }
 
 func executeClusterInstallationDNSMigrationCmd(flags clusterInstallationDNSMigrationFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	response, err := client.MigrateDNS(
 		&model.MigrateClusterInstallationRequest{
@@ -399,7 +399,7 @@ func newCmdDeleteInActiveClusterInstallation() *cobra.Command {
 
 func executeDeleteInActiveClusterInstallationCmd(flags inActiveClusterInstallationDeleteFlags) error {
 
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	if len(flags.clusterInstallationID) != 0 {
 		deletedCI, err := client.DeleteInActiveClusterInstallationByID(flags.clusterInstallationID)
@@ -447,7 +447,7 @@ func newCmdClusterRolesPostMigrationSwitch() *cobra.Command {
 }
 
 func executeClusterRolesPostMigrationSwitchCmd(flags clusterRolesPostMigrationSwitchFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	response, err := client.SwitchClusterRoles(
 		&model.MigrateClusterInstallationRequest{

--- a/cmd/cloud/dashboard.go
+++ b/cmd/cloud/dashboard.go
@@ -36,7 +36,7 @@ func newCmdDashboard() *cobra.Command {
 }
 
 func executeDashboardCmd(flags dashboardFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 	if flags.refreshSeconds < 1 {
 		return errors.Errorf("refresh seconds (%d) must be set to 1 or higher", flags.refreshSeconds)
 	}

--- a/cmd/cloud/dashboard_flag.go
+++ b/cmd/cloud/dashboard_flag.go
@@ -3,6 +3,7 @@ package main
 import "github.com/spf13/cobra"
 
 type dashboardFlags struct {
+	clusterFlags
 	serverAddress  string
 	refreshSeconds int
 }

--- a/cmd/cloud/databases.go
+++ b/cmd/cloud/databases.go
@@ -66,7 +66,7 @@ func newCmdDatabaseMultitenantList() *cobra.Command {
 }
 
 func executeDatabaseMultitenantListCmd(flags databaseMultiTenantListFlag) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 
@@ -120,7 +120,7 @@ func newCmdDatabaseMultitenantGet() *cobra.Command {
 		Short: "Get a particular multitenant database.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			multitenantDatabase, err := client.GetMultitenantDatabase(flags.multitenantDatabaseID)
 			if err != nil {
@@ -150,7 +150,7 @@ func newCmdDatabaseMultitenantUpdate() *cobra.Command {
 		Short: "Update an multitenant database's configuration",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			request := &model.PatchMultitenantDatabaseRequest{}
 			if flags.isMaxInstallationsChanged {
@@ -187,7 +187,7 @@ func newCmdDatabaseMultitenantDelete() *cobra.Command {
 		Short: "Delete an multitenant database's configuration",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			if err := client.DeleteMultitenantDatabase(flags.multitenantDatabaseID, flags.force); err != nil {
 				return errors.Wrap(err, "failed to delete multitenant database")
@@ -238,7 +238,7 @@ func newCmdDatabaseLogicalList() *cobra.Command {
 }
 
 func executeDatabaseLogicalListCmd(flags databaseLogicalListFlag) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 
@@ -291,7 +291,7 @@ func newCmdDatabaseLogicalGet() *cobra.Command {
 		Short: "Get a particular logical database.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			logicalDatabase, err := client.GetLogicalDatabase(flags.logicalDatabaseID)
 			if err != nil {
@@ -321,7 +321,7 @@ func newCmdDatabaseLogicalDelete() *cobra.Command {
 		Short: "Delete an empty PGBouncer logical database",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			if err := client.DeleteLogicalDatabase(flags.logicalDatabaseID); err != nil {
 				return errors.Wrap(err, "failed to delete logical database")
@@ -371,7 +371,7 @@ func newCmdDatabaseSchemaList() *cobra.Command {
 }
 
 func executeDatabaseSchemaListCmd(flags databaseSchemaListFlag) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 
@@ -425,7 +425,7 @@ func newCmdDatabaseSchemaGet() *cobra.Command {
 		Short: "Get a particular database schema.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			databaseSchema, err := client.GetDatabaseSchema(flags.databaseSchemaID)
 			if err != nil {
@@ -468,7 +468,7 @@ func newCmdDatabaseValidationReport() *cobra.Command {
 }
 
 func executeDatabaseValidationReportCmd(flags clusterFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags)
 
 	installations, err := client.GetInstallations(&model.GetInstallationsRequest{
 		Paging: model.AllPagesNotDeleted(),
@@ -546,7 +546,7 @@ func newCmdDatabaseMultitenantReport() *cobra.Command {
 }
 
 func executeMultiTenantDatabaseReportCmd(flags databaseMultiTenantReportFlag) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	multitenantDatabase, err := client.GetMultitenantDatabase(flags.multitenantDatabaseID)
 	if err != nil {

--- a/cmd/cloud/events.go
+++ b/cmd/cloud/events.go
@@ -56,7 +56,7 @@ func newCmdStateChangeEventList() *cobra.Command {
 }
 
 func executeStateChangeEventListCmd(flags stateChangeEventListFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 

--- a/cmd/cloud/events_flag.go
+++ b/cmd/cloud/events_flag.go
@@ -15,6 +15,7 @@ func (flags *eventFlags) addFlags(command *cobra.Command) {
 }
 
 type stateChangeEventListFlags struct {
+	clusterFlags
 	eventFlags
 	pagingFlags
 	tableOptions

--- a/cmd/cloud/events_subscription.go
+++ b/cmd/cloud/events_subscription.go
@@ -34,7 +34,7 @@ func newCmdSubscriptionCreate() *cobra.Command {
 		Short: "Creates subscription.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			var headers model.Headers
 			for key, value := range flags.headers {
@@ -96,7 +96,7 @@ func newCmdSubscriptionList() *cobra.Command {
 		Short: "List subscriptions.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			paging := getPaging(flags.pagingFlags)
 
@@ -169,7 +169,7 @@ func newCmdSubscriptionGet() *cobra.Command {
 		Short: "Get subscription.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			subscription, err := client.GetSubscription(flags.subID)
 			if err != nil {
@@ -196,7 +196,7 @@ func newCmdSubscriptionDelete() *cobra.Command {
 		Short: "Delete subscription.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.DeleteSubscription(flags.subID); err != nil {
 				return errors.Wrap(err, "failed to delete subscription")
 			}

--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -46,7 +46,7 @@ func newCmdGroupCreate() *cobra.Command {
 		Short: "Create a group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			envVarMap, err := parseEnvVarInput(flags.mattermostEnv, false)
 			if err != nil {
 				return err
@@ -105,7 +105,7 @@ func newCmdGroupUpdate() *cobra.Command {
 }
 
 func executeGroupUpdateCmd(flags groupUpdateFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	envVarMap, err := parseEnvVarInput(flags.mattermostEnv, flags.mattermostEnvClear)
 	if err != nil {
@@ -155,7 +155,7 @@ func newCmdGroupDelete() *cobra.Command {
 		Short: "Delete a group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.DeleteGroup(flags.groupID); err != nil {
 				return errors.Wrap(err, "failed to delete group")
 			}
@@ -179,7 +179,7 @@ func newCmdGroupGet() *cobra.Command {
 		Short: "Get a particular group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			group, err := client.GetGroup(flags.groupID)
 			if err != nil {
 				return errors.Wrap(err, "failed to query group")
@@ -221,7 +221,7 @@ func newCmdGroupList() *cobra.Command {
 }
 
 func executeGroupListCmd(flags groupListFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 	groups, err := client.GetGroups(&model.GetGroupsRequest{
@@ -258,7 +258,7 @@ func newCmdGroupGetStatus() *cobra.Command {
 		Short: "Get a particular group's status.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			groupStatus, err := client.GetGroupStatus(flags.groupID)
 			if err != nil {
 				return errors.Wrap(err, "failed to query group status")
@@ -287,7 +287,7 @@ func newCmdGroupJoin() *cobra.Command {
 		Short: "Join an installation to the given group, leaving any existing group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			err := client.JoinGroup(flags.groupID, flags.installationID)
 			if err != nil {
 				return errors.Wrap(err, "failed to join group")
@@ -312,7 +312,7 @@ func newCmdGroupAssign() *cobra.Command {
 		Short: "Assign an installation to the group based on annotations, leaving any existing group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			err := client.AssignGroup(flags.installationID, model.AssignInstallationGroupRequest{GroupSelectionAnnotations: flags.annotations})
 			if err != nil {
 				return errors.Wrap(err, "failed to assign group")
@@ -338,7 +338,7 @@ func newCmdGroupLeave() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			request := &model.LeaveGroupRequest{RetainConfig: flags.retainConfig}
 			if err := client.LeaveGroup(flags.installationID, request); err != nil {
 				return errors.Wrap(err, "failed to leave group")
@@ -364,7 +364,7 @@ func newCmdGroupListStatus() *cobra.Command {
 		Short: "Get Status from all groups.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags)
 			groupStatus, err := client.GetGroupsStatus()
 			if err != nil {
 				return errors.Wrap(err, "failed to query group status")

--- a/cmd/cloud/group_annotation.go
+++ b/cmd/cloud/group_annotation.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +30,7 @@ func newCmdGroupAnnotationAdd() *cobra.Command {
 		Short: "Adds annotations to the group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			request := newAddAnnotationsRequest(flags.annotations)
 			if flags.dryRun {
 				return runDryRun(request)
@@ -66,7 +65,7 @@ func newCmdGroupAnnotationDelete() *cobra.Command {
 		Short: "Deletes Annotation from the group.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.DeleteGroupAnnotation(flags.groupID, flags.annotation); err != nil {
 				return errors.Wrap(err, "failed to delete group annotations")
 			}

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -71,7 +71,7 @@ func newCmdInstallationCreate() *cobra.Command {
 }
 
 func executeInstallationCreateCmd(flags installationCreateFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	envVarMap, err := parseEnvVarInput(flags.mattermostEnv, false)
 	if err != nil {
@@ -144,7 +144,7 @@ func newCmdInstallationUpdate() *cobra.Command {
 		Short: "Update an installation's configuration.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			request, err := flags.GetPatchInstallationRequest()
 			if err != nil {
@@ -181,7 +181,7 @@ func newCmdInstallationDelete() *cobra.Command {
 		Short: "Delete an installation.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			if err := client.DeleteInstallation(flags.installationID); err != nil {
 				return errors.Wrap(err, "failed to delete installation")
@@ -205,7 +205,7 @@ func newCmdInstallationUpdateDeletion() *cobra.Command {
 		Short: "Updates the pending deletion parameters of an installation.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			request := &model.PatchInstallationDeletionRequest{}
 			if flags.installationDeletionPatchRequestOptionsChanged.futureDeletionTimeChanged {
@@ -242,7 +242,7 @@ func newCmdInstallationCancelDeletion() *cobra.Command {
 		Short: "Cancels the pending deletion of an installation.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			if err := client.CancelInstallationDeletion(flags.installationID); err != nil {
 				return errors.Wrap(err, "failed to cancel installation deletion")
@@ -266,7 +266,7 @@ func newCmdInstallationHibernate() *cobra.Command {
 		Short: "Put an installation into hibernation.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			installation, err := client.HibernateInstallation(flags.installationID)
 			if err != nil {
@@ -292,7 +292,7 @@ func newCmdInstallationWakeup() *cobra.Command {
 		Short: "Wake an installation from hibernation.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			request, err := flags.GetPatchInstallationRequest()
 			if err != nil {
@@ -324,7 +324,7 @@ func newCmdInstallationGet() *cobra.Command {
 		Short: "Get a particular installation.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			installation, err := client.GetInstallation(flags.installationID, &model.GetInstallationRequest{
 				IncludeGroupConfig:          flags.includeGroupConfig,
@@ -375,7 +375,7 @@ func newCmdInstallationList() *cobra.Command {
 }
 
 func executeInstallationListCmd(flags installationListFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 
@@ -460,7 +460,7 @@ func newCmdInstallationGetStatuses() *cobra.Command {
 		Short: "Get status information for all installations.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			installationsStatus, err := client.GetInstallationsStatus()
 			if err != nil {
@@ -681,7 +681,7 @@ func newCmdInstallationDeploymentReport() *cobra.Command {
 }
 
 func executeInstallationDeploymentReportCmd(flags installationDeploymentReportFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	installation, err := client.GetInstallation(flags.installationID, &model.GetInstallationRequest{
 		IncludeGroupConfig:          true,
@@ -880,7 +880,7 @@ func newCmdInstallationDeletionReport() *cobra.Command {
 }
 
 func executeInstallationDeletionReportCmd(flags installationDeletionReportFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	installations, err := client.GetInstallations(&model.GetInstallationsRequest{
 		State:  model.InstallationStateDeletionPending,

--- a/cmd/cloud/installation_annotation.go
+++ b/cmd/cloud/installation_annotation.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +30,7 @@ func newCmdInstallationAnnotationAdd() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			request := newAddAnnotationsRequest(flags.annotations)
 
@@ -69,7 +68,7 @@ func newCmdInstallationAnnotationDelete() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			if err := client.DeleteInstallationAnnotation(flags.installationID, flags.annotation); err != nil {
 				return errors.Wrap(err, "failed to delete installation annotations")

--- a/cmd/cloud/installation_dns.go
+++ b/cmd/cloud/installation_dns.go
@@ -32,7 +32,7 @@ func newCmdInstallationDNSAdd() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			request := &model.AddDNSRecordRequest{
 				DNS: flags.dnsName,
@@ -72,7 +72,7 @@ func newCmdInstallationDNSSetPrimary() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			installation, err := client.SetInstallationDomainPrimary(flags.installationID, flags.domainNameID)
 			if err != nil {
@@ -104,7 +104,7 @@ func newCmdInstallationDNSDelete() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			installation, err := client.DeleteInstallationDNS(flags.installationID, flags.domainNameID)
 			if err != nil {

--- a/cmd/cloud/installation_operation_db_migration.go
+++ b/cmd/cloud/installation_operation_db_migration.go
@@ -35,7 +35,7 @@ func newCmdInstallationDBMigrationRequest() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			request := &model.InstallationDBMigrationRequest{
 				InstallationID:         flags.installationID,
@@ -86,7 +86,7 @@ func newCmdInstallationDBMigrationsList() *cobra.Command {
 }
 
 func executeInstallationDBMigrationsList(flags installationDBMigrationsListFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 
@@ -149,7 +149,7 @@ func newCmdInstallationDBMigrationGet() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			migrationOperation, err := client.GetInstallationDBMigrationOperation(flags.dbMigrationID)
 			if err != nil {
@@ -176,7 +176,7 @@ func newCmdInstallationDBMigrationCommit() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			migrationOperation, err := client.CommitInstallationDBMigration(flags.dbMigrationID)
 			if err != nil {
@@ -205,7 +205,7 @@ func newCmdInstallationDBMigrationRollback() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			migrationOperation, err := client.RollbackInstallationDBMigration(flags.dbMigrationID)
 			if err != nil {

--- a/cmd/cloud/installation_operation_restoration.go
+++ b/cmd/cloud/installation_operation_restoration.go
@@ -32,7 +32,7 @@ func newCmdInstallationRestorationRequest() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			installationDTO, err := client.RestoreInstallationDatabase(flags.installationID, flags.backupID)
 			if err != nil {
@@ -73,7 +73,7 @@ func newCmdInstallationRestorationsListCmd() *cobra.Command {
 }
 
 func executeInstallationRestorationsList(flags installationRestorationsListFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 
@@ -140,7 +140,7 @@ func newCmdInstallationRestorationGetCmd() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
 
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			restorationOperation, err := client.GetInstallationDBRestoration(flags.restorationID)
 			if err != nil {
 				return errors.Wrap(err, "failed to get installation database restoration")

--- a/cmd/cloud/nodegroup.go
+++ b/cmd/cloud/nodegroup.go
@@ -45,7 +45,7 @@ func newCmdClusterNodegroupCreate() *cobra.Command {
 }
 
 func addNodegroup(flags clusterNodegroupsCreateFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	if len(flags.nodegroups) == 0 {
 		return fmt.Errorf("nodegroups must be provided")
@@ -110,7 +110,7 @@ func newCmdClusterNodegroupDelete() *cobra.Command {
 }
 
 func deleteNodegroup(flags clusterNodegroupDeleteFlags) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	if len(flags.nodegroup) == 0 {
 		return fmt.Errorf("nodegroup must be provided")

--- a/cmd/cloud/security.go
+++ b/cmd/cloud/security.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -50,7 +49,7 @@ func newCmdSecurityClusterLock() *cobra.Command {
 		Short: "Lock API changes on a given cluster",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.LockAPIForCluster(flags.clusterID); err != nil {
 				return errors.Wrap(err, "failed to lock cluster API")
 			}
@@ -74,7 +73,7 @@ func newCmdSecurityClusterUnlock() *cobra.Command {
 		Short: "Unlock API changes on a given cluster",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.UnlockAPIForCluster(flags.clusterID); err != nil {
 				return errors.Wrap(err, "failed to unlock cluster API")
 			}
@@ -114,7 +113,7 @@ func newCmdSecurityInstallationLock() *cobra.Command {
 		Short: "Lock API changes on a given installation",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.LockAPIForInstallation(flags.installationID); err != nil {
 				return errors.Wrap(err, "failed to lock installation API")
 			}
@@ -138,7 +137,7 @@ func newCmdSecurityInstallationUnlock() *cobra.Command {
 		Short: "Unlock API changes on a given installation",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.UnlockAPIForInstallation(flags.installationID); err != nil {
 				return errors.Wrap(err, "failed to unlock installation API")
 			}
@@ -162,7 +161,7 @@ func newCmdSecurityInstallationDeletionUnlock() *cobra.Command {
 		Short: "Unlock deletion lock on installation, allowing it to be deleted",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.UnlockDeletionLockForInstallation(flags.installationID); err != nil {
 				return errors.Wrap(err, "failed to unlock installation deletion lock")
 			}
@@ -185,7 +184,7 @@ func newCmdSecurityInstallationDeletionLock() *cobra.Command {
 		Short: "Lock deletion lock on installation, preventing it from being deleted until unlocked",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.LockDeletionLockForInstallation(flags.installationID); err != nil {
 				return errors.Wrap(err, "failed to lock installation deletion lock")
 			}
@@ -223,7 +222,7 @@ func newCmdSecurityClusterInstallationLock() *cobra.Command {
 		Short: "Lock API changes on a given cluster installation",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.LockAPIForClusterInstallation(flags.clusterInstallationID); err != nil {
 				return errors.Wrap(err, "failed to lock cluster installation API")
 			}
@@ -247,7 +246,7 @@ func newCmdSecurityClusterInstallationUnlock() *cobra.Command {
 		Short: "Unlock API changes on a given cluster installation",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.UnlockAPIForClusterInstallation(flags.clusterInstallationID); err != nil {
 				return errors.Wrap(err, "failed to unlock cluster installation API")
 			}
@@ -285,7 +284,7 @@ func newCmdSecurityGroupLock() *cobra.Command {
 		Short: "Lock API changes on a given group",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.LockAPIForGroup(flags.groupID); err != nil {
 				return errors.Wrap(err, "failed to lock group API")
 			}
@@ -309,7 +308,7 @@ func newCmdSecurityGroupUnlock() *cobra.Command {
 		Short: "Unlock API changes on a given group",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.UnlockAPIForGroup(flags.groupID); err != nil {
 				return errors.Wrap(err, "failed to unlock group API")
 			}
@@ -347,7 +346,7 @@ func newCmdSecurityBackupLock() *cobra.Command {
 		Short: "Lock API changes on a given backup",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.LockAPIForBackup(flags.backupID); err != nil {
 				return errors.Wrap(err, "failed to lock backup API")
 			}
@@ -371,7 +370,7 @@ func newCmdSecurityBackupUnlock() *cobra.Command {
 		Short: "Unlock API changes on a given backup",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.UnlockAPIForBackup(flags.backupID); err != nil {
 				return errors.Wrap(err, "failed to unlock backup API")
 			}

--- a/cmd/cloud/security_flag.go
+++ b/cmd/cloud/security_flag.go
@@ -7,6 +7,7 @@ func setSecurityFlags(command *cobra.Command) {
 }
 
 type securityFlags struct {
+	clusterFlags
 	serverAddress string
 }
 

--- a/cmd/cloud/utils.go
+++ b/cmd/cloud/utils.go
@@ -60,11 +60,11 @@ func runDryRun(request interface{}) error {
 
 func createClient(flags clusterFlags) *model.Client {
 	if len(flags.headers) > 0 {
-		authHeaders := make(map[string]string, len(flags.headers))
+		headers := make(map[string]string, len(flags.headers))
 		for key, value := range flags.headers {
-			authHeaders[key] = value
+			headers[key] = value
 		}
-		return model.NewClientWithHeaders(flags.serverAddress, authHeaders)
+		return model.NewClientWithHeaders(flags.serverAddress, headers)
 	}
 
 	return model.NewClient(flags.serverAddress)

--- a/cmd/cloud/utils.go
+++ b/cmd/cloud/utils.go
@@ -59,8 +59,11 @@ func runDryRun(request interface{}) error {
 }
 
 func createClient(flags clusterFlags) *model.Client {
-	if flags.token != "" {
-		authHeaders := map[string]string{"x-api-key": flags.token}
+	if len(flags.headers) > 0 {
+		authHeaders := make(map[string]string, len(flags.headers))
+		for key, value := range flags.headers {
+			authHeaders[key] = value
+		}
 		return model.NewClientWithHeaders(flags.serverAddress, authHeaders)
 	}
 

--- a/cmd/cloud/utils.go
+++ b/cmd/cloud/utils.go
@@ -57,3 +57,12 @@ func runDryRun(request interface{}) error {
 	}
 	return nil
 }
+
+func createClient(flags clusterFlags) *model.Client {
+	if flags.token != "" {
+		authHeaders := map[string]string{"x-api-key": flags.token}
+		return model.NewClientWithHeaders(flags.serverAddress, authHeaders)
+	}
+
+	return model.NewClient(flags.serverAddress)
+}

--- a/cmd/cloud/webhook.go
+++ b/cmd/cloud/webhook.go
@@ -38,7 +38,7 @@ func newCmdWebhookCreate() *cobra.Command {
 		Short: "Create a webhook.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			var headers model.Headers
 			for key, value := range flags.headers {
@@ -90,7 +90,7 @@ func newCmdWebhookGet() *cobra.Command {
 		Short: "Get a particular webhook.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 
 			webhook, err := client.GetWebhook(flags.webhookID)
 			if err != nil {
@@ -133,7 +133,7 @@ func newCmdWebhookList() *cobra.Command {
 }
 
 func executeWebhookListCmd(flags webhookListFlag) error {
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 
 	paging := getPaging(flags.pagingFlags)
 	webhooks, err := client.GetWebhooks(&model.GetWebhooksRequest{
@@ -168,7 +168,7 @@ func newCmdWebhookDelete() *cobra.Command {
 		Short: "Delete a webhook.",
 		RunE: func(command *cobra.Command, args []string) error {
 			command.SilenceUsage = true
-			client := model.NewClient(flags.serverAddress)
+			client := createClient(flags.clusterFlags)
 			if err := client.DeleteWebhook(flags.webhookID); err != nil {
 				return errors.Wrap(err, "failed to delete webhook")
 			}

--- a/cmd/cloud/webhook_flag.go
+++ b/cmd/cloud/webhook_flag.go
@@ -13,6 +13,7 @@ func setWebhookFlags(command *cobra.Command) {
 }
 
 type webhookFlags struct {
+	clusterFlags
 	serverAddress string
 }
 

--- a/cmd/cloud/workbench.go
+++ b/cmd/cloud/workbench.go
@@ -10,7 +10,6 @@ import (
 	awsTools "github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/internal/tools/kops"
 	"github.com/mattermost/mattermost-cloud/internal/tools/terraform"
-	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -51,7 +50,7 @@ func newCmdWorkbenchCluster() *cobra.Command {
 func executeWorkbenchClusterCmd(flags workbenchClusterFlag) error {
 	// TODO: add support for EKS
 
-	client := model.NewClient(flags.serverAddress)
+	client := createClient(flags.clusterFlags)
 	cluster, err := client.GetCluster(flags.clusterID)
 	if err != nil {
 		return errors.Wrap(err, "failed to query cluster")

--- a/cmd/cloud/workbench_flag.go
+++ b/cmd/cloud/workbench_flag.go
@@ -8,6 +8,7 @@ func setWorkbenchFlags(command *cobra.Command) {
 }
 
 type workbenchFlags struct {
+	clusterFlags
 	serverAddress string
 	s3StateStore  string
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Introduce `--header` cli input to optionally provide the auth token
- Introduce new `createClient` function to create the respective client if token is provided
- Rerouted all client initializations through the new function 
- Added clusterFlags in all base flag types 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-7291

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Introduce --header variable in order to add extra headers for provisioner server api calls
```
