### PR TITLE
Add support for contexts requiring confirmation

### DIFF
--- a/cmd/cloud/clicontext/clicontext.go
+++ b/cmd/cloud/clicontext/clicontext.go
@@ -12,11 +12,12 @@ import (
 type ContextKeyServerURL struct{}
 
 type CLIContext struct {
-	AuthData  *auth.AuthorizationResponse `json:"auth_data"`
-	ClientID  string                      `json:"client_id"`
-	OrgURL    string                      `json:"org_url"`
-	ServerURL string                      `json:"server_url"`
-	Alias     string                      `json:"alias"`
+	AuthData             *auth.AuthorizationResponse `json:"auth_data"`
+	ClientID             string                      `json:"client_id"`
+	OrgURL               string                      `json:"org_url"`
+	ServerURL            string                      `json:"server_url"`
+	Alias                string                      `json:"alias"`
+	ConfirmationRequired bool                        `json:"confirmation_required"`
 }
 
 type Contexts struct {
@@ -33,13 +34,14 @@ func (c *Contexts) Current() *CLIContext {
 	return &context
 }
 
-func (c *Contexts) UpdateContext(contextName string, authData *auth.AuthorizationResponse, clientID, orgURL, alias, serverURL string) error {
+func (c *Contexts) UpdateContext(contextName string, authData *auth.AuthorizationResponse, clientID, orgURL, alias, serverURL string, confirmationRequired bool) error {
 	c.Contexts[contextName] = CLIContext{
-		AuthData:  authData,
-		ClientID:  clientID,
-		OrgURL:    orgURL,
-		Alias:     alias,
-		ServerURL: serverURL,
+		AuthData:             authData,
+		ClientID:             clientID,
+		OrgURL:               orgURL,
+		Alias:                alias,
+		ServerURL:            serverURL,
+		ConfirmationRequired: confirmationRequired,
 	}
 
 	return WriteContexts(c)

--- a/cmd/cloud/contexts.go
+++ b/cmd/cloud/contexts.go
@@ -82,8 +82,9 @@ func newCmdContextGet() *cobra.Command {
 
 type updateContextFlags struct {
 	createContextFlags
-	Context   string
-	ClearAuth bool
+	Context              string
+	ClearAuth            bool
+	ConfirmationRequired bool
 }
 
 func (f *updateContextFlags) addFlags(command *cobra.Command) {
@@ -91,6 +92,7 @@ func (f *updateContextFlags) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&f.Context, "context", "", "Name of the context to update")
 	command.MarkFlagRequired("context")
 	command.Flags().BoolVar(&f.ClearAuth, "clear-auth", false, "Turns off authentication for this context")
+	command.Flags().BoolVar(&f.ConfirmationRequired, "confirmation-required", false, "Require confirmation for commands run in this context")
 }
 
 func newCmdContextUpdate() *cobra.Command {
@@ -107,6 +109,7 @@ func newCmdContextUpdate() *cobra.Command {
 			Alias := flags.Alias
 			clearAuth := flags.ClearAuth
 			contextName := flags.Context
+			confirmationRequired := flags.ConfirmationRequired
 
 			contexts, err := clicontext.ReadContexts()
 			if err != nil {
@@ -133,6 +136,10 @@ func newCmdContextUpdate() *cobra.Command {
 
 			if Alias != "" && context.Alias != Alias {
 				context.Alias = Alias
+			}
+
+			if confirmationRequired != context.ConfirmationRequired {
+				context.ConfirmationRequired = confirmationRequired
 			}
 
 			if !skipAuth && !clearAuth && clientID != "" && orgURL != "" {
@@ -163,11 +170,12 @@ func newCmdContextUpdate() *cobra.Command {
 
 type createContextFlags struct {
 	clusterFlags
-	ClientID  string
-	OrgURL    string
-	SkipAuth  bool
-	Alias     string
-	ServerURL string
+	ClientID             string
+	OrgURL               string
+	SkipAuth             bool
+	Alias                string
+	ServerURL            string
+	ConfirmationRequired bool
 }
 
 func (f *createContextFlags) addFlags(command *cobra.Command) {
@@ -189,6 +197,7 @@ func newCmdContextCreate() *cobra.Command {
 			orgURL := flags.OrgURL
 			skipAuth := flags.SkipAuth
 			Alias := flags.Alias
+			confirmationRequired := flags.ConfirmationRequired
 			contextName := ""
 
 			if Alias != "" {
@@ -217,11 +226,12 @@ func newCmdContextCreate() *cobra.Command {
 			}
 
 			contexts.Contexts[contextName] = clicontext.CLIContext{
-				ClientID:  clientID,
-				OrgURL:    orgURL,
-				AuthData:  authData,
-				Alias:     Alias,
-				ServerURL: serverAddress,
+				ClientID:             clientID,
+				OrgURL:               orgURL,
+				AuthData:             authData,
+				Alias:                Alias,
+				ServerURL:            serverAddress,
+				ConfirmationRequired: confirmationRequired,
 			}
 
 			contexts.CurrentContext = contextName

--- a/cmd/cloud/login.go
+++ b/cmd/cloud/login.go
@@ -52,7 +52,7 @@ func newCmdLogin() *cobra.Command {
 
 			context.AuthData = &login
 
-			err = contexts.UpdateContext(contextName, context.AuthData, context.ClientID, context.OrgURL, context.Alias, context.ServerURL)
+			err = contexts.UpdateContext(contextName, context.AuthData, context.ClientID, context.OrgURL, context.Alias, context.ServerURL, context.ConfirmationRequired)
 			return err
 		},
 	}

--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -128,7 +128,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(new(bool), "y", "y", false, "Skip confirmation prompts")
 	rootCmd.PersistentFlags().String("context", viper.GetString("context"), "Override the current context")
 
+	rootCmd.AddCommand(newCmdServer())
 	rootCmd.AddCommand(newCmdCluster())
+	rootCmd.AddCommand(newCmdInstallation())
 	rootCmd.AddCommand(newCmdGroup())
 	rootCmd.AddCommand(newCmdDatabase())
 	rootCmd.AddCommand(newCmdSchema())

--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -6,7 +6,9 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -23,6 +25,18 @@ var instanceID string
 
 func isCommandThatSkipsAuth(cmd *cobra.Command) bool {
 	return cmd.Use == "migrate" || cmd.Use == "server" || cmd.Use == "login" || cmd.Parent().Use == "contexts"
+}
+
+func askConfirmation(contextURL string) bool {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("Commands against this context (URL: %s) require confirmation. Do you want to proceed? (Y/N): ", contextURL)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		logger.WithError(err).Fatal("Failed to read user input.")
+		return false
+	}
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y" || response == "yes"
 }
 
 // TODO: Add support for --context flag to all commands that can use a context different from current one
@@ -63,11 +77,21 @@ var rootCmd = &cobra.Command{
 			}
 
 			// Update disk copy of context with new auth data if any
-			err = contexts.UpdateContext(contexts.CurrentContext, authData, currentContext.ClientID, currentContext.OrgURL, currentContext.Alias, currentContext.ServerURL)
+			err = contexts.UpdateContext(contexts.CurrentContext, authData, currentContext.ClientID, currentContext.OrgURL, currentContext.Alias, currentContext.ServerURL, currentContext.ConfirmationRequired)
 			if err != nil {
 				logger.WithError(err).Fatal("Failed to update context with new auth data.")
 			}
 			cmd.SetContext(context.WithValue(cmd.Context(), clicontext.ContextKeyServerURL{}, currentContext.ServerURL))
+
+			skipConfirmation, _ := cmd.Flags().GetBool("y")
+			if currentContext.ConfirmationRequired && !skipConfirmation {
+				if !askConfirmation(currentContext.ServerURL) {
+					logger.Fatal("Confirmation required to proceed.")
+					return
+				}
+			} else if strings.Contains(currentContext.ServerURL, "prod") {
+				logger.Warn("\"Prod\" detected in server URL. Consider requiring confirmation on this context. Proceed with caution.")
+			}
 		}
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -88,6 +112,8 @@ func init() {
 	}
 
 	_ = rootCmd.MarkFlagRequired("database")
+
+	rootCmd.PersistentFlags().BoolVarP(new(bool), "y", "y", false, "Skip confirmation prompts")
 
 	rootCmd.AddCommand(newCmdServer())
 	rootCmd.AddCommand(newCmdCluster())


### PR DESCRIPTION
#### Summary
Adds ability to require a confirmation for commands run against a specific context. Contexts can be created or updated with the `--confirmation-required` flag. When set, commands run against that context will be greeted with

```
>cloud installation list
Commands against this context (URL: http://localhost:8075) require confirmation. Do you want to proceed? (Y/N):
```
You can skip the confirmation for a confirmation-required context by simply passing the `-y` flag.

When the CLI detects that you are hitting a cluster with `prod` in the URL, and your context is not requiring confirmation, a warning is displayed 
```
>cloud installation list -y --dns test.mattermost.cloud
WARN[2024-12-02T15:40:19-05:00] "Prod" detected in server URL. Consider requiring confirmation on this context. Proceed with caution.
```
#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8612

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
