### PR TITLE
QOL: Add ClusterIDs array to InstallationDTO object

### DIFF
--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -269,7 +269,7 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
-	outputJSON(c, w, installation.ToDTO(annotations, dnsRecords))
+	outputJSON(c, w, installation.ToDTO(annotations, dnsRecords, nil))
 }
 
 func selectGroupForAnnotation(c *Context, annotations []string) (string, error) {

--- a/internal/store/cluster_installation.go
+++ b/internal/store/cluster_installation.go
@@ -94,6 +94,29 @@ func (sqlStore *SQLStore) getClusterInstallations(db dbInterface, filter *model.
 	return clusterInstallations, nil
 }
 
+func (sqlStore *SQLStore) GetClusterInstallationsForInstallation(installationID string) ([]*model.ClusterInstallation, error) {
+	return sqlStore.getClusterInstallationsForInstallations(sqlStore.db, installationID)
+}
+
+func (sqlStore *SQLStore) GetClusterInstallationsForInstallations(installationIDs []string) ([]*model.ClusterInstallation, error) {
+	return sqlStore.getClusterInstallationsForInstallations(sqlStore.db, installationIDs...)
+}
+
+func (sqlStore *SQLStore) getClusterInstallationsForInstallations(db queryer, installationIDs ...string) ([]*model.ClusterInstallation, error) {
+	builder := clusterInstallationSelect.
+		Where(sq.Eq{"InstallationID": installationIDs}).
+		Where("DeleteAt = 0").
+		OrderBy("CreateAt ASC")
+
+	var clusterInstallations []*model.ClusterInstallation
+	err := sqlStore.selectBuilder(db, &clusterInstallations, builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query for clusterInstallations")
+	}
+
+	return clusterInstallations, nil
+}
+
 // UpdateClusterInstallation updates the given cluster installation in the database.
 func (sqlStore *SQLStore) UpdateClusterInstallation(clusterInstallation *model.ClusterInstallation) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.

--- a/internal/store/installation_dto.go
+++ b/internal/store/installation_dto.go
@@ -29,7 +29,17 @@ func (sqlStore *SQLStore) GetInstallationDTO(id string, includeGroupConfig, incl
 		return nil, errors.Wrap(err, "failed to fetch DNS records for installation")
 	}
 
-	return installation.ToDTO(annotations, dnsRecords), nil
+	clusterInstallations, err := sqlStore.GetClusterInstallationsForInstallation(id)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get cluster installations for installation")
+	}
+
+	clusterIDs := make([]*string, 0, len(clusterInstallations))
+	for _, clusterInstallation := range clusterInstallations {
+		clusterIDs = append(clusterIDs, &clusterInstallation.ClusterID)
+	}
+
+	return installation.ToDTO(annotations, dnsRecords, clusterIDs), nil
 }
 
 // GetInstallationDTOs fetches the given page of installation with data from connected tables. The first page is 0.
@@ -57,9 +67,19 @@ func (sqlStore *SQLStore) GetInstallationDTOs(filter *model.InstallationFilter, 
 		mapping[record.InstallationID] = append(mapping[record.InstallationID], record)
 	}
 
+	clusterInstallations, err := sqlStore.GetClusterInstallationsForInstallations(installationIDs)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get cluster installations for installations")
+	}
+
+	clusterMapping := make(map[string][]*string, len(installations))
+	for _, clusterInstallation := range clusterInstallations {
+		clusterMapping[clusterInstallation.InstallationID] = append(clusterMapping[clusterInstallation.InstallationID], &clusterInstallation.ClusterID)
+	}
+
 	dtos := make([]*model.InstallationDTO, 0, len(installations))
 	for _, inst := range installations {
-		dtos = append(dtos, inst.ToDTO(annotations[inst.ID], mapping[inst.ID]))
+		dtos = append(dtos, inst.ToDTO(annotations[inst.ID], mapping[inst.ID], clusterMapping[inst.ID]))
 	}
 
 	return dtos, nil

--- a/internal/store/installation_dto_test.go
+++ b/internal/store/installation_dto_test.go
@@ -83,13 +83,7 @@ func TestInstallationDTOs(t *testing.T) {
 		ClusterID:      model.NewID(),
 		InstallationID: installation1.ID,
 	}
-
 	clusterInstallation2 := &model.ClusterInstallation{
-		ClusterID:      model.NewID(),
-		InstallationID: installation1.ID,
-	}
-
-	clusterInstallation3 := &model.ClusterInstallation{
 		ClusterID:      model.NewID(),
 		InstallationID: installation2.ID,
 	}
