### PR TITLE
Remove prometheus-operator from cluster e2e

### DIFF
--- a/e2e/tests/shared/shared.go
+++ b/e2e/tests/shared/shared.go
@@ -115,9 +115,6 @@ func SetupTestWithDefaults(testName string, argoManagedUtilities bool) (*Test, e
 			model.ThanosCanonicalName: {
 				Chart: model.UnmanagedUtilityVersion,
 			},
-			model.PrometheusOperatorCanonicalName: {
-				Chart: model.UnmanagedUtilityVersion,
-			},
 			model.NodeProblemDetectorCanonicalName: {
 				Chart: model.UnmanagedUtilityVersion,
 			},


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
In test env, we don't have node group for Prometheus leading to a pending state and breaking provision into argocd. We'll remove it from argocd until we change the taints in test env. 

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
