### PR TITLE
Add probe overrides to installation level

### DIFF
--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -107,6 +107,7 @@ func executeInstallationCreateCmd(ctx context.Context, flags installationCreateF
 		Annotations:               flags.annotations,
 		GroupSelectionAnnotations: flags.groupSelectionAnnotations,
 		ScheduledDeletionTime:     scheduledDeletionTime,
+		PodProbeOverrides:         flags.generateProbeOverrides(),
 	}
 
 	// For CLI to be backward compatible, if only one DNS is passed we use

--- a/cmd/cloud/installation_flag.go
+++ b/cmd/cloud/installation_flag.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mattermost/mattermost-cloud/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type installationCreateRequestOptions struct {
@@ -28,6 +29,19 @@ type installationCreateRequestOptions struct {
 	annotations               []string
 	groupSelectionAnnotations []string
 	scheduledDeletionTime     time.Duration
+
+	// Probe override settings
+	probeLivenessFailureThreshold    int32
+	probeLivenessSuccessThreshold    int32
+	probeLivenessInitialDelaySeconds int32
+	probeLivenessPeriodSeconds       int32
+	probeLivenessTimeoutSeconds      int32
+
+	probeReadinessFailureThreshold    int32
+	probeReadinessSuccessThreshold    int32
+	probeReadinessInitialDelaySeconds int32
+	probeReadinessPeriodSeconds       int32
+	probeReadinessTimeoutSeconds      int32
 }
 
 func (flags *installationCreateRequestOptions) addFlags(command *cobra.Command) {
@@ -46,6 +60,19 @@ func (flags *installationCreateRequestOptions) addFlags(command *cobra.Command) 
 	command.Flags().StringArrayVar(&flags.annotations, "annotation", []string{}, "Additional annotations for the installation. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 	command.Flags().StringArrayVar(&flags.groupSelectionAnnotations, "group-selection-annotation", []string{}, "Annotations for automatic group selection. Accepts multiple values, for example: '... --group-selection-annotation abc --group-selection-annotation def'")
 	command.Flags().DurationVar(&flags.scheduledDeletionTime, "scheduled-deletion-time", 0, "The time from now when the installation should be deleted. Use 0 for no scheduled deletion.")
+
+	// Probe override flags
+	command.Flags().Int32Var(&flags.probeLivenessFailureThreshold, "probe-liveness-failure-threshold", 0, "Override for the liveness probe failure threshold. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeLivenessSuccessThreshold, "probe-liveness-success-threshold", 0, "Override for the liveness probe success threshold. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeLivenessInitialDelaySeconds, "probe-liveness-initial-delay-seconds", 0, "Override for the liveness probe initial delay seconds. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeLivenessPeriodSeconds, "probe-liveness-period-seconds", 0, "Override for the liveness probe period seconds. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeLivenessTimeoutSeconds, "probe-liveness-timeout-seconds", 0, "Override for the liveness probe timeout seconds. Use 0 to use server/operator defaults.")
+
+	command.Flags().Int32Var(&flags.probeReadinessFailureThreshold, "probe-readiness-failure-threshold", 0, "Override for the readiness probe failure threshold. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeReadinessSuccessThreshold, "probe-readiness-success-threshold", 0, "Override for the readiness probe success threshold. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeReadinessInitialDelaySeconds, "probe-readiness-initial-delay-seconds", 0, "Override for the readiness probe initial delay seconds. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeReadinessPeriodSeconds, "probe-readiness-period-seconds", 0, "Override for the readiness probe period seconds. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeReadinessTimeoutSeconds, "probe-readiness-timeout-seconds", 0, "Override for the readiness probe timeout seconds. Use 0 to use server/operator defaults.")
 
 	_ = command.MarkFlagRequired("owner")
 }
@@ -88,6 +115,19 @@ type installationPatchRequestChanges struct {
 	licenseChanged          bool
 	allowedIPRangesChanged  bool
 	overrideIPRangesChanged bool
+
+	// Probe override change flags
+	probeLivenessFailureThresholdChanged    bool
+	probeLivenessSuccessThresholdChanged    bool
+	probeLivenessInitialDelaySecondsChanged bool
+	probeLivenessPeriodSecondsChanged       bool
+	probeLivenessTimeoutSecondsChanged      bool
+
+	probeReadinessFailureThresholdChanged    bool
+	probeReadinessSuccessThresholdChanged    bool
+	probeReadinessInitialDelaySecondsChanged bool
+	probeReadinessPeriodSecondsChanged       bool
+	probeReadinessTimeoutSecondsChanged      bool
 }
 
 func (flags *installationPatchRequestChanges) addFlags(command *cobra.Command) {
@@ -98,6 +138,19 @@ func (flags *installationPatchRequestChanges) addFlags(command *cobra.Command) {
 	flags.licenseChanged = command.Flags().Changed("license")
 	flags.allowedIPRangesChanged = command.Flags().Changed("allowed-ip-ranges")
 	flags.overrideIPRangesChanged = command.Flags().Changed("override-ip-ranges")
+
+	// Probe override change flags
+	flags.probeLivenessFailureThresholdChanged = command.Flags().Changed("probe-liveness-failure-threshold")
+	flags.probeLivenessSuccessThresholdChanged = command.Flags().Changed("probe-liveness-success-threshold")
+	flags.probeLivenessInitialDelaySecondsChanged = command.Flags().Changed("probe-liveness-initial-delay-seconds")
+	flags.probeLivenessPeriodSecondsChanged = command.Flags().Changed("probe-liveness-period-seconds")
+	flags.probeLivenessTimeoutSecondsChanged = command.Flags().Changed("probe-liveness-timeout-seconds")
+
+	flags.probeReadinessFailureThresholdChanged = command.Flags().Changed("probe-readiness-failure-threshold")
+	flags.probeReadinessSuccessThresholdChanged = command.Flags().Changed("probe-readiness-success-threshold")
+	flags.probeReadinessInitialDelaySecondsChanged = command.Flags().Changed("probe-readiness-initial-delay-seconds")
+	flags.probeReadinessPeriodSecondsChanged = command.Flags().Changed("probe-readiness-period-seconds")
+	flags.probeReadinessTimeoutSecondsChanged = command.Flags().Changed("probe-readiness-timeout-seconds")
 }
 
 type installationPatchRequestOptions struct {
@@ -111,6 +164,19 @@ type installationPatchRequestOptions struct {
 	mattermostEnv      []string
 	mattermostEnvClear bool
 	overrideIPRanges   bool
+
+	// Probe override settings
+	probeLivenessFailureThreshold    int32
+	probeLivenessSuccessThreshold    int32
+	probeLivenessInitialDelaySeconds int32
+	probeLivenessPeriodSeconds       int32
+	probeLivenessTimeoutSeconds      int32
+
+	probeReadinessFailureThreshold    int32
+	probeReadinessSuccessThreshold    int32
+	probeReadinessInitialDelaySeconds int32
+	probeReadinessPeriodSeconds       int32
+	probeReadinessTimeoutSeconds      int32
 }
 
 func (flags *installationPatchRequestOptions) addFlags(command *cobra.Command) {
@@ -123,6 +189,19 @@ func (flags *installationPatchRequestOptions) addFlags(command *cobra.Command) {
 	command.Flags().StringArrayVar(&flags.mattermostEnv, "mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	command.Flags().BoolVar(&flags.mattermostEnvClear, "mattermost-env-clear", false, "Clears all env var data.")
 	command.Flags().BoolVar(&flags.overrideIPRanges, "override-ip-ranges", true, "Overrides Allowed IP ranges and force ignoring any previous value.")
+
+	// Probe override flags
+	command.Flags().Int32Var(&flags.probeLivenessFailureThreshold, "probe-liveness-failure-threshold", 0, "Override for the liveness probe failure threshold. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeLivenessSuccessThreshold, "probe-liveness-success-threshold", 0, "Override for the liveness probe success threshold. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeLivenessInitialDelaySeconds, "probe-liveness-initial-delay-seconds", 0, "Override for the liveness probe initial delay seconds. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeLivenessPeriodSeconds, "probe-liveness-period-seconds", 0, "Override for the liveness probe period seconds. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeLivenessTimeoutSeconds, "probe-liveness-timeout-seconds", 0, "Override for the liveness probe timeout seconds. Use 0 to use server/operator defaults.")
+
+	command.Flags().Int32Var(&flags.probeReadinessFailureThreshold, "probe-readiness-failure-threshold", 0, "Override for the readiness probe failure threshold. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeReadinessSuccessThreshold, "probe-readiness-success-threshold", 0, "Override for the readiness probe success threshold. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeReadinessInitialDelaySeconds, "probe-readiness-initial-delay-seconds", 0, "Override for the readiness probe initial delay seconds. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeReadinessPeriodSeconds, "probe-readiness-period-seconds", 0, "Override for the readiness probe period seconds. Use 0 to use server/operator defaults.")
+	command.Flags().Int32Var(&flags.probeReadinessTimeoutSeconds, "probe-readiness-timeout-seconds", 0, "Override for the readiness probe timeout seconds. Use 0 to use server/operator defaults.")
 }
 
 func (flags *installationPatchRequestOptions) GetPatchInstallationRequest() *model.PatchInstallationRequest {
@@ -152,7 +231,136 @@ func (flags *installationPatchRequestOptions) GetPatchInstallationRequest() *mod
 		request.OverrideIPRanges = &flags.overrideIPRanges
 	}
 
+	// Add probe overrides if any probe flags were changed
+	request.PodProbeOverrides = flags.generateProbeOverrides()
+
 	return &request
+}
+
+// generateProbeOverrides creates PodProbeOverrides from the installation flags
+func (flags *installationPatchRequestOptions) generateProbeOverrides() *model.PodProbeOverrides {
+	var probeOverrides *model.PodProbeOverrides
+
+	livenessOverride := &corev1.Probe{}
+	var livenessChanged bool
+	if flags.probeLivenessFailureThresholdChanged {
+		livenessOverride.FailureThreshold = flags.probeLivenessFailureThreshold
+		livenessChanged = true
+	}
+	if flags.probeLivenessSuccessThresholdChanged {
+		livenessOverride.SuccessThreshold = flags.probeLivenessSuccessThreshold
+		livenessChanged = true
+	}
+	if flags.probeLivenessInitialDelaySecondsChanged {
+		livenessOverride.InitialDelaySeconds = flags.probeLivenessInitialDelaySeconds
+		livenessChanged = true
+	}
+	if flags.probeLivenessPeriodSecondsChanged {
+		livenessOverride.PeriodSeconds = flags.probeLivenessPeriodSeconds
+		livenessChanged = true
+	}
+	if flags.probeLivenessTimeoutSecondsChanged {
+		livenessOverride.TimeoutSeconds = flags.probeLivenessTimeoutSeconds
+		livenessChanged = true
+	}
+
+	readinessOverride := &corev1.Probe{}
+	var readinessChanged bool
+	if flags.probeReadinessFailureThresholdChanged {
+		readinessOverride.FailureThreshold = flags.probeReadinessFailureThreshold
+		readinessChanged = true
+	}
+	if flags.probeReadinessSuccessThresholdChanged {
+		readinessOverride.SuccessThreshold = flags.probeReadinessSuccessThreshold
+		readinessChanged = true
+	}
+	if flags.probeReadinessInitialDelaySecondsChanged {
+		readinessOverride.InitialDelaySeconds = flags.probeReadinessInitialDelaySeconds
+		readinessChanged = true
+	}
+	if flags.probeReadinessPeriodSecondsChanged {
+		readinessOverride.PeriodSeconds = flags.probeReadinessPeriodSeconds
+		readinessChanged = true
+	}
+	if flags.probeReadinessTimeoutSecondsChanged {
+		readinessOverride.TimeoutSeconds = flags.probeReadinessTimeoutSeconds
+		readinessChanged = true
+	}
+
+	if livenessChanged || readinessChanged {
+		probeOverrides = &model.PodProbeOverrides{}
+		if livenessChanged {
+			probeOverrides.LivenessProbeOverride = livenessOverride
+		}
+		if readinessChanged {
+			probeOverrides.ReadinessProbeOverride = readinessOverride
+		}
+	}
+
+	return probeOverrides
+}
+
+// generateProbeOverridesForCreate creates PodProbeOverrides from the installation create flags
+func (flags *installationCreateRequestOptions) generateProbeOverrides() *model.PodProbeOverrides {
+	var probeOverrides *model.PodProbeOverrides
+
+	livenessOverride := &corev1.Probe{}
+	var livenessChanged bool
+	if flags.probeLivenessFailureThreshold > 0 {
+		livenessOverride.FailureThreshold = flags.probeLivenessFailureThreshold
+		livenessChanged = true
+	}
+	if flags.probeLivenessSuccessThreshold > 0 {
+		livenessOverride.SuccessThreshold = flags.probeLivenessSuccessThreshold
+		livenessChanged = true
+	}
+	if flags.probeLivenessInitialDelaySeconds > 0 {
+		livenessOverride.InitialDelaySeconds = flags.probeLivenessInitialDelaySeconds
+		livenessChanged = true
+	}
+	if flags.probeLivenessPeriodSeconds > 0 {
+		livenessOverride.PeriodSeconds = flags.probeLivenessPeriodSeconds
+		livenessChanged = true
+	}
+	if flags.probeLivenessTimeoutSeconds > 0 {
+		livenessOverride.TimeoutSeconds = flags.probeLivenessTimeoutSeconds
+		livenessChanged = true
+	}
+
+	readinessOverride := &corev1.Probe{}
+	var readinessChanged bool
+	if flags.probeReadinessFailureThreshold > 0 {
+		readinessOverride.FailureThreshold = flags.probeReadinessFailureThreshold
+		readinessChanged = true
+	}
+	if flags.probeReadinessSuccessThreshold > 0 {
+		readinessOverride.SuccessThreshold = flags.probeReadinessSuccessThreshold
+		readinessChanged = true
+	}
+	if flags.probeReadinessInitialDelaySeconds > 0 {
+		readinessOverride.InitialDelaySeconds = flags.probeReadinessInitialDelaySeconds
+		readinessChanged = true
+	}
+	if flags.probeReadinessPeriodSeconds > 0 {
+		readinessOverride.PeriodSeconds = flags.probeReadinessPeriodSeconds
+		readinessChanged = true
+	}
+	if flags.probeReadinessTimeoutSeconds > 0 {
+		readinessOverride.TimeoutSeconds = flags.probeReadinessTimeoutSeconds
+		readinessChanged = true
+	}
+
+	if livenessChanged || readinessChanged {
+		probeOverrides = &model.PodProbeOverrides{}
+		if livenessChanged {
+			probeOverrides.LivenessProbeOverride = livenessOverride
+		}
+		if readinessChanged {
+			probeOverrides.ReadinessProbeOverride = readinessOverride
+		}
+	}
+
+	return probeOverrides
 }
 
 type installationUpdateFlags struct {

--- a/internal/api/installation.go
+++ b/internal/api/installation.go
@@ -243,6 +243,7 @@ func handleCreateInstallation(c *Context, w http.ResponseWriter, r *http.Request
 		ScheduledDeletionTime:      createInstallationRequest.ScheduledDeletionTime,
 		SingleTenantDatabaseConfig: createInstallationRequest.SingleTenantDatabaseConfig.ToDBConfig(createInstallationRequest.Database),
 		ExternalDatabaseConfig:     createInstallationRequest.ExternalDatabaseConfig.ToDBConfig(createInstallationRequest.Database),
+		PodProbeOverrides:          createInstallationRequest.PodProbeOverrides,
 		CRVersion:                  model.DefaultCRVersion,
 		State:                      model.InstallationStateCreationRequested,
 	}

--- a/internal/provisioner/cluster_installation_provisioner_test.go
+++ b/internal/provisioner/cluster_installation_provisioner_test.go
@@ -153,7 +153,7 @@ func TestEnsurePodProbeOverrides(t *testing.T) {
 			},
 		}
 
-		provisioner.ensurePodProbeOverrides(mattermost)
+		provisioner.ensurePodProbeOverrides(mattermost, nil)
 
 		// Both probes should be cleared to empty Probe structs
 		assert.Equal(t, corev1.Probe{}, mattermost.Spec.Probes.LivenessProbe)
@@ -192,7 +192,7 @@ func TestEnsurePodProbeOverrides(t *testing.T) {
 			},
 		}
 
-		provisioner.ensurePodProbeOverrides(mattermost)
+		provisioner.ensurePodProbeOverrides(mattermost, nil)
 
 		// Liveness probe should be set to the override
 		assert.Equal(t, *livenessOverride, mattermost.Spec.Probes.LivenessProbe)
@@ -232,7 +232,7 @@ func TestEnsurePodProbeOverrides(t *testing.T) {
 			},
 		}
 
-		provisioner.ensurePodProbeOverrides(mattermost)
+		provisioner.ensurePodProbeOverrides(mattermost, nil)
 
 		// Liveness probe should be cleared
 		assert.Equal(t, corev1.Probe{}, mattermost.Spec.Probes.LivenessProbe)
@@ -273,7 +273,7 @@ func TestEnsurePodProbeOverrides(t *testing.T) {
 			Spec: mmv1beta1.MattermostSpec{},
 		}
 
-		provisioner.ensurePodProbeOverrides(mattermost)
+		provisioner.ensurePodProbeOverrides(mattermost, nil)
 
 		// Both probes should be set to their respective overrides
 		assert.Equal(t, *livenessOverride, mattermost.Spec.Probes.LivenessProbe)
@@ -319,7 +319,7 @@ func TestEnsurePodProbeOverrides(t *testing.T) {
 			},
 		}
 
-		provisioner.ensurePodProbeOverrides(mattermost)
+		provisioner.ensurePodProbeOverrides(mattermost, nil)
 
 		// Liveness probe should be completely replaced with the override
 		assert.Equal(t, *livenessOverride, mattermost.Spec.Probes.LivenessProbe)
@@ -356,7 +356,7 @@ func TestEnsurePodProbeOverrides(t *testing.T) {
 			Spec: mmv1beta1.MattermostSpec{},
 		}
 
-		provisioner.ensurePodProbeOverrides(mattermost)
+		provisioner.ensurePodProbeOverrides(mattermost, nil)
 
 		expectedLiveness := corev1.Probe{
 			FailureThreshold: 15,
@@ -370,5 +370,331 @@ func TestEnsurePodProbeOverrides(t *testing.T) {
 			// All other fields should be zero values
 		}
 		assert.Equal(t, expectedReadiness, mattermost.Spec.Probes.ReadinessProbe)
+	})
+}
+
+func TestEnsurePodProbeOverrides_InstallationLevel(t *testing.T) {
+	t.Run("installation overrides with no server overrides", func(t *testing.T) {
+		livenessOverride := &corev1.Probe{
+			FailureThreshold:    8,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 45,
+			PeriodSeconds:       20,
+			TimeoutSeconds:      12,
+		}
+
+		readinessOverride := &corev1.Probe{
+			FailureThreshold:    6,
+			SuccessThreshold:    2,
+			InitialDelaySeconds: 35,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      8,
+		}
+
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{}, // No server overrides
+			},
+		}
+
+		installation := &model.Installation{
+			PodProbeOverrides: &model.PodProbeOverrides{
+				LivenessProbeOverride:  livenessOverride,
+				ReadinessProbeOverride: readinessOverride,
+			},
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost, installation)
+
+		// Both probes should be set to installation overrides
+		assert.Equal(t, *livenessOverride, mattermost.Spec.Probes.LivenessProbe)
+		assert.Equal(t, *readinessOverride, mattermost.Spec.Probes.ReadinessProbe)
+	})
+
+	t.Run("installation overrides override server overrides", func(t *testing.T) {
+		serverLivenessOverride := &corev1.Probe{
+			FailureThreshold:    5,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      5,
+		}
+
+		serverReadinessOverride := &corev1.Probe{
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 20,
+			PeriodSeconds:       8,
+			TimeoutSeconds:      3,
+		}
+
+		installationLivenessOverride := &corev1.Probe{
+			FailureThreshold:    12,
+			SuccessThreshold:    2,
+			InitialDelaySeconds: 60,
+			PeriodSeconds:       25,
+			TimeoutSeconds:      15,
+		}
+
+		installationReadinessOverride := &corev1.Probe{
+			FailureThreshold:    10,
+			SuccessThreshold:    3,
+			InitialDelaySeconds: 50,
+			PeriodSeconds:       20,
+			TimeoutSeconds:      12,
+		}
+
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{
+					LivenessProbeOverride:  serverLivenessOverride,
+					ReadinessProbeOverride: serverReadinessOverride,
+				},
+			},
+		}
+
+		installation := &model.Installation{
+			PodProbeOverrides: &model.PodProbeOverrides{
+				LivenessProbeOverride:  installationLivenessOverride,
+				ReadinessProbeOverride: installationReadinessOverride,
+			},
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost, installation)
+
+		// Both probes should be set to installation overrides (not server overrides)
+		assert.Equal(t, *installationLivenessOverride, mattermost.Spec.Probes.LivenessProbe)
+		assert.Equal(t, *installationReadinessOverride, mattermost.Spec.Probes.ReadinessProbe)
+	})
+
+	t.Run("partial installation overrides with server fallback", func(t *testing.T) {
+		serverLivenessOverride := &corev1.Probe{
+			FailureThreshold:    5,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      5,
+		}
+
+		serverReadinessOverride := &corev1.Probe{
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 20,
+			PeriodSeconds:       8,
+			TimeoutSeconds:      3,
+		}
+
+		// Installation only overrides liveness, readiness should fall back to server
+		installationLivenessOverride := &corev1.Probe{
+			FailureThreshold:    15,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 90,
+			PeriodSeconds:       30,
+			TimeoutSeconds:      20,
+		}
+
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{
+					LivenessProbeOverride:  serverLivenessOverride,
+					ReadinessProbeOverride: serverReadinessOverride,
+				},
+			},
+		}
+
+		installation := &model.Installation{
+			PodProbeOverrides: &model.PodProbeOverrides{
+				LivenessProbeOverride:  installationLivenessOverride,
+				ReadinessProbeOverride: nil, // No installation override for readiness
+			},
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost, installation)
+
+		// Liveness should use installation override
+		assert.Equal(t, *installationLivenessOverride, mattermost.Spec.Probes.LivenessProbe)
+		// Readiness should fall back to server override
+		assert.Equal(t, *serverReadinessOverride, mattermost.Spec.Probes.ReadinessProbe)
+	})
+
+	t.Run("installation with nil probe overrides uses server defaults", func(t *testing.T) {
+		serverLivenessOverride := &corev1.Probe{
+			FailureThreshold:    7,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 40,
+			PeriodSeconds:       12,
+			TimeoutSeconds:      6,
+		}
+
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{
+					LivenessProbeOverride:  serverLivenessOverride,
+					ReadinessProbeOverride: nil,
+				},
+			},
+		}
+
+		installation := &model.Installation{
+			PodProbeOverrides: nil, // No installation overrides
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost, installation)
+
+		// Should use server overrides
+		assert.Equal(t, *serverLivenessOverride, mattermost.Spec.Probes.LivenessProbe)
+		assert.Equal(t, corev1.Probe{}, mattermost.Spec.Probes.ReadinessProbe)
+	})
+
+	t.Run("installation with empty probe overrides uses server defaults", func(t *testing.T) {
+		serverReadinessOverride := &corev1.Probe{
+			FailureThreshold:    4,
+			SuccessThreshold:    2,
+			InitialDelaySeconds: 25,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      4,
+		}
+
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{
+					LivenessProbeOverride:  nil,
+					ReadinessProbeOverride: serverReadinessOverride,
+				},
+			},
+		}
+
+		installation := &model.Installation{
+			PodProbeOverrides: &model.PodProbeOverrides{
+				LivenessProbeOverride:  nil,
+				ReadinessProbeOverride: nil,
+			},
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost, installation)
+
+		// Should use server overrides since installation overrides are nil
+		assert.Equal(t, corev1.Probe{}, mattermost.Spec.Probes.LivenessProbe)
+		assert.Equal(t, *serverReadinessOverride, mattermost.Spec.Probes.ReadinessProbe)
+	})
+
+	t.Run("installation overrides only readiness, liveness falls back", func(t *testing.T) {
+		serverLivenessOverride := &corev1.Probe{
+			FailureThreshold:    6,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 35,
+			PeriodSeconds:       12,
+			TimeoutSeconds:      7,
+		}
+
+		installationReadinessOverride := &corev1.Probe{
+			FailureThreshold:    9,
+			SuccessThreshold:    3,
+			InitialDelaySeconds: 55,
+			PeriodSeconds:       18,
+			TimeoutSeconds:      11,
+		}
+
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{
+					LivenessProbeOverride:  serverLivenessOverride,
+					ReadinessProbeOverride: nil,
+				},
+			},
+		}
+
+		installation := &model.Installation{
+			PodProbeOverrides: &model.PodProbeOverrides{
+				LivenessProbeOverride:  nil,
+				ReadinessProbeOverride: installationReadinessOverride,
+			},
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost, installation)
+
+		// Liveness should fall back to server override
+		assert.Equal(t, *serverLivenessOverride, mattermost.Spec.Probes.LivenessProbe)
+		// Readiness should use installation override
+		assert.Equal(t, *installationReadinessOverride, mattermost.Spec.Probes.ReadinessProbe)
+	})
+
+	t.Run("no server or installation overrides", func(t *testing.T) {
+		provisioner := Provisioner{
+			params: ProvisioningParams{
+				PodProbeOverrides: PodProbeOverrides{}, // No server overrides
+			},
+		}
+
+		installation := &model.Installation{
+			PodProbeOverrides: nil, // No installation overrides
+		}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mattermost",
+			},
+			Spec: mmv1beta1.MattermostSpec{
+				// Set some initial values to ensure they get cleared
+				Probes: mmv1beta1.Probes{
+					LivenessProbe: corev1.Probe{
+						FailureThreshold: 999,
+						TimeoutSeconds:   999,
+					},
+					ReadinessProbe: corev1.Probe{
+						FailureThreshold: 888,
+						TimeoutSeconds:   888,
+					},
+				},
+			},
+		}
+
+		provisioner.ensurePodProbeOverrides(mattermost, installation)
+
+		// Both probes should be cleared to empty Probe structs
+		assert.Equal(t, corev1.Probe{}, mattermost.Spec.Probes.LivenessProbe)
+		assert.Equal(t, corev1.Probe{}, mattermost.Spec.Probes.ReadinessProbe)
 	})
 }

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -30,7 +30,7 @@ func init() {
 			"Installation.CreateAt", "Installation.DeleteAt",
 			"Installation.DeletionPendingExpiry", "APISecurityLock", "LockAcquiredBy",
 			"LockAcquiredAt", "CRVersion", "Installation.DeletionLocked",
-			"AllowedIPRanges", "Volumes", "ScheduledDeletionTime",
+			"AllowedIPRanges", "Volumes", "ScheduledDeletionTime", "PodProbeOverrides",
 		).From(installationTable)
 }
 
