### PR TITLE
Add per-cluster PgBouncerConfig

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -86,6 +86,7 @@ func newCmdClusterCreate() *cobra.Command {
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			flags.clusterFlags.addFlags(cmd)
+			flags.pgBouncerConfigChanges.addFlags(cmd)
 		},
 	}
 	flags.addFlags(cmd)
@@ -116,6 +117,7 @@ func executeClusterCreateCmd(flags clusterCreateFlags) error {
 		VPC:                    flags.vpc,
 		Provisioner:            model.ProvisionerKops,
 		ArgocdClusterRegister:  flags.argocdRegister,
+		PgBouncerConfig:        flags.GetPgBouncerConfig(),
 	}
 
 	if flags.useEKS {
@@ -212,6 +214,7 @@ func newCmdClusterProvision() *cobra.Command {
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			flags.clusterFlags.addFlags(cmd)
+			flags.pgBouncerConfigChanges.addFlags(cmd)
 		},
 	}
 	flags.addFlags(cmd)
@@ -226,6 +229,7 @@ func executeClusterProvisionCmd(flags clusterProvisionFlags) error {
 		Force:                  flags.reprovisionAllUtilities,
 		DesiredUtilityVersions: processUtilityFlags(flags.utilityFlags),
 		ArgocdClusterRegister:  flags.argocdRegister,
+		PgBouncerConfig:        flags.GetPatchPgBouncerConfig(),
 	}
 
 	if flags.dryRun {

--- a/cmd/cloud/cluster_flag.go
+++ b/cmd/cloud/cluster_flag.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/spf13/cobra"
 )
 
@@ -140,6 +141,7 @@ type clusterCreateFlags struct {
 	createRequestOptions
 	utilityFlags
 	sizeOptions
+	pgBouncerConfigOptions
 	cluster string
 }
 
@@ -147,6 +149,7 @@ func (flags *clusterCreateFlags) addFlags(command *cobra.Command) {
 	flags.createRequestOptions.addFlags(command)
 	flags.utilityFlags.addFlags(command)
 	flags.sizeOptions.addFlags(command)
+	flags.pgBouncerConfigOptions.addFlags(command)
 
 	command.Flags().StringVar(&flags.cluster, "cluster", "", "The id of the cluster. If provided and the cluster exists the creation will be retried ignoring other parameters.")
 }
