### PR TITLE
e2e/eventstest: fix 'occured' -> 'occurred' in handler.go log message

### DIFF
--- a/e2e/pkg/eventstest/handler.go
+++ b/e2e/pkg/eventstest/handler.go
@@ -194,7 +194,7 @@ func (ev *EventsRecorder) VerifyInOrder(expectedEvents []EventOccurrence) error 
 
 	if len(expectedEvents) > 0 {
 		return fmt.Errorf("not all expected events appeared in correct order, "+
-			"%d expected events occured, "+
+			"%d expected events occurred, "+
 			"stuck at expected event: %v", expEvLen-len(expectedEvents), expectedEvents[0])
 	}
 


### PR DESCRIPTION
Log format string in `e2e/pkg/eventstest/handler.go` line 197 reads `events occured`. Fixed to `occurred`. String-literal-only change.

```release-note
NONE
```