### PR TITLE
Add VPC cluster type tag check

### DIFF
--- a/internal/tools/aws/cluster_management.go
+++ b/internal/tools/aws/cluster_management.go
@@ -332,6 +332,10 @@ func (a *Client) GetAndClaimVpcResources(cluster *model.Cluster, owner string, l
 			Name:   aws.String(VpcAvailableTagKey),
 			Values: []string{VpcAvailableTagValueTrue},
 		},
+		{
+			Name:   aws.String(VpcClusterTypeTagKey),
+			Values: []string{VpcClusterTypeTagValueKops},
+		},
 	}
 
 	vpcs, err := a.GetVpcsWithFilters(vpcFilters)

--- a/internal/tools/aws/constants.go
+++ b/internal/tools/aws/constants.go
@@ -31,6 +31,13 @@ const (
 	// cluster running in that VPC.
 	VpcClusterIDTagKey = "tag:" + ClusterIDTagKey
 
+	// VpcClusterTypeTagKey is the tag key used determine which type of k8s
+	// cluster will be used in the VPC.
+	VpcClusterTypeTagKey = "tag:CloudClusterType"
+
+	// VpcClusterTypeTagValueKops is the tag value for a kops cluster type.
+	VpcClusterTypeTagValueKops = "kops"
+
 	// VpcClusterOwnerKey is the tag key  used to store the owner of the
 	// cluster's human name so that the VPC's owner can be identified
 	VpcClusterOwnerKey = "tag:CloudClusterOwner"


### PR DESCRIPTION
When building a kops cluster we now check for another VPC tag to ensure the cluster type matches. This will prevent claiming VPCs which are meant for EKS or other cluster types.

Fixes https://mattermost.atlassian.net/browse/CLD-8096

```release-note
Add VPC cluster type tag check
```
