### PR TITLE
PGBouncer provisioning improvements

### DIFF
--- a/cmd/cloud/utils.go
+++ b/cmd/cloud/utils.go
@@ -11,11 +11,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-func parseEnvVarInput(rawInput []string, clear bool) (model.EnvVarMap, error) {
-	if len(rawInput) != 0 && clear {
+func parseEnvVarInput(rawInput []string, clearEnv bool) (model.EnvVarMap, error) {
+	if len(rawInput) != 0 && clearEnv {
 		return nil, errors.New("both mattermost-env and mattermost-env-clear were set; use one or the other")
 	}
-	if clear {
+	if clearEnv {
 		// An empty non-nil map is what the API expects for a full env wipe.
 		return make(model.EnvVarMap), nil
 	}

--- a/internal/api/cluster_test.go
+++ b/internal/api/cluster_test.go
@@ -1068,8 +1068,7 @@ func TestResizeCluster(t *testing.T) {
 		errTest := sqlStore.UpdateCluster(cluster1.Cluster)
 		require.NoError(t, errTest)
 
-		max := int64(1)
-		clusterResp, errTest := client.ResizeCluster(cluster1.ID, &model.PatchClusterSizeRequest{NodeMaxCount: &max})
+		clusterResp, errTest := client.ResizeCluster(cluster1.ID, &model.PatchClusterSizeRequest{NodeMaxCount: util.IToP(1)})
 		require.EqualError(t, errTest, "failed with status code 400")
 		assert.Nil(t, clusterResp)
 	})
@@ -1079,9 +1078,10 @@ func TestResizeCluster(t *testing.T) {
 		errTest := sqlStore.UpdateCluster(cluster1.Cluster)
 		require.NoError(t, errTest)
 
-		min := int64(10)
-		max := int64(5)
-		clusterResp, errTest := client.ResizeCluster(cluster1.ID, &model.PatchClusterSizeRequest{NodeMinCount: &min, NodeMaxCount: &max})
+		clusterResp, errTest := client.ResizeCluster(cluster1.ID, &model.PatchClusterSizeRequest{
+			NodeMinCount: util.IToP(10),
+			NodeMaxCount: util.IToP(5),
+		})
 		require.EqualError(t, errTest, "failed with status code 400")
 		assert.Nil(t, clusterResp)
 	})

--- a/internal/provisioner/cluster_provisioning.go
+++ b/internal/provisioner/cluster_provisioning.go
@@ -394,14 +394,11 @@ func provisionCluster(
 	}
 
 	// Sync PGBouncer configmap if there is any change
-	var vpc string
-	if cluster.Provisioner == model.ProvisionerKops {
-		vpc = cluster.ProvisionerMetadataKops.VPC
-	} else if cluster.Provisioner == model.ProvisionerEKS {
-		vpc = cluster.ProvisionerMetadataEKS.VPC
-	} else {
-		return errors.New("cannot get metadata from unknown provisioner")
+	vpc := cluster.VpcID()
+	if vpc == "" {
+		return errors.New("cluster metadata returned an empty VPC ID")
 	}
+
 	ctx, cancel = context.WithTimeout(context.Background(), time.Duration(10)*time.Second)
 	defer cancel()
 	err = pgbouncer.UpdatePGBouncerConfigMap(ctx, vpc, store, cluster.PgBouncerConfig, k8sClient, logger)

--- a/internal/provisioner/eks_provisioner.go
+++ b/internal/provisioner/eks_provisioner.go
@@ -554,8 +554,7 @@ func (provisioner *EKSProvisioner) isMigrationRequired(oldNodeGroup *eksTypes.No
 		return true
 	}
 
-	if oldNodeGroup.InstanceTypes != nil && len(oldNodeGroup.InstanceTypes) > 0 &&
-		oldNodeGroup.InstanceTypes[0] != ngChangeRequest.InstanceType {
+	if len(oldNodeGroup.InstanceTypes) > 0 && oldNodeGroup.InstanceTypes[0] != ngChangeRequest.InstanceType {
 		return true
 	}
 

--- a/internal/provisioner/external_provisioner.go
+++ b/internal/provisioner/external_provisioner.go
@@ -117,7 +117,7 @@ func (provisioner *ExternalProvisioner) ProvisionCluster(cluster *model.Cluster)
 		return err
 	}
 	if cluster.HasAWSInfrastructure() {
-		logger.Info("Provisiong resources for AWS infrastructure")
+		logger.Info("Provisioning resources for AWS infrastructure")
 
 		err = utility.DeployPgbouncerManifests(k8sClient, logger)
 		if err != nil {

--- a/internal/provisioner/external_provisioner.go
+++ b/internal/provisioner/external_provisioner.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/mattermost/mattermost-cloud/internal/provisioner/utility"
 	"github.com/mattermost/mattermost-cloud/internal/store"
 	"github.com/mattermost/mattermost-cloud/internal/supervisor"
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
@@ -105,9 +106,24 @@ func (provisioner *ExternalProvisioner) DeleteNodegroups(cluster *model.Cluster)
 	return nil
 }
 
-// ProvisionCluster is no-op for external clusters.
+// ProvisionCluster runs provisioning tasks for external clusters.
 func (provisioner *ExternalProvisioner) ProvisionCluster(cluster *model.Cluster) error {
-	provisioner.logger.WithField("cluster", cluster.ID).Info("Cluster is managed externally; skipping provision...")
+	logger := provisioner.logger.WithField("cluster", cluster.ID)
+
+	logger.Info("Provisioning cluster")
+
+	k8sClient, err := provisioner.getKubeClient(cluster)
+	if err != nil {
+		return err
+	}
+	if cluster.HasAWSInfrastructure() {
+		logger.Info("Provisiong resources for AWS infrastructure")
+
+		err = utility.DeployPgbouncerManifests(k8sClient, logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to deploy pgbouncer manifests")
+		}
+	}
 
 	return nil
 }

--- a/internal/provisioner/utility/pgbouncer.go
+++ b/internal/provisioner/utility/pgbouncer.go
@@ -89,7 +89,7 @@ func (p *pgbouncer) CreateOrUpgrade() error {
 		return errors.Wrap(err, "failed to set up the k8s client")
 	}
 
-	err = deployManifests(k8sClient, p.logger)
+	err = DeployPgbouncerManifests(k8sClient, p.logger)
 	if err != nil {
 		return err
 	}
@@ -144,8 +144,9 @@ func (p *pgbouncer) Name() string {
 	return model.PgbouncerCanonicalName
 }
 
-// deployManifests deploy pgbouncer manifests if they don't exist: pgbouncer-configmap and pgbouncer-userlist-secret
-func deployManifests(k8sClient *k8s.KubeClient, logger log.FieldLogger) error {
+// DeployManifests deploy pgbouncer manifests if they don't exist:
+// pgbouncer-configmap and pgbouncer-userlist-secret
+func DeployPgbouncerManifests(k8sClient *k8s.KubeClient, logger log.FieldLogger) error {
 	logger = logger.WithField("pgbouncer-action", "create-manifests")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(180)*time.Second)
@@ -168,7 +169,7 @@ func deployManifests(k8sClient *k8s.KubeClient, logger log.FieldLogger) error {
 		}
 		err = k8sClient.CreateFromFile(file, "")
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to create pgbouncer-configmap")
 		}
 	} else if err != nil {
 		return errors.Wrap(err, "failed to get configmap for pgbouncer-configmap")

--- a/internal/provisioner/utility/unmanaged.go
+++ b/internal/provisioner/utility/unmanaged.go
@@ -70,7 +70,7 @@ func (u *unmanaged) CreateOrUpgrade() error {
 
 	switch u.Name() {
 	case model.PgbouncerCanonicalName:
-		err = deployManifests(k8sClient, u.logger)
+		err = DeployPgbouncerManifests(k8sClient, u.logger)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change does the following:
 - Improves handling of the PGBouncer configmap to avoid panics when it may be improperly created.
 - Run PGBouncer provisioning tasks in the external cluster type.
 - Fix a VPC ID bug for some cluster tasks.

Fixes https://mattermost.atlassian.net/browse/CLD-8137

```release-note
PGBouncer provisioning improvements
```
