### PR TITLE
Add Mattermost debug data gathering

### DIFF
--- a/cmd/cloud/cluster_installation_flag.go
+++ b/cmd/cloud/cluster_installation_flag.go
@@ -98,6 +98,17 @@ func (flags *clusterInstallationMattermostCLIFlags) addFlags(command *cobra.Comm
 	_ = command.MarkFlagRequired("command")
 }
 
+type clusterInstallationPPROFFlags struct {
+	clusterFlags
+	clusterInstallationID string
+}
+
+func (flags *clusterInstallationPPROFFlags) addFlags(command *cobra.Command) {
+	command.Flags().StringVar(&flags.clusterInstallationID, "cluster-installation", "", "The id of the cluster installation.")
+
+	_ = command.MarkFlagRequired("cluster-installation")
+}
+
 type clusterInstallationMigrationFlags struct {
 	clusterFlags
 	installation  string

--- a/internal/api/cluster_installation.go
+++ b/internal/api/cluster_installation.go
@@ -360,7 +360,7 @@ func handleRunClusterInstallationGetPPROF(c *Context, w http.ResponseWriter, r *
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-
+c.Logger = c.Logger.WithField("cluster_id", cluster.ID)
 	debugData, execErr, err := c.Provisioner.ExecClusterInstallationPPROF(cluster, clusterInstallation)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to prepare command execution")

--- a/internal/api/cluster_installation.go
+++ b/internal/api/cluster_installation.go
@@ -360,7 +360,8 @@ func handleRunClusterInstallationGetPPROF(c *Context, w http.ResponseWriter, r *
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-c.Logger = c.Logger.WithField("cluster_id", cluster.ID)
+
+	c.Logger = c.Logger.WithField("cluster_id", cluster.ID)
 	debugData, execErr, err := c.Provisioner.ExecClusterInstallationPPROF(cluster, clusterInstallation)
 	if err != nil {
 		c.Logger.WithError(err).Error("failed to prepare command execution")

--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -31,6 +31,7 @@ func (m *mockMetrics) ObserveAPIEndpointDuration(handler, method string, statusC
 
 type mockProvisioner struct {
 	Output       []byte
+	DebugData    model.ClusterInstallationDebugData
 	ExecError    error
 	CommandError error
 }
@@ -65,6 +66,10 @@ func (s *mockProvisioner) ExecMattermostCLI(*model.Cluster, *model.ClusterInstal
 	}
 
 	return s.Output, s.CommandError
+}
+
+func (s *mockProvisioner) ExecClusterInstallationPPROF(*model.Cluster, *model.ClusterInstallation) (model.ClusterInstallationDebugData, error, error) {
+	return s.DebugData, s.ExecError, s.CommandError
 }
 
 func (s *mockProvisioner) GetClusterResources(*model.Cluster, bool, log.FieldLogger) (*k8s.ClusterResources, error) {

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -137,6 +137,7 @@ type Provisioner interface {
 	ExecClusterInstallationCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error, error)
 	ExecMMCTL(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
 	ExecMattermostCLI(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation, args ...string) ([]byte, error)
+	ExecClusterInstallationPPROF(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation) (model.ClusterInstallationDebugData, error, error)
 	GetClusterInstallationStatus(cluster *model.Cluster, clusterInstallation *model.ClusterInstallation) (*model.ClusterInstallationStatus, error)
 }
 

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -5,8 +5,10 @@
 package api
 
 import (
+	"archive/zip"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/mattermost/mattermost-cloud/model"
 
@@ -104,4 +106,25 @@ func parseDeletionLocked(u *url.URL) (*bool, error) {
 	}
 
 	return &locked, nil
+}
+
+func populateZipfile(w *zip.Writer, fileDatas []model.FileData) error {
+	defer w.Close()
+	for _, fd := range fileDatas {
+		f, err := w.CreateHeader(&zip.FileHeader{
+			Name:     fd.Filename,
+			Method:   zip.Deflate,
+			Modified: time.Now(),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		_, err = f.Write(fd.Body)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/model/client.go
+++ b/model/client.go
@@ -1051,6 +1051,25 @@ func (c *Client) ExecClusterInstallationCLI(clusterInstallationID, command strin
 	}
 }
 
+// ExecClusterInstallationPPROF runs a gathers pprof data from a cluster installation.
+func (c *Client) ExecClusterInstallationPPROF(clusterInstallationID string) ([]byte, error) {
+	resp, err := c.doGet(c.buildURL("/api/cluster_installation/%s/pprof", clusterInstallationID))
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	bytes, _ := io.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return bytes, nil
+
+	default:
+		return bytes, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // CreateGroup requests the creation of a group from the configured provisioning server.
 func (c *Client) CreateGroup(request *CreateGroupRequest) (*GroupDTO, error) {
 	resp, err := c.doPost(c.buildURL("/api/groups"), request)

--- a/model/cluster_installation.go
+++ b/model/cluster_installation.go
@@ -6,6 +6,7 @@ package model
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -43,6 +44,45 @@ type ClusterInstallationStatus struct {
 	ReadyPod          *int32 `json:"ReadyPod,omitempty"`
 	StartedPod        *int32 `json:"StartedPod,omitempty"`
 	ReadyLocalServer  *int32 `json:"ReadyLocalServer,omitempty"`
+}
+
+type ClusterInstallationDebugData []PodDebugData
+
+func (d *ClusterInstallationDebugData) ToFileData() []FileData {
+	files := []FileData{}
+	for _, podDebugData := range *d {
+		files = append(files,
+			podDebugData.GetHeapProfFile(),
+			podDebugData.GetGoroutinesProfFile(),
+		)
+	}
+
+	return files
+}
+
+type PodDebugData struct {
+	Name          string
+	HeapProf      []byte
+	GoroutineProf []byte
+}
+
+func (pd *PodDebugData) GetHeapProfFile() FileData {
+	return FileData{
+		Filename: fmt.Sprintf("%s.heap.prof", pd.Name),
+		Body:     pd.HeapProf,
+	}
+}
+
+func (pd *PodDebugData) GetGoroutinesProfFile() FileData {
+	return FileData{
+		Filename: fmt.Sprintf("%s.goroutine.prof", pd.Name),
+		Body:     pd.GoroutineProf,
+	}
+}
+
+type FileData struct {
+	Filename string
+	Body     []byte
 }
 
 // MigrateClusterInstallationRequest describes the parameters used to compose migration request between two clusters.


### PR DESCRIPTION
This is initial work to allow for obtaining pprof information from a given Mattermost deployment. The heap and goroutine performance profiles can now be obtained in a zip file for all pods in a cluster installation. The zip is processed on the server and then sent to the cloud client to be reviewed.

Fixes https://mattermost.atlassian.net/browse/CLD-7704

```release-note
Add Mattermost debug data gathering
```