@@ -495,6 +495,7 @@ func (sqlStore *SQLStore) createInstallation(db execer, installation *model.Inst
 		"DeletionLocked":        installation.DeletionLocked,
 		"AllowedIPRanges":       installation.AllowedIPRanges,
 		"Volumes":               installation.Volumes,
+		"PodProbeOverrides":     installation.PodProbeOverrides,
 	}
 
 	singleTenantDBConfJSON, err := installation.SingleTenantDatabaseConfig.ToJSON()
@@ -572,6 +573,7 @@ func (sqlStore *SQLStore) updateInstallation(db execer, installation *model.Inst
 			"ScheduledDeletionTime": installation.ScheduledDeletionTime,
 			"AllowedIPRanges":       installation.AllowedIPRanges,
 			"Volumes":               installation.Volumes,
+			"PodProbeOverrides":     installation.PodProbeOverrides,
 		}).
 		Where("ID = ?", installation.ID),
 	)

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1865,9 +1865,11 @@ var migrations = []migration{
 						State TEXT NOT NULL,
 						APISecurityLock NOT NULL DEFAULT FALSE,
 						SingleTenantDatabaseConfigRaw BYTEA NULL,
+						ExternalDatabaseConfigRaw BYTEA NULL,
 						CRVersion TEXT NOT NULL DEFAULT 'mattermost.com/v1alpha1',
 						CreateAt BIGINT NOT NULL,
 						DeleteAt BIGINT NOT NULL,
+						DeletionPendingExpiry BIGINT NOT NULL,
 						LockAcquiredBy TEXT NULL,
 						LockAcquiredAt BIGINT NOT NULL
 					);
