### PR TITLE
Show VPC IDs for external clusters in cluster table

### DIFF
--- a/cmd/cloud/cluster.go
+++ b/cmd/cloud/cluster.go
@@ -628,6 +628,9 @@ func defaultClustersTableData(clusters []*model.ClusterDTO) ([]string, [][]strin
 			amiEntry = "external"
 			networkingEntry = "external"
 			vpcEntry = "external"
+			if cluster.HasAWSInfrastructure() {
+				vpcEntry = cluster.VpcID()
+			}
 		}
 
 		values = append(values, []string{


### PR DESCRIPTION
If an external cluster was imported with a VPC ID then we will now show that ID in the cluster list table.

Fixes https://mattermost.atlassian.net/browse/CLD-8688

```release-note
Show VPC IDs for external clusters in cluster table
```
