### PR TITLE
Remove deprecated server flags

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -237,10 +237,6 @@ func executeServerCmd(flags serverFlags) error {
 		"deploy-mysql-operator":                         flags.deployMySQLOperator,
 		"deploy-minio-operator":                         flags.deployMinioOperator,
 		"ndots-value":                                   flags.ndotsDefaultValue,
-		"maxDatabaseConnectionsPerPool":                 flags.maxDatabaseConnectionsPerPool,
-		"defaultPoolSize":                               flags.defaultPoolSize,
-		"minPoolSize":                                   flags.minPoolSize,
-		"maxClientConnections":                          flags.maxClientConnections,
 		"disable-db-init-check":                         flags.disableDBInitCheck,
 		"enable-route53":                                flags.enableRoute53,
 		"disable-dns-updates":                           flags.disableDNSUpdates,
@@ -587,13 +583,7 @@ func checkRequirements(logger logrus.FieldLogger) error {
 // deprecationWarnings performs all checks for deprecated settings and warns if
 // any are found.
 func deprecationWarnings(logger logrus.FieldLogger, flags serverFlags) {
-	if flags.debugHelm {
-		logger.Warn("The debug-helm flag has been deprecated")
-	}
 
-	// Generic warning for old flags.
-	// TODO: Remove after deployments are updated.
-	logger.Warn("All pgbouncer config.ini flags have been deprecated. Review server flags to ensure you are not setting any as they will be removed later.")
 }
 
 // getHumanReadableID  represents  a  best  effort  attempt  to  retrieve  an

--- a/cmd/cloud/server_flag.go
+++ b/cmd/cloud/server_flag.go
@@ -108,36 +108,6 @@ func (flags *provisioningParams) addFlags(command *cobra.Command) {
 
 }
 
-type pgBouncerConfig struct {
-	minPoolSize                   int64
-	defaultPoolSize               int64
-	reservePoolSize               int64
-	maxClientConnections          int64
-	maxDatabaseConnectionsPerPool int64
-	serverIdleTimeout             int64
-	serverLifetime                int64
-	serverResetQueryAlways        int64
-}
-
-func (flags *pgBouncerConfig) addFlags(command *cobra.Command) {
-	command.Flags().Int64Var(&flags.minPoolSize, "min-proxy-db-pool-size", 1, "Deprecated")
-	command.Flags().MarkDeprecated("min-proxy-db-pool-size", "PgBouncer config is now set on clusters")
-	command.Flags().Int64Var(&flags.defaultPoolSize, "default-proxy-db-pool-size", 5, "Deprecated")
-	command.Flags().MarkDeprecated("default-proxy-db-pool-size", "PgBouncer config is now set on clusters")
-	command.Flags().Int64Var(&flags.reservePoolSize, "reserve-proxy-db-pool-size", 10, "Deprecated")
-	command.Flags().MarkDeprecated("reserve-proxy-db-pool-size", "PgBouncer config is now set on clusters")
-	command.Flags().Int64Var(&flags.maxClientConnections, "max-client-connections", 20000, "Deprecated")
-	command.Flags().MarkDeprecated("max-client-connections", "PgBouncer config is now set on clusters")
-	command.Flags().Int64Var(&flags.maxDatabaseConnectionsPerPool, "max-proxy-db-connections-per-pool", 20, "Deprecated")
-	command.Flags().MarkDeprecated("max-proxy-db-connections-per-pool", "PgBouncer config is now set on clusters")
-	command.Flags().Int64Var(&flags.serverIdleTimeout, "server-idle-timeout", 30, "Deprecated")
-	command.Flags().MarkDeprecated("server-idle-timeout", "PgBouncer config is now set on clusters")
-	command.Flags().Int64Var(&flags.serverLifetime, "server-lifetime", 300, "Deprecated")
-	command.Flags().MarkDeprecated("server-lifetime", "PgBouncer config is now set on clusters")
-	command.Flags().Int64Var(&flags.serverResetQueryAlways, "server-reset-query-always", 0, "Deprecated")
-	command.Flags().MarkDeprecated("server-reset-query-always", "PgBouncer config is now set on clusters")
-}
-
 type installationOptions struct {
 	keepDatabaseData              bool
 	keepFileStoreData             bool
@@ -198,7 +168,6 @@ type serverFlags struct {
 	supervisorOptions
 	schedulingOptions
 	provisioningParams
-	pgBouncerConfig
 	installationOptions
 	dbUtilizationSettings
 	serverFlagChanged
@@ -207,7 +176,6 @@ type serverFlags struct {
 	metricsPort int
 
 	debug                    bool
-	debugHelm                bool
 	devMode                  bool
 	machineLogs              bool
 	enableLogStacktrace      bool
@@ -228,7 +196,6 @@ func (flags *serverFlags) addFlags(command *cobra.Command) {
 	flags.supervisorOptions.addFlags(command)
 	flags.schedulingOptions.addFlags(command)
 	flags.provisioningParams.addFlags(command)
-	flags.pgBouncerConfig.addFlags(command)
 	flags.installationOptions.addFlags(command)
 	flags.dbUtilizationSettings.addFlags(command)
 
@@ -236,7 +203,6 @@ func (flags *serverFlags) addFlags(command *cobra.Command) {
 	command.Flags().IntVar(&flags.metricsPort, "metrics-port", 8076, "Port on which the metrics server should be listening.")
 
 	command.Flags().BoolVar(&flags.debug, "debug", false, "Whether to output debug logs.")
-	command.Flags().BoolVar(&flags.debugHelm, "debug-helm", false, "Whether to include Helm output in debug logs.")
 	command.Flags().BoolVar(&flags.devMode, "dev", false, "Set sane defaults for development")
 	command.Flags().BoolVar(&flags.machineLogs, "machine-readable-logs", false, "Output the logs in machine readable format.")
 	command.Flags().BoolVar(&flags.enableLogStacktrace, "enable-log-stacktrace", false, "Add stacktrace in error logs.")

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/mattermost/mattermost-cloud
 
 go 1.22.0
 
-toolchain go1.22.5
+toolchain go1.22.7
 
 require (
 	github.com/0xAX/notificator v0.0.0-20220220101646-ee9b8921e557


### PR DESCRIPTION
This removes server flags which have been deprecated for some time.

Fixes https://mattermost.atlassian.net/browse/CLD-8336

```release-note
Remove deprecated server flags
```
