### PR TITLE
Separate installation scheduling locks

### DIFF
--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -571,6 +571,15 @@ func handleDeleteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	newState := model.ClusterInstallationStateDeletionRequested
 
+	// Cluster deletion requires acquiring the standard cluster and scheduling
+	// locks for safe deletion.
+	status, unlockSchedulingOnce := lockClusterScheduling(c, clusterID)
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	defer unlockSchedulingOnce()
+
 	clusterDTO, status, unlockOnce := getClusterForTransition(c, clusterID, newState)
 	if status != 0 {
 		w.WriteHeader(status)

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -31,6 +31,8 @@ type Store interface {
 	UpdateCluster(cluster *model.Cluster) error
 	LockCluster(clusterID, lockerID string) (bool, error)
 	UnlockCluster(clusterID, lockerID string, force bool) (bool, error)
+	LockClusterScheduling(clusterID, lockerID string) (bool, error)
+	UnlockClusterScheduling(clusterID, lockerID string, force bool) (bool, error)
 	LockClusterAPI(clusterID string) error
 	UnlockClusterAPI(clusterID string) error
 	DeleteCluster(clusterID string) error

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -320,7 +320,7 @@ func (sqlStore *SQLStore) GetDeliveriesForSubscription(subID string) ([]*model.E
 
 // lockSubscription marks the subscription as locked for exclusive use by the caller.
 func (sqlStore *SQLStore) lockSubscription(db execer, subID, lockerID string) (bool, error) {
-	return sqlStore.lockRowsTx(db, subscriptionsTable, []string{subID}, lockerID)
+	return sqlStore.lockRowsTx(db, subscriptionsTable, standardLockByName, standardLockAtName, []string{subID}, lockerID)
 }
 
 // UnlockSubscription releases a lock previously acquired against a caller.

--- a/internal/store/lock.go
+++ b/internal/store/lock.go
@@ -5,26 +5,40 @@
 package store
 
 import (
+	"fmt"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 )
 
+const (
+	standardLockByName = "LockAcquiredBy"
+	standardLockAtName = "LockAcquiredAt"
+)
+
 // lockRow marks the row in the given table as locked for exclusive use by the caller.
 func (sqlStore *SQLStore) lockRows(table string, ids []string, lockerID string) (bool, error) {
-	return sqlStore.lockRowsTx(sqlStore.db, table, ids, lockerID)
+	return sqlStore.lockRowsTx(sqlStore.db, table, standardLockByName, standardLockAtName, ids, lockerID)
 }
 
-func (sqlStore *SQLStore) lockRowsTx(db execer, table string, ids []string, lockerID string) (bool, error) {
+// lockCustomRows marks the custom lock rows in the given table as locked for
+// exclusive use by the caller.
+func (sqlStore *SQLStore) lockCustomRows(table, lockByName, lockAtName string, ids []string, lockerID string) (bool, error) {
+	return sqlStore.lockRowsTx(sqlStore.db, table, lockByName, lockAtName, ids, lockerID)
+}
+
+// lockRowsTx performs the resource locking transaction.
+func (sqlStore *SQLStore) lockRowsTx(db execer, table, lockByName, lockAtName string, ids []string, lockerID string) (bool, error) {
 	result, err := sqlStore.execBuilder(db, sq.
 		Update(table).
 		SetMap(map[string]interface{}{
-			"LockAcquiredBy": lockerID,
-			"LockAcquiredAt": model.GetMillis(),
+			lockByName: lockerID,
+			lockAtName: model.GetMillis(),
 		}).
 		Where(sq.Eq{
-			"ID":             ids,
-			"LockAcquiredAt": 0,
+			"ID":       ids,
+			lockAtName: 0,
 		}),
 	)
 	if err != nil {
@@ -47,12 +61,22 @@ func (sqlStore *SQLStore) lockRowsTx(db execer, table string, ids []string, lock
 	return locked, nil
 }
 
-// unlockRow releases a lock previously acquired against a caller.
+// unlockRows releases a lock previously acquired against a caller.
 func (sqlStore *SQLStore) unlockRows(table string, ids []string, lockerID string, force bool) (bool, error) {
+	return sqlStore.unlockRowsTx(table, standardLockByName, standardLockAtName, ids, lockerID, force)
+}
+
+// unlockCustomRows releases a cusotm lock previously acquired against a caller.
+func (sqlStore *SQLStore) unlockCustomRows(table, lockByName, lockAtName string, ids []string, lockerID string, force bool) (bool, error) {
+	return sqlStore.unlockRowsTx(table, lockByName, lockAtName, ids, lockerID, force)
+}
+
+// unlockRowsTx performs the resource unlocking transaction.
+func (sqlStore *SQLStore) unlockRowsTx(table, lockByName, lockAtName string, ids []string, lockerID string, force bool) (bool, error) {
 	builder := sq.Update(table).
 		SetMap(map[string]interface{}{
-			"LockAcquiredBy": nil,
-			"LockAcquiredAt": 0,
+			lockByName: nil,
+			lockAtName: 0,
 		}).
 		Where(sq.Eq{
 			"ID": ids,
@@ -60,11 +84,11 @@ func (sqlStore *SQLStore) unlockRows(table string, ids []string, lockerID string
 
 	if force {
 		// If forcing the unlock, only require that a lock was held by someone.
-		builder = builder.Where("LockAcquiredAt <> 0")
+		builder = builder.Where(fmt.Sprintf("%s <> 0", lockAtName))
 	} else {
 		// If not forcing the unlock, require that the current instance held the lock.
 		builder = builder.Where(sq.Eq{
-			"LockAcquiredBy": lockerID,
+			lockByName: lockerID,
 		})
 	}
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -2216,4 +2216,27 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.47.0"), semver.MustParse("0.48.0"), func(e execer) error {
+		_, err := e.Exec(`ALTER TABLE Cluster ADD COLUMN SchedulingLockAcquiredBy TEXT NULL;`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`ALTER TABLE Cluster ADD COLUMN SchedulingLockAcquiredAt BIGINT;`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`UPDATE Cluster SET SchedulingLockAcquiredAt = 0;`)
+		if err != nil {
+			return err
+		}
+
+		_, err = e.Exec(`ALTER TABLE Cluster ALTER COLUMN SchedulingLockAcquiredAt SET NOT NULL;`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/internal/supervisor/backup.go
+++ b/internal/supervisor/backup.go
@@ -168,10 +168,10 @@ func (s *BackupSupervisor) transitionBackup(backup *model.InstallationBackup, in
 		return s.triggerBackup(backup, instanceID, logger)
 
 	case model.InstallationBackupStateBackupInProgress:
-		return s.monitorBackup(backup, instanceID, logger)
+		return s.monitorBackup(backup, logger)
 
 	case model.InstallationBackupStateDeletionRequested:
-		return s.deleteBackup(backup, instanceID, logger)
+		return s.deleteBackup(backup, logger)
 
 	default:
 		logger.Warnf("Found backup pending work in unexpected state %s", backup.State)
@@ -234,7 +234,7 @@ func (s *BackupSupervisor) triggerBackup(backup *model.InstallationBackup, insta
 	return model.InstallationBackupStateBackupInProgress
 }
 
-func (s *BackupSupervisor) monitorBackup(backup *model.InstallationBackup, instanceID string, logger log.FieldLogger) model.InstallationBackupState {
+func (s *BackupSupervisor) monitorBackup(backup *model.InstallationBackup, logger log.FieldLogger) model.InstallationBackupState {
 	cluster, err := getClusterForClusterInstallation(s.store, backup.ClusterInstallationID)
 	if err != nil {
 		logger.WithError(err).Error("Failed to get cluster")
@@ -267,7 +267,7 @@ func (s *BackupSupervisor) monitorBackup(backup *model.InstallationBackup, insta
 	return model.InstallationBackupStateBackupSucceeded
 }
 
-func (s *BackupSupervisor) deleteBackup(backup *model.InstallationBackup, instanceID string, logger log.FieldLogger) model.InstallationBackupState {
+func (s *BackupSupervisor) deleteBackup(backup *model.InstallationBackup, logger log.FieldLogger) model.InstallationBackupState {
 	cluster, err := getClusterForClusterInstallation(s.store, backup.ClusterInstallationID)
 	if err != nil {
 		logger.WithError(err).Error("Failed to get cluster for backup")

--- a/internal/supervisor/cluster.go
+++ b/internal/supervisor/cluster.go
@@ -22,6 +22,8 @@ type clusterStore interface {
 	UpdateCluster(cluster *model.Cluster) error
 	LockCluster(clusterID, lockerID string) (bool, error)
 	UnlockCluster(clusterID string, lockerID string, force bool) (bool, error)
+	LockClusterScheduling(clusterID, lockerID string) (bool, error)
+	UnlockClusterScheduling(clusterID string, lockerID string, force bool) (bool, error)
 	DeleteCluster(clusterID string) error
 
 	GetWebhooks(filter *model.WebhookFilter) ([]*model.Webhook, error)

--- a/internal/supervisor/cluster_lock.go
+++ b/internal/supervisor/cluster_lock.go
@@ -11,6 +11,8 @@ import (
 type clusterLockStore interface {
 	LockCluster(clusterID, lockerID string) (bool, error)
 	UnlockCluster(clusterID, lockerID string, force bool) (bool, error)
+	LockClusterScheduling(clusterID, lockerID string) (bool, error)
+	UnlockClusterScheduling(clusterID, lockerID string, force bool) (bool, error)
 }
 
 type clusterLock struct {
@@ -45,5 +47,40 @@ func (l *clusterLock) Unlock() {
 		l.logger.WithError(err).Error("failed to unlock cluster")
 	} else if !unlocked {
 		l.logger.Error("failed to release lock for cluster")
+	}
+}
+
+type clusterScheduleLock struct {
+	clusterID string
+	lockerID  string
+	store     clusterLockStore
+	logger    log.FieldLogger
+}
+
+func newClusterScheduleLock(clusterID, lockerID string, store clusterLockStore, logger log.FieldLogger) *clusterScheduleLock {
+	return &clusterScheduleLock{
+		clusterID: clusterID,
+		lockerID:  lockerID,
+		store:     store,
+		logger:    logger,
+	}
+}
+
+func (l *clusterScheduleLock) TryLock() bool {
+	locked, err := l.store.LockClusterScheduling(l.clusterID, l.lockerID)
+	if err != nil {
+		l.logger.WithError(err).Error("failed to lock cluster scheduling")
+		return false
+	}
+
+	return locked
+}
+
+func (l *clusterScheduleLock) Unlock() {
+	unlocked, err := l.store.UnlockClusterScheduling(l.clusterID, l.lockerID, false)
+	if err != nil {
+		l.logger.WithError(err).Error("failed to unlock cluster scheduling")
+	} else if !unlocked {
+		l.logger.Error("failed to release lock for cluster scheduling")
 	}
 }

--- a/internal/supervisor/cluster_test.go
+++ b/internal/supervisor/cluster_test.go
@@ -64,6 +64,17 @@ func (s *mockClusterStore) UnlockCluster(clusterID string, lockerID string, forc
 	return true, nil
 }
 
+func (s *mockClusterStore) LockClusterScheduling(clusterID, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (s *mockClusterStore) UnlockClusterScheduling(clusterID string, lockerID string, force bool) (bool, error) {
+	if s.UnlockChan != nil {
+		close(s.UnlockChan)
+	}
+	return true, nil
+}
+
 func (s *mockClusterStore) DeleteCluster(clusterID string) error {
 	return nil
 }

--- a/internal/supervisor/installation_deletion.go
+++ b/internal/supervisor/installation_deletion.go
@@ -124,7 +124,7 @@ func (s *InstallationDeletionSupervisor) Supervise(installation *model.Installat
 
 	logger.Debugf("Supervising installation in state %s", installation.State)
 
-	newState := s.transitionInstallation(installation, s.instanceID, logger)
+	newState := s.transitionInstallation(installation, logger)
 
 	installation, err = s.store.GetInstallation(installation.ID, true, false)
 	if err != nil {
@@ -154,17 +154,17 @@ func (s *InstallationDeletionSupervisor) Supervise(installation *model.Installat
 }
 
 // transitionInstallation works with the given installation to transition it to a final state.
-func (s *InstallationDeletionSupervisor) transitionInstallation(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
+func (s *InstallationDeletionSupervisor) transitionInstallation(installation *model.Installation, logger log.FieldLogger) string {
 	switch installation.State {
 	case model.InstallationStateDeletionPending:
-		return s.checkIfInstallationShouldBeDeleted(installation, instanceID, logger)
+		return s.checkIfInstallationShouldBeDeleted(installation, logger)
 	default:
 		logger.Warnf("Found installation pending deletion in unexpected state %s", installation.State)
 		return installation.State
 	}
 }
 
-func (s *InstallationDeletionSupervisor) checkIfInstallationShouldBeDeleted(installation *model.Installation, instanceID string, logger log.FieldLogger) string {
+func (s *InstallationDeletionSupervisor) checkIfInstallationShouldBeDeleted(installation *model.Installation, logger log.FieldLogger) string {
 	if installation.DeletionPendingExpiry != 0 {
 		// Primary deletion pending check.
 		if model.GetMillis() < installation.DeletionPendingExpiry {

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/mattermost/mattermost-cloud/k8s"
 	"github.com/mattermost/mattermost-cloud/model"
 	mmv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,6 +60,14 @@ func (s *mockInstallationStore) LockCluster(clusterID, lockerID string) (bool, e
 }
 
 func (s *mockInstallationStore) UnlockCluster(clusterID string, lockerID string, force bool) (bool, error) {
+	return true, nil
+}
+
+func (s *mockInstallationStore) LockClusterScheduling(clusterID, lockerID string) (bool, error) {
+	return true, nil
+}
+
+func (s *mockInstallationStore) UnlockClusterScheduling(clusterID string, lockerID string, force bool) (bool, error) {
 	return true, nil
 }
 
@@ -635,11 +642,11 @@ func (m *mockEventProducer) ProduceClusterInstallationStateChangeEvent(clusterIn
 
 type mockCloudflareClient struct{}
 
-func (m *mockCloudflareClient) CreateDNSRecords(customerDNSName []string, dnsEndpoints []string, logger logrus.FieldLogger) error {
+func (m *mockCloudflareClient) CreateDNSRecords(customerDNSName []string, dnsEndpoints []string, logger log.FieldLogger) error {
 	return nil
 
 }
-func (m *mockCloudflareClient) DeleteDNSRecords(customerDNSName []string, logger logrus.FieldLogger) error {
+func (m *mockCloudflareClient) DeleteDNSRecords(customerDNSName []string, logger log.FieldLogger) error {
 	return nil
 }
 

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -14,22 +14,24 @@ import (
 
 // Cluster represents a Kubernetes cluster.
 type Cluster struct {
-	ID                      string
-	State                   string
-	Provider                string
-	ProviderMetadataAWS     *AWSMetadata
-	Provisioner             string
-	ProvisionerMetadataKops *KopsMetadata
-	ProvisionerMetadataEKS  *EKSMetadata
-	Networking              string
-	UtilityMetadata         *UtilityMetadata
-	PgBouncerConfig         *PgBouncerConfig
-	AllowInstallations      bool
-	CreateAt                int64
-	DeleteAt                int64
-	APISecurityLock         bool
-	LockAcquiredBy          *string
-	LockAcquiredAt          int64
+	ID                       string
+	State                    string
+	Provider                 string
+	ProviderMetadataAWS      *AWSMetadata
+	Provisioner              string
+	ProvisionerMetadataKops  *KopsMetadata
+	ProvisionerMetadataEKS   *EKSMetadata
+	Networking               string
+	UtilityMetadata          *UtilityMetadata
+	PgBouncerConfig          *PgBouncerConfig
+	AllowInstallations       bool
+	CreateAt                 int64
+	DeleteAt                 int64
+	APISecurityLock          bool
+	SchedulingLockAcquiredBy *string
+	SchedulingLockAcquiredAt int64
+	LockAcquiredBy           *string
+	LockAcquiredAt           int64
 }
 
 // Clone returns a deep copy the cluster.

--- a/model/cluster_states.go
+++ b/model/cluster_states.go
@@ -4,6 +4,8 @@
 
 package model
 
+import "github.com/pkg/errors"
+
 const (
 	// ClusterStateStable is a cluster in a stable state and undergoing no changes.
 	ClusterStateStable = "stable"
@@ -112,6 +114,36 @@ var AllClusterRequestStates = []string{
 	ClusterStateResizeRequested,
 	ClusterStateNodegroupsCreationRequested,
 	ClusterStateDeletionRequested,
+}
+
+var ClusterStatesInstallationScheduable = []string{
+	ClusterStateStable,
+	ClusterStateProvisionInProgress,
+	ClusterStateProvisioningRequested,
+	ClusterStateRefreshMetadata,
+	ClusterStateProvisioningFailed,
+	ClusterStateUpgradeRequested,
+	ClusterStateUpgradeFailed,
+	ClusterStateResizeRequested,
+	ClusterStateResizeFailed,
+	ClusterStateWaitingForNodes,
+	ClusterStateNodegroupsCreationRequested,
+	ClusterStateNodegroupsCreationFailed,
+	ClusterStateNodegroupsDeletionRequested,
+	ClusterStateNodegroupsDeletionFailed,
+}
+
+// CanScheduleInstallations returns whether a cluster is in a valid state to
+// accept new installations.
+func (c *Cluster) CanScheduleInstallations() error {
+	if !c.AllowInstallations {
+		return errors.New("cluster set to not allow for new installation scheduling")
+	}
+	if !contains(ClusterStatesInstallationScheduable, c.State) {
+		return errors.Errorf("not in a state to accept new installations (currently %s)", c.State)
+	}
+
+	return nil
 }
 
 // ValidTransitionState returns whether a cluster can be transitioned into the

--- a/model/cluster_states_test.go
+++ b/model/cluster_states_test.go
@@ -5,13 +5,13 @@
 package model
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCluster_ValidTransitionState(t *testing.T) {
-
 	// Couple of tests to verify mechanism is working - we can add more for specific cases
 	for _, testCase := range []struct {
 		oldState string
@@ -49,6 +49,82 @@ func TestCluster_ValidTransitionState(t *testing.T) {
 
 			isValid := cluster.ValidTransitionState(testCase.newState)
 			assert.Equal(t, testCase.isValid, isValid)
+		})
+	}
+}
+
+func TestClusterCanScheduleInstallations(t *testing.T) {
+	for _, testCase := range []struct {
+		state              string
+		allowInstallations bool
+		canSchedule        bool
+	}{
+		{
+			state:              ClusterStateCreationRequested,
+			allowInstallations: true,
+			canSchedule:        false,
+		},
+		{
+			state:              ClusterStateCreationInProgress,
+			allowInstallations: true,
+			canSchedule:        false,
+		},
+		{
+			state:              ClusterStateDeletionRequested,
+			allowInstallations: true,
+			canSchedule:        false,
+		},
+		{
+			state:              ClusterStateDeletionFailed,
+			allowInstallations: true,
+			canSchedule:        false,
+		},
+		{
+			state:              ClusterStateDeleted,
+			allowInstallations: true,
+			canSchedule:        false,
+		},
+		{
+			state:              ClusterStateProvisionInProgress,
+			allowInstallations: false,
+			canSchedule:        false,
+		},
+		{
+			state:              ClusterStateProvisionInProgress,
+			allowInstallations: true,
+			canSchedule:        true,
+		},
+		{
+			state:              ClusterStateResizeRequested,
+			allowInstallations: false,
+			canSchedule:        false,
+		},
+		{
+			state:              ClusterStateResizeRequested,
+			allowInstallations: true,
+			canSchedule:        true,
+		},
+		{
+			state:              ClusterStateUpgradeRequested,
+			allowInstallations: false,
+			canSchedule:        false,
+		},
+		{
+			state:              ClusterStateUpgradeRequested,
+			allowInstallations: true,
+			canSchedule:        true,
+		},
+	} {
+		t.Run(fmt.Sprintf("state-%s_allow-%v", testCase.state, testCase.allowInstallations), func(t *testing.T) {
+			cluster := Cluster{
+				State:              testCase.state,
+				AllowInstallations: testCase.allowInstallations,
+			}
+			if testCase.canSchedule {
+				assert.NoError(t, cluster.CanScheduleInstallations())
+			} else {
+				assert.Error(t, cluster.CanScheduleInstallations())
+			}
 		})
 	}
 }


### PR DESCRIPTION
This change introduces a new type of cluster lock that is used for installation scheduling. This lock is used to coordinate new installation creation without requiring a full lock on the underlying cluster. This allows for one provisioner instance to update the cluster while another instance can schedule new installations assuming the cluster is in a valid state.

This allows for scheduling installations on clusters that are being provisioned, resized, or upgraded.

Example lock fields:

```
    "SchedulingLockAcquiredBy": "gabe-provisioner-secondary",
    "SchedulingLockAcquiredAt": 1716224993595,
    "LockAcquiredBy": "gabe-provisioner-primary",
    "LockAcquiredAt": 1716224901292
```

Fixes https://mattermost.atlassian.net/browse/CLD-7709

```release-note
Separate installation scheduling locks
```
