### PR TITLE
Deprecate ArgoCD server flags

### DIFF
--- a/cmd/cloud/server.go
+++ b/cmd/cloud/server.go
@@ -94,22 +94,6 @@ func executeServerCmd(flags serverFlags) error {
 	if len(model.GetGitlabToken()) == 0 {
 		logger.Warnf("The gitlab-oauth flag and %s were empty; using local helm charts", model.GitlabOAuthTokenKey)
 	}
-	ArgocdApiToken := flags.argocdApiToken
-	if len(ArgocdApiToken) == 0 {
-		ArgocdApiToken = os.Getenv(model.ArgocdApiToken)
-	}
-	model.SetArgocdApiToken(ArgocdApiToken)
-	if len(model.GetArgocdApiToken()) == 0 {
-		logger.Warnf("The argocd-api-token flag and %s were empty; using managed utilities", model.ArgocdApiToken)
-	}
-	ArgocdServerApi := flags.argocdServerApi
-	if len(ArgocdServerApi) == 0 {
-		ArgocdServerApi = os.Getenv(model.ArgocdServerApi)
-	}
-	model.SetArgocdServerApi(ArgocdServerApi)
-	if len(model.GetArgocdServerApi()) == 0 {
-		logger.Warnf("The argocd-server-api flag and %s were empty; using managed utilities", model.ArgocdServerApi)
-	}
 
 	if flags.machineLogs {
 		logger.SetFormatter(&logrus.JSONFormatter{})
@@ -302,7 +286,6 @@ func executeServerCmd(flags serverFlags) error {
 		sqlStore,
 		logger,
 		gitlabOAuthToken,
-		ArgocdApiToken,
 	)
 
 	eksProvisioner := provisioner.NewEKSProvisioner(
@@ -600,7 +583,12 @@ func checkRequirements(logger logrus.FieldLogger) error {
 // deprecationWarnings performs all checks for deprecated settings and warns if
 // any are found.
 func deprecationWarnings(logger logrus.FieldLogger, flags serverFlags) {
-
+	if flags.argocdApiToken != "" {
+		logger.Warn("ArgocdApiToken flag is deprecated")
+	}
+	if flags.argocdServerApi != "" {
+		logger.Warn("ArgocdServerApi flag is deprecated")
+	}
 }
 
 // getHumanReadableID  represents  a  best  effort  attempt  to  retrieve  an

--- a/helm-charts/mattermost-operator.yaml
+++ b/helm-charts/mattermost-operator.yaml
@@ -11,7 +11,7 @@ mattermostOperator:
     requeuOnLimitDelay: 20s
   image:
     repository: mattermost/mattermost-operator
-    tag: v1.23.0-rc.0
+    tag: v1.24.0-rc.1
     pullPolicy: IfNotPresent
   args:
     - --enable-leader-election

--- a/internal/provisioner/kops_provisioner.go
+++ b/internal/provisioner/kops_provisioner.go
@@ -34,7 +34,6 @@ type KopsProvisioner struct {
 	logger           log.FieldLogger
 	kopsCache        map[string]*kops.Cmd
 	gitlabOAuthToken string
-	argocdApiToken   string
 }
 
 var _ supervisor.ClusterProvisioner = (*KopsProvisioner)(nil)
@@ -46,7 +45,6 @@ func NewKopsProvisioner(
 	store model.InstallationDatabaseStoreInterface,
 	logger log.FieldLogger,
 	gitlabOAuthToken string,
-	argocdApiToken string,
 ) *KopsProvisioner {
 
 	logger = logger.WithField("provisioner", "kops")
@@ -58,7 +56,6 @@ func NewKopsProvisioner(
 		logger:           logger,
 		kopsCache:        make(map[string]*kops.Cmd),
 		gitlabOAuthToken: gitlabOAuthToken,
-		argocdApiToken:   argocdApiToken,
 	}
 }
 

--- a/internal/provisioner/kops_provisioner_test.go
+++ b/internal/provisioner/kops_provisioner_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestGetCachedKopsClient(t *testing.T) {
 	logger := testlib.MakeLogger(t)
-	provisioner := NewKopsProvisioner(ProvisioningParams{}, nil, nil, logger, "", "")
+	provisioner := NewKopsProvisioner(ProvisioningParams{}, nil, nil, logger, "")
 
 	// Using &kops.Cmd{} here because kops.New() checks for the binary in your
 	// PATH which isn't needed for the test and fails in CI/CD.

--- a/internal/provisioner/utility/utility_group.go
+++ b/internal/provisioner/utility/utility_group.go
@@ -5,8 +5,6 @@
 package utility
 
 import (
-	"os"
-
 	"github.com/mattermost/mattermost-cloud/internal/tools/aws"
 	"github.com/mattermost/mattermost-cloud/internal/tools/helm"
 	"github.com/mattermost/mattermost-cloud/model"
@@ -59,7 +57,6 @@ type utilityGroup struct {
 	cluster            *model.Cluster
 	awsClient          aws.AWS
 	kubeconfigPath     string
-	tempDir            string
 	allowCIDRRangeList []string
 }
 
@@ -206,14 +203,6 @@ func (group utilityGroup) ProvisionUtilityGroup() error {
 	}
 
 	logger.Info("Ensuring all Helm repos are added")
-	// Check if the cluster directory exists
-	_, err = os.Stat(group.tempDir + "/apps/dev/helm-values/" + group.cluster.ID)
-	if os.IsNotExist(err) {
-		// Create the cluster directory
-		if err = os.MkdirAll(group.tempDir+"/apps/dev/helm-values/"+group.cluster.ID, 0755); err != nil {
-			return errors.Wrap(err, "failed to create cluster directory for helm values")
-		}
-	}
 
 	logger.Info("Adding new Helm repos.")
 	for repoName, repoURL := range helmRepos {

--- a/model/cluster_utility.go
+++ b/model/cluster_utility.go
@@ -48,22 +48,10 @@ const (
 	// GitOpsRepoPath is the name of the Environment Variable which
 	// contains the path to the gitops repo. e.g. /cloud/gitops.git
 	GitOpsRepoPath = "GITOPS_REPO_PATH"
-	// ArgocdApiToken is the name of the Environment Variable which
-	// contains the token for accessing the ArgoCD API
-	ArgocdApiToken = "ARGOCD_API_TOKEN"
-	// argocdServerApi is the name of the Environment Variable which
-	// contains the address of the ArgoCD API
-	ArgocdServerApi = "ARGOCD_SERVER_API"
 )
 
 // gitlabToken is the token that will be used for remote helm charts.
 var gitlabToken string
-
-// argocdApiToken is the token that will be used for accessing the ArgoCD API.
-var argocdApiToken string
-
-// argocdServerApi is the address of the ArgoCD API.
-var argocdServerApi string
 
 var gitOpsRepoURL string
 var gitOpsRepoPath string
@@ -77,17 +65,6 @@ func SetGitlabToken(val string) {
 // GetGitlabToken returns the value of gitlabToken.
 func GetGitlabToken() string {
 	return gitlabToken
-}
-
-// SetArgocdApiToken is used to define the argocd token that will be used for
-// accessing the ArgoCD API.
-func SetArgocdApiToken(val string) {
-	argocdApiToken = val
-}
-
-// GetArgocdApiToken returns the value of argocdApiToken.
-func GetArgocdApiToken() string {
-	return argocdApiToken
 }
 
 func SetGitopsRepoURL(val string) {
@@ -104,14 +81,6 @@ func SetGitopsRepoPath(val string) {
 
 func GetGitopsRepoPath() string {
 	return gitOpsRepoPath
-}
-
-func SetArgocdServerApi(val string) {
-	argocdServerApi = val
-}
-
-func GetArgocdServerApi() string {
-	return argocdServerApi
 }
 
 // DefaultUtilityVersions holds the default values for all the HelmUtilityVersions


### PR DESCRIPTION
This deprecates the ArgoCD server flags so that a warning is displayed on server startup if they are in use. This also cleans up some remaining temp dir logic that is no longer needed.

Fixes https://mattermost.atlassian.net/browse/CLD-9361

```release-note
Deprecate ArgoCD server flags
```
