### PR TITLE
Add VPC claiming for external cluster types

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -226,6 +226,7 @@ func executeClusterImportCmd(flags clusterImportFlags) error {
 
 	request := &model.ImportClusterRequest{
 		ExternalClusterSecretName: flags.secretName,
+		VpcID:                     flags.vpcID,
 		Annotations:               flags.annotations,
 		AllowInstallations:        flags.allowInstallations,
 	}

--- a/cmd/cloud/cluster_flag.go
+++ b/cmd/cloud/cluster_flag.go
@@ -156,12 +156,14 @@ func (flags *clusterCreateFlags) addFlags(command *cobra.Command) {
 
 type importClusterRequestOptions struct {
 	secretName         string
+	vpcID              string
 	annotations        []string
 	allowInstallations bool
 }
 
 func (flags *importClusterRequestOptions) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.secretName, "secret-name", "", "The name of the AWS Secret Manager secret containing the cluster kubeconfig.")
+	command.Flags().StringVar(&flags.vpcID, "vpc-id", "", "Optional VPC ID for clusters running in our managed VPCs. This must be provided for allowing installations to be scheduled with our managed backends (ex. pgbouncer and bifrost).")
 	command.Flags().BoolVar(&flags.allowInstallations, "allow-installations", true, "Whether the cluster will allow for new installations to be scheduled.")
 	command.Flags().StringArrayVar(&flags.annotations, "annotation", []string{}, "Additional annotations for the cluster. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 }

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -142,6 +142,7 @@ type Provisioner interface {
 
 // AwsClient describes the interface required to communicate with the AWS
 type AwsClient interface {
+	EnsureVPCExists(vpcID string) error
 	SwitchClusterTags(clusterID string, targetClusterID string, logger log.FieldLogger) error
 	SecretsManagerValidateExternalClusterSecret(name string) error
 	SecretsManagerValidateExternalDatabaseSecret(name string) error

--- a/internal/api/db_multitenant_database_test.go
+++ b/internal/api/db_multitenant_database_test.go
@@ -274,6 +274,10 @@ type mockAWSClient struct {
 	expectedRDSID string
 }
 
+func (m mockAWSClient) EnsureVPCExists(vpcID string) error {
+	return nil
+}
+
 func (m mockAWSClient) SwitchClusterTags(clusterID string, targetClusterID string, logger log.FieldLogger) error {
 	return nil
 }

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -713,13 +713,9 @@ func prepareClusterUtilities(
 		return errors.Wrap(err, "failed to create k8s client from file")
 	}
 
-	var vpc string
-	if cluster.ProvisionerMetadataKops != nil {
-		vpc = cluster.ProvisionerMetadataKops.VPC
-	} else if cluster.ProvisionerMetadataEKS != nil {
-		vpc = cluster.ProvisionerMetadataEKS.VPC
-	} else {
-		return errors.New("cluster metadata is nil cannot determine VPC")
+	vpc := cluster.VpcID()
+	if vpc == "" {
+		return errors.New("cluster metadata returned an empty VPC ID")
 	}
 
 	// TODO: Yeah, so this is definitely a bit of a race condition. We would

--- a/internal/provisioner/eks_provisioner.go
+++ b/internal/provisioner/eks_provisioner.go
@@ -59,7 +59,7 @@ func NewEKSProvisioner(
 	}
 }
 
-// PrepareCluster is noop for EKSProvisioner.
+// PrepareCluster prepares metadata for EKSProvisioner.
 func (provisioner *EKSProvisioner) PrepareCluster(cluster *model.Cluster) bool {
 	// Don't regenerate the name if already set.
 	if cluster.ProvisionerMetadataEKS.Name != "" {

--- a/internal/supervisor/installation.go
+++ b/internal/supervisor/installation.go
@@ -705,6 +705,11 @@ func (s *InstallationSupervisor) installationCanBeScheduledOnCluster(cluster *mo
 		return false
 	}
 
+	if installation.RequiresAWSInfrasctructure() && !cluster.HasAWSInfrastructure() {
+		logger.Debugf("Cluster %s can only support installations with external infrastructure", cluster.ID)
+		return false
+	}
+
 	existingClusterInstallations, err := s.store.GetClusterInstallations(&model.ClusterInstallationFilter{
 		Paging:    model.AllPagesNotDeleted(),
 		ClusterID: cluster.ID,

--- a/internal/tools/aws/cluster_management_test.go
+++ b/internal/tools/aws/cluster_management_test.go
@@ -7,12 +7,15 @@ package aws
 import (
 	"context"
 	"fmt"
+	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/golang/mock/gomock"
+	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func (a *AWSTestSuite) TestFixSubnetTagsForVPC() {
@@ -1384,4 +1387,32 @@ func (a *AWSTestSuite) TestReleaseVPC() {
 		err := a.Mocks.AWS.ReleaseVpc(cluster, logger)
 		a.Assert().NoError(err)
 	})
+}
+
+func TestGetClusterTag(t *testing.T) {
+	kopsCluster := &model.Cluster{
+		ID:                      model.NewID(),
+		Provisioner:             model.ProvisionerKops,
+		ProvisionerMetadataKops: &model.KopsMetadata{Name: "kops-name"},
+	}
+	assert.Equal(t, kopsCluster.ProvisionerMetadataKops.Name, getClusterTag(kopsCluster))
+
+	eksCluster := &model.Cluster{
+		ID:                     model.NewID(),
+		Provisioner:            model.ProvisionerEKS,
+		ProvisionerMetadataEKS: &model.EKSMetadata{Name: "eks-name"},
+	}
+	assert.Equal(t, eksCluster.ProvisionerMetadataEKS.Name, getClusterTag(eksCluster))
+
+	externalCluster := &model.Cluster{
+		ID:                          model.NewID(),
+		Provisioner:                 model.ProvisionerExternal,
+		ProvisionerMetadataExternal: &model.ExternalClusterMetadata{Name: "external-name"},
+	}
+	assert.Equal(t, externalCluster.ProvisionerMetadataExternal.Name, getClusterTag(externalCluster))
+
+	invalidCluster := &model.Cluster{
+		ID: model.NewID(),
+	}
+	assert.Equal(t, "", getClusterTag(invalidCluster))
 }

--- a/internal/tools/aws/vpc.go
+++ b/internal/tools/aws/vpc.go
@@ -15,6 +15,25 @@ import (
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
+// GetVPC gets a VPC by ID.
+func (a *Client) GetVPC(vpcID string) (*ec2Types.Vpc, error) {
+	vpcOut, err := a.Service().ec2.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{VpcIds: []string{vpcID}})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to describe vpc")
+	}
+	if len(vpcOut.Vpcs) == 0 {
+		return nil, errors.Errorf("couldn't find vpc %s", vpcID)
+	}
+
+	return &vpcOut.Vpcs[0], nil
+}
+
+// EnsureVPCExists ensures a VPC with the given ID exists.
+func (a *Client) EnsureVPCExists(vpcID string) error {
+	_, err := a.GetVPC(vpcID)
+	return err
+}
+
 // GetCIDRByVPCTag fetches VPC CIDR block by 'Name' tag.
 func (a *Client) GetCIDRByVPCTag(vpcTagName string, logger log.FieldLogger) (string, error) {
 	ctx := context.TODO()

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -271,6 +271,7 @@ func NewCreateClusterRequestFromReader(reader io.Reader) (*CreateClusterRequest,
 // ImportClusterRequest specifies the parameters for importing a new cluster.
 type ImportClusterRequest struct {
 	ExternalClusterSecretName string   `json:"external-cluster-secret-name,omitempty"`
+	VpcID                     string   `json:"vpc-id,omitempty"`
 	Annotations               []string `json:"annotations,omitempty"`
 	AllowInstallations        bool     `json:"allow-installations"`
 	APISecurityLock           bool     `json:"api-security-lock"`

--- a/model/external_cluster_metadata.go
+++ b/model/external_cluster_metadata.go
@@ -13,8 +13,10 @@ const ProvisionerExternal = "external"
 // ExternalClusterMetadata is the provisioner metadata stored in a model.Cluster
 // for external clusters.
 type ExternalClusterMetadata struct {
+	Name       string
 	SecretName string
 	Version    string
+	VPC        string   `json:"VPC,omitempty"`
 	Warnings   []string `json:"Warnings,omitempty"`
 }
 
@@ -28,8 +30,9 @@ func (ecm *ExternalClusterMetadata) AddWarning(warning string) {
 	ecm.Warnings = append(ecm.Warnings, warning)
 }
 
-func (ecm *ExternalClusterMetadata) ApplyClusterImportRequest(createRequest *ImportClusterRequest) bool {
-	ecm.SecretName = createRequest.ExternalClusterSecretName
+func (ecm *ExternalClusterMetadata) ApplyClusterImportRequest(importRequest *ImportClusterRequest) bool {
+	ecm.SecretName = importRequest.ExternalClusterSecretName
+	ecm.VPC = importRequest.VpcID
 	return true
 }
 

--- a/model/external_provider_metadata.go
+++ b/model/external_provider_metadata.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import "encoding/json"
+
+// ExternalProviderMetadata is the provider metadata stored from external
+// clusters.
+type ExternalProviderMetadata struct {
+	HasAWSInfrastructure bool
+}
+
+func (epm *ExternalProviderMetadata) ApplyClusterImportRequest(importRequest *ImportClusterRequest) {
+	epm.HasAWSInfrastructure = importRequest.VpcID != ""
+}
+
+// NewExternalProviderMetadata creates an instance of ExternalProviderMetadata
+// given the raw provider metadata.
+func NewExternalProviderMetadata(metadataBytes []byte) (*ExternalProviderMetadata, error) {
+	if metadataBytes == nil || string(metadataBytes) == "null" {
+		return nil, nil
+	}
+
+	var externalProviderMetadata ExternalProviderMetadata
+	err := json.Unmarshal(metadataBytes, &externalProviderMetadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return &externalProviderMetadata, nil
+}

--- a/model/installation.go
+++ b/model/installation.go
@@ -266,6 +266,31 @@ func (i *Installation) GetDatabaseWeight() float64 {
 	return DefaultDatabaseWeight
 }
 
+// RequiresAWSInfrasctructure returns if the installation has a database and
+// filestore that are externally managed or not.
+func (i *Installation) RequiresAWSInfrasctructure() bool {
+	return !i.ExternalDatabase() || !i.ExternalFilestore()
+}
+
+// InternalDatabase returns true if the installation's database is internal
+// to the kubernetes cluster it is running on.
+func (i *Installation) InternalDatabase() bool {
+	return i.Database == InstallationDatabaseMysqlOperator
+}
+
+// ExternalDatabase returns true if the installation's database is fully
+// provisioned by an external service.
+func (i *Installation) ExternalDatabase() bool {
+	return i.Database == InstallationDatabaseExternal
+}
+
+// ExternalFilestore returns true if the installation's filestore is fully
+// provisioned by an external service.
+func (i *Installation) ExternalFilestore() bool {
+	// TODO: There are no external filestore options yet.
+	return false
+}
+
 // IsInGroup returns if the installation is in a group or not.
 func (i *Installation) IsInGroup() bool {
 	return i.GroupID != nil

--- a/model/installation_database.go
+++ b/model/installation_database.go
@@ -185,12 +185,6 @@ func IsSupportedDatabase(database string) bool {
 	return true
 }
 
-// InternalDatabase returns true if the installation's database is internal
-// to the kubernetes cluster it is running on.
-func (i *Installation) InternalDatabase() bool {
-	return i.Database == InstallationDatabaseMysqlOperator
-}
-
 // IsSingleTenantRDS returns true if the given database is single tenant RDS db.
 func IsSingleTenantRDS(database string) bool {
 	switch database {

--- a/model/installation_test.go
+++ b/model/installation_test.go
@@ -7,6 +7,7 @@ package model
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/mattermost/mattermost-cloud/internal/util"
@@ -416,6 +417,45 @@ func TestInstallationGetDatabaseWeight(t *testing.T) {
 	} {
 		t.Run(testCase.installation.State, func(t *testing.T) {
 			assert.Equal(t, testCase.expectedWeight, testCase.installation.GetDatabaseWeight())
+		})
+	}
+}
+
+func TestInstallationRequiresAWSInfrasctructure(t *testing.T) {
+	tests := []struct {
+		installation          Installation
+		expectedRequiresInfra bool
+	}{
+		{
+			Installation{
+				Database:  InstallationDatabaseMultiTenantRDSPostgresPGBouncer,
+				Filestore: InstallationFilestoreBifrost,
+			},
+			true,
+		}, {
+			Installation{
+				Database:  InstallationDatabaseMultiTenantRDSMySQL,
+				Filestore: InstallationFilestoreBifrost,
+			},
+			true,
+		}, {
+			Installation{
+				Database:  InstallationDatabaseExternal,
+				Filestore: InstallationFilestoreBifrost,
+			},
+			true,
+		}, {
+			Installation{
+				Database:  InstallationDatabaseExternal,
+				Filestore: InstallationFilestoreAwsS3,
+			},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s_%s", test.installation.Database, test.installation.Filestore), func(t *testing.T) {
+			assert.Equal(t, test.expectedRequiresInfra, test.installation.RequiresAWSInfrasctructure())
 		})
 	}
 }


### PR DESCRIPTION
In an effort to support EKS clusters in our standard production AWS accounts, this change allows for importing clusters with VPC claiming. Clusters imported in this way will be able to perform AWS resource lookups to manage installations with pgbouncer, bifrost, and similar dependencies.

This is example metadata for an external cluster with a claimed VPC:

```
        "ID": "k5mk7fr1k3r8tmi46dbbf5wj6w",
        "State": "stable",
        "Provider": "external",
        "ProviderMetadataExternal": {
            "HasAWSInfrastructure": true
        },
        "Provisioner": "external",
        "ProvisionerMetadataExternal": {
            "Name": "k5mk7fr1k3r8tmi46dbbf5wj6w-external-k8s",
            "SecretName": "kubeconfig-net-calico",
            "Version": "1.29.4-eks-036c24b",
            "VPC": "vpc-0846s82b132aad7e7",
            "Warnings": [
                "Health Check: failed to find any deployments in namespace bifrost"
            ]
        },
```

A follow-up PR will be needed to incorporate new VPC lookup filters so that kops clusters can't accidentally claim a VPC with EKS clusters in them.

Fixes https://mattermost.atlassian.net/browse/CLD-7985

```release-note
Add VPC claiming for external cluster types
```
