### PR TITLE
[CLD-8390]Fix cloud user home dir

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -29,12 +29,14 @@ LABEL name="Mattermost Cloud" \
 
 ENV CLOUD=/mattermost-cloud/cloud \
   USER_UID=10001 \
-  USER_NAME=cloud
+  USER_NAME=cloud \
+  HOME=/mattermost-cloud
 
 RUN  apk update && apk add libc6-compat \
                            ca-certificates \
                            mandoc \
                            aws-cli \
+                           shadow \
                            && rm -rf /var/cache/apk/*
 COPY --from=build /mattermost-cloud/build/terraform /usr/local/bin/
 COPY --from=build /mattermost-cloud/build/kops /usr/local/bin/
@@ -44,11 +46,11 @@ COPY --from=build /mattermost-cloud/helm-charts /mattermost-cloud/helm-charts
 COPY --from=build /mattermost-cloud/manifests /mattermost-cloud/manifests
 COPY --from=build /mattermost-cloud/build/_output/${TARGETARCH}/bin/cloud /mattermost-cloud/cloud
 COPY --from=build /mattermost-cloud/build/bin /usr/local/bin
-RUN chown -R ${USER_UID}:${USER_UID} /mattermost-cloud/
+RUN useradd ${USER_NAME} -u ${USER_UID} -d ${HOME} -s /sbin/nologin
 RUN  /usr/local/bin/user_setup
 WORKDIR /mattermost-cloud/
 
-USER ${USER_UID}
+USER ${USER_NAME}
 
 EXPOSE 8075
 EXPOSE 8076


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR will fix the home dir for cloud user to be able to create .aws directory.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
