### PR TITLE
Add cluster names

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -306,6 +306,7 @@ func newCmdClusterUpdate() *cobra.Command {
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			flags.clusterFlags.addFlags(cmd)
+			flags.clusterPatchRequestChanges.addFlags(cmd)
 		},
 	}
 	flags.addFlags(cmd)
@@ -314,12 +315,9 @@ func newCmdClusterUpdate() *cobra.Command {
 }
 
 func executeClusterUpdateCmd(flags clusterUpdateFlags) error {
-
 	client := createClient(flags.clusterFlags)
 
-	request := &model.UpdateClusterRequest{
-		AllowInstallations: flags.allowInstallations,
-	}
+	request := flags.GetPatchClusterRequest()
 
 	if flags.dryRun {
 		return runDryRun(request)
@@ -595,7 +593,7 @@ func executeClusterListCmd(flags clusterListFlags) error {
 }
 
 func defaultClustersTableData(clusters []*model.ClusterDTO) ([]string, [][]string) {
-	keys := []string{"ID", "STATE", "VERSION", "MASTER NODES", "WORKER NODES", "AMI ID/NAME", "NETWORKING", "VPC", "STATUS"}
+	keys := []string{"ID", "NAME", "STATE", "VERSION", "MASTER NODES", "WORKER NODES", "AMI ID/NAME", "NETWORKING", "VPC", "STATUS"}
 	values := make([][]string, 0, len(clusters))
 
 	for _, cluster := range clusters {
@@ -632,7 +630,7 @@ func defaultClustersTableData(clusters []*model.ClusterDTO) ([]string, [][]strin
 		}
 
 		values = append(values, []string{
-			cluster.ID, cluster.State,
+			cluster.ID, cluster.Name, cluster.State,
 			versionEntry, masterEntry, workerEntry, amiEntry, networkingEntry, vpcEntry,
 			status,
 		})

--- a/cmd/cloud/cluster_flag.go
+++ b/cmd/cloud/cluster_flag.go
@@ -286,17 +286,43 @@ func (flags *pgBouncerConfigOptions) GetPatchPgBouncerConfig() *model.PatchPgBou
 	return &request
 }
 
+func (flags *clusterPatchRequestChanges) addFlags(command *cobra.Command) {
+	flags.nameChanged = command.Flags().Changed("name")
+	flags.allowInstallationsChanged = command.Flags().Changed("allow-installations")
+}
+
+type clusterPatchRequestChanges struct {
+	nameChanged               bool
+	allowInstallationsChanged bool
+}
+
 type clusterUpdateFlags struct {
 	clusterFlags
+	clusterPatchRequestChanges
 	cluster            string
+	name               string
 	allowInstallations bool
 }
 
 func (flags *clusterUpdateFlags) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.cluster, "cluster", "", "The id of the cluster to be updated.")
+	command.Flags().StringVar(&flags.name, "name", "", "An optional name value to identify the cluster.")
 	command.Flags().BoolVar(&flags.allowInstallations, "allow-installations", true, "Whether the cluster will allow for new installations to be scheduled.")
 
 	_ = command.MarkFlagRequired("cluster")
+}
+
+func (flags *clusterUpdateFlags) GetPatchClusterRequest() *model.UpdateClusterRequest {
+	request := model.UpdateClusterRequest{}
+
+	if flags.nameChanged {
+		request.Name = &flags.name
+	}
+	if flags.allowInstallationsChanged {
+		request.AllowInstallations = &flags.allowInstallations
+	}
+
+	return &request
 }
 
 type rotatorConfig struct {

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -344,8 +344,7 @@ func handleUpdateClusterConfiguration(c *Context, w http.ResponseWriter, r *http
 		return
 	}
 
-	if clusterDTO.AllowInstallations != updateClusterRequest.AllowInstallations {
-		clusterDTO.AllowInstallations = updateClusterRequest.AllowInstallations
+	if clusterDTO.ApplyClusterUpdatePatch(updateClusterRequest) {
 		err := c.Store.UpdateCluster(clusterDTO.Cluster)
 		if err != nil {
 			c.Logger.WithError(err).Error("failed to update cluster")

--- a/internal/store/cluster.go
+++ b/internal/store/cluster.go
@@ -18,7 +18,7 @@ var clusterSelect sq.SelectBuilder
 
 func init() {
 	clusterSelect = sq.
-		Select("Cluster.ID", "Provider", "Provisioner", "ProviderMetadataRaw", "ProvisionerMetadataRaw",
+		Select("Cluster.ID", "Name", "Provider", "Provisioner", "ProviderMetadataRaw", "ProvisionerMetadataRaw",
 			"UtilityMetadataRaw", "PgBouncerConfig", "State", "AllowInstallations", "CreateAt", "DeleteAt",
 			"APISecurityLock", "SchedulingLockAcquiredBy", "SchedulingLockAcquiredAt", "LockAcquiredBy", "LockAcquiredAt").
 		From("Cluster")
@@ -256,6 +256,7 @@ func (sqlStore *SQLStore) createCluster(execer execer, cluster *model.Cluster) e
 		Insert("Cluster").
 		SetMap(map[string]interface{}{
 			"ID":                       cluster.ID,
+			"Name":                     cluster.Name,
 			"State":                    cluster.State,
 			"Provider":                 cluster.Provider,
 			"ProviderMetadataRaw":      rawMetadata.ProviderMetadataRaw,
@@ -290,6 +291,7 @@ func (sqlStore *SQLStore) UpdateCluster(cluster *model.Cluster) error {
 		Update("Cluster").
 		SetMap(map[string]interface{}{
 			"State":                  cluster.State,
+			"Name":                   cluster.Name,
 			"Provider":               cluster.Provider,
 			"ProviderMetadataRaw":    rawMetadata.ProviderMetadataRaw,
 			"Provisioner":            cluster.Provisioner,

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -2239,4 +2239,12 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.48.0"), semver.MustParse("0.49.0"), func(e execer) error {
+		_, err := e.Exec(`ALTER TABLE Cluster ADD COLUMN Name TEXT NOT NULL DEFAULT '';`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -15,6 +15,7 @@ import (
 // Cluster represents a Kubernetes cluster.
 type Cluster struct {
 	ID                          string
+	Name                        string
 	State                       string
 	Provider                    string
 	ProviderMetadataAWS         *AWSMetadata              `json:"ProviderMetadataAWS,omitempty"`
@@ -77,6 +78,20 @@ func (c *Cluster) HasAWSInfrastructure() bool {
 	}
 
 	return true
+}
+
+func (c *Cluster) ApplyClusterUpdatePatch(patchRequest *UpdateClusterRequest) bool {
+	var applied bool
+	if patchRequest.Name != nil && *patchRequest.Name != c.Name {
+		applied = true
+		c.Name = *patchRequest.Name
+	}
+	if patchRequest.AllowInstallations != nil && *patchRequest.AllowInstallations != c.AllowInstallations {
+		applied = true
+		c.AllowInstallations = *patchRequest.AllowInstallations
+	}
+
+	return applied
 }
 
 // ClusterFromReader decodes a json-encoded cluster from the given io.Reader.

--- a/model/cluster_request.go
+++ b/model/cluster_request.go
@@ -322,7 +322,8 @@ func (request *GetClustersRequest) ApplyToURL(u *url.URL) {
 
 // UpdateClusterRequest specifies the parameters available for updating a cluster.
 type UpdateClusterRequest struct {
-	AllowInstallations bool
+	Name               *string
+	AllowInstallations *bool
 }
 
 // NewUpdateClusterRequestFromReader will create an UpdateClusterRequest from an io.Reader with JSON data.

--- a/model/cluster_test.go
+++ b/model/cluster_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/mattermost/mattermost-cloud/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -125,6 +126,59 @@ func TestClusterHasAWSInfrastructure(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.expectedHasInfra, test.cluster.HasAWSInfrastructure())
+		})
+	}
+}
+
+func TestClusterApplyClusterUpdatePatch(t *testing.T) {
+	tests := []struct {
+		name            string
+		cluster         Cluster
+		patch           *UpdateClusterRequest
+		expectedApply   bool
+		expectedCluster Cluster
+	}{
+		{
+			"empty patch",
+			Cluster{},
+			&UpdateClusterRequest{},
+			false,
+			Cluster{},
+		},
+		{
+			"name only",
+			Cluster{},
+			&UpdateClusterRequest{Name: util.SToP("new1")},
+			true,
+			Cluster{Name: "new1"},
+		},
+		{
+			"allow installations only",
+			Cluster{},
+			&UpdateClusterRequest{AllowInstallations: util.BToP(true)},
+			true,
+			Cluster{AllowInstallations: true},
+		},
+		{
+			"all values",
+			Cluster{},
+			&UpdateClusterRequest{
+				Name:               util.SToP("new2"),
+				AllowInstallations: util.BToP(true),
+			},
+			true,
+			Cluster{
+				Name:               "new2",
+				AllowInstallations: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			applied := test.cluster.ApplyClusterUpdatePatch(test.patch)
+			assert.Equal(t, test.expectedApply, applied)
+			assert.Equal(t, test.expectedCluster, test.cluster)
 		})
 	}
 }


### PR DESCRIPTION
Clusters can now be given a name value to help identify them. Names are completely optional and can be updated at any time.

Fixes https://mattermost.atlassian.net/browse/CLD-8219

```release-note
Add cluster names
```
