### PR TITLE
Improve argocd provisioning resilience

### DIFF
--- a/internal/provisioner/utility/argo_utility.go
+++ b/internal/provisioner/utility/argo_utility.go
@@ -119,21 +119,14 @@ func ProvisionUtilityArgocd(utilityName, tempDir, clusterID string, allowCIDRRan
 	}
 
 	appName := utilityName + "-sre-" + awsClient.GetCloudEnvironmentName() + "-" + clusterID
-	gitopsAppName := "gitops-sre-" + awsClient.GetCloudEnvironmentName()
-
-	app, err := argocdClient.SyncApplication(gitopsAppName)
-	if err != nil {
-		return errors.Wrap(err, "failed to sync application")
-	}
 
 	timeout := time.Second * 600
-
 	err = argocdClient.WaitForAppHealthy(appName, timeout)
 	if err != nil {
 		return errors.Wrap(err, "failed to wait for application to be healthy")
 	}
 
-	logger.WithField("app:", app.Name).Info("Deployed utility successfully.")
+	logger.WithField("Utility:", utilityName).Info("Deployed utility successfully.")
 
 	return nil
 }

--- a/internal/tools/argocd/application.go
+++ b/internal/tools/argocd/application.go
@@ -47,12 +47,11 @@ func (c *ApiClient) WaitForAppHealthy(appName string, timeout time.Duration) err
 			Name:    &appName,
 			Refresh: &refresh,
 		})
-		if err != nil {
-			return err
-		}
 
-		if app.Status.Health.Status == health.HealthStatusHealthy && app.Status.Sync.Status == argoappv1.SyncStatusCodeSynced {
-			break
+		if err == nil {
+			if app.Status.Health.Status == health.HealthStatusHealthy && app.Status.Sync.Status == argoappv1.SyncStatusCodeSynced {
+				break
+			}
 		}
 
 		// Check for timeout


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR will remove the synchronization of the app of apps letting argocd handle this. This will keep the process simple for the provisioner. The other change is skip error handling for the argocd get app due to some inconsistencies in the Argocd API response.

#### Ticket Link

 Fixes https://mattermost.atlassian.net/browse/CLD-7839

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
