### PR TITLE
'Upgrade' version of k8s.io/client-go to proper format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	k8s.io/api v0.30.3
 	k8s.io/apiextensions-apiserver v0.30.3
 	k8s.io/apimachinery v0.30.3
-	k8s.io/client-go v1.5.2
+	k8s.io/client-go v0.31.1
 	k8s.io/kube-aggregator v0.30.3
 )
 


### PR DESCRIPTION

#### Summary
In https://github.com/mattermost/mattermost-cloud/pull/1017 the version of this package was changed from `v0.27.2` to `v1.5.2` while on the surface this appears to be an upgrade, it was actually a downgrade. The package itself seems to have changed up it's versioning scheme with the introduction of Go modules in go1.16 - see the README [here](https://github.com/kubernetes/client-go). This PR returns the package version to the proper way, and upgrades it to the latest minor version. This enables other projects to use go get against the Provisioner.
#### Ticket Link
N/a

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
