### PR TITLE
[CLD-7849]fix private certificate for nginx-internal

### DIFF
--- a/internal/provisioner/utility/argo_utility.go
+++ b/internal/provisioner/utility/argo_utility.go
@@ -76,18 +76,28 @@ func ProvisionUtilityArgocd(utilityName, tempDir, clusterID string, allowCIDRRan
 		return errors.New("retrieved certificate does not have ARN")
 	}
 
+	privateCertificate, err := awsClient.GetCertificateSummaryByTag(aws.DefaultInstallPrivateCertificatesTagKey, aws.DefaultInstallPrivateCertificatesTagValue, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrive the AWS Private ACM")
+	}
+
+	if privateCertificate.ARN == nil {
+		return errors.New("retrieved certificate does not have ARN")
+	}
+
 	privateZoneDomainName, err := awsClient.GetPrivateZoneDomainName(logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to get private zone domain name")
 	}
 
 	replacements := map[string]string{
-		"<VPC_ID>":         vpc,
-		"<CERTFICATE_ARN>": *certificate.ARN,
-		"<CLUSTER_ID>":     clusterID,
-		"<ENV>":            awsClient.GetCloudEnvironmentName(),
-		"<IP_RANGE>":       strings.Join(allowCIDRRangeList, ","),
-		"<PRIVATE_DOMAIN>": privateZoneDomainName,
+		"<VPC_ID>":                  vpc,
+		"<CERTFICATE_ARN>":          *certificate.ARN,
+		"<PRIVATE_CERTIFICATE_ARN>": *privateCertificate.ARN,
+		"<CLUSTER_ID>":              clusterID,
+		"<ENV>":                     awsClient.GetCloudEnvironmentName(),
+		"<IP_RANGE>":                strings.Join(allowCIDRRangeList, ","),
+		"<PRIVATE_DOMAIN>":          privateZoneDomainName,
 		// Add more replacements as needed
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This will fix the certificate for nginx-internal utility to use internal one. 

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/CLD-7849

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