@@ -154,17 +157,108 @@ func (flags *clusterCreateFlags) addFlags(command *cobra.Command) {
 type clusterProvisionFlags struct {
 	clusterFlags
 	utilityFlags
+	pgBouncerConfigOptions
 	cluster                 string
 	reprovisionAllUtilities bool
 }
 
 func (flags *clusterProvisionFlags) addFlags(command *cobra.Command) {
 	flags.utilityFlags.addFlags(command)
+	flags.pgBouncerConfigOptions.addFlags(command)
 
 	command.Flags().StringVar(&flags.cluster, "cluster", "", "The id of the cluster to be provisioned.")
 	command.Flags().BoolVar(&flags.reprovisionAllUtilities, "reprovision-all-utilities", false, "Set to true if all utilities should be reprovisioned and not just ones with new versions")
 
 	_ = command.MarkFlagRequired("cluster")
+}
+
+type pgBouncerConfigChanges struct {
+	minPoolSizeChanged                   bool
+	defaultPoolSizeChanged               bool
+	reservePoolSizeChanged               bool
+	maxClientConnectionsChanged          bool
+	maxDatabaseConnectionsPerPoolChanged bool
+	serverIdleTimeoutChanged             bool
+	serverLifetimeChanged                bool
+	serverResetQueryAlwaysChanged        bool
+}
+
+func (flags *pgBouncerConfigChanges) addFlags(command *cobra.Command) {
+	flags.minPoolSizeChanged = command.Flags().Changed("pgbouncer-min-proxy-db-pool-size")
+	flags.defaultPoolSizeChanged = command.Flags().Changed("pgbouncer-default-proxy-db-pool-size")
+	flags.reservePoolSizeChanged = command.Flags().Changed("pgbouncer-reserve-proxy-db-pool-size")
+	flags.maxClientConnectionsChanged = command.Flags().Changed("pgbouncer-max-client-connections")
+	flags.maxDatabaseConnectionsPerPoolChanged = command.Flags().Changed("pgbouncer-max-proxy-db-connections-per-pool")
+	flags.serverIdleTimeoutChanged = command.Flags().Changed("pgbouncer-server-idle-timeout")
+	flags.serverLifetimeChanged = command.Flags().Changed("pgbouncer-server-lifetime")
+	flags.serverResetQueryAlwaysChanged = command.Flags().Changed("pgbouncer-server-reset-query-always")
+}
+
+func (flags *pgBouncerConfigOptions) addFlags(command *cobra.Command) {
+	command.Flags().Int64Var(&flags.minPoolSize, "pgbouncer-min-proxy-db-pool-size", model.PgBouncerDefaultMinPoolSize, "The db proxy min pool size.")
+	command.Flags().Int64Var(&flags.defaultPoolSize, "pgbouncer-default-proxy-db-pool-size", model.PgBouncerDefaultPoolSize, "The db proxy default pool size per user.")
+	command.Flags().Int64Var(&flags.reservePoolSize, "pgbouncer-reserve-proxy-db-pool-size", model.PgBouncerDefaultReservePoolSize, "The db proxy reserve pool size per logical database.")
+	command.Flags().Int64Var(&flags.maxClientConnections, "pgbouncer-max-client-connections", model.PgBouncerDefaultMaxClientConnections, "The db proxy max client connections.")
+	command.Flags().Int64Var(&flags.maxDatabaseConnectionsPerPool, "pgbouncer-max-proxy-db-connections-per-pool", model.PgBouncerDefaultMaxDatabaseConnectionsPerPool, "The maximum number of proxy database connections per pool (logical database).")
+	command.Flags().Int64Var(&flags.serverIdleTimeout, "pgbouncer-server-idle-timeout", model.PgBouncerDefaultServerIdleTimeout, "The server idle timeout.")
+	command.Flags().Int64Var(&flags.serverLifetime, "pgbouncer-server-lifetime", model.PgBouncerDefaultServerLifetime, "The server lifetime.")
+	command.Flags().Int64Var(&flags.serverResetQueryAlways, "pgbouncer-server-reset-query-always", model.PgBouncerDefaultServerResetQueryAlways, "Whether server_reset_query should be run in all pooling modes.")
+}
+
+type pgBouncerConfigOptions struct {
+	pgBouncerConfigChanges
+	minPoolSize                   int64
+	defaultPoolSize               int64
+	reservePoolSize               int64
+	maxClientConnections          int64
+	maxDatabaseConnectionsPerPool int64
+	serverIdleTimeout             int64
+	serverLifetime                int64
+	serverResetQueryAlways        int64
+}
+
+func (flags *pgBouncerConfigOptions) GetPgBouncerConfig() *model.PgBouncerConfig {
+	return &model.PgBouncerConfig{
+		MinPoolSize:                   flags.minPoolSize,
+		DefaultPoolSize:               flags.defaultPoolSize,
+		ReservePoolSize:               flags.reservePoolSize,
+		MaxClientConnections:          flags.maxClientConnections,
+		MaxDatabaseConnectionsPerPool: 20,
+		ServerIdleTimeout:             30,
+		ServerLifetime:                300,
+		ServerResetQueryAlways:        0,
+	}
+}
+
+func (flags *pgBouncerConfigOptions) GetPatchPgBouncerConfig() *model.PatchPgBouncerConfig {
+	request := model.PatchPgBouncerConfig{}
+
+	if flags.minPoolSizeChanged {
+		request.MinPoolSize = &flags.minPoolSize
+	}
+	if flags.defaultPoolSizeChanged {
+		request.DefaultPoolSize = &flags.defaultPoolSize
+	}
+	if flags.reservePoolSizeChanged {
+		request.ReservePoolSize = &flags.reservePoolSize
+	}
+	if flags.maxClientConnectionsChanged {
+		request.MaxClientConnections = &flags.maxClientConnections
+	}
+	if flags.maxDatabaseConnectionsPerPoolChanged {
+		request.MaxDatabaseConnectionsPerPool = &flags.maxDatabaseConnectionsPerPool
+	}
+	if flags.serverIdleTimeoutChanged {
+		request.ServerIdleTimeout = &flags.serverIdleTimeout
+	}
+	if flags.serverLifetimeChanged {
+		request.ServerLifetime = &flags.serverLifetime
+	}
+	if flags.serverResetQueryAlwaysChanged {
+		request.ServerResetQueryAlways = &flags.serverResetQueryAlways
+	}
+
+	return &request
 }
 
 type clusterUpdateFlags struct {

--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -25,7 +25,6 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/events"
 	"github.com/mattermost/mattermost-cloud/internal/metrics"
 	"github.com/mattermost/mattermost-cloud/internal/provisioner"
-	"github.com/mattermost/mattermost-cloud/internal/provisioner/pgbouncer"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/supervisor"
 	awsTools "github.com/mattermost/mattermost-cloud/internal/tools/aws"
@@ -84,16 +83,6 @@ func executeServerCmd(flags serverFlags) error {
 
 	if err := model.SetDefaultProxyDatabaseMaxInstallationsPerLogicalDatabase(flags.maxSchemas); err != nil {
 		return err
-	}
-
-	pgbouncerConfig := pgbouncer.NewPGBouncerConfig(
-		flags.minPoolSize, flags.defaultPoolSize, flags.reservePoolSize,
-		flags.maxClientConnections, flags.maxDatabaseConnectionsPerPool,
-		flags.serverIdleTimeout, flags.serverLifetime, flags.serverResetQueryAlways,
-	)
-
-	if err := pgbouncerConfig.Validate(); err != nil {
-		return errors.Wrap(err, "pgbouncer config failed validation")
 	}
 
 	gitlabOAuthToken := flags.gitlabOAuthToken
@@ -300,7 +289,6 @@ func executeServerCmd(flags serverFlags) error {
 		MattermostOperatorHelmDir: flags.mattermostOperatorHelmDir,
 		NdotsValue:                flags.ndotsDefaultValue,
 		InternalIPRanges:          flags.internalIPRanges,
-		PGBouncerConfig:           pgbouncerConfig,
 		SLOInstallationGroups:     flags.sloInstallationGroups,
 		SLOEnterpriseGroups:       flags.sloEnterpriseGroups,
 		EtcdManagerEnv:            etcdManagerEnv,
@@ -594,6 +582,10 @@ func deprecationWarnings(logger logrus.FieldLogger, flags serverFlags) {
 	if flags.debugHelm {
 		logger.Warn("The debug-helm flag has been deprecated")
 	}
+
+	// Generic warning for old flags.
+	// TODO: Remove after deployments are updated.
+	logger.Warn("All pgbouncer config.ini flags have been deprecated. Review server flags to ensure you are not setting any as they will be removed later.")
 }
 
 // getHumanReadableID  represents  a  best  effort  attempt  to  retrieve  an

--- a/cmd/cloud/server_flag.go
+++ b/cmd/cloud/server_flag.go
@@ -107,25 +107,33 @@ func (flags *provisioningParams) addFlags(command *cobra.Command) {
 }
 
 type pgBouncerConfig struct {
-	minPoolSize                   int
-	defaultPoolSize               int
-	reservePoolSize               int
-	maxClientConnections          int
-	maxDatabaseConnectionsPerPool int
-	serverIdleTimeout             int
-	serverLifetime                int
-	serverResetQueryAlways        int
+	minPoolSize                   int64
+	defaultPoolSize               int64
+	reservePoolSize               int64
+	maxClientConnections          int64
+	maxDatabaseConnectionsPerPool int64
+	serverIdleTimeout             int64
+	serverLifetime                int64
+	serverResetQueryAlways        int64
 }
 
 func (flags *pgBouncerConfig) addFlags(command *cobra.Command) {
-	command.Flags().IntVar(&flags.minPoolSize, "min-proxy-db-pool-size", 1, "The db proxy min pool size.")
-	command.Flags().IntVar(&flags.defaultPoolSize, "default-proxy-db-pool-size", 5, "The db proxy default pool size per user.")
-	command.Flags().IntVar(&flags.reservePoolSize, "reserve-proxy-db-pool-size", 10, "The db proxy reserve pool size per logical database.")
-	command.Flags().IntVar(&flags.maxClientConnections, "max-client-connections", 20000, "The db proxy max client connections.")
-	command.Flags().IntVar(&flags.maxDatabaseConnectionsPerPool, "max-proxy-db-connections-per-pool", 20, "The maximum number of proxy database connections per pool (logical database).")
-	command.Flags().IntVar(&flags.serverIdleTimeout, "server-idle-timeout", 30, "The server idle timeout.")
-	command.Flags().IntVar(&flags.serverLifetime, "server-lifetime", 300, "The server lifetime.")
-	command.Flags().IntVar(&flags.serverResetQueryAlways, "server-reset-query-always", 0, "Whether server_reset_query should be run in all pooling modes.")
+	command.Flags().Int64Var(&flags.minPoolSize, "min-proxy-db-pool-size", 1, "Deprecated")
+	command.Flags().MarkDeprecated("min-proxy-db-pool-size", "PgBouncer config is now set on clusters")
+	command.Flags().Int64Var(&flags.defaultPoolSize, "default-proxy-db-pool-size", 5, "Deprecated")
+	command.Flags().MarkDeprecated("default-proxy-db-pool-size", "PgBouncer config is now set on clusters")
+	command.Flags().Int64Var(&flags.reservePoolSize, "reserve-proxy-db-pool-size", 10, "Deprecated")
+	command.Flags().MarkDeprecated("reserve-proxy-db-pool-size", "PgBouncer config is now set on clusters")
+	command.Flags().Int64Var(&flags.maxClientConnections, "max-client-connections", 20000, "Deprecated")
+	command.Flags().MarkDeprecated("max-client-connections", "PgBouncer config is now set on clusters")
+	command.Flags().Int64Var(&flags.maxDatabaseConnectionsPerPool, "max-proxy-db-connections-per-pool", 20, "Deprecated")
+	command.Flags().MarkDeprecated("max-proxy-db-connections-per-pool", "PgBouncer config is now set on clusters")
+	command.Flags().Int64Var(&flags.serverIdleTimeout, "server-idle-timeout", 30, "Deprecated")
+	command.Flags().MarkDeprecated("server-idle-timeout", "PgBouncer config is now set on clusters")
+	command.Flags().Int64Var(&flags.serverLifetime, "server-lifetime", 300, "Deprecated")
+	command.Flags().MarkDeprecated("server-lifetime", "PgBouncer config is now set on clusters")
+	command.Flags().Int64Var(&flags.serverResetQueryAlways, "server-reset-query-always", 0, "Deprecated")
+	command.Flags().MarkDeprecated("server-reset-query-always", "PgBouncer config is now set on clusters")
 }
 
 type installationOptions struct {

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -42,6 +42,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"velero":                {Chart: "5.1.5", ValuesPath: ""},
 				"cloudprober":           {Chart: "0.1.4", ValuesPath: ""},
 			},
+			PgBouncerConfig: model.NewDefaultPgBouncerConfig(),
 		}
 	}
 
@@ -112,6 +113,7 @@ func TestNewCreateClusterRequestFromReader(t *testing.T) {
 				"velero":                {Chart: "5.1.5", ValuesPath: ""},
 				"cloudprober":           {Chart: "0.1.4", ValuesPath: ""},
 			},
+			PgBouncerConfig: model.NewDefaultPgBouncerConfig(),
 		}, clusterRequest)
 	})
 }

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -173,7 +173,7 @@ func (provisioner Provisioner) PrepareClusterUtilities(cluster *model.Cluster, i
 		return errors.Wrap(err, "failed to get kube config path")
 	}
 
