### PR TITLE
update pgbouncer config when execute cluster provision for external clusters

### DIFF
--- a/internal/provisioner/eks_provisioner.go
+++ b/internal/provisioner/eks_provisioner.go
@@ -29,6 +29,8 @@ const EKSProvisionerType = "eks"
 
 type clusterUpdateStore interface {
 	UpdateCluster(cluster *model.Cluster) error
+	GetMultitenantDatabases(filter *model.MultitenantDatabaseFilter) ([]*model.MultitenantDatabase, error)
+	GetLogicalDatabases(filter *model.LogicalDatabaseFilter) ([]*model.LogicalDatabase, error)
 }
 
 // EKSProvisioner provisions clusters using AWS EKS.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
With this change, when we execute `cluster provision` for external clusters, pgbouncer configmap will be generated/updated. This is a quick way to generate the configs for pgbouncer in case we delete/change it accidentally.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9031

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
UpdatePGBouncerConfigMap when execute cluster provision for external clusters.
```
