### PR TITLE
Add support for --context flag

### DIFF
--- a/cmd/cloud/clicontext/clicontext.go
+++ b/cmd/cloud/clicontext/clicontext.go
@@ -33,6 +33,15 @@ func (c *Contexts) Current() *CLIContext {
 	return &context
 }
 
+func (c *Contexts) Get(contextName string) *CLIContext {
+	context, ok := c.Contexts[contextName]
+	if !ok {
+		return nil
+	}
+
+	return &context
+}
+
 func (c *Contexts) UpdateContext(contextName string, authData *auth.AuthorizationResponse, clientID, orgURL, alias, serverURL string) error {
 	c.Contexts[contextName] = CLIContext{
 		AuthData:  authData,


### PR DESCRIPTION
#### Summary
Adds support for a global --context flag, allowing you to override the context used from your ~/.cloud/config.json file for a single run. This value can also be set via the `CP_CONTEXT` env variable if that workflow suits you better. The value in currentcontext of your ~/.cloud/config.json folder is used if either of the above are not specified. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8611

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