@@ -98,8 +92,6 @@ func TestInstallationDTOs(t *testing.T) {
 	require.NoError(t, err)
 	err = sqlStore.CreateClusterInstallation(clusterInstallation2)
 	require.NoError(t, err)
-	err = sqlStore.CreateClusterInstallation(clusterInstallation3)
-	require.NoError(t, err)
 
 	t.Run("get installation DTO", func(t *testing.T) {
 		installationDTO, err := sqlStore.GetInstallationDTO(installation1.ID, false, false)
@@ -107,7 +99,7 @@ func TestInstallationDTOs(t *testing.T) {
 		assert.Equal(t, installation1, installationDTO.Installation)
 		assert.Equal(t, len(annotations), len(installationDTO.Annotations))
 		assert.Equal(t, annotations, model.SortAnnotations(installationDTO.Annotations))
-		assert.ElementsMatch(t, []string{clusterInstallation1.ClusterID}, installationDTO.ClusterIDs)
+		assert.ElementsMatch(t, []*string{&clusterInstallation1.ClusterID}, installationDTO.ClusterIDs)
 	})
 
 	t.Run("get installation DTOs", func(t *testing.T) {
@@ -122,8 +114,8 @@ func TestInstallationDTOs(t *testing.T) {
 			model.SortAnnotations(i.Annotations)
 		}
 		assert.ElementsMatch(t, []*model.InstallationDTO{
-			installation1.ToDTO(annotations, dnsRecords1, []*string{&clusterInstallation1.ClusterID, &clusterInstallation2.ClusterID}),
-			installation2.ToDTO(nil, dnsRecords2, []*string{&clusterInstallation3.ClusterID}),
+			installation1.ToDTO(annotations, dnsRecords1, []*string{&clusterInstallation1.ClusterID}),
+			installation2.ToDTO(nil, dnsRecords2, []*string{&clusterInstallation2.ClusterID}),
 		}, installationDTOs)
 	})
 }

--- a/internal/store/installation_dto_test.go
+++ b/internal/store/installation_dto_test.go
@@ -79,12 +79,35 @@ func TestInstallationDTOs(t *testing.T) {
 	err = sqlStore.CreateInstallation(installation2, nil, dnsRecords2)
 	require.NoError(t, err)
 
+	clusterInstallation1 := &model.ClusterInstallation{
+		ClusterID:      model.NewID(),
+		InstallationID: installation1.ID,
+	}
+
+	clusterInstallation2 := &model.ClusterInstallation{
+		ClusterID:      model.NewID(),
+		InstallationID: installation1.ID,
+	}
+
+	clusterInstallation3 := &model.ClusterInstallation{
+		ClusterID:      model.NewID(),
+		InstallationID: installation2.ID,
+	}
+
+	err = sqlStore.CreateClusterInstallation(clusterInstallation1)
+	require.NoError(t, err)
+	err = sqlStore.CreateClusterInstallation(clusterInstallation2)
+	require.NoError(t, err)
+	err = sqlStore.CreateClusterInstallation(clusterInstallation3)
+	require.NoError(t, err)
+
 	t.Run("get installation DTO", func(t *testing.T) {
 		installationDTO, err := sqlStore.GetInstallationDTO(installation1.ID, false, false)
 		require.NoError(t, err)
 		assert.Equal(t, installation1, installationDTO.Installation)
 		assert.Equal(t, len(annotations), len(installationDTO.Annotations))
 		assert.Equal(t, annotations, model.SortAnnotations(installationDTO.Annotations))
+		assert.ElementsMatch(t, []string{clusterInstallation1.ClusterID}, installationDTO.ClusterIDs)
 	})
 
 	t.Run("get installation DTOs", func(t *testing.T) {
@@ -98,6 +121,9 @@ func TestInstallationDTOs(t *testing.T) {
 		for _, i := range installationDTOs {
 			model.SortAnnotations(i.Annotations)
 		}
-		assert.Equal(t, []*model.InstallationDTO{installation1.ToDTO(annotations, dnsRecords1), installation2.ToDTO(nil, dnsRecords2)}, installationDTOs)
+		assert.ElementsMatch(t, []*model.InstallationDTO{
+			installation1.ToDTO(annotations, dnsRecords1, []*string{&clusterInstallation1.ClusterID, &clusterInstallation2.ClusterID}),
+			installation2.ToDTO(nil, dnsRecords2, []*string{&clusterInstallation3.ClusterID}),
+		}, installationDTOs)
 	})
 }

--- a/model/installation.go
+++ b/model/installation.go
@@ -207,7 +207,7 @@ func (i *Installation) Clone() *Installation {
 }
 
 // ToDTO expands installation to InstallationDTO.
-func (i *Installation) ToDTO(annotations []*Annotation, dnsRecords []*InstallationDNS) *InstallationDTO {
+func (i *Installation) ToDTO(annotations []*Annotation, dnsRecords []*InstallationDNS, clusterIDs []*string) *InstallationDTO {
 	var dns string
 	for _, record := range dnsRecords {
 		if record.IsPrimary {
@@ -221,6 +221,7 @@ func (i *Installation) ToDTO(annotations []*Annotation, dnsRecords []*Installati
 		Annotations:  annotations,
 		DNSRecords:   dnsRecords,
 		DNS:          dns,
+		ClusterIDs:   clusterIDs,
 	}
 }
 

--- a/model/installation_dto.go
+++ b/model/installation_dto.go
@@ -11,4 +11,5 @@ type InstallationDTO struct {
 	// Deprecated: This is for backward compatibility until we switch all clients, as DNS was removed from Installation.
 	DNS        string
 	DNSRecords []*InstallationDNS
+	ClusterIDs []*string `json:"ClusterIDs,omitempty"`
 }


### PR DESCRIPTION
#### Summary
Adds ClusterID to the InstallationDTO object. Currently, when given an installation's DNS, it takes 2 CLI commands to figure out the cluster - first, you must run `cloud installation list --dns <dns>` to get the installation ID, from there you can get the Cluster ID (there are various other routes you can take, but the list step happens in each). This PR makes it so that the list command (and `installation get` command) return the ClusterID, saving you from the second step. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8669

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
