### PR TITLE
Handle missing VPC ID on initial provision

### DIFF
--- a/internal/provisioner/cluster_provisioning.go
+++ b/internal/provisioner/cluster_provisioning.go
@@ -396,7 +396,10 @@ func provisionCluster(
 	// Sync PGBouncer configmap if there is any change
 	vpc := cluster.VpcID()
 	if vpc == "" {
-		return errors.New("cluster metadata returned an empty VPC ID")
+		vpc, err = awsClient.GetClaimedVPC(cluster.ID, logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to lookup cluster VPC")
+		}
 	}
 
 	ctx, cancel = context.WithTimeout(context.Background(), time.Duration(10)*time.Second)


### PR DESCRIPTION
Kops clusters don't have their VPC ID stored in metadata the first time the cluster is provisioned. This change adds a direct lookup in those cases.

Fixes https://mattermost.atlassian.net/browse/CLD-8293

```release-note
Handle missing VPC ID on initial provision
```
