### PR TITLE
Fix serverAddress flag duplication

### DIFF
--- a/cmd/cloud/dashboard_flag.go
+++ b/cmd/cloud/dashboard_flag.go
@@ -4,7 +4,6 @@ import "github.com/spf13/cobra"
 
 type dashboardFlags struct {
 	clusterFlags
-	serverAddress  string
 	refreshSeconds int
 }
 

--- a/cmd/cloud/security_flag.go
+++ b/cmd/cloud/security_flag.go
@@ -8,7 +8,6 @@ func setSecurityFlags(command *cobra.Command) {
 
 type securityFlags struct {
 	clusterFlags
-	serverAddress string
 }
 
 func (flags *securityFlags) addFlags(command *cobra.Command) {

--- a/cmd/cloud/webhook_flag.go
+++ b/cmd/cloud/webhook_flag.go
@@ -14,7 +14,6 @@ func setWebhookFlags(command *cobra.Command) {
 
 type webhookFlags struct {
 	clusterFlags
-	serverAddress string
 }
 
 func (flags *webhookFlags) addFlags(command *cobra.Command) {

--- a/cmd/cloud/workbench_flag.go
+++ b/cmd/cloud/workbench_flag.go
@@ -9,8 +9,7 @@ func setWorkbenchFlags(command *cobra.Command) {
 
 type workbenchFlags struct {
 	clusterFlags
-	serverAddress string
-	s3StateStore  string
+	s3StateStore string
 }
 
 func (flags *workbenchFlags) addFlags(command *cobra.Command) {


### PR DESCRIPTION
This fixes a regression where the serverAddress flag was set twice for certain CLI subcommands and wasn't parsed correctly. The issue was introduced in https://github.com/mattermost/mattermost-cloud/pull/1029

Fixes https://mattermost.atlassian.net/browse/CLD-7382

```release-note
Fix serverAddress flag duplication
```
