### PR TITLE
skip utility deployment if it's already managed by argocd

### DIFF
--- a/internal/provisioner/utility/unmanaged.go
+++ b/internal/provisioner/utility/unmanaged.go
@@ -56,6 +56,12 @@ func (u *unmanaged) ValuesPath() string {
 }
 
 func (u *unmanaged) CreateOrUpgrade() error {
+	if u.ActualVersion().Version() == model.UnmanagedUtilityVersion {
+		//skip if the utility is already unmanaged
+		u.logger.WithField("unmanaged-action", "skip").Info("Utility is unmanaged; skipping...")
+		return nil
+	}
+
 	u.logger.WithField("unmanaged-action", "create").Info("Utility is unmanaged; deploying with argocd...")
 
 	privateDomainName, err := u.awsClient.GetPrivateZoneDomainName(u.logger)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Some utilities have custom values managed by Provisioner with this change; if the utility is already managed by argocd, we will skip it.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8858

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
