### PR TITLE
Allow for skipping E2E tests

### DIFF
--- a/build/bin-e2e/entrypoint
+++ b/build/bin-e2e/entrypoint
@@ -3,11 +3,19 @@
 # Don't exit on test failures, but capture them for final return.
 failures=0
 
-echo "Running Cluster E2E Tests"
-/mattermost-cloud-e2e/mattermost-cloud-e2e-cluster-tests || failures=$(($failures+1))
+if [[ -z "${SKIP_CLUSTER_TESTS}" ]]; then
+  echo "Running Cluster E2E Tests"
+  /mattermost-cloud-e2e/mattermost-cloud-e2e-cluster-tests || failures=$(($failures+1))
+else
+  echo "Skipping Cluster E2E Tests"
+fi
 
-echo "Running Installation E2E Tests"
-/mattermost-cloud-e2e/mattermost-cloud-e2e-installation-tests || failures=$(($failures+1))
+if [[ -z "${SKIP_INSTALLATION_TESTS}" ]]; then
+  echo "Running Installation E2E Tests"
+  /mattermost-cloud-e2e/mattermost-cloud-e2e-installation-tests || failures=$(($failures+1))
+else
+  echo "Skipping Installation E2E Tests"
+fi
 
 echo "\n$failures tests failed"
 if [ $failures -ne 0 ]; then

--- a/e2e/tests/cluster/cluster_test.go
+++ b/e2e/tests/cluster/cluster_test.go
@@ -33,7 +33,7 @@ func SetupClusterLifecycleTest() (*shared.Test, error) {
 		return nil, errors.Wrap(err, "failed to setup test environment")
 	}
 	if test.ClusterSuite.Params.UseExistingCluster {
-		return nil, errors.Wrap(err, "test configuration invalid; cluster creation must be set to true for cluster lifecycle tests")
+		return nil, errors.New("test configuration invalid; cluster creation must be set to true for cluster lifecycle tests")
 	}
 
 	return test, nil


### PR DESCRIPTION
This change updates the E2E script to allow for skipping specific tests by setting different environment variables. It also fixes a bad E2E error return.

Fixes https://mattermost.atlassian.net/browse/CLD-8984

```release-note
Allow for skipping E2E tests
```
