### PR TITLE
Support existing clusters in E2E tests

### DIFF
--- a/e2e/tests/cluster/cluster_test.go
+++ b/e2e/tests/cluster/cluster_test.go
@@ -28,9 +28,12 @@ func TestMain(m *testing.M) {
 
 // SetupClusterLifecycleTest sets up cluster lifecycle test.
 func SetupClusterLifecycleTest() (*shared.Test, error) {
-	test, err := shared.SetupTestWithDefaults("cluster-lifecycle", true)
+	test, err := shared.SetupTestWithDefaults("cluster-lifecycle")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to setup test environment")
+	}
+	if test.ClusterSuite.Params.UseExistingCluster {
+		return nil, errors.Wrap(err, "test configuration invalid; cluster creation must be set to true for cluster lifecycle tests")
 	}
 
 	return test, nil

--- a/e2e/tests/cluster/steps.go
+++ b/e2e/tests/cluster/steps.go
@@ -12,7 +12,6 @@ import (
 )
 
 func clusterLifecycleSteps(clusterSuite *workflow.ClusterSuite, installationSuite *workflow.InstallationSuite) []*workflow.Step {
-
 	return []*workflow.Step{
 		{
 			Name:              "CreateCluster",

--- a/e2e/tests/installation/installation_test.go
+++ b/e2e/tests/installation/installation_test.go
@@ -26,8 +26,7 @@ func TestMain(m *testing.M) {
 }
 
 func SetupInstallationLifecycleTest() (*shared.Test, error) {
-	test, err := shared.SetupTestWithDefaults("installation-lifecycle", false)
-
+	test, err := shared.SetupTestWithDefaults("installation-lifecycle")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to setup test environment")
 	}

--- a/e2e/tests/installation/steps.go
+++ b/e2e/tests/installation/steps.go
@@ -12,17 +12,26 @@ import (
 )
 
 func versionedS3BucketInstallationLifecycleSteps(clusterSuite *workflow.ClusterSuite, installationSuite *workflow.InstallationSuite) []*workflow.Step {
-	return []*workflow.Step{
-		{
-			Name:              "CreateCluster",
-			Func:              clusterSuite.CreateCluster,
-			DependsOn:         []string{},
-			GetExpectedEvents: clusterSuite.ClusterCreationEvents,
-		},
+	var initialDepends []string
+	var steps []*workflow.Step
+
+	if !clusterSuite.Params.UseExistingCluster {
+		initialDepends = []string{"CreateCluster"}
+		steps = []*workflow.Step{
+			{
+				Name:              "CreateCluster",
+				Func:              clusterSuite.CreateCluster,
+				DependsOn:         []string{},
+				GetExpectedEvents: clusterSuite.ClusterCreationEvents,
+			},
+		}
+	}
+
+	steps = append(steps, []*workflow.Step{
 		{
 			Name:              "CreateInstallationWithVersionedAWSS3Filestore",
 			Func:              installationSuite.CreateInstallationWithVersionedAWSS3Filestore,
-			DependsOn:         []string{"CreateCluster"},
+			DependsOn:         initialDepends,
 			GetExpectedEvents: installationSuite.InstallationCreationEvents,
 		},
 		{
@@ -46,21 +55,32 @@ func versionedS3BucketInstallationLifecycleSteps(clusterSuite *workflow.ClusterS
 			DependsOn:         []string{"CheckVersionedAWSS3FilestoreInstallation"},
 			GetExpectedEvents: installationSuite.InstallationDeletionEvents,
 		},
-	}
+	}...)
+
+	return steps
 }
 
 func largeInstallationSizeLifecycleSteps(clusterSuite *workflow.ClusterSuite, installationSuite *workflow.InstallationSuite) []*workflow.Step {
-	return []*workflow.Step{
-		{
-			Name:              "CreateCluster",
-			Func:              clusterSuite.CreateCluster,
-			DependsOn:         []string{},
-			GetExpectedEvents: clusterSuite.ClusterCreationEvents,
-		},
+	var initialDepends []string
+	var steps []*workflow.Step
+
+	if !clusterSuite.Params.UseExistingCluster {
+		initialDepends = []string{"CreateCluster"}
+		steps = []*workflow.Step{
+			{
+				Name:              "CreateCluster",
+				Func:              clusterSuite.CreateCluster,
+				DependsOn:         []string{},
+				GetExpectedEvents: clusterSuite.ClusterCreationEvents,
+			},
+		}
+	}
+
+	steps = append(steps, []*workflow.Step{
 		{
 			Name:              "CreateInstallationWithLargeSize",
 			Func:              installationSuite.CreateInstallationWithCustomProvisionerSize,
-			DependsOn:         []string{"CreateCluster"},
+			DependsOn:         initialDepends,
 			GetExpectedEvents: installationSuite.InstallationCreationEvents,
 		},
 		{
@@ -84,21 +104,32 @@ func largeInstallationSizeLifecycleSteps(clusterSuite *workflow.ClusterSuite, in
 			DependsOn:         []string{"CheckLargeSizeInstallation"},
 			GetExpectedEvents: installationSuite.InstallationDeletionEvents,
 		},
-	}
+	}...)
+
+	return steps
 }
 
 func basicCreateDeleteInstallationSteps(clusterSuite *workflow.ClusterSuite, installationSuite *workflow.InstallationSuite) []*workflow.Step {
-	return []*workflow.Step{
-		{
-			Name:              "CreateCluster",
-			Func:              clusterSuite.CreateCluster,
-			DependsOn:         []string{},
-			GetExpectedEvents: clusterSuite.ClusterCreationEvents,
-		},
+	var initialDepends []string
+	var steps []*workflow.Step
+
+	if !clusterSuite.Params.UseExistingCluster {
+		initialDepends = []string{"CreateCluster"}
+		steps = []*workflow.Step{
+			{
+				Name:              "CreateCluster",
+				Func:              clusterSuite.CreateCluster,
+				DependsOn:         []string{},
+				GetExpectedEvents: clusterSuite.ClusterCreationEvents,
+			},
+		}
+	}
+
+	steps = append(steps, []*workflow.Step{
 		{
 			Name:              "CreateInstallation",
 			Func:              installationSuite.CreateInstallation,
-			DependsOn:         []string{"CreateCluster"},
+			DependsOn:         initialDepends,
 			GetExpectedEvents: installationSuite.InstallationCreationEvents,
 		},
 		{
@@ -127,5 +158,7 @@ func basicCreateDeleteInstallationSteps(clusterSuite *workflow.ClusterSuite, ins
 			DependsOn:         []string{"CheckInstallation"},
 			GetExpectedEvents: installationSuite.InstallationDeletionEvents,
 		},
-	}
+	}...)
+
+	return steps
 }

--- a/e2e/tests/state/state.go
+++ b/e2e/tests/state/state.go
@@ -10,6 +10,7 @@ var (
 	ClusterID      string
 	InstallationID string
 	TestID         string
+	TestName       string
 	StartTime      time.Time
 	EndTime        time.Time
 )

--- a/e2e/workflow/cluster.go
+++ b/e2e/workflow/cluster.go
@@ -42,6 +42,7 @@ type ClusterSuite struct {
 
 // ClusterSuiteParams contains parameters for ClusterSuite.
 type ClusterSuiteParams struct {
+	UseExistingCluster   bool
 	CreateRequest        model.CreateClusterRequest
 	ReprovisionUtilities map[string]*model.HelmUtilityVersion
 }


### PR DESCRIPTION
This change adds configuration and logic to E2E tests to support using existing clusters. Installation tests can now be run without creating new clusters which is required for environments with only external cluster support. This change also improves webhooks by reporting the test name and skipping fields that aren't set in tests.

Fixes https://mattermost.atlassian.net/browse/CLD-8978

```release-note
Support existing clusters in E2E tests
```
