### PR TITLE
CLD-8818:Modify e2e to fetch AMI from aws

### DIFF
--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -265,6 +265,14 @@ func (m *MockAWS) IsValidAMI(AMIImage string, logger logrus.FieldLogger) (bool, 
 	return ret0, ret1
 }
 
+func (m *MockAWS) GetAMIByTag(tagKey, tagValue string, logger logrus.FieldLogger) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAMIByTag", tagKey, tagValue, logger)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
 // IsValidAMI indicates an expected call of IsValidAMI
 func (mr *MockAWSMockRecorder) IsValidAMI(AMIImage, logger interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()

--- a/internal/mocks/aws-tools/client.go
+++ b/internal/mocks/aws-tools/client.go
@@ -265,6 +265,13 @@ func (m *MockAWS) IsValidAMI(AMIImage string, logger logrus.FieldLogger) (bool, 
 	return ret0, ret1
 }
 
+// IsValidAMI indicates an expected call of IsValidAMI
+func (mr *MockAWSMockRecorder) IsValidAMI(AMIImage, logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidAMI", reflect.TypeOf((*MockAWS)(nil).IsValidAMI), AMIImage, logger)
+}
+
+// GetAMIByTag mocks base method
 func (m *MockAWS) GetAMIByTag(tagKey, tagValue string, logger logrus.FieldLogger) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAMIByTag", tagKey, tagValue, logger)
@@ -273,10 +280,10 @@ func (m *MockAWS) GetAMIByTag(tagKey, tagValue string, logger logrus.FieldLogger
 	return ret0, ret1
 }
 
-// IsValidAMI indicates an expected call of IsValidAMI
-func (mr *MockAWSMockRecorder) IsValidAMI(AMIImage, logger interface{}) *gomock.Call {
+// GetAMIByTag indicates an expected call of GetAMIByTag
+func (mr *MockAWSMockRecorder) GetAMIByTag(tagKey, tagValue, logger interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidAMI", reflect.TypeOf((*MockAWS)(nil).IsValidAMI), AMIImage, logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAMIByTag", reflect.TypeOf((*MockAWS)(nil).GetAMIByTag), tagKey, tagValue, logger)
 }
 
 // S3EnsureBucketDeleted mocks base method

--- a/internal/supervisor/installation_test.go
+++ b/internal/supervisor/installation_test.go
@@ -593,6 +593,10 @@ func (a *mockAWS) IsValidAMI(AMIID string, logger log.FieldLogger) (bool, error)
 	return true, nil
 }
 
+func (a *mockAWS) GetAMIByTag(tagKey, tagValue string, logger log.FieldLogger) (string, error) {
+	return "ami-1234567890", nil
+}
+
 func (a *mockAWS) GeneratePerseusUtilitySecret(clusterID string, logger log.FieldLogger) (*corev1.Secret, error) {
 	return nil, nil
 }

--- a/internal/tools/aws/client.go
+++ b/internal/tools/aws/client.go
@@ -52,6 +52,7 @@ type AWS interface {
 	UpsertPublicCNAMEs(dnsNames []string, endpoints []string, logger log.FieldLogger) error
 
 	IsValidAMI(AMIImage string, logger log.FieldLogger) (bool, error)
+	GetAMIByTag(tagKey, tagValue string, logger log.FieldLogger) (string, error)
 
 	S3EnsureBucketDeleted(bucketName string, logger log.FieldLogger) error
 	S3EnsureObjectDeleted(bucketName, path string) error

--- a/model/kops_metadata.go
+++ b/model/kops_metadata.go
@@ -15,6 +15,8 @@ import (
 
 const (
 	ProvisionerKops = "kops"
+	AMDKopsAmiName  = "mattermost-cloud-kops-hardened-*-amd64"
+	ARMKopsAmiName  = "mattermost-cloud-kops-hardened-*-arm64"
 )
 
 // KopsMetadata is the provisioner metadata stored in a model.Cluster.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
E2E tests rely on an existing Kops cluster to pick up an AMI. This change will fetch the latest AMI from AWS if the cluster is external.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/CLD-8818

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
