### PR TITLE
Add installation deletion scheduling

### DIFF
--- a/cmd/cloud/installation_flag.go
+++ b/cmd/cloud/installation_flag.go
@@ -27,6 +27,7 @@ type installationCreateRequestOptions struct {
 	priorityEnv               []string
 	annotations               []string
 	groupSelectionAnnotations []string
+	scheduledDeletionTime     time.Duration
 }
 
 func (flags *installationCreateRequestOptions) addFlags(command *cobra.Command) {
@@ -44,6 +45,7 @@ func (flags *installationCreateRequestOptions) addFlags(command *cobra.Command) 
 	command.Flags().StringArrayVar(&flags.priorityEnv, "priority-env", []string{}, "Env vars to add to the Mattermost App that take priority over group config. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	command.Flags().StringArrayVar(&flags.annotations, "annotation", []string{}, "Additional annotations for the installation. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 	command.Flags().StringArrayVar(&flags.groupSelectionAnnotations, "group-selection-annotation", []string{}, "Annotations for automatic group selection. Accepts multiple values, for example: '... --group-selection-annotation abc --group-selection-annotation def'")
+	command.Flags().DurationVar(&flags.scheduledDeletionTime, "scheduled-deletion-time", 0, "The time from now when the installation should be deleted. Use 0 for no scheduled deletion.")
 
 	_ = command.MarkFlagRequired("owner")
 }
@@ -523,4 +525,33 @@ type installationDeletionReportFlags struct {
 
 func (flags *installationDeletionReportFlags) addFlags(command *cobra.Command) {
 	command.Flags().IntVar(&flags.days, "days", 7, "The number of days include in the deletion report.")
+}
+
+type installationScheduledDeletionRequestOptions struct {
+	scheduledDeletionTime time.Duration
+}
+
+func (flags *installationScheduledDeletionRequestOptions) addFlags(command *cobra.Command) {
+	command.Flags().DurationVar(&flags.scheduledDeletionTime, "scheduled-deletion-time", 0, "The time from now when the installation should be deleted. Use 0 to cancel scheduled deletion.")
+}
+
+type installationScheduledDeletionRequestOptionsChanged struct {
+	scheduledDeletionTimeChanged bool
+}
+
+func (flags *installationScheduledDeletionRequestOptionsChanged) addFlags(command *cobra.Command) {
+	flags.scheduledDeletionTimeChanged = command.Flags().Changed("scheduled-deletion-time")
+}
+
+type installationScheduledDeletionFlags struct {
+	clusterFlags
+	installationScheduledDeletionRequestOptions
+	installationScheduledDeletionRequestOptionsChanged
+	installationID string
+}
+
+func (flags *installationScheduledDeletionFlags) addFlags(command *cobra.Command) {
+	flags.installationScheduledDeletionRequestOptions.addFlags(command)
+	command.Flags().StringVar(&flags.installationID, "installation", "", "The id of the installation to schedule deletion for.")
+	_ = command.MarkFlagRequired("installation")
 }

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -2255,4 +2255,20 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.50.0"), semver.MustParse("0.51.0"), func(e execer) error {
+		_, err := e.Exec(`
+			ALTER TABLE Installation
+			ADD COLUMN ScheduledDeletionTime BIGINT NOT NULL DEFAULT '0';
+		`)
+		if err != nil {
+			return errors.Wrap(err, "failed to create ScheduledDeletionTime column")
+		}
+
+		_, err = e.Exec("ALTER TABLE Installation ALTER COLUMN ScheduledDeletionTime SET NOT NULL;")
+		if err != nil {
+			return errors.Wrap(err, "failed to remove not null constraint")
+		}
+
+		return nil
+	}},
 }

--- a/model/client.go
+++ b/model/client.go
@@ -1962,3 +1962,20 @@ func (c *Client) GetClusterInstallationStatus(clusterInstallationID string) (*Cl
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
 	}
 }
+
+// UpdateInstallationScheduledDeletion updates the scheduled deletion time of an installation.
+func (c *Client) UpdateInstallationScheduledDeletion(installationID string, request *PatchInstallationScheduledDeletionRequest) (*InstallationDTO, error) {
+	resp, err := c.doPut(c.buildURL("/api/installation/%s/deletion/schedule", installationID), request)
+	if err != nil {
+		return nil, err
+	}
+	defer closeBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return DTOFromReader[InstallationDTO](resp.Body)
+
+	default:
+		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
+	}
+}

--- a/model/installation.go
+++ b/model/installation.go
@@ -53,6 +53,7 @@ type Installation struct {
 	CreateAt                   int64
 	DeleteAt                   int64
 	DeletionPendingExpiry      int64 `json:"DeletionPendingExpiry,omitempty"`
+	ScheduledDeletionTime      int64 `json:"ScheduledDeletionTime,omitempty"`
 	APISecurityLock            bool
 	DeletionLocked             bool
 	LockAcquiredBy             *string
@@ -240,6 +241,16 @@ func (i *Installation) DeletionDateString() string {
 	}
 
 	return DateStringFromMillis(i.DeleteAt)
+}
+
+// ScheculedDeletionCompleteTimeString returns a standardized time string for
+// an installation's scheduled deletion or 'n/a' if no deletion is scheduled.
+func (i *Installation) ScheculedDeletionCompleteTimeString() string {
+	if i.ScheduledDeletionTime == 0 {
+		return "n/a"
+	}
+
+	return DateTimeStringFromMillis(i.ScheduledDeletionTime)
 }
 
 // DeletionPendingExpiryCompleteTimeString returns a standardized time string for

--- a/model/installation_states.go
+++ b/model/installation_states.go
@@ -183,6 +183,20 @@ var AllInstallationRequestStates = []string{
 	InstallationStateDeletionRequested,
 }
 
+// AllInstallationDeletionStates is a list of all states that an installation
+// moves through when being deleted.
+var AllInstallationDeletionStates = []string{
+	InstallationStateDeletionPendingRequested,
+	InstallationStateDeletionPendingInProgress,
+	InstallationStateDeletionPending,
+	InstallationStateDeletionCancellationRequested,
+	InstallationStateDeletionRequested,
+	InstallationStateDeletionInProgress,
+	InstallationStateDeletionFinalCleanup,
+	InstallationStateDeletionFailed,
+	InstallationStateDeleted,
+}
+
 // ValidTransitionState returns whether an installation can be transitioned into
 // the new state or not based on its current state.
 func (i *Installation) ValidTransitionState(newState string) bool {


### PR DESCRIPTION
This change adds optional installation deletion scheduling logic to the provisioner. Installations can now be created with a configurable TTL which can be useful for quick testing and other use-cases.

Installations with scheduled deletion will only be deleted if they are not deletion-locked and the current time is past their scheduled deletion time. Deletion-locked installations will be deleted once their lock is removed if the scheduled deletion time has passed.

This is completely separate from the existing deleting pending logic which allows for specifying how long an installation remains in a deletion-pending state after it was scheduled for deletion.

Fixes https://mattermost.atlassian.net/browse/CLD-9188

```release-note
Add installation deletion scheduling
```