@@ -1896,9 +1898,11 @@ var migrations = []migration{
 						State,
 						APISecurityLock,
 						SingleTenantDatabaseConfigRaw,
+						ExternalDatabaseConfigRaw,
 						CRVersion,
 						CreateAt,
 						DeleteAt,
+						'0',
 						LockAcquiredBy,
 						LockAcquiredAt
 					FROM
@@ -2267,6 +2271,14 @@ var migrations = []migration{
 		_, err = e.Exec("ALTER TABLE Installation ALTER COLUMN ScheduledDeletionTime SET NOT NULL;")
 		if err != nil {
 			return errors.Wrap(err, "failed to remove not null constraint")
+		}
+
+		return nil
+	}},
+	{semver.MustParse("0.51.0"), semver.MustParse("0.52.0"), func(e execer) error {
+		_, err := e.Exec(`ALTER TABLE Installation ADD COLUMN PodProbeOverrides JSON DEFAULT NULL;`)
+		if err != nil {
+			return errors.Wrap(err, "failed to create PodProbeOverrides column")
 		}
 
 		return nil

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1865,11 +1865,9 @@ var migrations = []migration{
 						State TEXT NOT NULL,
 						APISecurityLock NOT NULL DEFAULT FALSE,
 						SingleTenantDatabaseConfigRaw BYTEA NULL,
-						ExternalDatabaseConfigRaw BYTEA NULL,
 						CRVersion TEXT NOT NULL DEFAULT 'mattermost.com/v1alpha1',
 						CreateAt BIGINT NOT NULL,
 						DeleteAt BIGINT NOT NULL,
-						DeletionPendingExpiry BIGINT NOT NULL,
 						LockAcquiredBy TEXT NULL,
 						LockAcquiredAt BIGINT NOT NULL
 					);
@@ -1898,11 +1896,9 @@ var migrations = []migration{
 						State,
 						APISecurityLock,
 						SingleTenantDatabaseConfigRaw,
-						ExternalDatabaseConfigRaw,
 						CRVersion,
 						CreateAt,
 						DeleteAt,
-						'0',
 						LockAcquiredBy,
 						LockAcquiredAt
 					FROM

--- a/model/installation.go
+++ b/model/installation.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 )
 
 //go:generate provisioner-code-gen generate --out-file=installation_gen.go --boilerplate-file=../hack/boilerplate/boilerplate.generatego.txt --type=github.com/mattermost/mattermost-cloud/model.Installation --generator=get_id,get_state,is_deleted,as_resources
@@ -58,7 +59,8 @@ type Installation struct {
 	DeletionLocked             bool
 	LockAcquiredBy             *string
 	LockAcquiredAt             int64
-	GroupOverrides             map[string]string `json:"GroupOverrides,omitempty"`
+	GroupOverrides             map[string]string  `json:"GroupOverrides,omitempty"`
+	PodProbeOverrides          *PodProbeOverrides `json:"PodProbeOverrides,omitempty"`
 
 	// configconfigMergedWithGroup is set when the installation configuration
 	// has been overridden with group configuration. This value can then be
@@ -69,6 +71,12 @@ type Installation struct {
 	// configMergeGroupSequence is the Sequence value of the group at the time
 	// it was merged with the installation.
 	configMergeGroupSequence int64
+}
+
+// PodProbeOverrides contains configuration for overriding pod probe settings.
+type PodProbeOverrides struct {
+	LivenessProbeOverride  *corev1.Probe `json:"LivenessProbeOverride,omitempty"`
+	ReadinessProbeOverride *corev1.Probe `json:"ReadinessProbeOverride,omitempty"`
 }
 
 // InstallationsCount represents the number of installations

--- a/model/installation_request.go
+++ b/model/installation_request.go
@@ -63,6 +63,8 @@ type CreateInstallationRequest struct {
 	SingleTenantDatabaseConfig SingleTenantDatabaseRequest
 	// ExternalDatabaseConfig is ignored if Database is not single external.
 	ExternalDatabaseConfig ExternalDatabaseRequest
+	// PodProbeOverrides contains probe override settings for this installation.
+	PodProbeOverrides *PodProbeOverrides
 }
 
 // https://man7.org/linux/man-pages/man7/hostname.7.html
@@ -350,6 +352,8 @@ type PatchInstallationRequest struct {
 	OverrideIPRanges *bool
 	PriorityEnv      EnvVarMap
 	MattermostEnv    EnvVarMap
+	// PodProbeOverrides contains probe override settings for this installation.
+	PodProbeOverrides *PodProbeOverrides
 }
 
 // Validate validates the values of a installation patch request.
@@ -427,6 +431,11 @@ func (p *PatchInstallationRequest) Apply(installation *Installation) bool {
 		if installation.PriorityEnv.ClearOrPatch(&p.PriorityEnv) {
 			applied = true
 		}
+	}
+
+	if p.PodProbeOverrides != nil {
+		installation.PodProbeOverrides = p.PodProbeOverrides
+		applied = true
 	}
 
 	return applied


### PR DESCRIPTION
#### Summary
Extends https://github.com/mattermost/mattermost-cloud/pull/1112 to allow for Pod Probe Overrides at the installation level, rather than only working server-wide. This is primarily in an effort to support the new Cloud Preview environments (which take longer to spin up because of database load) but could be useful elsewhere.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Support for installation level overrides of PodProbeOverrides
```
