### PR TITLE
[CLD-8390]Fix folder permissions

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -44,6 +44,7 @@ COPY --from=build /mattermost-cloud/helm-charts /mattermost-cloud/helm-charts
 COPY --from=build /mattermost-cloud/manifests /mattermost-cloud/manifests
 COPY --from=build /mattermost-cloud/build/_output/${TARGETARCH}/bin/cloud /mattermost-cloud/cloud
 COPY --from=build /mattermost-cloud/build/bin /usr/local/bin
+RUN chown -R ${USER_UID}:${USER_UID} /mattermost-cloud/
 RUN  /usr/local/bin/user_setup
 WORKDIR /mattermost-cloud/
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR will fix permission for cloud user to right in ~/.aws to be able to run kubeclt in EKS clusters.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8390

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
