### PR TITLE
[CLD-9197]: Removing Argocd cluster deregistration to be able to dele…

### DIFF
--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -885,30 +885,6 @@ func (provisioner *KopsProvisioner) cleanupCluster(cluster *model.Cluster, tempD
 		return errors.Wrap(err, "failed to destroy all services in the utility group")
 	}
 
-	// Remove utility and cluster from argocd
-	// if cluster.UtilityMetadata.ManagedByArgocd {
-	// 	err = ugh.RemoveUtilityFromArgocd(gitClient)
-	// 	if err != nil {
-	// 		return errors.Wrap(err, "failed to remove utility from argocd")
-	// 	}
-
-	// 	appName := fmt.Sprintf("%s-%s", "gitops-sre", provisioner.awsClient.GetCloudEnvironmentName())
-	// 	err = argocdClient.WaitForAppHealthy(appName)
-	// 	if err != nil {
-	// 		return errors.Wrap(err, "failed to wait for app to be healthy")
-	// 	}
-
-	// 	var cr *ClusterRegister
-	// 	cr, err = NewClusterRegisterHandle(cluster, gitClient, provisioner.awsClient.GetCloudEnvironmentName(), tempDir, logger)
-	// 	if err != nil {
-	// 		return errors.Wrap(err, "Failed to create new cluster register handle")
-	// 	}
-
-	// 	if err = cr.deregisterClusterFromArgocd(); err != nil {
-	// 		return errors.Wrap(err, "failed to remove cluster from Argocd")
-	// 	}
-	// }
-
 	iamRole := fmt.Sprintf("nodes.%s", kopsMetadata.Name)
 	err = provisioner.awsClient.DetachPolicyFromRole(iamRole, aws.CustomNodePolicyName, logger)
 	if err != nil {

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -886,28 +886,28 @@ func (provisioner *KopsProvisioner) cleanupCluster(cluster *model.Cluster, tempD
 	}
 
 	// Remove utility and cluster from argocd
-	if cluster.UtilityMetadata.ManagedByArgocd {
-		err = ugh.RemoveUtilityFromArgocd(gitClient)
-		if err != nil {
-			return errors.Wrap(err, "failed to remove utility from argocd")
-		}
+	// if cluster.UtilityMetadata.ManagedByArgocd {
+	// 	err = ugh.RemoveUtilityFromArgocd(gitClient)
+	// 	if err != nil {
+	// 		return errors.Wrap(err, "failed to remove utility from argocd")
+	// 	}
 
-		appName := fmt.Sprintf("%s-%s", "gitops-sre", provisioner.awsClient.GetCloudEnvironmentName())
-		err = argocdClient.WaitForAppHealthy(appName)
-		if err != nil {
-			return errors.Wrap(err, "failed to wait for app to be healthy")
-		}
+	// 	appName := fmt.Sprintf("%s-%s", "gitops-sre", provisioner.awsClient.GetCloudEnvironmentName())
+	// 	err = argocdClient.WaitForAppHealthy(appName)
+	// 	if err != nil {
+	// 		return errors.Wrap(err, "failed to wait for app to be healthy")
+	// 	}
 
-		var cr *ClusterRegister
-		cr, err = NewClusterRegisterHandle(cluster, gitClient, provisioner.awsClient.GetCloudEnvironmentName(), tempDir, logger)
-		if err != nil {
-			return errors.Wrap(err, "Failed to create new cluster register handle")
-		}
+	// 	var cr *ClusterRegister
+	// 	cr, err = NewClusterRegisterHandle(cluster, gitClient, provisioner.awsClient.GetCloudEnvironmentName(), tempDir, logger)
+	// 	if err != nil {
+	// 		return errors.Wrap(err, "Failed to create new cluster register handle")
+	// 	}
 
-		if err = cr.deregisterClusterFromArgocd(); err != nil {
-			return errors.Wrap(err, "failed to remove cluster from Argocd")
-		}
-	}
+	// 	if err = cr.deregisterClusterFromArgocd(); err != nil {
+	// 		return errors.Wrap(err, "failed to remove cluster from Argocd")
+	// 	}
+	// }
 
 	iamRole := fmt.Sprintf("nodes.%s", kopsMetadata.Name)
 	err = provisioner.awsClient.DetachPolicyFromRole(iamRole, aws.CustomNodePolicyName, logger)


### PR DESCRIPTION
…te kops clusters.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Because we no longer have GitLab, the provisioner is still trying to hit it. So, to delete a cluster, we can skip this part as we don't plan to migrate it to GitHub.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9197

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Skip cluster deregistration from argocd.
```
