### PR TITLE
SEC-9253: opt-in cross-installation node separation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+
+## Pod scheduling / affinity
+
+- The provisioner OWNS the Mattermost CR's scheduling: `ensureScheduling` in
+  `internal/provisioner/cluster_installation_provisioner.go` overwrites
+  `mattermost.Spec.Scheduling.Affinity` (via `generateAffinityConfig`) and
+  `mattermost.Spec.ResourceLabels` (via `clusterInstallationStableLabels`) on EVERY
+  create/update reconcile. Hand-patching the CR or the Deployment is reverted on the next
+  reconcile — durable scheduling changes must live in the provisioner. The operator sets no
+  default affinity; it passes `spec.scheduling.affinity` straight through.
+- Pod labels come from `Spec.ResourceLabels` (the operator seeds pod labels from it), so any
+  label added in `clusterInstallationStableLabels` lands on the pods and is selectable by
+  anti-affinity.
+- `model.Installation` does NOT carry its annotations (separate join). Fetch them via
+  `store.GetAnnotationsForInstallation(installation.ID)` at the reconcile call sites (see
+  `resolveNodeSeparation`). The `separate-nodes` annotation is the opt-in for cross-installation
+  node separation (SEC-9253).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -32,6 +32,18 @@ The scheduling is guided by the following principles:
     - The Installation cannot be scheduled on any Cluster.
 
 
