### PR TITLE
Add local-ephemeral filestore option

### DIFF
--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -1215,6 +1215,9 @@ func getMattermostEnvWithOverrides(installation *model.Installation) model.EnvVa
 		mattermostEnv["MM_FILESETTINGS_AMAZONS3SSE"] = model.EnvVar{Value: "false"}
 		mattermostEnv["MM_FILESETTINGS_AMAZONS3SSL"] = model.EnvVar{Value: "false"}
 	}
+	if installation.Filestore == model.InstallationFilestoreLocalEphemeral {
+		mattermostEnv["MM_FILESETTINGS_DRIVERNAME"] = model.EnvVar{Value: "local"}
+	}
 
 	return mattermostEnv
 }

--- a/internal/tools/utils/utils.go
+++ b/internal/tools/utils/utils.go
@@ -119,6 +119,8 @@ func (r *ResourceUtil) GetFilestore(installation *model.Installation) model.File
 	switch installation.Filestore {
 	case model.InstallationFilestoreMinioOperator:
 		return model.NewMinioOperatorFilestore()
+	case model.InstallationFilestoreLocalEphemeral:
+		return model.NewLocalEphemeralFilestore()
 	case model.InstallationFilestoreAwsS3:
 		return aws.NewS3Filestore(installation.ID, r.awsClient, r.enableS3Versioning)
 	case model.InstallationFilestoreMultiTenantAwsS3:

--- a/model/installation_filestore.go
+++ b/model/installation_filestore.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -22,6 +23,10 @@ const (
 	// InstallationFilestoreBifrost is a filestore hosted via a shared Amazon S3
 	// bucket using the bifrost gateway.
 	InstallationFilestoreBifrost = "bifrost"
+	// InstallationFilestoreLocalEphemeral is a local ephemeral filestore.
+	// WARNING: This should NOT be used for any long-lived installations and
+	// requires singleton deployments to function.
+	InstallationFilestoreLocalEphemeral = "local-ephemeral"
 )
 
 // Filestore is the interface for managing Mattermost filestores.
@@ -69,10 +74,59 @@ func (f *MinioOperatorFilestore) GenerateFilestoreSpecAndSecret(store Installati
 	return nil, nil, nil
 }
 
+// LocalEphemeralFilestore is a local ephemeral filestore.
+type LocalEphemeralFilestore struct{}
+
+// NewLocalEphemeralFilestore returns a new LocalEphemeralFilestore interface.
+func NewLocalEphemeralFilestore() *LocalEphemeralFilestore {
+	return &LocalEphemeralFilestore{}
+}
+
+// Provision completes all the steps necessary to provision a local ephemeral filestore.
+func (f *LocalEphemeralFilestore) Provision(store InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	logger.Info("Local ephemeral filestore requires no pre-provisioning; skipping...")
+
+	return nil
+}
+
+// Teardown removes all local ephemeral filestore resources related to a given installation.
+func (f *LocalEphemeralFilestore) Teardown(keepData bool, store InstallationDatabaseStoreInterface, logger log.FieldLogger) error {
+	logger.Info("Local ephemeral filestore requires no teardown; skipping...")
+	if keepData {
+		logger.Warn("Data preservation was requested, but isn't possible with local ephemeral filestore")
+	}
+
+	return nil
+}
+
+// GenerateFilestoreSpecAndSecret creates the k8s filestore spec and secret for
+// accessing the local ephemeral filestore. An S3-like configuration is returned
+// as there is no option available in the Operator to provide an ephemeral
+// filestore. The Mattermost image will be responsible for overwriting the
+// filestore configuration as needed.
+func (f *LocalEphemeralFilestore) GenerateFilestoreSpecAndSecret(store InstallationDatabaseStoreInterface, logger log.FieldLogger) (*FilestoreConfig, *corev1.Secret, error) {
+	return &FilestoreConfig{
+			URL:    "local-ephemeral",
+			Bucket: "local-ephemeral",
+			Secret: "local-ephemeral",
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "local-ephemeral",
+			},
+			StringData: map[string]string{
+				"accesskey": "local-ephemeral",
+				"secretkey": "local-ephemeral",
+			},
+		},
+		nil
+}
+
 // InternalFilestore returns true if the installation's filestore is internal
 // to the kubernetes cluster it is running on.
 func (i *Installation) InternalFilestore() bool {
-	return i.Filestore == InstallationFilestoreMinioOperator
+	return i.Filestore == InstallationFilestoreMinioOperator ||
+		i.Filestore == InstallationFilestoreLocalEphemeral
 }
 
 // IsSupportedFilestore returns true if the given filestore string is supported.
@@ -80,5 +134,6 @@ func IsSupportedFilestore(filestore string) bool {
 	return filestore == InstallationFilestoreMinioOperator ||
 		filestore == InstallationFilestoreAwsS3 ||
 		filestore == InstallationFilestoreMultiTenantAwsS3 ||
-		filestore == InstallationFilestoreBifrost
+		filestore == InstallationFilestoreBifrost ||
+		filestore == InstallationFilestoreLocalEphemeral
 }

--- a/model/installation_request_test.go
+++ b/model/installation_request_test.go
@@ -291,6 +291,25 @@ func TestCreateInstallationRequestValid(t *testing.T) {
 				ExternalDatabaseConfig: model.ExternalDatabaseRequest{},
 			},
 		},
+		{
+			"valid local-ephemeral filestore",
+			false,
+			&model.CreateInstallationRequest{
+				OwnerID:   "owner1",
+				DNSNames:  []string{"my-installation.example.com"},
+				Name:      "my-installation",
+				Filestore: model.InstallationFilestoreLocalEphemeral,
+			},
+		},
+		{
+			"local-ephemeral filestore with minimal config",
+			false,
+			&model.CreateInstallationRequest{
+				OwnerID:   "owner1",
+				DNS:       "domain4321.com",
+				Filestore: model.InstallationFilestoreLocalEphemeral,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -347,6 +366,19 @@ func TestCreateInstallationRequestValid(t *testing.T) {
 
 		assert.Equal(t, "my-installation", request.Name)
 		assert.Equal(t, []string{"my-installation.mattermost.cloud.com"}, request.DNSNames)
+	})
+
+	t.Run("set default filestore with local-ephemeral override", func(t *testing.T) {
+		request := &model.CreateInstallationRequest{
+			OwnerID:   "owner1",
+			DNS:       "my-installation.mattermost.cloud.com",
+			Filestore: model.InstallationFilestoreLocalEphemeral,
+		}
+
+		request.SetDefaults()
+
+		assert.Equal(t, model.InstallationFilestoreLocalEphemeral, request.Filestore)
+		assert.Equal(t, "my-installation", request.Name)
 	})
 }
 


### PR DESCRIPTION
This is the initial implementation of a new local ephemeral filestore backend option for installations. This new option is intended to be used by very short-lived installations such a trials. The operator doesn't directly support this type of backend so a combination of S3 configuration and env overrides are used to instruct Mattermost to use a local directory for filestore data.

Fixes https://mattermost.atlassian.net/browse/CLD-9368

```release-note
Add local-ephemeral filestore option
```
