### PR TITLE
Add custom installation volume support

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -32,6 +32,9 @@ func newCmdInstallation() *cobra.Command {
 	cmd.AddCommand(newCmdInstallationCreate())
 	cmd.AddCommand(newCmdInstallationUpdate())
 	cmd.AddCommand(newCmdInstallationDelete())
+	cmd.AddCommand(newCmdInstallationVolumeCreate())
+	cmd.AddCommand(newCmdInstallationVolumeUpdate())
+	cmd.AddCommand(newCmdInstallationVolumeDelete())
 	cmd.AddCommand(newCmdInstallationUpdateDeletion())
 	cmd.AddCommand(newCmdInstallationCancelDeletion())
 	cmd.AddCommand(newCmdInstallationHibernate())
@@ -165,6 +168,104 @@ func newCmdInstallationUpdate() *cobra.Command {
 		PreRun: func(cmd *cobra.Command, args []string) {
 			flags.clusterFlags.addFlags(cmd)
 			flags.installationPatchRequestChanges.addFlags(cmd)
+		},
+	}
+
+	flags.addFlags(cmd)
+
+	return cmd
+}
+
+func newCmdInstallationVolumeCreate() *cobra.Command {
+	var flags installationCreateVolumeFlags
+
+	cmd := &cobra.Command{
+		Use:   "create-volume",
+		Short: "Creates a new volume for an installation.",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+			client := createClient(command.Context(), flags.clusterFlags)
+
+			request := flags.GetCreateInstallationVolumeRequest()
+
+			if flags.dryRun {
+				return runDryRun(request)
+			}
+
+			installation, err := client.CreateInstallationVolume(flags.installationID, request)
+			if err != nil {
+				return errors.Wrap(err, "failed to create installation volume")
+			}
+
+			return printJSON(installation)
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.clusterFlags.addFlags(cmd)
+		},
+	}
+
+	flags.addFlags(cmd)
+
+	return cmd
+}
+
+func newCmdInstallationVolumeUpdate() *cobra.Command {
+	var flags installationUpdateVolumeFlags
+
+	cmd := &cobra.Command{
+		Use:   "update-volume",
+		Short: "Updates an existing volume for an installation.",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+			client := createClient(command.Context(), flags.clusterFlags)
+
+			err := flags.Validate()
+			if err != nil {
+				return err
+			}
+			request := flags.GetUpdateInstallationVolumeRequest()
+
+			if flags.dryRun {
+				return runDryRun(request)
+			}
+
+			installation, err := client.UpdateInstallationVolume(flags.installationID, flags.volumeName, request)
+			if err != nil {
+				return errors.Wrap(err, "failed to update installation volume")
+			}
+
+			return printJSON(installation)
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.clusterFlags.addFlags(cmd)
+			flags.installationUpdateVolumeChanges.addFlags(cmd)
+		},
+	}
+
+	flags.addFlags(cmd)
+
+	return cmd
+}
+
+func newCmdInstallationVolumeDelete() *cobra.Command {
+	var flags installationDeleteVolumeFlags
+
+	cmd := &cobra.Command{
+		Use:   "delete-volume",
+		Short: "Delete an existing volume from an installation.",
+		RunE: func(command *cobra.Command, args []string) error {
+			command.SilenceUsage = true
+			client := createClient(command.Context(), flags.clusterFlags)
+
+			installation, err := client.DeleteInstallationVolume(flags.installationID, flags.volumeName)
+			if err != nil {
+				return errors.Wrap(err, "failed to delete installation volume")
+			}
+
+			return printJSON(installation)
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags.clusterFlags.addFlags(cmd)
 		},
 	}
 

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -146,6 +146,9 @@ type Provisioner interface {
 type AwsClient interface {
 	EnsureVPCExists(vpcID string) error
 	SwitchClusterTags(clusterID string, targetClusterID string, logger log.FieldLogger) error
+	SecretsManagerCreateSecret(secretName, description string, secretBytes []byte, logger log.FieldLogger) error
+	SecretsManagerUpdateSecret(secretName string, secretBytes []byte, logger log.FieldLogger) error
+	SecretsManagerEnsureSecretDeleted(secretName string, logger log.FieldLogger) error
 	SecretsManagerValidateExternalClusterSecret(name string) error
 	SecretsManagerValidateExternalDatabaseSecret(name string) error
 	RDSDBCLusterExists(awsID string) (bool, error)

--- a/internal/api/db_multitenant_database_test.go
+++ b/internal/api/db_multitenant_database_test.go
@@ -301,6 +301,18 @@ func (m mockAWSClient) DeletePGBouncerLogicalDatabase(multitenantDatabase *model
 	return nil
 }
 
+func (m mockAWSClient) SecretsManagerCreateSecret(secretName, description string, secretBytes []byte, logger log.FieldLogger) error {
+	return nil
+}
+
+func (m mockAWSClient) SecretsManagerUpdateSecret(secretName string, secretBytes []byte, logger log.FieldLogger) error {
+	return nil
+}
+
+func (m mockAWSClient) SecretsManagerEnsureSecretDeleted(secretName string, logger log.FieldLogger) error {
+	return nil
+}
+
 func TestDeleteMultitenantDatabase(t *testing.T) {
 	logger := testlib.MakeLogger(t)
 	sqlStore := store.MakeTestSQLStore(t, logger)

--- a/internal/mocks/aws-sdk/secrets_manager.go
+++ b/internal/mocks/aws-sdk/secrets_manager.go
@@ -116,3 +116,23 @@ func (mr *MockSecretsManagerAPIMockRecorder) RestoreSecret(arg0, arg1 interface{
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RestoreSecret), varargs...)
 }
+
+// UpdateSecret mocks base method
+func (m *MockSecretsManagerAPI) UpdateSecret(arg0 context.Context, arg1 *secretsmanager.UpdateSecretInput, arg2 ...func(*secretsmanager.Options)) (*secretsmanager.UpdateSecretOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateSecret", varargs...)
+	ret0, _ := ret[0].(*secretsmanager.UpdateSecretOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateSecret indicates an expected call of UpdateSecret
+func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecret(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecret), varargs...)
+}

--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -431,6 +431,35 @@ func (mr *MockAWSMockRecorder) SecretsManagerGetSecretBytes(secretName interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretsManagerGetSecretBytes", reflect.TypeOf((*MockAWS)(nil).SecretsManagerGetSecretBytes), secretName)
 }
 
+// SecretsManagerGetSecretAsK8sSecretData mocks base method
+func (m *MockAWS) SecretsManagerGetSecretAsK8sSecretData(secretName string) (map[string][]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretsManagerGetSecretAsK8sSecretData", secretName)
+	ret0, _ := ret[0].(map[string][]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SecretsManagerGetSecretAsK8sSecretData indicates an expected call of SecretsManagerGetSecretAsK8sSecretData
+func (mr *MockAWSMockRecorder) SecretsManagerGetSecretAsK8sSecretData(secretName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretsManagerGetSecretAsK8sSecretData", reflect.TypeOf((*MockAWS)(nil).SecretsManagerGetSecretAsK8sSecretData), secretName)
+}
+
+// SecretsManagerEnsureSecretDeleted mocks base method
+func (m *MockAWS) SecretsManagerEnsureSecretDeleted(secretName string, logger logrus.FieldLogger) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretsManagerEnsureSecretDeleted", secretName, logger)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SecretsManagerEnsureSecretDeleted indicates an expected call of SecretsManagerEnsureSecretDeleted
+func (mr *MockAWSMockRecorder) SecretsManagerEnsureSecretDeleted(secretName, logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretsManagerEnsureSecretDeleted", reflect.TypeOf((*MockAWS)(nil).SecretsManagerEnsureSecretDeleted), secretName, logger)
+}
+
 // EnsureEKSCluster mocks base method
 func (m *MockAWS) EnsureEKSCluster(cluster *model.Cluster, resources aws.ClusterResources) (*types.Cluster, error) {
 	m.ctrl.T.Helper()

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -23,13 +23,15 @@ const (
 func init() {
 	installationSelect = sq.
 		Select(
-			"Installation.ID", "Installation.Name", "OwnerID", "Version", "Image", "Database", "Filestore", "Size",
-			"Affinity", "GroupID", "GroupSequence", "Installation.State", "License",
-			"MattermostEnvRaw", "PriorityEnvRaw", "SingleTenantDatabaseConfigRaw", "ExternalDatabaseConfigRaw",
-			"Installation.CreateAt", "Installation.DeleteAt", "Installation.DeletionPendingExpiry",
-			"APISecurityLock", "LockAcquiredBy", "LockAcquiredAt", "CRVersion", "Installation.DeletionLocked", "AllowedIPRanges",
-		).
-		From(installationTable)
+			"Installation.ID", "Installation.Name", "OwnerID", "Version", "Image",
+			"Database", "Filestore", "Size", "Affinity", "GroupID", "GroupSequence",
+			"Installation.State", "License", "MattermostEnvRaw", "PriorityEnvRaw",
+			"SingleTenantDatabaseConfigRaw", "ExternalDatabaseConfigRaw",
+			"Installation.CreateAt", "Installation.DeleteAt",
+			"Installation.DeletionPendingExpiry", "APISecurityLock", "LockAcquiredBy",
+			"LockAcquiredAt", "CRVersion", "Installation.DeletionLocked",
+			"AllowedIPRanges", "Volumes",
+		).From(installationTable)
 }
 
 type rawInstallation struct {
@@ -453,6 +455,7 @@ func (sqlStore *SQLStore) createInstallation(db execer, installation *model.Inst
 		"CRVersion":             installation.CRVersion,
 		"DeletionLocked":        installation.DeletionLocked,
 		"AllowedIPRanges":       installation.AllowedIPRanges,
+		"Volumes":               installation.Volumes,
 	}
 
 	singleTenantDBConfJSON, err := installation.SingleTenantDatabaseConfig.ToJSON()
@@ -524,6 +527,7 @@ func (sqlStore *SQLStore) updateInstallation(db execer, installation *model.Inst
 			"CRVersion":             installation.CRVersion,
 			"DeletionPendingExpiry": installation.DeletionPendingExpiry,
 			"AllowedIPRanges":       installation.AllowedIPRanges,
+			"Volumes":               installation.Volumes,
 		}).
 		Where("ID = ?", installation.ID),
 	)

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -2247,4 +2247,12 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.49.0"), semver.MustParse("0.50.0"), func(e execer) error {
+		_, err := e.Exec(`ALTER TABLE Installation ADD COLUMN Volumes JSON DEFAULT NULL;`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}},
 }

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -624,6 +624,14 @@ func (a *mockAWS) GetVpcsWithFilters(filters []ec2Types.Filter) ([]ec2Types.Vpc,
 	return nil, nil
 }
 
+func (m mockAWS) SecretsManagerEnsureSecretDeleted(secretName string, logger log.FieldLogger) error {
+	return nil
+}
+
+func (m mockAWS) SecretsManagerGetSecretAsK8sSecretData(secretName string) (map[string][]byte, error) {
+	return nil, nil
+}
+
 type mockEventProducer struct {
 	installationListByEventOrder        []string
 	clusterListByEventOrder             []string

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -68,6 +68,8 @@ type AWS interface {
 	SecretsManagerGetPGBouncerAuthUserPassword(vpcID string) (string, error)
 
 	SecretsManagerGetSecretBytes(secretName string) ([]byte, error)
+	SecretsManagerGetSecretAsK8sSecretData(secretName string) (map[string][]byte, error)
+	SecretsManagerEnsureSecretDeleted(secretName string, logger log.FieldLogger) error
 
 	EnsureEKSCluster(cluster *model.Cluster, resources ClusterResources) (*eksTypes.Cluster, error)
 	EnsureEKSClusterUpdated(cluster *model.Cluster) (*eksTypes.Update, error)

--- a/internal/tools/aws/secrets_mangager_types.go
+++ b/internal/tools/aws/secrets_mangager_types.go
@@ -13,6 +13,7 @@ import (
 // SecretsManagerAPI represents the series of calls we require from the AWS SDK v2 SecretsManager Client
 type SecretsManagerAPI interface {
 	CreateSecret(ctx context.Context, params *secretsmanager.CreateSecretInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.CreateSecretOutput, error)
+	UpdateSecret(ctx context.Context, params *secretsmanager.UpdateSecretInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.UpdateSecretOutput, error)
 	DeleteSecret(ctx context.Context, params *secretsmanager.DeleteSecretInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.DeleteSecretOutput, error)
 	RestoreSecret(ctx context.Context, params *secretsmanager.RestoreSecretInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.RestoreSecretOutput, error)
 	GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)

--- a/internal/tools/utils/utils.go
+++ b/internal/tools/utils/utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 // CopyDirectory copy the entire directory to another destination
@@ -188,6 +189,12 @@ func (r *ResourceUtil) GetDatabase(installationID, dbType string) model.Database
 	// Warning: we should never get here as it would mean that we didn't match
 	// our database type.
 	return model.NewMysqlOperatorDatabase()
+}
+
+// EnsureSecretManagerSecretDeleted ensures a secret with the provided name is
+// marked for deletion in AWS Secrets Manager.
+func (r *ResourceUtil) EnsureSecretManagerSecretDeleted(secretName string, logger log.FieldLogger) error {
+	return r.awsClient.SecretsManagerEnsureSecretDeleted(secretName, logger)
 }
 
 // Retry is retrying a function for a maximum number of attempts and time

--- a/model/client.go
+++ b/model/client.go
@@ -605,6 +605,57 @@ func (c *Client) UpdateInstallation(installationID string, request *PatchInstall
 	}
 }
 
+// CreateInstallationVolume creates an installation volume.
+func (c *Client) CreateInstallationVolume(installationID string, request *CreateInstallationVolumeRequest) (*InstallationDTO, error) {
+	resp, err := c.doPost(c.buildURL("/api/installation/%s/volumes", installationID), request)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return DTOFromReader[InstallationDTO](resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// UpdateInstallationVolume updates an installation volume.
+func (c *Client) UpdateInstallationVolume(installationID, volumeName string, request *PatchInstallationVolumeRequest) (*InstallationDTO, error) {
+	resp, err := c.doPut(c.buildURL("/api/installation/%s/volume/%s", installationID, volumeName), request)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return DTOFromReader[InstallationDTO](resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
+// DeleteInstallationVolume deletes an installation volume.
+func (c *Client) DeleteInstallationVolume(installationID, volumeName string) (*InstallationDTO, error) {
+	resp, err := c.doDelete(c.buildURL("/api/installation/%s/volume/%s", installationID, volumeName))
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return DTOFromReader[InstallationDTO](resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}
+
 // HibernateInstallation puts an installation into hibernation.
 func (c *Client) HibernateInstallation(installationID string) (*InstallationDTO, error) {
 	resp, err := c.doPost(c.buildURL("/api/installation/%s/hibernate", installationID), nil)

--- a/model/installation.go
+++ b/model/installation.go
@@ -43,6 +43,7 @@ type Installation struct {
 	Filestore                  string
 	License                    string
 	AllowedIPRanges            *AllowedIPRanges
+	Volumes                    *VolumeMap
 	MattermostEnv              EnvVarMap
 	PriorityEnv                EnvVarMap
 	Size                       string
@@ -118,7 +119,7 @@ func (a AllowedIPRanges) Value() (driver.Value, error) {
 func (a *AllowedIPRanges) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("Could not assert type of AllowedIPRanges")
+		return errors.New("could not assert type of AllowedIPRanges")
 	}
 
 	var i AllowedIPRanges
@@ -290,6 +291,11 @@ func (i *Installation) ExternalDatabase() bool {
 func (i *Installation) ExternalFilestore() bool {
 	// TODO: There are no external filestore options yet.
 	return false
+}
+
+// HasVolumes returns if the installation has custom volumes or not.
+func (i *Installation) HasVolumes() bool {
+	return i.Volumes != nil
 }
 
 // IsInGroup returns if the installation is in a group or not.

--- a/model/pgbouncer.go
+++ b/model/pgbouncer.go
@@ -118,7 +118,7 @@ func (c *PgBouncerConfig) Value() (driver.Value, error) {
 func (c *PgBouncerConfig) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("Could not assert type of PgBouncerConfig")
+		return errors.New("could not assert type of PgBouncerConfig")
 	}
 
 	var i PgBouncerConfig

--- a/model/volumes.go
+++ b/model/volumes.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"regexp"
+	"sort"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	VolumeTypeSecret = "secret"
+
+	volumeNameMinLen        = 3
+	volumeNameMaxLen        = 64
+	volumeNameAllowedFormat = "volumes must start with a letter and can contain only lowercase letters, numbers or '_', '-' characters"
+)
+
+var volumeNameRegex = regexp.MustCompile("^[a-z]+[a-z0-9_-]*$")
+
+// Volume contains metadata on a k8s volume.
+type Volume struct {
+	Type          string
+	BackingSecret string
+	MountPath     string
+	ReadOnly      bool
+}
+
+// VolumeMap is a map of multiple Volume names to their values.
+type VolumeMap map[string]Volume
+
+// Validate returns wheather Volume has valid value configuration.
+func (v *Volume) Validate() error {
+	if v.Type != VolumeTypeSecret {
+		return errors.Errorf("%s is an invalid volume type", v.Type)
+	}
+	if len(v.MountPath) == 0 {
+		return errors.New("mount path is empty")
+	}
+
+	return nil
+}
+
+// Validate returns wheather the VolumeMap has valid value configuration.
+func (vm *VolumeMap) Validate() error {
+	for name, env := range *vm {
+		err := env.Validate()
+		if err != nil {
+			return errors.Wrapf(err, "invalid volume %s", name)
+		}
+	}
+
+	return nil
+}
+
+// Add applies a CreateInstallationVolumeRequest to a VolumeMap.
+func (vm VolumeMap) Add(request *CreateInstallationVolumeRequest) error {
+	if _, ok := vm[request.Name]; ok {
+		return errors.Errorf("cannot create new volume, %s already exists", request.Name)
+	}
+	if len(request.Name) < volumeNameMinLen || len(request.Name) > volumeNameMaxLen {
+		return errors.Errorf("volume '%s' is invalid: volume names must be between %d and %d characters long", request.Name, volumeNameMinLen, volumeNameMaxLen)
+	}
+	if !volumeNameRegex.MatchString(request.Name) {
+		return errors.Errorf("volume '%s' is invalid: %s", request.Name, volumeNameAllowedFormat)
+	}
+	for name, existing := range vm {
+		if existing.MountPath == request.Volume.MountPath {
+			return errors.Errorf("mount path %s conflicts with volume %s", existing.MountPath, name)
+		}
+	}
+
+	vm[request.Name] = *request.Volume
+
+	return nil
+}
+
+// Patch applies a PatchInstallationVolumeRequest to a VolumeMap.
+func (vm VolumeMap) Patch(request *PatchInstallationVolumeRequest, volumeName string) (string, error) {
+	volume, ok := vm[volumeName]
+	if !ok {
+		return "", errors.Errorf("cannot update volume %s as it doesn't exist", volumeName)
+	}
+
+	if request.MountPath != nil {
+		for existingName, existing := range vm {
+			if existing.MountPath == *request.MountPath && existingName != volumeName {
+				return "", errors.Errorf("mount path %s conflicts with volume %s", existing.MountPath, existingName)
+			}
+		}
+		volume.MountPath = *request.MountPath
+	}
+	if request.ReadOnly != nil {
+		volume.ReadOnly = *request.ReadOnly
+	}
+
+	vm[volumeName] = volume
+
+	return volume.BackingSecret, nil
+}
+
+// ToCoreV1Volumes returns a list of standard corev1.Volume.
+func (vm *VolumeMap) ToCoreV1Volumes() []corev1.Volume {
+	volumes := []corev1.Volume{}
+
+	for name, vol := range *vm {
+		volumes = append(volumes, corev1.Volume{
+			Name:         name,
+			VolumeSource: vol.CoreV1VolumeSource(name),
+		})
+	}
+
+	// To retain consistent order of volumes we sort the slice by name.
+	sort.Slice(volumes, func(i, j int) bool {
+		return volumes[i].Name < volumes[j].Name
+	})
+
+	return volumes
+}
+
+// ToCoreV1VolumeMounts returns a list of standard corev1.VolumeMount.
+func (vm *VolumeMap) ToCoreV1VolumeMounts() []corev1.VolumeMount {
+	volumeMounts := []corev1.VolumeMount{}
+
+	for name, vol := range *vm {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      name,
+			ReadOnly:  vol.ReadOnly,
+			MountPath: vol.MountPath,
+		})
+	}
+
+	// To retain consistent order of volume mounts we sort the slice by name.
+	sort.Slice(volumeMounts, func(i, j int) bool {
+		return volumeMounts[i].Name < volumeMounts[j].Name
+	})
+
+	return volumeMounts
+}
+
+// CoreV1VolumeSource returns a corev1.VolumeSource for a given volume.
+func (v *Volume) CoreV1VolumeSource(name string) corev1.VolumeSource {
+	volumeSource := corev1.VolumeSource{}
+
+	switch v.Type {
+	case VolumeTypeSecret:
+		volumeSource.Secret = &corev1.SecretVolumeSource{
+			SecretName: name,
+		}
+	}
+
+	return volumeSource
+}
+
+func (vm VolumeMap) Value() (driver.Value, error) {
+	if vm == nil {
+		return nil, nil
+	}
+
+	return json.Marshal(vm)
+}
+
+func (vm *VolumeMap) Scan(src interface{}) error {
+	source, ok := src.([]byte)
+	if !ok {
+		return errors.Errorf("could not assert type of VolumeMap (value: %+v)", src)
+	}
+
+	var i VolumeMap
+	err := json.Unmarshal(source, &i)
+	if err != nil {
+		return err
+	}
+	*vm = i
+	return nil
+}

--- a/model/volumes_test.go
+++ b/model/volumes_test.go
@@ -1,0 +1,303 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package model_test
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/internal/util"
+	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateVolumeMap(t *testing.T) {
+	var testCases = []struct {
+		description string
+		config      *model.VolumeMap
+		valid       bool
+	}{
+		{
+			"valid",
+			&model.VolumeMap{
+				"test1": model.Volume{Type: model.VolumeTypeSecret, MountPath: "/test1", ReadOnly: true},
+				"test2": model.Volume{Type: model.VolumeTypeSecret, MountPath: "/test2", ReadOnly: true},
+			},
+			true,
+		},
+		{
+			"no mount path",
+			&model.VolumeMap{
+				"test1": model.Volume{Type: model.VolumeTypeSecret, ReadOnly: true},
+				"test2": model.Volume{Type: model.VolumeTypeSecret, MountPath: "/test2", ReadOnly: true},
+			},
+			false,
+		},
+		{
+			"invalid volume type",
+			&model.VolumeMap{
+				"test1": model.Volume{Type: "invalid", MountPath: "/test1", ReadOnly: true},
+				"test2": model.Volume{Type: model.VolumeTypeSecret, MountPath: "/test2", ReadOnly: true},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.valid {
+				assert.NoError(t, tc.config.Validate())
+			} else {
+				assert.Error(t, tc.config.Validate())
+			}
+		})
+	}
+}
+
+func TestVolumeMapAdd(t *testing.T) {
+	var sizeTests = []struct {
+		name        string
+		original    *model.VolumeMap
+		request     *model.CreateInstallationVolumeRequest
+		expected    *model.VolumeMap
+		expectError bool
+	}{
+		{
+			"new volumes",
+			&model.VolumeMap{},
+			&model.CreateInstallationVolumeRequest{
+				Name: "test",
+				Data: map[string][]byte{"testfile": []byte("testdata")},
+				Volume: &model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test",
+					ReadOnly:  false,
+				},
+			},
+			&model.VolumeMap{
+				"test": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test",
+					ReadOnly:  false,
+				},
+			},
+			false,
+		},
+		{
+			"add second volume",
+			&model.VolumeMap{
+				"test1": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test1",
+					ReadOnly:  false,
+				},
+			},
+			&model.CreateInstallationVolumeRequest{
+				Name: "test2",
+				Data: map[string][]byte{"testfile": []byte("testdata")},
+				Volume: &model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test2",
+					ReadOnly:  false,
+				},
+			},
+			&model.VolumeMap{
+				"test1": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test1",
+					ReadOnly:  false,
+				},
+				"test2": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test2",
+					ReadOnly:  false,
+				},
+			},
+			false,
+		},
+		{
+			"conflicting mount points",
+			&model.VolumeMap{
+				"test1": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test1",
+					ReadOnly:  false,
+				},
+			},
+			&model.CreateInstallationVolumeRequest{
+				Name: "test2",
+				Data: map[string][]byte{"testfile": []byte("testdata")},
+				Volume: &model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test1",
+					ReadOnly:  false,
+				},
+			},
+			&model.VolumeMap{
+				"test1": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test1",
+					ReadOnly:  false,
+				},
+			},
+			true,
+		},
+		{
+			"invalid name",
+			&model.VolumeMap{},
+			&model.CreateInstallationVolumeRequest{
+				Name: "%*#$&%&#($*&%)",
+				Data: map[string][]byte{"testfile": []byte("testdata")},
+				Volume: &model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test",
+					ReadOnly:  false,
+				},
+			},
+			&model.VolumeMap{},
+			true,
+		},
+	}
+
+	for _, tt := range sizeTests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.request != nil {
+				assert.NoError(t, tt.request.Validate())
+			}
+			err := tt.original.Add(tt.request)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.original, tt.expected)
+		})
+	}
+}
+
+func TestVolumeMapUpdate(t *testing.T) {
+	var sizeTests = []struct {
+		name        string
+		original    *model.VolumeMap
+		volumeName  string
+		request     *model.PatchInstallationVolumeRequest
+		expected    *model.VolumeMap
+		expectError bool
+	}{
+		{
+			"update everything",
+			&model.VolumeMap{
+				"test": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/old",
+					ReadOnly:  false,
+				},
+			},
+			"test",
+			&model.PatchInstallationVolumeRequest{
+				MountPath: util.SToP("/new"),
+				ReadOnly:  util.BToP(true),
+			},
+			&model.VolumeMap{
+				"test": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/new",
+					ReadOnly:  true,
+				},
+			},
+			false,
+		},
+		{
+			"update mount path only",
+			&model.VolumeMap{
+				"test": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/old",
+					ReadOnly:  false,
+				},
+			},
+			"test",
+			&model.PatchInstallationVolumeRequest{
+				MountPath: util.SToP("/new"),
+			},
+			&model.VolumeMap{
+				"test": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/new",
+					ReadOnly:  false,
+				},
+			},
+			false,
+		},
+		{
+			"volume doesn't exist",
+			&model.VolumeMap{
+				"test": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/old",
+					ReadOnly:  false,
+				},
+			},
+			"invalid",
+			&model.PatchInstallationVolumeRequest{
+				MountPath: util.SToP("/new"),
+			},
+			&model.VolumeMap{
+				"test": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/old",
+					ReadOnly:  false,
+				},
+			},
+			true,
+		},
+		{
+			"conflicting mount points",
+			&model.VolumeMap{
+				"test1": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test1",
+					ReadOnly:  false,
+				},
+				"test2": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test2",
+					ReadOnly:  false,
+				},
+			},
+			"test2",
+			&model.PatchInstallationVolumeRequest{
+				MountPath: util.SToP("/test1"),
+			},
+			&model.VolumeMap{
+				"test1": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test1",
+					ReadOnly:  false,
+				},
+				"test2": model.Volume{
+					Type:      model.VolumeTypeSecret,
+					MountPath: "/test2",
+					ReadOnly:  false,
+				},
+			},
+			true,
+		},
+	}
+
+	for _, tt := range sizeTests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.request != nil {
+				assert.NoError(t, tt.request.Validate())
+			}
+			_, err := tt.original.Patch(tt.request, tt.volumeName)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.original, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
Kubernetes volumes can now be added to installation deployments. Volumes backed by secrets can be created, updated, and deleted after an installation has been created. The volume secret data is first stored in AWS Secrets Manager and then appended as a k8s secret in an installation update. Volumes are mounted in the specified mount path of the container which should support many cases where sensitive information is required at the filesystem level of Mattermost.

Fixes https://mattermost.atlassian.net/browse/CLD-8711

```release-note
Add custom installation volume support
```