+## Special annotations
+
+Most Annotations only constrain Cluster scheduling as described above. A few Annotations
+additionally change how an Installation's pods are scheduled *within* a Cluster:
+
+- **`separate-nodes`** — Opts the Installation into cross-installation, node-level
+  anti-affinity (SEC-9253). The Installation's pods will avoid sharing a node with the pods
+  of any other Installation that also carries this Annotation. It is used to keep
+  `community` and `hub` on distinct nodes. This is a soft preference: the scheduler strongly
+  prefers separate nodes but will co-locate rather than leave a pod Pending when node
+  capacity is tight. Installations without the Annotation are scheduled exactly as before.
+
 ## Assigning annotations
 
 Annotations can be assigned to the Cluster and Installation during the creation. 

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -209,10 +209,10 @@ func (provisioner Provisioner) createClusterInstallation(clusterInstallation *mo
 			Image:         installation.Image,
 			MattermostEnv: mattermostEnv.ToEnvList(),
 			Ingress:       makeIngressSpec(installationDNS, getIngressAnnotations()),
-			// Set `installation-id` and `cluster-installation-id` labels for all related resources.
-			ResourceLabels: clusterInstallationStableLabels(installation, clusterInstallation, cluster, nodeSeparation),
-			Scheduling:     mmv1beta1.Scheduling{},
-			DNSConfig:      setNdots(provisioner.params.NdotsValue),
+			// ResourceLabels (installation-id, cluster-installation-id, ...) are set by
+			// ensureScheduling below, the single owner of the scheduling-related spec.
+			Scheduling: mmv1beta1.Scheduling{},
+			DNSConfig:  setNdots(provisioner.params.NdotsValue),
 			DeploymentTemplate: &mmv1beta1.DeploymentTemplate{
 				RevisionHistoryLimit: ptr.Int32(1),
 			},
@@ -440,8 +440,8 @@ func (provisioner Provisioner) updateClusterInstallation(
 	}
 
 	mattermost.ObjectMeta.Labels = generateClusterInstallationResourceLabels(installation, clusterInstallation, cluster)
-	mattermost.Spec.ResourceLabels = clusterInstallationStableLabels(installation, clusterInstallation, cluster, nodeSeparation)
 
+	// ensureScheduling is the single owner of ResourceLabels + Affinity; it sets both.
 	ensureScheduling(mattermost, installation, clusterInstallation, cluster, nodeSeparation)
 
 	// Set custom command if provided
@@ -683,6 +683,10 @@ func ensureScheduling(
 	cluster *model.Cluster,
 	nodeSeparation bool,
 ) {
+	// Single owner of the scheduling-related spec: the provisioner overwrites both the
+	// affinity and the resource labels (which seed pod labels) on every reconcile, so the
+	// node-separation affinity term and the label it selects always stay in sync.
+	mattermost.Spec.ResourceLabels = clusterInstallationStableLabels(installation, clusterInstallation, cluster, nodeSeparation)
 	mattermost.Spec.Scheduling.Affinity = generateAffinityConfig(installation, clusterInstallation, cluster, nodeSeparation)
 	if installation.Scheduling != nil {
 		mattermost.Spec.Scheduling.NodeSelector = installation.Scheduling.NodeSelector

--- a/internal/provisioner/cluster_installation_provisioner.go
+++ b/internal/provisioner/cluster_installation_provisioner.go
@@ -192,6 +192,11 @@ func (provisioner Provisioner) createClusterInstallation(clusterInstallation *mo
 		return errors.Wrap(err, "failed to prepare cluster installation env")
 	}
 
+	nodeSeparation, err := provisioner.resolveNodeSeparation(installation)
+	if err != nil {
+		return errors.Wrap(err, "failed to resolve node separation annotation")
+	}
+
 	mattermostEnv := getMattermostEnvWithOverrides(installation)
 	mattermost := &mmv1beta1.Mattermost{
 		ObjectMeta: metav1.ObjectMeta{
@@ -205,7 +210,7 @@ func (provisioner Provisioner) createClusterInstallation(clusterInstallation *mo
 			MattermostEnv: mattermostEnv.ToEnvList(),
 			Ingress:       makeIngressSpec(installationDNS, getIngressAnnotations()),
 			// Set `installation-id` and `cluster-installation-id` labels for all related resources.
-			ResourceLabels: clusterInstallationStableLabels(installation, clusterInstallation, cluster),
+			ResourceLabels: clusterInstallationStableLabels(installation, clusterInstallation, cluster, nodeSeparation),
 			Scheduling:     mmv1beta1.Scheduling{},
 			DNSConfig:      setNdots(provisioner.params.NdotsValue),
 			DeploymentTemplate: &mmv1beta1.DeploymentTemplate{
@@ -214,7 +219,7 @@ func (provisioner Provisioner) createClusterInstallation(clusterInstallation *mo
 		},
 	}
 
-	ensureScheduling(mattermost, installation, clusterInstallation, cluster)
+	ensureScheduling(mattermost, installation, clusterInstallation, cluster, nodeSeparation)
 
 	// Set custom command if provided
 	ensureCustomCommand(mattermost, installation)
@@ -429,10 +434,15 @@ func (provisioner Provisioner) updateClusterInstallation(
 
 	logger.WithField("status", fmt.Sprintf("%+v", mattermost.Status)).Debug("Got mattermost installation")
 
-	mattermost.ObjectMeta.Labels = generateClusterInstallationResourceLabels(installation, clusterInstallation, cluster)
-	mattermost.Spec.ResourceLabels = clusterInstallationStableLabels(installation, clusterInstallation, cluster)
+	nodeSeparation, err := provisioner.resolveNodeSeparation(installation)
+	if err != nil {
+		return errors.Wrap(err, "failed to resolve node separation annotation")
+	}
 
-	ensureScheduling(mattermost, installation, clusterInstallation, cluster)
+	mattermost.ObjectMeta.Labels = generateClusterInstallationResourceLabels(installation, clusterInstallation, cluster)
+	mattermost.Spec.ResourceLabels = clusterInstallationStableLabels(installation, clusterInstallation, cluster, nodeSeparation)
+
+	ensureScheduling(mattermost, installation, clusterInstallation, cluster, nodeSeparation)
 
 	// Set custom command if provided
 	ensureCustomCommand(mattermost, installation)
@@ -671,8 +681,9 @@ func ensureScheduling(
 	installation *model.Installation,
 	clusterInstallation *model.ClusterInstallation,
 	cluster *model.Cluster,
+	nodeSeparation bool,
 ) {
-	mattermost.Spec.Scheduling.Affinity = generateAffinityConfig(installation, clusterInstallation, cluster)
+	mattermost.Spec.Scheduling.Affinity = generateAffinityConfig(installation, clusterInstallation, cluster, nodeSeparation)
 	if installation.Scheduling != nil {
 		mattermost.Spec.Scheduling.NodeSelector = installation.Scheduling.NodeSelector
 		mattermost.Spec.Scheduling.Tolerations = installation.Scheduling.Tolerations
@@ -1038,10 +1049,48 @@ func mapDomains(installationDNS []*model.InstallationDNS) []mmv1beta1.IngressHos
 	return hosts
 }
 
+const (
+	// nodeSeparationAnnotation, when present on an installation, opts it into
+	// cross-installation node-level anti-affinity (SEC-9253): the installation's
+	// pods will not share a node with any OTHER installation that also carries
+	// this annotation. Applied to `community` and `hub` on the internal cluster.
+	nodeSeparationAnnotation = "separate-nodes"
+	// nodeSeparationLabel is stamped on the pods of opted-in installations (via
+	// ResourceLabels) so the cross-namespace anti-affinity term can select them.
+	nodeSeparationLabel = "node-separation-group"
+)
+
+// resolveNodeSeparation fetches the installation's annotations from the store and
+// reports whether it opted into cross-installation node separation. model.Installation
+// does not carry its annotations (they are a separate join), so the lookup happens
+// here at the reconcile call sites.
+func (provisioner Provisioner) resolveNodeSeparation(installation *model.Installation) (bool, error) {
+	annotations, err := provisioner.store.GetAnnotationsForInstallation(installation.ID)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get annotations for installation")
+	}
+	return installationWantsNodeSeparation(annotations), nil
+}
+
+// installationWantsNodeSeparation reports whether the installation opted into
+// cross-installation node separation via nodeSeparationAnnotation.
+//
+// Installations without the annotation get affinity and labels byte-identical to today.
+func installationWantsNodeSeparation(annotations []*model.Annotation) bool {
+	for _, annotation := range annotations {
+		if annotation != nil && annotation.Name == nodeSeparationAnnotation {
+			return true
+		}
+	}
+	return false
+}
+
 // generateAffinityConfig generates pods Affinity configuration aiming to spread pods of single cluster installation
-// across different availability zones and nodes.
-func generateAffinityConfig(installation *model.Installation, clusterInstallation *model.ClusterInstallation, cluster *model.Cluster) *corev1.Affinity {
-	return &corev1.Affinity{
+// across different availability zones and nodes. When the installation opts into node separation
+// (nodeSeparationAnnotation), it additionally keeps the installation's pods off any node running a
+// pod from another opted-in installation (SEC-9253).
+func generateAffinityConfig(installation *model.Installation, clusterInstallation *model.ClusterInstallation, cluster *model.Cluster, nodeSeparation bool) *corev1.Affinity {
+	affinity := &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
 			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 				{
@@ -1067,6 +1116,35 @@ func generateAffinityConfig(installation *model.Installation, clusterInstallatio
 			},
 		},
 	}
+
+	if nodeSeparation {
+		// Cross-installation, node-level separation. NamespaceSelector is the empty
+		// selector (ALL namespaces) on purpose: peer installations live in their own
+		// namespaces, so unlike the self-spread terms above this must match across
+		// namespaces. topologyKey is the node.
+		//
+		// Modeled as a soft preference (weight 100) so it never blocks scheduling: the
+		// scheduler strongly prefers to keep opted-in installations on distinct nodes
+		// but will co-locate rather than leave a pod Pending when node headroom is
+		// tight. For a hard guarantee, move this into
+		// RequiredDuringSchedulingIgnoredDuringExecution instead (requires guaranteed
+		// spare-node capacity).
+		affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			corev1.WeightedPodAffinityTerm{
+				Weight: 100,
+				PodAffinityTerm: corev1.PodAffinityTerm{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{nodeSeparationLabel: nodeSeparationAnnotation},
+					},
+					NamespaceSelector: &metav1.LabelSelector{},
+					TopologyKey:       "kubernetes.io/hostname",
+				},
+			},
+		)
+	}
+
+	return affinity
 }
 
 func setMMInstanceSize(installation *model.Installation, mattermost *mmv1beta1.Mattermost) error {
@@ -1285,9 +1363,15 @@ func clusterInstallationBaseLabels(installation *model.Installation, clusterInst
 	return labels
 }
 
-func clusterInstallationStableLabels(installation *model.Installation, clusterInstallation *model.ClusterInstallation, cluster *model.Cluster) map[string]string {
+func clusterInstallationStableLabels(installation *model.Installation, clusterInstallation *model.ClusterInstallation, cluster *model.Cluster, nodeSeparation bool) map[string]string {
 	labels := clusterInstallationBaseLabels(installation, clusterInstallation, cluster)
 	labels["state"] = "running"
+	if nodeSeparation {
+		// Stamp the separation label so it reaches the pods (via Spec.ResourceLabels)
+		// and the cross-namespace anti-affinity term in generateAffinityConfig can
+		// select it. Only opted-in installations carry it (SEC-9253).
+		labels[nodeSeparationLabel] = nodeSeparationAnnotation
+	}
 	return labels
 }
 

--- a/internal/provisioner/cluster_installation_provisioner_test.go
+++ b/internal/provisioner/cluster_installation_provisioner_test.go
@@ -814,7 +814,7 @@ func TestEnsureScheduling(t *testing.T) {
 			},
 		}
 
-		ensureScheduling(mattermost, installationWithScheduling, clusterInstallation, cluster)
+		ensureScheduling(mattermost, installationWithScheduling, clusterInstallation, cluster, false)
 
 		// Verify affinity is always set
 		require.NotNil(t, mattermost.Spec.Scheduling.Affinity)
@@ -858,7 +858,7 @@ func TestEnsureScheduling(t *testing.T) {
 			},
 		}
 
-		ensureScheduling(mattermost, installation, clusterInstallation, cluster)
+		ensureScheduling(mattermost, installation, clusterInstallation, cluster, false)
 
 		// Verify affinity is always set
 		require.NotNil(t, mattermost.Spec.Scheduling.Affinity)
@@ -894,7 +894,7 @@ func TestEnsureScheduling(t *testing.T) {
 			},
 		}
 
-		ensureScheduling(mattermost, installationNilScheduling, clusterInstallation, cluster)
+		ensureScheduling(mattermost, installationNilScheduling, clusterInstallation, cluster, false)
 
 		// Verify affinity is always set
 		require.NotNil(t, mattermost.Spec.Scheduling.Affinity)
@@ -919,7 +919,7 @@ func TestEnsureScheduling(t *testing.T) {
 			},
 		}
 
-		ensureScheduling(mattermost, installationEmptyScheduling, clusterInstallation, cluster)
+		ensureScheduling(mattermost, installationEmptyScheduling, clusterInstallation, cluster, false)
 
 		// Verify affinity is always set
 		require.NotNil(t, mattermost.Spec.Scheduling.Affinity)
@@ -943,7 +943,7 @@ func TestGenerateAffinityConfig(t *testing.T) {
 	}
 
 	t.Run("generates correct affinity configuration", func(t *testing.T) {
-		affinity := generateAffinityConfig(installation, clusterInstallation, cluster)
+		affinity := generateAffinityConfig(installation, clusterInstallation, cluster, false)
 
 		require.NotNil(t, affinity)
 		require.NotNil(t, affinity.PodAntiAffinity)
@@ -974,7 +974,7 @@ func TestGenerateAffinityConfig(t *testing.T) {
 	})
 
 	t.Run("generates affinity with nil cluster", func(t *testing.T) {
-		affinity := generateAffinityConfig(installation, clusterInstallation, nil)
+		affinity := generateAffinityConfig(installation, clusterInstallation, nil, false)
 
 		require.NotNil(t, affinity)
 		require.NotNil(t, affinity.PodAntiAffinity)
@@ -995,7 +995,7 @@ func TestGenerateAffinityConfig(t *testing.T) {
 		emptyNameCluster := &model.Cluster{
 			Name: "",
 		}
-		affinity := generateAffinityConfig(installation, clusterInstallation, emptyNameCluster)
+		affinity := generateAffinityConfig(installation, clusterInstallation, emptyNameCluster, false)
 
 		require.NotNil(t, affinity)
 		require.NotNil(t, affinity.PodAntiAffinity)
@@ -1010,5 +1010,106 @@ func TestGenerateAffinityConfig(t *testing.T) {
 		}
 		assert.Equal(t, expectedLabels, terms[0].PodAffinityTerm.LabelSelector.MatchLabels)
 		assert.Equal(t, expectedLabels, terms[1].PodAffinityTerm.LabelSelector.MatchLabels)
+	})
+
+	t.Run("opted-out affinity is byte-identical to today", func(t *testing.T) {
+		baseLabels := map[string]string{
+			"installation-id":         "test-installation-id",
+			"cluster-installation-id": "test-cluster-installation-id",
+			"dns":                     "test-cluster-public",
+		}
+		expected := &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+					{
+						Weight: 100,
+						PodAffinityTerm: corev1.PodAffinityTerm{
+							LabelSelector: &metav1.LabelSelector{MatchLabels: baseLabels},
+							Namespaces:    []string{"test-namespace"},
+							TopologyKey:   "kubernetes.io/hostname",
+						},
+					},
+					{
+						Weight: 100,
+						PodAffinityTerm: corev1.PodAffinityTerm{
+							LabelSelector: &metav1.LabelSelector{MatchLabels: baseLabels},
+							Namespaces:    []string{"test-namespace"},
+							TopologyKey:   "topology.kubernetes.io/zone",
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, expected, generateAffinityConfig(installation, clusterInstallation, cluster, false))
+	})
+
+	t.Run("opted-in adds the cross-installation node separation term", func(t *testing.T) {
+		affinity := generateAffinityConfig(installation, clusterInstallation, cluster, true)
+
+		require.NotNil(t, affinity)
+		require.NotNil(t, affinity.PodAntiAffinity)
+
+		terms := affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		// The two self-spread terms are preserved and the extra term is appended.
+		require.Len(t, terms, 3)
+
+		// Self-spread terms unchanged: own namespace, no NamespaceSelector.
+		for _, term := range terms[:2] {
+			assert.Equal(t, []string{"test-namespace"}, term.PodAffinityTerm.Namespaces)
+			assert.Nil(t, term.PodAffinityTerm.NamespaceSelector)
+		}
+
+		sep := terms[2]
+		assert.Equal(t, int32(100), sep.Weight)
+		assert.Equal(t, "kubernetes.io/hostname", sep.PodAffinityTerm.TopologyKey)
+		// Cross-namespace: empty (all-namespaces) selector, no Namespaces restriction.
+		require.NotNil(t, sep.PodAffinityTerm.NamespaceSelector)
+		assert.Equal(t, &metav1.LabelSelector{}, sep.PodAffinityTerm.NamespaceSelector)
+		assert.Empty(t, sep.PodAffinityTerm.Namespaces)
+		assert.Equal(t, map[string]string{
+			"node-separation-group": "separate-nodes",
+		}, sep.PodAffinityTerm.LabelSelector.MatchLabels)
+	})
+}
+
+func TestClusterInstallationStableLabels(t *testing.T) {
+	installation := &model.Installation{ID: "test-installation-id"}
+	clusterInstallation := &model.ClusterInstallation{
+		ID:        "test-cluster-installation-id",
+		Namespace: "test-namespace",
+	}
+	cluster := &model.Cluster{Name: "test-cluster"}
+
+	t.Run("opted-out omits the node-separation-group label", func(t *testing.T) {
+		labels := clusterInstallationStableLabels(installation, clusterInstallation, cluster, false)
+		assert.NotContains(t, labels, "node-separation-group")
+		assert.Equal(t, map[string]string{
+			"installation-id":         "test-installation-id",
+			"cluster-installation-id": "test-cluster-installation-id",
+			"dns":                     "test-cluster-public",
+			"state":                   "running",
+		}, labels)
+	})
+
+	t.Run("opted-in includes the node-separation-group label", func(t *testing.T) {
+		labels := clusterInstallationStableLabels(installation, clusterInstallation, cluster, true)
+		assert.Equal(t, "separate-nodes", labels["node-separation-group"])
+	})
+}
+
+func TestInstallationWantsNodeSeparation(t *testing.T) {
+	t.Run("no annotations", func(t *testing.T) {
+		assert.False(t, installationWantsNodeSeparation(nil))
+	})
+
+	t.Run("unrelated annotations", func(t *testing.T) {
+		annotations := []*model.Annotation{{Name: "multi-tenant"}, {Name: "internal"}}
+		assert.False(t, installationWantsNodeSeparation(annotations))
+	})
+
+	t.Run("separate-nodes annotation present", func(t *testing.T) {
+		annotations := []*model.Annotation{{Name: "internal"}, {Name: "separate-nodes"}}
+		assert.True(t, installationWantsNodeSeparation(annotations))
 	})
 }

--- a/internal/provisioner/node_separation_e2e_test.go
+++ b/internal/provisioner/node_separation_e2e_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+//
+
+package provisioner
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-cloud/internal/store"
+	"github.com/mattermost/mattermost-cloud/internal/testlib"
+	"github.com/mattermost/mattermost-cloud/model"
+	mmv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8syaml "sigs.k8s.io/yaml"
+)
+
+// TestNodeSeparation_EndToEnd exercises the full SEC-9253 opt-in path exactly as
+// the provisioner does on reconcile:
+//
+//	installation annotation (in the store)  ->  resolveNodeSeparation
+//	                                        ->  ensureScheduling (single owner)
+//	                                        ->  the Mattermost CR the operator applies
+//
+// It renders the resulting CR scheduling spec (ResourceLabels + Affinity) as YAML
+// so a reviewer can see what actually lands on the pods for an opted-in
+// (community/hub) installation versus an ordinary one.
+func TestNodeSeparation_EndToEnd(t *testing.T) {
+	logger := testlib.MakeLogger(t)
+	sqlStore := store.MakeTestSQLStore(t, logger)
+	defer store.CloseConnection(t, sqlStore)
+
+	// An opted-in installation (e.g. `community` or `hub`) carries the
+	// `separate-nodes` annotation alongside unrelated ones.
+	optedIn := &model.Installation{Name: "community"}
+	err := sqlStore.CreateInstallation(optedIn, []*model.Annotation{
+		{Name: "internal"},
+		{Name: nodeSeparationAnnotation},
+	}, nil)
+	require.NoError(t, err)
+
+	// A regular customer installation without the annotation.
+	optedOut := &model.Installation{Name: "customer"}
+	err = sqlStore.CreateInstallation(optedOut, []*model.Annotation{
+		{Name: "multi-tenant"},
+	}, nil)
+	require.NoError(t, err)
+
+	provisioner := Provisioner{store: sqlStore}
+
+	renderScheduling := func(t *testing.T, installation *model.Installation) (bool, mmv1beta1.MattermostSpec) {
+		t.Helper()
+
+		// This is the exact store lookup the provisioner performs at reconcile.
+		nodeSeparation, err := provisioner.resolveNodeSeparation(installation)
+		require.NoError(t, err)
+
+		clusterInstallation := &model.ClusterInstallation{
+			ID:        installation.ID + "-ci",
+			Namespace: installation.ID + "-ns",
+		}
+		cluster := &model.Cluster{Name: "internal-cluster"}
+
+		mattermost := &mmv1beta1.Mattermost{
+			ObjectMeta: metav1.ObjectMeta{Name: installation.Name},
+		}
+		// ensureScheduling is the single owner of ResourceLabels + Affinity.
+		ensureScheduling(mattermost, installation, clusterInstallation, cluster, nodeSeparation)
+
+		// Only render the scheduling-relevant slice of the CR spec.
+		rendered := mmv1beta1.MattermostSpec{
+			ResourceLabels: mattermost.Spec.ResourceLabels,
+			Scheduling:     mattermost.Spec.Scheduling,
+		}
+		return nodeSeparation, rendered
+	}
+
+	t.Run("opted-in installation gets cross-installation node separation", func(t *testing.T) {
+		nodeSeparation, spec := renderScheduling(t, optedIn)
+		require.True(t, nodeSeparation, "installation with the separate-nodes annotation must opt in")
+
+		// The separation label is stamped on the pods (via ResourceLabels).
+		assert.Equal(t, nodeSeparationAnnotation, spec.ResourceLabels[nodeSeparationLabel],
+			"opted-in pods must carry the node-separation-group label")
+
+		terms := spec.Scheduling.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		require.Len(t, terms, 3, "two self-spread terms plus the cross-installation separation term")
+
+		sep := terms[2]
+		assert.Equal(t, int32(100), sep.Weight)
+		assert.Equal(t, "kubernetes.io/hostname", sep.PodAffinityTerm.TopologyKey,
+			"separation must be at the node level")
+		// Cross-installation: matches the separation label in ALL namespaces.
+		require.NotNil(t, sep.PodAffinityTerm.NamespaceSelector)
+		assert.Equal(t, &metav1.LabelSelector{}, sep.PodAffinityTerm.NamespaceSelector)
+		assert.Empty(t, sep.PodAffinityTerm.Namespaces)
+		assert.Equal(t, map[string]string{nodeSeparationLabel: nodeSeparationAnnotation},
+			sep.PodAffinityTerm.LabelSelector.MatchLabels)
+
+		yamlOut, err := k8syaml.Marshal(spec)
+		require.NoError(t, err)
+		t.Logf("\n===== OPTED-IN (community) rendered Mattermost CR scheduling spec =====\n%s", string(yamlOut))
+	})
+
+	t.Run("regular installation is unchanged", func(t *testing.T) {
+		nodeSeparation, spec := renderScheduling(t, optedOut)
+		require.False(t, nodeSeparation, "installation without the annotation must not opt in")
+
+		assert.NotContains(t, spec.ResourceLabels, nodeSeparationLabel,
+			"non-opted-in pods must not carry the separation label")
+
+		terms := spec.Scheduling.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		require.Len(t, terms, 2, "only the two self-spread terms, no cross-installation term")
+		for _, term := range terms {
+			assert.Nil(t, term.PodAffinityTerm.NamespaceSelector,
+				"self-spread terms stay scoped to the installation's own namespace")
+		}
+
+		yamlOut, err := k8syaml.Marshal(spec)
+		require.NoError(t, err)
+		t.Logf("\n===== OPTED-OUT (customer) rendered Mattermost CR scheduling spec =====\n%s", string(yamlOut))
+	})
+}


### PR DESCRIPTION
#### Summary

Community (`mm-rxoc`) and hub (`mm-c4ja`) Mattermost Cloud installations share the internal cluster and can currently be scheduled onto the **same node**. This adds an **opt-in** mechanism so annotated installations avoid co-locating with any other opted-in installation.

The provisioner owns and **overwrites** the CR's `Spec.Scheduling.Affinity` and `Spec.ResourceLabels` on every reconcile, so the durable fix lives in `internal/provisioner/cluster_installation_provisioner.go`:

- A new Cloud annotation `separate-nodes` opts an installation in.
- When opted in, `clusterInstallationStableLabels` stamps a `node-separation-group=separate-nodes` pod label (reaches pods via `Spec.ResourceLabels`).
- `generateAffinityConfig` appends a **soft** (`PreferredDuringSchedulingIgnoredDuringExecution`, weight 100) `podAntiAffinity` term selecting that label, with `NamespaceSelector: {}` (cross-namespace — peers live in their own namespaces) and `topologyKey: kubernetes.io/hostname`.
- `model.Installation` doesn't carry annotations (separate join), so `resolveNodeSeparation` fetches them via `store.GetAnnotationsForInstallation` at the create/update reconcile call sites.

Separation is **soft on purpose** (captain's decision): it never blocks scheduling — under node pressure the scheduler may still co-locate rather than leave a pod `Pending`. Flipping to a hard guarantee is a one-line change (move the term to `RequiredDuringSchedulingIgnoredDuringExecution`) once guaranteed spare-node capacity is confirmed.

**Blast radius:** installations **without** the `separate-nodes` annotation get byte-identical generated affinity and labels to before (covered by tests). All changes are in mattermost-cloud; no operator changes.

Rollout after merge: add the `separate-nodes` annotation to `community` and `hub`, then reconcile.

#### Ticket Link

https://mattermost.atlassian.net/browse/SEC-9253

#### Release Note

```release-note
NONE
```
