### PR TITLE
[CLD-9158] Allow -y to quell the production warning as well as skip confirmation

### DIFF
--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -101,7 +101,7 @@ var rootCmd = &cobra.Command{
 					logger.Fatal("Confirmation required to proceed.")
 					return
 				}
-			} else if strings.Contains(currentContext.ServerURL, "prod") {
+			} else if strings.Contains(currentContext.ServerURL, "prod") && !skipConfirmation {
 				logger.Warn("\"Prod\" detected in server URL. Consider requiring confirmation on this context. Proceed with caution.")
 			}
 		}


### PR DESCRIPTION
#### Summary
If you tried to use the Cloud CLI against a prod instance in a bash script where you pipe into jq, it would break, because this warning would appear before the JSON, and couldn't be parsed. This PR extends the `-y` parameter to quell not only the confirmation, but the warning itself.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9158

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
