### PR TITLE
Add group scheduling

### DIFF
--- a/cmd/cloud/group.go
+++ b/cmd/cloud/group.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -61,6 +62,14 @@ func newCmdGroupCreate() *cobra.Command {
 				Image:         flags.image,
 				MattermostEnv: envVarMap,
 				Annotations:   flags.annotations,
+			}
+
+			if flags.scheduling != "" {
+				scheduling := &model.Scheduling{}
+				if err = json.Unmarshal([]byte(flags.scheduling), scheduling); err != nil {
+					return errors.Wrap(err, "failed to parse scheduling JSON")
+				}
+				request.Scheduling = scheduling
 			}
 
 			if flags.dryRun {
@@ -134,6 +143,15 @@ func executeGroupUpdateCmd(ctx context.Context, flags groupUpdateFlags) error {
 	}
 	if flags.isImageChanged {
 		request.Image = &flags.image
+	}
+	if flags.isSchedulingChanged {
+		if flags.scheduling != "" {
+			scheduling := &model.Scheduling{}
+			if err = json.Unmarshal([]byte(flags.scheduling), scheduling); err != nil {
+				return errors.Wrap(err, "failed to parse scheduling JSON")
+			}
+			request.Scheduling = scheduling
+		}
 	}
 
 	if flags.dryRun {

--- a/cmd/cloud/group_flag.go
+++ b/cmd/cloud/group_flag.go
@@ -10,6 +10,7 @@ type groupCreateFlags struct {
 	image         string
 	maxRolling    int64
 	mattermostEnv []string
+	scheduling    string
 	annotations   []string
 }
 
@@ -20,6 +21,7 @@ func (flags *groupCreateFlags) addFlags(command *cobra.Command) {
 	command.Flags().StringVar(&flags.image, "image", "", "The Mattermost container image to use.")
 	command.Flags().Int64Var(&flags.maxRolling, "max-rolling", 1, "The maximum number of installations that can be updated at one time when a group is updated")
 	command.Flags().StringArrayVar(&flags.mattermostEnv, "mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
+	command.Flags().StringVar(&flags.scheduling, "scheduling", "", "Scheduling configuration as JSON string containing nodeSelector and tolerations for pod placement.")
 	command.Flags().StringArrayVar(&flags.annotations, "annotation", []string{}, "Annotations for a group used for automatic group selection. Accepts multiple values, for example: '... --annotation abc --annotation def'")
 
 	_ = command.MarkFlagRequired("name")
@@ -31,6 +33,7 @@ type groupUpgradeFlagChanged struct {
 	isVersionChanged     bool
 	isImageChanged       bool
 	isMaxRollingChanged  bool
+	isSchedulingChanged  bool
 }
 
 func (flags *groupUpgradeFlagChanged) addFlags(command *cobra.Command) {
@@ -39,6 +42,7 @@ func (flags *groupUpgradeFlagChanged) addFlags(command *cobra.Command) {
 	flags.isVersionChanged = command.Flags().Changed("version")
 	flags.isImageChanged = command.Flags().Changed("image")
 	flags.isMaxRollingChanged = command.Flags().Changed("max-rolling")
+	flags.isSchedulingChanged = command.Flags().Changed("scheduling")
 }
 
 type groupUpdateFlags struct {
@@ -52,6 +56,7 @@ type groupUpdateFlags struct {
 	maxRolling               int64
 	mattermostEnv            []string
 	mattermostEnvClear       bool
+	scheduling               string
 	forceSequenceUpdate      bool
 	forceInstallationRestart bool
 }
@@ -65,6 +70,7 @@ func (flags *groupUpdateFlags) addFlags(command *cobra.Command) {
 	command.Flags().Int64Var(&flags.maxRolling, "max-rolling", 0, "The maximum number of installations that can be updated at one time when a group is updated")
 	command.Flags().StringArrayVar(&flags.mattermostEnv, "mattermost-env", []string{}, "Env vars to add to the Mattermost App. Accepts format: KEY_NAME=VALUE. Use the flag multiple times to set multiple env vars.")
 	command.Flags().BoolVar(&flags.mattermostEnvClear, "mattermost-env-clear", false, "Clears all env var data.")
+	command.Flags().StringVar(&flags.scheduling, "scheduling", "", "Scheduling configuration as JSON string containing nodeSelector and tolerations for pod placement.")
 	command.Flags().BoolVar(&flags.forceSequenceUpdate, "force-sequence-update", false, "Forces the group version sequence to be increased by 1 even when no updates are present.")
 	command.Flags().BoolVar(&flags.forceInstallationRestart, "force-installation-restart", false, "Forces the restart of all installations in the group even if Mattermost CR does not change.")
 

--- a/cmd/cloud/installation.go
+++ b/cmd/cloud/installation.go
@@ -952,7 +952,13 @@ func executeInstallationDeploymentReportCmd(ctx context.Context, flags installat
 		}
 		output += fmt.Sprintf(" ├ Group: %s\n", group.ID)
 		output += fmt.Sprintf(" │ ├ Name: %s\n", group.Name)
-		output += fmt.Sprintf(" │ └ Description: %s\n", group.Description)
+		output += fmt.Sprintf(" │ ├ Description: %s\n", group.Description)
+		if group.Scheduling != nil {
+			output += fmt.Sprintf(" │ ├ Node Selector: %s\n", group.Scheduling.NodeSelectorValueString())
+			output += fmt.Sprintf(" │ └ Tolerations: %s\n", group.Scheduling.TolerationsValueString())
+		} else {
+			output += " │ └ Scheduling: n/a\n"
+		}
 	}
 
 	clusterInstallations, err := client.GetClusterInstallations(&model.GetClusterInstallationsRequest{

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.10.9
 	github.com/mattermost/awat v0.2.0
-	github.com/mattermost/mattermost-operator v1.24.0-rc.1
+	github.com/mattermost/mattermost-operator v1.24.0
 	github.com/mattermost/rotator v0.2.1-0.20230830064954-61490ed26761
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pborman/uuid v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1057,8 +1057,8 @@ github.com/mattermost/mattermost-cloud v0.39.0/go.mod h1:GbWfZajyp+DvdEpoNfFeJ3Z
 github.com/mattermost/mattermost-cloud v0.48.0/go.mod h1:1u1LQsuNVMcoxo6MvKKL6sGZ+LJrGdXg8TGyyTe3yjY=
 github.com/mattermost/mattermost-operator v1.12.0/go.mod h1:a6pSJI6bDaIfO65M/Hvuqg8kUNYQQYDHLayoT5XZx5o=
 github.com/mattermost/mattermost-operator v1.15.0/go.mod h1:9esaQrOcruyyGQme3AnXGnoCDbpER7XAifDVu3HlCm8=
-github.com/mattermost/mattermost-operator v1.24.0-rc.1 h1:65EMJlC10dZdQqEM77tcJY24u6b/GA8EokCz0suvXdQ=
-github.com/mattermost/mattermost-operator v1.24.0-rc.1/go.mod h1:6YkVPLpNT/0/YMmXR0QwpnAGT5bx6VGePkxwWAxGNkk=
+github.com/mattermost/mattermost-operator v1.24.0 h1:reRi0myz/YTzJTOkwFtxM7KuPwVv8vP+BvoD6QJMyRI=
+github.com/mattermost/mattermost-operator v1.24.0/go.mod h1:6YkVPLpNT/0/YMmXR0QwpnAGT5bx6VGePkxwWAxGNkk=
 github.com/mattermost/mattermost-server/v5 v5.23.0/go.mod h1:nMrt08IvThjybZpXPe/nqe/oJuvJxhqKkGI+m7M0R00=
 github.com/mattermost/mmetl v0.0.2-0.20210316151859-38824e5f5efd/go.mod h1:w6GNqrudkzs/GddfgqkgUqsXVQ/4ImK5JJfNj5KJeUQ=
 github.com/mattermost/rotator v0.1.2/go.mod h1:1oxWiEhVdZRckZ0uHGd5Zqf04yynm4U/YGHUPsf4sQ8=

--- a/helm-charts/mattermost-operator.yaml
+++ b/helm-charts/mattermost-operator.yaml
@@ -11,7 +11,7 @@ mattermostOperator:
     requeuOnLimitDelay: 20s
   image:
     repository: mattermost/mattermost-operator
-    tag: v1.24.0-rc.1
+    tag: v1.24.0
     pullPolicy: IfNotPresent
   args:
     - --enable-leader-election

--- a/internal/api/group.go
+++ b/internal/api/group.go
@@ -107,6 +107,7 @@ func handleCreateGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 		MaxRolling:      createGroupRequest.MaxRolling,
 		APISecurityLock: createGroupRequest.APISecurityLock,
 		MattermostEnv:   createGroupRequest.MattermostEnv,
+		Scheduling:      createGroupRequest.Scheduling,
 	}
 
 	annotations, err := model.AnnotationsFromStringSlice(createGroupRequest.Annotations)

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -205,7 +205,9 @@ func (provisioner Provisioner) createClusterInstallation(clusterInstallation *mo
 			// Set `installation-id` and `cluster-installation-id` labels for all related resources.
 			ResourceLabels: clusterInstallationStableLabels(installation, clusterInstallation, cluster),
 			Scheduling: mmv1beta1.Scheduling{
-				Affinity: generateAffinityConfig(installation, clusterInstallation, cluster),
+				Affinity:     generateAffinityConfig(installation, clusterInstallation, cluster),
+				NodeSelector: installation.Scheduling.NodeSelector,
+				Tolerations:  installation.Scheduling.Tolerations,
 			},
 			DNSConfig: setNdots(provisioner.params.NdotsValue),
 			DeploymentTemplate: &mmv1beta1.DeploymentTemplate{
@@ -423,6 +425,8 @@ func (provisioner Provisioner) updateClusterInstallation(
 	mattermost.Spec.ResourceLabels = clusterInstallationStableLabels(installation, clusterInstallation, cluster)
 
 	mattermost.Spec.Scheduling.Affinity = generateAffinityConfig(installation, clusterInstallation, cluster)
+	mattermost.Spec.Scheduling.NodeSelector = installation.Scheduling.NodeSelector
+	mattermost.Spec.Scheduling.Tolerations = installation.Scheduling.Tolerations
 
 	mattermost.Spec.DNSConfig = setNdots(provisioner.params.NdotsValue)
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -2279,4 +2279,12 @@ var migrations = []migration{
 
 		return nil
 	}},
+	{semver.MustParse("0.52.0"), semver.MustParse("0.53.0"), func(e execer) error {
+		_, err := e.Exec(`ALTER TABLE "Group" ADD COLUMN Scheduling JSON DEFAULT NULL;`)
+		if err != nil {
+			return errors.Wrap(err, "failed to create Scheduling column")
+		}
+
+		return nil
+	}},
 }

--- a/model/installation.go
+++ b/model/installation.go
@@ -61,6 +61,7 @@ type Installation struct {
 	LockAcquiredAt             int64
 	GroupOverrides             map[string]string  `json:"GroupOverrides,omitempty"`
 	PodProbeOverrides          *PodProbeOverrides `json:"PodProbeOverrides,omitempty"`
+	Scheduling                 *Scheduling        `json:"Scheduling,omitempty"`
 
 	// configconfigMergedWithGroup is set when the installation configuration
 	// has been overridden with group configuration. This value can then be
@@ -418,6 +419,9 @@ func (i *Installation) MergeWithGroup(group *Group, includeOverrides bool) {
 			}
 		}
 		i.MattermostEnv[key] = value
+	}
+	if group.Scheduling != nil {
+		i.Scheduling = group.Scheduling
 	}
 }
 

--- a/model/installation_test.go
+++ b/model/installation_test.go
@@ -182,6 +182,8 @@ func TestMergeWithGroup(t *testing.T) {
 		for key := range group.MattermostEnv {
 			assert.Equal(t, installation.MattermostEnv[key].Value, group.MattermostEnv[key].Value)
 		}
+
+		assert.Equal(t, installation.Scheduling, group.Scheduling)
 	}
 
 	t.Run("without overrides", func(t *testing.T) {
@@ -307,6 +309,36 @@ func TestMergeWithGroup(t *testing.T) {
 		installation.MergeWithGroup(group, false)
 		checkMergeValues(t, installation, group)
 		assert.True(t, installation.InstallationSequenceMatchesMergedGroupSequence())
+	})
+
+	t.Run("scheduling set", func(t *testing.T) {
+		installation := &Installation{
+			ID:            NewID(),
+			OwnerID:       "owner",
+			Version:       "iversion",
+			Image:         "iImage",
+			Name:          "test",
+			License:       "this_is_my_license",
+			Affinity:      InstallationAffinityIsolated,
+			GroupID:       util.SToP("group_id"),
+			GroupSequence: util.IToP(1),
+			State:         InstallationStateStable,
+		}
+
+		group := &Group{
+			ID:       NewID(),
+			Sequence: 2,
+			Version:  "gversion",
+			Image:    "gImage",
+			Scheduling: &Scheduling{
+				NodeSelector: map[string]string{
+					"key": "value",
+				},
+			},
+		}
+
+		installation.MergeWithGroup(group, false)
+		checkMergeValues(t, installation, group)
 	})
 
 	t.Run("without overrides, group sequence doesn't match", func(t *testing.T) {


### PR DESCRIPTION
This change adds NodeSelector and Tolerations configuration to groups. This configuration is applied to all installations in the group allowing for more control over which cluster hosts the pods will run on.

Example:

```
❯ cloud group update --group=example --dry-run=true --scheduling='{"NodeSelector":{"instanceType":"preview"}}'
{
    "ID": "example",
    "MaxRolling": null,
    "Name": null,
    "Description": null,
    "Version": null,
    "Image": null,
    "MattermostEnv": null,
    "Scheduling": {
        "NodeSelector": {
            "instanceType": "preview"
        },
        "Tolerations": null
    },
    "ForceSequenceUpdate": false,
    "ForceInstallationsRestart": false
}
```

Fixes https://mattermost.atlassian.net/browse/CLD-9404

```release-note
Add group scheduling
```
