### PR TITLE
Use HOSTNAME env var for instanceID

### DIFF
--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -32,7 +32,14 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	instanceID = model.NewID()
+	// If the environment variable "HOSTNAME" is set then that will be used for
+	// the instance ID value of this server. In Kubernetes this should pick up
+	// the pod replica name. If this environment value is not set then the
+	// original behavior will kick in and set the ID to a random ID.
+	instanceID = os.Getenv("HOSTNAME")
+	if len(instanceID) == 0 {
+		instanceID = model.NewID()
+	}
 
 	_ = rootCmd.MarkFlagRequired("database")
 


### PR DESCRIPTION
If the HOSTNAME env var is set then that will be used for the instanceID value of this server. This will help correlate resource locks with matching provisioner server instance.

Fixes https://mattermost.atlassian.net/browse/CLD-7705

```release-note
Use HOSTNAME env var for instanceID
```
