### PR TITLE
Add LIKE support to cloud API

### DIFF
--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-cloud/model"
@@ -191,7 +192,11 @@ func (sqlStore *SQLStore) applyInstallationFilter(builder sq.SelectBuilder, filt
 		builder = builder.Where("State = ?", filter.State)
 	}
 	if filter.DNS != "" {
-		builder = builder.Where("InstallationDNS.DomainName = ?", filter.DNS)
+		if strings.Contains(filter.DNS, "%") {
+			builder = builder.Where("InstallationDNS.DomainName LIKE ?", filter.DNS)
+		} else {
+			builder = builder.Where("InstallationDNS.DomainName = ?", filter.DNS)
+		}
 	}
 	if filter.Name != "" {
 		builder = builder.Where("Installation.Name = ?", filter.Name)

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -337,6 +337,22 @@ func TestInstallations(t *testing.T) {
 			[]*model.Installation{installation3},
 		},
 		{
+			"dns LIKE pattern",
+			&model.InstallationFilter{
+				DNS:    "dns-%",
+				Paging: model.AllPagesNotDeleted(),
+			},
+			[]*model.Installation{installation1, installation2, installation3},
+		},
+		{
+			"dns LIKE pattern no match",
+			&model.InstallationFilter{
+				DNS:    "nonexistent-%",
+				Paging: model.AllPagesNotDeleted(),
+			},
+			nil,
+		},
+		{
 			"state stable",
 			&model.InstallationFilter{
 				State:  model.InstallationStateStable,


### PR DESCRIPTION
The servers created when running mobile or desktop e2e have a hex in the DNS name. 
Deleting the server is failing silently as the DNS look up is for exact name and doesn't account for dynamic hex for the servers.



```release-note
NONE
```
