### PR TITLE
Use new bulk import flags

### DIFF
--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -69,7 +69,7 @@ type mmctl struct {
 }
 
 func (m *mmctl) Run(args ...string) ([]byte, error) {
-	args = append([]string{"--format", "json", "--local"}, args...)
+	args = append([]string{"--json", "--local"}, args...)
 	return m.provisioner.ExecMMCTL(m.cluster, m.clusterInstallation, args...)
 }
 
@@ -381,7 +381,7 @@ func (s *ImportSupervisor) copyImportToWorkspaceFilestore(imprt *awat.ImportStat
 }
 
 func (s *ImportSupervisor) startImportProcessAndWait(mmctl *mmctl, logger logrus.FieldLogger, importArchiveFilename, awatImportID string) error {
-	output, err := mmctl.Run("import", "process", importArchiveFilename)
+	output, err := mmctl.Run("import", "process", "--extract-content=false", importArchiveFilename)
 	if err != nil {
 		return errors.Wrap(err, "failed to start import process in Mattermost itself")
 	}


### PR DESCRIPTION
The flag --extract-content=false is used to increase import performance by skipping attachment parsing. The --json flag replaces the old format flag, but behaves the same.

Fixes https://mattermost.atlassian.net/browse/CLD-7856

```release-note
Use new bulk import flags
```
