### PR TITLE
Add second key to thanos-objstore-config in order to unify secrets but be BC at the same time keeping the old one

### DIFF
--- a/internal/provisioner/utility/prometheus_operator.go
+++ b/internal/provisioner/utility/prometheus_operator.go
@@ -97,7 +97,8 @@ func (p *prometheusOperator) CreateOrUpgrade() error {
 			Name: "thanos-objstore-config",
 		},
 		StringData: map[string]string{
-			"thanos.yaml": string(secret),
+			"thanos.yaml":  string(secret),
+			"objstore.yml": string(secret),
 		},
 	}
 

--- a/internal/provisioner/utility/unmanaged.go
+++ b/internal/provisioner/utility/unmanaged.go
@@ -122,7 +122,8 @@ func (u *unmanaged) CreateOrUpgrade() error {
 				Name: "thanos-objstore-config",
 			},
 			StringData: map[string]string{
-				"thanos.yaml": string(secret),
+				"thanos.yaml":  string(secret),
+				"objstore.yml": string(secret),
 			},
 		}
 


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add second key to thanos-objstore-config in order to unify secrets but be BC at the same time keeping the old one

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-7923

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add second key to thanos-objstore-config in order to unify secrets but be BC at the same time keeping the old one
```
