### PR TITLE
Add server flags for pod probe overrides

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -291,6 +291,7 @@ func executeServerCmd(flags serverFlags) error {
 		SLOInstallationGroups:     flags.sloInstallationGroups,
 		SLOEnterpriseGroups:       flags.sloEnterpriseGroups,
 		EtcdManagerEnv:            etcdManagerEnv,
+		PodProbeOverrides:         flags.generateProbeOverrides(),
 	}
 
 	resourceUtil := utils.NewResourceUtil(instanceID, awsClient, dbClusterUtilizationSettingsFromFlags(flags), flags.disableDBInitCheck, flags.enableS3Versioning)

--- a/cmd/cloud/server_flag_test.go
+++ b/cmd/cloud/server_flag_test.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/internal/provisioner"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestGenerateProbeOverrides(t *testing.T) {
+	t.Run("no probe flags changed", func(t *testing.T) {
+		flags := &serverFlags{}
+		result := flags.generateProbeOverrides()
+
+		expected := provisioner.PodProbeOverrides{}
+		assert.Equal(t, expected, result)
+		assert.Nil(t, result.LivenessProbeOverride)
+		assert.Nil(t, result.ReadinessProbeOverride)
+	})
+
+	t.Run("only liveness probe flags changed", func(t *testing.T) {
+		flags := &serverFlags{
+			provisioningParams: provisioningParams{
+				probeLivenessFailureThreshold:    5,
+				probeLivenessSuccessThreshold:    2,
+				probeLivenessInitialDelaySeconds: 60,
+				probeLivenessPeriodSeconds:       15,
+				probeLivenessTimeoutSeconds:      10,
+			},
+			serverFlagChanged: serverFlagChanged{
+				probeLivenessFailureThresholdChanged:    true,
+				probeLivenessSuccessThresholdChanged:    true,
+				probeLivenessInitialDelaySecondsChanged: true,
+				probeLivenessPeriodSecondsChanged:       true,
+				probeLivenessTimeoutSecondsChanged:      true,
+			},
+		}
+
+		result := flags.generateProbeOverrides()
+
+		assert.NotNil(t, result.LivenessProbeOverride)
+		assert.Nil(t, result.ReadinessProbeOverride)
+
+		expected := &corev1.Probe{
+			FailureThreshold:    5,
+			SuccessThreshold:    2,
+			InitialDelaySeconds: 60,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      10,
+		}
+		assert.Equal(t, expected, result.LivenessProbeOverride)
+	})
+
+	t.Run("only readiness probe flags changed", func(t *testing.T) {
+		flags := &serverFlags{
+			provisioningParams: provisioningParams{
+				probeReadinessFailureThreshold:    3,
+				probeReadinessSuccessThreshold:    1,
+				probeReadinessInitialDelaySeconds: 45,
+				probeReadinessPeriodSeconds:       20,
+				probeReadinessTimeoutSeconds:      8,
+			},
+			serverFlagChanged: serverFlagChanged{
+				probeReadinessFailureThresholdChanged:    true,
+				probeReadinessSuccessThresholdChanged:    true,
+				probeReadinessInitialDelaySecondsChanged: true,
+				probeReadinessPeriodSecondsChanged:       true,
+				probeReadinessTimeoutSecondsChanged:      true,
+			},
+		}
+
+		result := flags.generateProbeOverrides()
+
+		assert.Nil(t, result.LivenessProbeOverride)
+		assert.NotNil(t, result.ReadinessProbeOverride)
+
+		expected := &corev1.Probe{
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 45,
+			PeriodSeconds:       20,
+			TimeoutSeconds:      8,
+		}
+		assert.Equal(t, expected, result.ReadinessProbeOverride)
+	})
+
+	t.Run("both liveness and readiness probe flags changed", func(t *testing.T) {
+		flags := &serverFlags{
+			provisioningParams: provisioningParams{
+				probeLivenessFailureThreshold:     4,
+				probeLivenessSuccessThreshold:     1,
+				probeLivenessInitialDelaySeconds:  30,
+				probeLivenessPeriodSeconds:        5,
+				probeLivenessTimeoutSeconds:       3,
+				probeReadinessFailureThreshold:    6,
+				probeReadinessSuccessThreshold:    2,
+				probeReadinessInitialDelaySeconds: 20,
+				probeReadinessPeriodSeconds:       10,
+				probeReadinessTimeoutSeconds:      7,
+			},
+			serverFlagChanged: serverFlagChanged{
+				probeLivenessFailureThresholdChanged:     true,
+				probeLivenessSuccessThresholdChanged:     true,
+				probeLivenessInitialDelaySecondsChanged:  true,
+				probeLivenessPeriodSecondsChanged:        true,
+				probeLivenessTimeoutSecondsChanged:       true,
+				probeReadinessFailureThresholdChanged:    true,
+				probeReadinessSuccessThresholdChanged:    true,
+				probeReadinessInitialDelaySecondsChanged: true,
+				probeReadinessPeriodSecondsChanged:       true,
+				probeReadinessTimeoutSecondsChanged:      true,
+			},
+		}
+
+		result := flags.generateProbeOverrides()
+
+		assert.NotNil(t, result.LivenessProbeOverride)
+		assert.NotNil(t, result.ReadinessProbeOverride)
+
+		expectedLiveness := &corev1.Probe{
+			FailureThreshold:    4,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      3,
+		}
+		assert.Equal(t, expectedLiveness, result.LivenessProbeOverride)
+
+		expectedReadiness := &corev1.Probe{
+			FailureThreshold:    6,
+			SuccessThreshold:    2,
+			InitialDelaySeconds: 20,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      7,
+		}
+		assert.Equal(t, expectedReadiness, result.ReadinessProbeOverride)
+	})
+
+	t.Run("partial liveness probe flags changed", func(t *testing.T) {
+		flags := &serverFlags{
+			provisioningParams: provisioningParams{
+				probeLivenessFailureThreshold: 8,
+				probeLivenessTimeoutSeconds:   12,
+			},
+			serverFlagChanged: serverFlagChanged{
+				probeLivenessFailureThresholdChanged: true,
+				probeLivenessTimeoutSecondsChanged:   true,
+				// Other liveness flags not changed
+			},
+		}
+
+		result := flags.generateProbeOverrides()
+
+		assert.NotNil(t, result.LivenessProbeOverride)
+		assert.Nil(t, result.ReadinessProbeOverride)
+
+		expected := &corev1.Probe{
+			FailureThreshold: 8,
+			TimeoutSeconds:   12,
+			// Other fields should be zero values since they weren't changed
+		}
+		assert.Equal(t, expected, result.LivenessProbeOverride)
+	})
+
+	t.Run("partial readiness probe flags changed", func(t *testing.T) {
+		flags := &serverFlags{
+			provisioningParams: provisioningParams{
+				probeReadinessSuccessThreshold:    3,
+				probeReadinessPeriodSeconds:       25,
+				probeReadinessInitialDelaySeconds: 100,
+			},
+			serverFlagChanged: serverFlagChanged{
+				probeReadinessSuccessThresholdChanged:    true,
+				probeReadinessPeriodSecondsChanged:       true,
+				probeReadinessInitialDelaySecondsChanged: true,
+				// Other readiness flags not changed
+			},
+		}
+
+		result := flags.generateProbeOverrides()
+
+		assert.Nil(t, result.LivenessProbeOverride)
+		assert.NotNil(t, result.ReadinessProbeOverride)
+
+		expected := &corev1.Probe{
+			SuccessThreshold:    3,
+			PeriodSeconds:       25,
+			InitialDelaySeconds: 100,
+			// Other fields should be zero values since they weren't changed
+		}
+		assert.Equal(t, expected, result.ReadinessProbeOverride)
+	})
+
+	t.Run("single liveness flag changed", func(t *testing.T) {
+		flags := &serverFlags{
+			provisioningParams: provisioningParams{
+				probeLivenessFailureThreshold: 15,
+			},
+			serverFlagChanged: serverFlagChanged{
+				probeLivenessFailureThresholdChanged: true,
+			},
+		}
+
+		result := flags.generateProbeOverrides()
+
+		assert.NotNil(t, result.LivenessProbeOverride)
+		assert.Nil(t, result.ReadinessProbeOverride)
+
+		expected := &corev1.Probe{
+			FailureThreshold: 15,
+		}
+		assert.Equal(t, expected, result.LivenessProbeOverride)
+	})
+
+	t.Run("single readiness flag changed", func(t *testing.T) {
+		flags := &serverFlags{
+			provisioningParams: provisioningParams{
+				probeReadinessInitialDelaySeconds: 200,
+			},
+			serverFlagChanged: serverFlagChanged{
+				probeReadinessInitialDelaySecondsChanged: true,
+			},
+		}
+
+		result := flags.generateProbeOverrides()
+
+		assert.Nil(t, result.LivenessProbeOverride)
+		assert.NotNil(t, result.ReadinessProbeOverride)
+
+		expected := &corev1.Probe{
+			InitialDelaySeconds: 200,
+		}
+		assert.Equal(t, expected, result.ReadinessProbeOverride)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.7
 require (
 	github.com/0xAX/notificator v0.0.0-20220220101646-ee9b8921e557
 	github.com/Masterminds/squirrel v1.5.4
+	github.com/MicahParks/keyfunc/v3 v3.3.5
 	github.com/agnivade/easy-scrypt v1.0.0
 	github.com/argoproj/argo-cd/v2 v2.9.8
 	github.com/argoproj/gitops-engine v0.7.1-0.20230906152414-b0fffe419a0f
@@ -32,6 +33,7 @@ require (
 	github.com/cloudflare/cloudflare-go v0.100.0
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/go-sql-driver/mysql v1.8.1
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gosuri/uilive v0.0.4
@@ -41,7 +43,6 @@ require (
 	github.com/mattermost/awat v0.2.0
 	github.com/mattermost/mattermost-operator v1.22.0
 	github.com/mattermost/rotator v0.2.1-0.20230830064954-61490ed26761
-	github.com/okta/okta-jwt-verifier-golang v1.3.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pborman/uuid v1.2.1
 	github.com/pkg/errors v0.9.1
@@ -75,7 +76,6 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/MicahParks/jwkset v0.5.20 // indirect
-	github.com/MicahParks/keyfunc/v3 v3.3.5 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/argoproj/pkg v0.13.7-0.20230626144333-d56162821bd1 // indirect
@@ -106,7 +106,6 @@ require (
 	github.com/coreos/go-oidc/v3 v3.6.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
@@ -133,7 +132,6 @@ require (
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
@@ -163,12 +161,6 @@ require (
 	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
-	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
-	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
-	github.com/lestrrat-go/httpcc v1.0.1 // indirect
-	github.com/lestrrat-go/iter v1.0.2 // indirect
-	github.com/lestrrat-go/jwx v1.2.30 // indirect
-	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -988,10 +988,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d/go.mod h1:tmAIfUFEirG/Y8jhZ9M+h36obRZAk/1fcSpXwAVlfqE=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnNEcHYvcCuK6dPZSg=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
@@ -1315,7 +1311,6 @@ github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/V
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
-github.com/goccy/go-json v0.9.4/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
 github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
@@ -1333,7 +1328,6 @@ github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48/go.mod h1:SlYgWuQ5
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
@@ -1730,26 +1724,6 @@ github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhR
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
-github.com/lestrrat-go/backoff/v2 v2.0.8 h1:oNb5E5isby2kiro9AgdHLv5N5tint1AnDVVf2E2un5A=
-github.com/lestrrat-go/backoff/v2 v2.0.8/go.mod h1:rHP/q/r9aT27n24JQLa7JhSQZCKBBOiM/uP402WwN8Y=
-github.com/lestrrat-go/blackmagic v1.0.0/go.mod h1:TNgH//0vYSs8VXDCfkZLgIrVTTXQELZffUV0tz3MtdQ=
-github.com/lestrrat-go/blackmagic v1.0.2 h1:Cg2gVSc9h7sz9NOByczrbUvLopQmXrfFx//N+AkAr5k=
-github.com/lestrrat-go/blackmagic v1.0.2/go.mod h1:UrEqBzIR2U6CnzVyUtfM6oZNMt/7O7Vohk2J0OGSAtU=
-github.com/lestrrat-go/codegen v1.0.0/go.mod h1:JhJw6OQAuPEfVKUCLItpaVLumDGWQznd1VaXrBk9TdM=
-github.com/lestrrat-go/httpcc v1.0.0/go.mod h1:tGS/u00Vh5N6FHNkExqGGNId8e0Big+++0Gf8MBnAvE=
-github.com/lestrrat-go/httpcc v1.0.1 h1:ydWCStUeJLkpYyjLDHihupbn2tYmZ7m22BGkcvZZrIE=
-github.com/lestrrat-go/httpcc v1.0.1/go.mod h1:qiltp3Mt56+55GPVCbTdM9MlqhvzyuL6W/NMDA8vA5E=
-github.com/lestrrat-go/iter v1.0.1/go.mod h1:zIdgO1mRKhn8l9vrZJZz9TUMMFbQbLeTsbqPDrJ/OJc=
-github.com/lestrrat-go/iter v1.0.2 h1:gMXo1q4c2pHmC3dn8LzRhJfP1ceCbgSiT9lUydIzltI=
-github.com/lestrrat-go/iter v1.0.2/go.mod h1:Momfcq3AnRlRjI5b5O8/G5/BvpzrhoFTZcn06fEOPt4=
-github.com/lestrrat-go/jwx v1.2.18/go.mod h1:bWTBO7IHHVMtNunM8so9MT8wD+euEY1PzGEyCnuI2qM=
-github.com/lestrrat-go/jwx v1.2.30 h1:VKIFrmjYn0z2J51iLPadqoHIVLzvWNa1kCsTqNDHYPA=
-github.com/lestrrat-go/jwx v1.2.30/go.mod h1:vMxrwFhunGZ3qddmfmEm2+uced8MSI6QFWGTKygjSzQ=
-github.com/lestrrat-go/option v0.0.0-20210103042652-6f1ecfceda35/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
-github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
-github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
-github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
-github.com/lestrrat-go/pdebug/v3 v3.0.1/go.mod h1:za+m+Ve24yCxTEhR59N7UlnJomWwCiIqbJRmKeiADU4=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
@@ -1930,8 +1904,6 @@ github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtb
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/okta/okta-jwt-verifier-golang v1.3.1 h1:V+9W5KD3nG7xN0UYtnzXtkurGcs71bLwzPFuUGNMwdE=
-github.com/okta/okta-jwt-verifier-golang v1.3.1/go.mod h1:cHffA777f7Yi4K+yDzUp89sGD5v8sk04Pc3CiT1OMR8=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
@@ -2003,7 +1975,6 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
-github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
@@ -2507,7 +2478,6 @@ golang.org/x/crypto v0.0.0-20200422194213-44a606286825/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -2942,8 +2912,6 @@ golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20220922220347-f3bd1da661af/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.1.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
-golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
 golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -3023,7 +2991,6 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
-golang.org/x/tools v0.0.0-20200918232735-d647fc253266/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201124115921-2c860bdd6e78/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
@@ -3032,7 +2999,6 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=

--- a/internal/provisioner/cluster_installation_provisioner_test.go
+++ b/internal/provisioner/cluster_installation_provisioner_test.go
@@ -8,8 +8,11 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-cloud/model"
+	mmv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAddSourceRangeWhitelistToAnnotations(t *testing.T) {
@@ -121,4 +124,251 @@ func TestClusterInstallationBaseLabels(t *testing.T) {
 			assert.Equal(t, tc.expected, labels)
 		})
 	}
+}
+
+func TestEnsurePodProbeOverrides(t *testing.T) {
+	t.Run("no probe overrides", func(t *testing.T) {
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{},
+			},
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{
+				// Set some initial probe values to ensure they get cleared
+				Probes: mmv1beta1.Probes{
+					LivenessProbe: corev1.Probe{
+						FailureThreshold: 5,
+						TimeoutSeconds:   10,
+					},
+					ReadinessProbe: corev1.Probe{
+						FailureThreshold: 3,
+						TimeoutSeconds:   5,
+					},
+				},
+			},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost)
+
+		// Both probes should be cleared to empty Probe structs
+		assert.Equal(t, corev1.Probe{}, mattermost.Spec.Probes.LivenessProbe)
+		assert.Equal(t, corev1.Probe{}, mattermost.Spec.Probes.ReadinessProbe)
+	})
+
+	t.Run("only liveness probe override", func(t *testing.T) {
+		livenessOverride := &corev1.Probe{
+			FailureThreshold:    10,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 60,
+			PeriodSeconds:       30,
+			TimeoutSeconds:      15,
+		}
+
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{
+					LivenessProbeOverride:  livenessOverride,
+					ReadinessProbeOverride: nil,
+				},
+			},
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{
+				Probes: mmv1beta1.Probes{
+					ReadinessProbe: corev1.Probe{
+						FailureThreshold: 3,
+						TimeoutSeconds:   5,
+					},
+				},
+			},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost)
+
+		// Liveness probe should be set to the override
+		assert.Equal(t, *livenessOverride, mattermost.Spec.Probes.LivenessProbe)
+		// Readiness probe should be cleared
+		assert.Equal(t, corev1.Probe{}, mattermost.Spec.Probes.ReadinessProbe)
+	})
+
+	t.Run("only readiness probe override", func(t *testing.T) {
+		readinessOverride := &corev1.Probe{
+			FailureThreshold:    5,
+			SuccessThreshold:    2,
+			InitialDelaySeconds: 45,
+			PeriodSeconds:       20,
+			TimeoutSeconds:      10,
+		}
+
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{
+					LivenessProbeOverride:  nil,
+					ReadinessProbeOverride: readinessOverride,
+				},
+			},
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{
+				Probes: mmv1beta1.Probes{
+					LivenessProbe: corev1.Probe{
+						FailureThreshold: 8,
+						TimeoutSeconds:   12,
+					},
+				},
+			},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost)
+
+		// Liveness probe should be cleared
+		assert.Equal(t, corev1.Probe{}, mattermost.Spec.Probes.LivenessProbe)
+		// Readiness probe should be set to the override
+		assert.Equal(t, *readinessOverride, mattermost.Spec.Probes.ReadinessProbe)
+	})
+
+	t.Run("both probe overrides", func(t *testing.T) {
+		livenessOverride := &corev1.Probe{
+			FailureThreshold:    12,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 90,
+			PeriodSeconds:       25,
+			TimeoutSeconds:      20,
+		}
+
+		readinessOverride := &corev1.Probe{
+			FailureThreshold:    8,
+			SuccessThreshold:    3,
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      8,
+		}
+
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{
+					LivenessProbeOverride:  livenessOverride,
+					ReadinessProbeOverride: readinessOverride,
+				},
+			},
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost)
+
+		// Both probes should be set to their respective overrides
+		assert.Equal(t, *livenessOverride, mattermost.Spec.Probes.LivenessProbe)
+		assert.Equal(t, *readinessOverride, mattermost.Spec.Probes.ReadinessProbe)
+	})
+
+	t.Run("overrides replace existing values", func(t *testing.T) {
+		livenessOverride := &corev1.Probe{
+			FailureThreshold: 7,
+			TimeoutSeconds:   25,
+		}
+
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{
+					LivenessProbeOverride:  livenessOverride,
+					ReadinessProbeOverride: nil,
+				},
+			},
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{
+				Probes: mmv1beta1.Probes{
+					LivenessProbe: corev1.Probe{
+						FailureThreshold:    999,
+						SuccessThreshold:    999,
+						InitialDelaySeconds: 999,
+						PeriodSeconds:       999,
+						TimeoutSeconds:      999,
+					},
+					ReadinessProbe: corev1.Probe{
+						FailureThreshold:    888,
+						SuccessThreshold:    888,
+						InitialDelaySeconds: 888,
+						PeriodSeconds:       888,
+						TimeoutSeconds:      888,
+					},
+				},
+			},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost)
+
+		// Liveness probe should be completely replaced with the override
+		assert.Equal(t, *livenessOverride, mattermost.Spec.Probes.LivenessProbe)
+		// Readiness probe should be cleared (not the old values)
+		assert.Equal(t, corev1.Probe{}, mattermost.Spec.Probes.ReadinessProbe)
+	})
+
+	t.Run("partial probe configuration", func(t *testing.T) {
+		// Test that we can override with partial probe configuration
+		livenessOverride := &corev1.Probe{
+			FailureThreshold: 15,
+			// Only setting one field, others should be zero values
+		}
+
+		readinessOverride := &corev1.Probe{
+			InitialDelaySeconds: 120,
+			TimeoutSeconds:      30,
+			// Only setting two fields, others should be zero values
+		}
+
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{
+					LivenessProbeOverride:  livenessOverride,
+					ReadinessProbeOverride: readinessOverride,
+				},
+			},
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost)
+
+		expectedLiveness := corev1.Probe{
+			FailureThreshold: 15,
+			// All other fields should be zero values
+		}
+		assert.Equal(t, expectedLiveness, mattermost.Spec.Probes.LivenessProbe)
+
+		expectedReadiness := corev1.Probe{
+			InitialDelaySeconds: 120,
+			TimeoutSeconds:      30,
+			// All other fields should be zero values
+		}
+		assert.Equal(t, expectedReadiness, mattermost.Spec.Probes.ReadinessProbe)
+	})
 }

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/internal/tools/utils"
 	"github.com/mattermost/mattermost-cloud/model"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type ClusterProvisionerOption struct {
@@ -46,6 +47,12 @@ type ProvisioningParams struct {
 	SLOInstallationGroups     []string
 	SLOEnterpriseGroups       []string
 	EtcdManagerEnv            map[string]string
+	PodProbeOverrides         PodProbeOverrides
+}
+
+type PodProbeOverrides struct {
+	LivenessProbeOverride  *corev1.Probe
+	ReadinessProbeOverride *corev1.Probe
 }
 
 type Provisioner struct {


### PR DESCRIPTION
New server flags have been added which allow for setting new probe override values for the liveness and readiness probes of Mattermost containers. These values are passed on to the custom resource for each installation to modify the deployment.

Values are only changed when a flag is set and only for the specific value of the specific probe. The Operator defaults are used for everything else.

Pods will pick up new override values when they are next updated.

Example with defaults:

```
    Liveness:   http-get http://:8065/api/v4/system/ping delay=10s timeout=1s period=10s #success=1 #failure=3
    Readiness:  http-get http://:8065/api/v4/system/ping delay=10s timeout=1s period=5s #success=1 #failure=6
```

Example with two Overrides:

```
    Liveness:   http-get http://:8065/api/v4/system/ping delay=10s timeout=1s period=12s #success=1 #failure=3
    Readiness:  http-get http://:8065/api/v4/system/ping delay=10s timeout=1s period=5s #success=1 #failure=9
```

Fixes https://mattermost.atlassian.net/browse/CLD-9199 and https://mattermost.atlassian.net/browse/CLD-9246

```release-note
Add server flags for pod probe overrides
```
