### PR TITLE
Log API calls when group ID is invalid

### DIFF
--- a/internal/api/lock.go
+++ b/internal/api/lock.go
@@ -90,6 +90,7 @@ func lockGroup(c *Context, groupID string) (*model.GroupDTO, int, func()) {
 		return nil, http.StatusInternalServerError, nil
 	}
 	if group == nil {
+		c.Logger.Errorf("no group with ID %s found", groupID)
 		return nil, http.StatusNotFound, nil
 	}
 


### PR DESCRIPTION
This was previously handled with a silent 404.

Fixes https://mattermost.atlassian.net/browse/CLD-9270

```release-note
Log API calls when group ID is invalid
```