-	return prepareClusterUtilities(cluster, configLocation, store, provisioner.awsClient, provisioner.params.PGBouncerConfig, logger)
+	return prepareClusterUtilities(cluster, configLocation, store, provisioner.awsClient, logger)
 }
 
 func (provisioner Provisioner) createClusterInstallation(clusterInstallation *model.ClusterInstallation, installation *model.Installation, installationDNS []*model.InstallationDNS, kubeconfigPath string, logger log.FieldLogger) error {
@@ -707,7 +707,6 @@ func prepareClusterUtilities(
 	configLocation string,
 	store model.ClusterUtilityDatabaseStoreInterface,
 	awsClient aws.AWS,
-	pgbouncerConfig *model.PGBouncerConfig,
 	logger log.FieldLogger) error {
 	k8sClient, err := k8s.NewFromFile(configLocation, logger)
 	if err != nil {
@@ -728,7 +727,7 @@ func prepareClusterUtilities(
 	// isn't really feasible right now.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10)*time.Second)
 	defer cancel()
-	err = pgbouncer.UpdatePGBouncerConfigMap(ctx, vpc, store, pgbouncerConfig, k8sClient, logger)
+	err = pgbouncer.UpdatePGBouncerConfigMap(ctx, vpc, store, cluster.PgBouncerConfig, k8sClient, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to update configmap for pgbouncer-configmap")
 	}

--- a/internal/provisioner/cluster_provisioning.go
+++ b/internal/provisioner/cluster_provisioning.go
@@ -405,7 +405,7 @@ func provisionCluster(
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Duration(10)*time.Second)
 	defer cancel()
-	err = pgbouncer.UpdatePGBouncerConfigMap(ctx, vpc, store, params.PGBouncerConfig, k8sClient, logger)
+	err = pgbouncer.UpdatePGBouncerConfigMap(ctx, vpc, store, cluster.PgBouncerConfig, k8sClient, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to update configmap for pgbouncer-configmap")
 	}

--- a/internal/provisioner/pgbouncer/pgbouncer.go
+++ b/internal/provisioner/pgbouncer/pgbouncer.go
@@ -45,7 +45,7 @@ server_reset_query_always = %d
 [databases]
 `
 
-func generatePGBouncerIni(vpcID string, store model.ClusterUtilityDatabaseStoreInterface, config *model.PGBouncerConfig) (string, error) {
+func generatePGBouncerIni(vpcID string, store model.ClusterUtilityDatabaseStoreInterface, config *model.PgBouncerConfig) (string, error) {
 	ini := generatePGBouncerBaseIni(config)
 
 	multitenantDatabases, err := store.GetMultitenantDatabases(&model.MultitenantDatabaseFilter{
@@ -106,7 +106,7 @@ func GeneratePGBouncerUserlist(vpcID string, awsClient aws.AWS) (string, error) 
 	return userlist, nil
 }
 
-func generatePGBouncerBaseIni(c *model.PGBouncerConfig) string {
+func generatePGBouncerBaseIni(c *model.PgBouncerConfig) string {
 	return fmt.Sprintf(
 		baseIni,
 		c.MinPoolSize, c.DefaultPoolSize, c.ReservePoolSize,
@@ -115,21 +115,7 @@ func generatePGBouncerBaseIni(c *model.PGBouncerConfig) string {
 	)
 }
 
-// NewPGBouncerConfig returns a new PGBouncerConfig with the provided configuration.
-func NewPGBouncerConfig(minPoolSize, defaultPoolSize, reservePoolSize, maxClientConnections, maxDatabaseConnectionsPerPool, serverIdleTimeout, serverLifetime, serverResetQueryAlways int) *model.PGBouncerConfig {
-	return &model.PGBouncerConfig{
-		MinPoolSize:                   minPoolSize,
-		DefaultPoolSize:               defaultPoolSize,
-		ReservePoolSize:               reservePoolSize,
-		MaxClientConnections:          maxClientConnections,
-		MaxDatabaseConnectionsPerPool: maxDatabaseConnectionsPerPool,
-		ServerIdleTimeout:             serverIdleTimeout,
-		ServerLifetime:                serverLifetime,
-		ServerResetQueryAlways:        serverResetQueryAlways,
-	}
-}
-
-func UpdatePGBouncerConfigMap(ctx context.Context, vpc string, store model.ClusterUtilityDatabaseStoreInterface, pgbouncerConfig *model.PGBouncerConfig, k8sClient *k8s.KubeClient, logger log.FieldLogger) error {
+func UpdatePGBouncerConfigMap(ctx context.Context, vpc string, store model.ClusterUtilityDatabaseStoreInterface, pgbouncerConfig *model.PgBouncerConfig, k8sClient *k8s.KubeClient, logger log.FieldLogger) error {
 	ini, err := generatePGBouncerIni(vpc, store, pgbouncerConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate updated pgbouncer ini contents")

--- a/internal/provisioner/pgbouncer/pgbouncer_test.go
+++ b/internal/provisioner/pgbouncer/pgbouncer_test.go
@@ -13,47 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidatePGBouncerConfig(t *testing.T) {
-	var testCases = []struct {
-		description string
-		config      *model.PGBouncerConfig
-		valid       bool
-	}{
-		{
-			"valid",
-			NewPGBouncerConfig(5, 10, 5, 2000, 20, 10, 20, 0),
-			true,
-		},
-		{
-			"MaxDatabaseConnectionsPerPool is too low",
-			NewPGBouncerConfig(5, 10, 5, 2000, 0, 10, 20, 0),
-			false,
-		},
-		{
-			"DefaultPoolSize is too low",
-			NewPGBouncerConfig(5, 0, 5, 2000, 20, 10, 20, 0),
-			false,
-		},
-		{
-			"ServerResetQueryAlways is invalid",
-			NewPGBouncerConfig(5, 10, 5, 2000, 20, 10, 20, 2),
-			false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			if tc.valid {
-				assert.NoError(t, tc.config.Validate())
-			} else {
-				assert.Error(t, tc.config.Validate())
-			}
-		})
-	}
-}
-
 func TestGeneratePGBouncerBaseIni(t *testing.T) {
-	config := NewPGBouncerConfig(5, 10, 54, 2000, 63, 11, 44, 0)
+	config := model.NewPgBouncerConfig(5, 10, 54, 2000, 63, 11, 44, 0)
 	require.NoError(t, config.Validate())
 
 	ini := generatePGBouncerBaseIni(config)

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -39,7 +39,6 @@ type ProvisioningParams struct {
 	MattermostOperatorHelmDir string
 	NdotsValue                string
 	InternalIPRanges          []string
-	PGBouncerConfig           *model.PGBouncerConfig
 	SLOInstallationGroups     []string
 	SLOEnterpriseGroups       []string
 	EtcdManagerEnv            map[string]string

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -19,7 +19,7 @@ var clusterSelect sq.SelectBuilder
 func init() {
 	clusterSelect = sq.
 		Select("Cluster.ID", "Provider", "Provisioner", "ProviderMetadataRaw", "ProvisionerMetadataRaw",
-			"UtilityMetadataRaw", "State", "AllowInstallations", "CreateAt", "DeleteAt",
+			"UtilityMetadataRaw", "PgBouncerConfig", "State", "AllowInstallations", "CreateAt", "DeleteAt",
 			"APISecurityLock", "LockAcquiredBy", "LockAcquiredAt").
 		From("Cluster")
 }
@@ -232,6 +232,7 @@ func (sqlStore *SQLStore) createCluster(execer execer, cluster *model.Cluster) e
 			"Provisioner":            cluster.Provisioner,
 			"ProvisionerMetadataRaw": rawMetadata.ProvisionerMetadataRaw,
 			"UtilityMetadataRaw":     rawMetadata.UtilityMetadataRaw,
+			"PgBouncerConfig":        cluster.PgBouncerConfig,
 			"AllowInstallations":     cluster.AllowInstallations,
 			"CreateAt":               cluster.CreateAt,
 			"DeleteAt":               0,
@@ -262,6 +263,7 @@ func (sqlStore *SQLStore) UpdateCluster(cluster *model.Cluster) error {
 			"Provisioner":            cluster.Provisioner,
 			"ProvisionerMetadataRaw": rawMetadata.ProvisionerMetadataRaw,
 			"UtilityMetadataRaw":     rawMetadata.UtilityMetadataRaw,
+			"PgBouncerConfig":        cluster.PgBouncerConfig,
 			"AllowInstallations":     cluster.AllowInstallations,
 		}).
 		Where("ID = ?", cluster.ID),

--- a/internal/store/cluster_dto_test.go
+++ b/internal/store/cluster_dto_test.go
@@ -39,6 +39,7 @@ func TestClusterDTOs(t *testing.T) {
 		ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
 		ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
 		UtilityMetadata:         &model.UtilityMetadata{},
+		PgBouncerConfig:         &model.PgBouncerConfig{},
 		State:                   model.ClusterStateCreationRequested,
 		AllowInstallations:      false,
 	}
@@ -49,6 +50,7 @@ func TestClusterDTOs(t *testing.T) {
 		ProviderMetadataAWS:    &model.AWSMetadata{Zones: []string{"zone1"}},
 		ProvisionerMetadataEKS: &model.EKSMetadata{Version: "version1"},
 		UtilityMetadata:        &model.UtilityMetadata{},
+		PgBouncerConfig:        &model.PgBouncerConfig{},
 		State:                  model.ClusterStateStable,
 		AllowInstallations:     true,
 	}

--- a/internal/store/cluster_test.go
+++ b/internal/store/cluster_test.go
@@ -35,6 +35,7 @@ func TestClusters(t *testing.T) {
 			ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
 			ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
 			UtilityMetadata:         &model.UtilityMetadata{},
+			PgBouncerConfig:         &model.PgBouncerConfig{},
 			State:                   model.ClusterStateCreationRequested,
 			AllowInstallations:      false,
 		}
@@ -45,6 +46,7 @@ func TestClusters(t *testing.T) {
 			ProviderMetadataAWS:    &model.AWSMetadata{Zones: []string{"zone1"}},
 			ProvisionerMetadataEKS: &model.EKSMetadata{Version: "version1"},
 			UtilityMetadata:        &model.UtilityMetadata{},
+			PgBouncerConfig:        &model.PgBouncerConfig{MinPoolSize: 1},
 			State:                  model.ClusterStateStable,
 			AllowInstallations:     true,
 		}
@@ -103,6 +105,7 @@ func TestClusters(t *testing.T) {
 			ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
 			ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
 			UtilityMetadata:         &model.UtilityMetadata{},
+			PgBouncerConfig:         &model.PgBouncerConfig{MinPoolSize: 1},
 			State:                   model.ClusterStateCreationRequested,
 			AllowInstallations:      false,
 		}
@@ -113,6 +116,7 @@ func TestClusters(t *testing.T) {
 			ProviderMetadataAWS:    &model.AWSMetadata{Zones: []string{"zone1"}},
 			ProvisionerMetadataEKS: &model.EKSMetadata{Version: "version1"},
 			UtilityMetadata:        &model.UtilityMetadata{},
+			PgBouncerConfig:        &model.PgBouncerConfig{MinPoolSize: 1},
 			State:                  model.ClusterStateStable,
 			AllowInstallations:     true,
 		}
@@ -154,6 +158,7 @@ func TestClusters(t *testing.T) {
 			ProviderMetadataAWS:     &model.AWSMetadata{Zones: []string{"zone1"}},
 			ProvisionerMetadataKops: &model.KopsMetadata{Version: "version1"},
 			UtilityMetadata:         &model.UtilityMetadata{},
+			PgBouncerConfig:         &model.PgBouncerConfig{},
 			AllowInstallations:      false,
 		}
 
@@ -163,6 +168,7 @@ func TestClusters(t *testing.T) {
 			ProviderMetadataAWS:    &model.AWSMetadata{Zones: []string{"zone1"}},
 			ProvisionerMetadataEKS: &model.EKSMetadata{Version: "version1"},
 			UtilityMetadata:        &model.UtilityMetadata{},
+			PgBouncerConfig:        &model.PgBouncerConfig{},
 			AllowInstallations:     true,
 		}
 
@@ -225,8 +231,9 @@ func TestGetUnlockedClustersPendingWork(t *testing.T) {
 	sqlStore := MakeTestSQLStore(t, logger)
 
 	creationRequestedCluster := &model.Cluster{
-		Provisioner: model.ProvisionerKops,
-		State:       model.ClusterStateCreationRequested,
+		Provisioner:     model.ProvisionerKops,
+		State:           model.ClusterStateCreationRequested,
+		PgBouncerConfig: model.NewDefaultPgBouncerConfig(),
 	}
 	err := sqlStore.CreateCluster(creationRequestedCluster, nil)
 	require.NoError(t, err)
@@ -234,8 +241,9 @@ func TestGetUnlockedClustersPendingWork(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 
 	upgradeRequestedCluster := &model.Cluster{
-		Provisioner: model.ProvisionerKops,
-		State:       model.ClusterStateUpgradeRequested,
+		Provisioner:     model.ProvisionerKops,
+		State:           model.ClusterStateUpgradeRequested,
+		PgBouncerConfig: model.NewDefaultPgBouncerConfig(),
 	}
 	err = sqlStore.CreateCluster(upgradeRequestedCluster, nil)
 	require.NoError(t, err)
@@ -243,8 +251,9 @@ func TestGetUnlockedClustersPendingWork(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 
 	deletionRequestedCluster := &model.Cluster{
-		Provisioner: model.ProvisionerKops,
-		State:       model.ClusterStateDeletionRequested,
+		Provisioner:     model.ProvisionerKops,
+		State:           model.ClusterStateDeletionRequested,
+		PgBouncerConfig: model.NewDefaultPgBouncerConfig(),
 	}
 	err = sqlStore.CreateCluster(deletionRequestedCluster, nil)
 	require.NoError(t, err)
@@ -445,7 +454,8 @@ func TestClustersAnnotationsFilter(t *testing.T) {
 	clusters := make([]*model.Cluster, len(clustersAnnotations))
 	for i := range clusters {
 		clusters[i] = &model.Cluster{
-			Provisioner: model.ProvisionerKops,
+			Provisioner:     model.ProvisionerKops,
+			PgBouncerConfig: model.NewDefaultPgBouncerConfig(),
 		}
 		err := sqlStore.CreateCluster(clusters[i], clustersAnnotations[i])
 		require.NoError(t, err)

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -2191,4 +2191,29 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.46.0"), semver.MustParse("0.47.0"), func(e execer) error {
+		_, err := e.Exec(`ALTER TABLE Cluster ADD COLUMN PgBouncerConfig JSON`)
+		if err != nil {
+			return err
+		}
+
+		// Set some default config for all clusters.
+		defaultPgBouncerConfig := model.NewDefaultPgBouncerConfig()
+		value, err := defaultPgBouncerConfig.Value()
+		if err != nil {
+			return err
+		}
+		_, err = e.Exec(`UPDATE Cluster SET PgBouncerConfig = $1;`, value)
+		if err != nil {
+			return err
+		}
+
+		// Prevent null configs in the future.
+		_, err = e.Exec(`ALTER TABLE Cluster ALTER COLUMN PgBouncerConfig SET NOT NULL;`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -21,14 +21,15 @@ type Cluster struct {
 	Provisioner             string
 	ProvisionerMetadataKops *KopsMetadata
 	ProvisionerMetadataEKS  *EKSMetadata
+	Networking              string
 	UtilityMetadata         *UtilityMetadata
+	PgBouncerConfig         *PgBouncerConfig
 	AllowInstallations      bool
 	CreateAt                int64
 	DeleteAt                int64
 	APISecurityLock         bool
 	LockAcquiredBy          *string
 	LockAcquiredAt          int64
-	Networking              string
 }
 
 // Clone returns a deep copy the cluster.

--- a/model/pgbouncer.go
+++ b/model/pgbouncer.go
@@ -4,9 +4,14 @@
 
 package model
 
-import "github.com/pkg/errors"
+import (
+	"database/sql/driver"
+	"encoding/json"
 
-// PGBouncerConfig contains the configuration for the PGBouncer utility.
+	"github.com/pkg/errors"
+)
+
+// PgBouncerConfig contains the configuration for the PGBouncer utility.
 // //////////////////////////////////////////////////////////////////////////////
 //   - MaxDatabaseConnectionsPerPool is the maximum number of connections per
 //     logical database pool when using proxy databases.
@@ -20,19 +25,78 @@ import "github.com/pkg/errors"
 //     be run in all pooling modes.
 //
 // //////////////////////////////////////////////////////////////////////////////
-type PGBouncerConfig struct {
-	MinPoolSize                   int
-	DefaultPoolSize               int
-	ReservePoolSize               int
-	MaxClientConnections          int
-	MaxDatabaseConnectionsPerPool int
-	ServerIdleTimeout             int
-	ServerLifetime                int
-	ServerResetQueryAlways        int
+
+const (
+	PgBouncerDefaultMinPoolSize                   int64 = 1
+	PgBouncerDefaultPoolSize                      int64 = 5
+	PgBouncerDefaultReservePoolSize               int64 = 10
+	PgBouncerDefaultMaxClientConnections          int64 = 20000
+	PgBouncerDefaultMaxDatabaseConnectionsPerPool int64 = 20
+	PgBouncerDefaultServerIdleTimeout             int64 = 30
+	PgBouncerDefaultServerLifetime                int64 = 300
+	PgBouncerDefaultServerResetQueryAlways        int64 = 0
+)
+
+type PgBouncerConfig struct {
+	MinPoolSize                   int64
+	DefaultPoolSize               int64
+	ReservePoolSize               int64
+	MaxClientConnections          int64
+	MaxDatabaseConnectionsPerPool int64
+	ServerIdleTimeout             int64
+	ServerLifetime                int64
+	ServerResetQueryAlways        int64
 }
 
-// Validate validates a PGBouncerConfig.
-func (c *PGBouncerConfig) Validate() error {
+// NewPgBouncerConfig returns a new PgBouncerConfig with the provided configuration.
+func NewPgBouncerConfig(minPoolSize, defaultPoolSize, reservePoolSize, maxClientConnections, maxDatabaseConnectionsPerPool, serverIdleTimeout, serverLifetime, serverResetQueryAlways int64) *PgBouncerConfig {
+	return &PgBouncerConfig{
+		MinPoolSize:                   minPoolSize,
+		DefaultPoolSize:               defaultPoolSize,
+		ReservePoolSize:               reservePoolSize,
+		MaxClientConnections:          maxClientConnections,
+		MaxDatabaseConnectionsPerPool: maxDatabaseConnectionsPerPool,
+		ServerIdleTimeout:             serverIdleTimeout,
+		ServerLifetime:                serverLifetime,
+		ServerResetQueryAlways:        serverResetQueryAlways,
+	}
+}
+
+// NewPgBouncerConfig returns a new PgBouncerConfig with the default values.
+func NewDefaultPgBouncerConfig() *PgBouncerConfig {
+	c := &PgBouncerConfig{}
+	c.SetDefaults()
+	return c
+}
+
+// SetDefaults sets default values for empty PgBouncerConfig values.
+func (c *PgBouncerConfig) SetDefaults() {
+	if c.MinPoolSize == 0 {
+		c.MinPoolSize = PgBouncerDefaultMinPoolSize
+	}
+	if c.DefaultPoolSize == 0 {
+		c.DefaultPoolSize = PgBouncerDefaultPoolSize
+	}
+	if c.ReservePoolSize == 0 {
+		c.ReservePoolSize = PgBouncerDefaultReservePoolSize
+	}
+	if c.MaxClientConnections == 0 {
+		c.MaxClientConnections = PgBouncerDefaultMaxClientConnections
+	}
+	if c.MaxDatabaseConnectionsPerPool == 0 {
+		c.MaxDatabaseConnectionsPerPool = PgBouncerDefaultMaxDatabaseConnectionsPerPool
+	}
+	if c.ServerIdleTimeout == 0 {
+		c.ServerIdleTimeout = PgBouncerDefaultServerIdleTimeout
+	}
+	if c.ServerLifetime == 0 {
+		c.ServerLifetime = PgBouncerDefaultServerLifetime
+	}
+	// ServerResetQueryAlways default is already 0
+}
+
+// Validate validates a PgBouncerConfig.
+func (c *PgBouncerConfig) Validate() error {
 	if c.MaxDatabaseConnectionsPerPool < 1 {
 		return errors.New("MaxDatabaseConnectionsPerPool must be 1 or greater")
 	}
@@ -40,6 +104,92 @@ func (c *PGBouncerConfig) Validate() error {
 		return errors.New("DefaultPoolSize must be 1 or greater")
 	}
 	if c.ServerResetQueryAlways != 0 && c.ServerResetQueryAlways != 1 {
+		return errors.New("ServerResetQueryAlways must be 0 or 1")
+	}
+
+	return nil
+}
+
+func (c *PgBouncerConfig) Value() (driver.Value, error) {
+	return json.Marshal(c)
+}
+
+func (c *PgBouncerConfig) Scan(src interface{}) error {
+	source, ok := src.([]byte)
+	if !ok {
+		return errors.New("Could not assert type of PgBouncerConfig")
+	}
+
+	var i PgBouncerConfig
+	err := json.Unmarshal(source, &i)
+	if err != nil {
+		return err
+	}
+	*c = i
+	return nil
+}
+
+func (c *PgBouncerConfig) FromJSONString(PgBouncerConfigStr string) (*PgBouncerConfig, error) {
+	// Unmarshal the JSON into an PgBouncerConfig struct.
+	var pgBouncerConfig PgBouncerConfig
+	err := json.Unmarshal([]byte(PgBouncerConfigStr), &pgBouncerConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parses JSON")
+	}
+	return &pgBouncerConfig, nil
+}
+
+// ApplyPatch applies patch values to PgBouncerConfig.
+func (c *PgBouncerConfig) ApplyPatch(p *PatchPgBouncerConfig) {
+	if p == nil {
+		return
+	}
+
+	if p.MinPoolSize != nil {
+		c.MinPoolSize = *p.MinPoolSize
+	}
+	if p.DefaultPoolSize != nil {
+		c.DefaultPoolSize = *p.DefaultPoolSize
+	}
+	if p.ReservePoolSize != nil {
+		c.ReservePoolSize = *p.ReservePoolSize
+	}
+	if p.MaxClientConnections != nil {
+		c.MaxClientConnections = *p.MaxClientConnections
+	}
+	if p.MaxDatabaseConnectionsPerPool != nil {
+		c.MaxDatabaseConnectionsPerPool = *p.MaxDatabaseConnectionsPerPool
+	}
+	if p.ServerIdleTimeout != nil {
+		c.ServerIdleTimeout = *p.ServerIdleTimeout
+	}
+	if p.ServerLifetime != nil {
+		c.ServerLifetime = *p.ServerLifetime
+	}
+	if p.ServerResetQueryAlways != nil {
+		c.ServerResetQueryAlways = *p.ServerResetQueryAlways
+	}
+}
+
+type PatchPgBouncerConfig struct {
+	MinPoolSize                   *int64
+	DefaultPoolSize               *int64
+	ReservePoolSize               *int64
+	MaxClientConnections          *int64
+	MaxDatabaseConnectionsPerPool *int64
+	ServerIdleTimeout             *int64
+	ServerLifetime                *int64
+	ServerResetQueryAlways        *int64
+}
+
+func (c *PatchPgBouncerConfig) Validate() error {
+	if c.MaxDatabaseConnectionsPerPool != nil && *c.MaxDatabaseConnectionsPerPool < 1 {
+		return errors.New("MaxDatabaseConnectionsPerPool must be 1 or greater")
+	}
+	if c.DefaultPoolSize != nil && *c.DefaultPoolSize < 1 {
+		return errors.New("DefaultPoolSize must be 1 or greater")
+	}
+	if c.ServerResetQueryAlways != nil && *c.ServerResetQueryAlways != 0 && *c.ServerResetQueryAlways != 1 {
 		return errors.New("ServerResetQueryAlways must be 0 or 1")
 	}
 

--- a/model/pgbouncer_test.go
+++ b/model/pgbouncer_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model_test
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/internal/util"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatePGBouncerConfig(t *testing.T) {
+	var testCases = []struct {
+		description string
+		config      *model.PgBouncerConfig
+		valid       bool
+	}{
+		{
+			"valid",
+			model.NewPgBouncerConfig(5, 10, 5, 2000, 20, 10, 20, 0),
+			true,
+		},
+		{
+			"MaxDatabaseConnectionsPerPool is too low",
+			model.NewPgBouncerConfig(5, 10, 5, 2000, 0, 10, 20, 0),
+			false,
+		},
+		{
+			"DefaultPoolSize is too low",
+			model.NewPgBouncerConfig(5, 0, 5, 2000, 20, 10, 20, 0),
+			false,
+		},
+		{
+			"ServerResetQueryAlways is invalid",
+			model.NewPgBouncerConfig(5, 10, 5, 2000, 20, 10, 20, 2),
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.valid {
+				assert.NoError(t, tc.config.Validate())
+			} else {
+				assert.Error(t, tc.config.Validate())
+			}
+		})
+	}
+}
+
+func TestPgBouncerPatch(t *testing.T) {
+	var sizeTests = []struct {
+		name     string
+		config   *model.PgBouncerConfig
+		patch    *model.PatchPgBouncerConfig
+		expected *model.PgBouncerConfig
+	}{
+		{"nil",
+			&model.PgBouncerConfig{MinPoolSize: 10},
+			nil,
+			&model.PgBouncerConfig{MinPoolSize: 10},
+		},
+		{"one value patched",
+			&model.PgBouncerConfig{MinPoolSize: 10},
+			&model.PatchPgBouncerConfig{MinPoolSize: util.IToP(11)},
+			&model.PgBouncerConfig{MinPoolSize: 11},
+		},
+		{"full patch",
+			&model.PgBouncerConfig{
+				MinPoolSize:                   1,
+				DefaultPoolSize:               1,
+				ReservePoolSize:               1,
+				MaxClientConnections:          1,
+				MaxDatabaseConnectionsPerPool: 1,
+				ServerIdleTimeout:             1,
+				ServerLifetime:                1,
+				ServerResetQueryAlways:        1,
+			},
+			&model.PatchPgBouncerConfig{
+				MinPoolSize:                   util.IToP(2),
+				DefaultPoolSize:               util.IToP(3),
+				ReservePoolSize:               util.IToP(4),
+				MaxClientConnections:          util.IToP(5),
+				MaxDatabaseConnectionsPerPool: util.IToP(6),
+				ServerIdleTimeout:             util.IToP(7),
+				ServerLifetime:                util.IToP(8),
+				ServerResetQueryAlways:        util.IToP(0),
+			},
+			&model.PgBouncerConfig{
+				MinPoolSize:                   2,
+				DefaultPoolSize:               3,
+				ReservePoolSize:               4,
+				MaxClientConnections:          5,
+				MaxDatabaseConnectionsPerPool: 6,
+				ServerIdleTimeout:             7,
+				ServerLifetime:                8,
+				ServerResetQueryAlways:        0,
+			},
+		},
+	}
+
+	for _, tt := range sizeTests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.patch != nil {
+				assert.NoError(t, tt.patch.Validate())
+			}
+			tt.config.ApplyPatch(tt.patch)
+			assert.Equal(t, tt.config, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
This change does the following:
 - Stores PgBouncerConfig values for each cluster individually.
 - PgBouncerConfig can be updated with `cluster provision` flags which are then deployed.
 - Server flags for PgBouncerConfig values are now deprecated.

Fixes https://mattermost.atlassian.net/browse/CLD-7129

```release-note
Add per-cluster PgBouncerConfig
```
